### PR TITLE
Remove Mac and visionOS from supported destinations

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -939,10 +939,11 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FamilyFoqos.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/FamilyFoqos";
 				XROS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -962,10 +963,11 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FamilyFoqos.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/FamilyFoqos";
 				XROS_DEPLOYMENT_TARGET = 2.0;
 			};


### PR DESCRIPTION
## Summary
- Simplify project by removing Mac (macOS) and Apple Vision (visionOS) from supported destinations
- App uses FamilyControls/ScreenTime APIs which are iOS-only, so these platforms were never viable

## Test plan
- [ ] Build succeeds for iOS target
- [ ] Destination picker in Xcode shows only iOS devices/simulators

## Summary by Sourcery

Build:
- Update Xcode project settings to drop macOS and visionOS from the list of supported destinations, leaving iOS as the sole target platform.