### PR TITLE
Add ProfileSession schema and migration complete flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ import WidgetKit
 - **Booleans**: Prefix with `is`, `has`, `enable`, `allow` (e.g., `isActive`, `hasPermission`)
 - **Private properties**: camelCase, no underscore prefix
 - **Static properties**: camelCase or PascalCase based on usage
+- **UserDefaults keys**: Use `family_foqos_` prefix (e.g., `family_foqos_app_mode`)
 
 ### SwiftUI Patterns
 - Use `@State` for local view state

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -144,9 +144,11 @@ class ProfileSyncManager: ObservableObject {
       try await createSyncZoneIfNeeded()
 
       // Migrate legacy session records to new format
+      let userRecordID = try await container.userRecordID()
       let migration = SessionSyncMigration(
         database: privateDatabase,
-        zoneID: syncZoneID
+        zoneID: syncZoneID,
+        userRecordName: userRecordID.recordName
       )
       await migration.migrateIfNeeded()
 

--- a/Foqos/CloudKit/SessionSyncMigration.swift
+++ b/Foqos/CloudKit/SessionSyncMigration.swift
@@ -6,23 +6,29 @@ class SessionSyncMigration {
 
   private let privateDatabase: CKDatabase
   private let syncZoneID: CKRecordZone.ID
+  private let userRecordName: String
 
-  private static let migrationCompleteKey = "SessionSyncMigrationComplete"
+  private static let migrationCompleteKeyPrefix = "SessionSyncMigrationComplete_"
 
-  private static var isMigrationComplete: Bool {
+  private var migrationCompleteKey: String {
+    Self.migrationCompleteKeyPrefix + userRecordName
+  }
+
+  private var isMigrationComplete: Bool {
     get { UserDefaults.standard.bool(forKey: migrationCompleteKey) }
     set { UserDefaults.standard.set(newValue, forKey: migrationCompleteKey) }
   }
 
-  init(database: CKDatabase, zoneID: CKRecordZone.ID) {
+  init(database: CKDatabase, zoneID: CKRecordZone.ID, userRecordName: String) {
     self.privateDatabase = database
     self.syncZoneID = zoneID
+    self.userRecordName = userRecordName
   }
 
   /// Check if migration is needed and perform it
   func migrateIfNeeded() async {
-    // Skip if migration already completed
-    if Self.isMigrationComplete {
+    // Skip if migration already completed for this account
+    if isMigrationComplete {
       return
     }
 
@@ -55,7 +61,7 @@ class SessionSyncMigration {
 
       if allResults.isEmpty {
         print("SessionSyncMigration: No legacy records to migrate")
-        Self.isMigrationComplete = true
+        isMigrationComplete = true
         return
       }
 
@@ -71,6 +77,9 @@ class SessionSyncMigration {
           profileSessions[session.profileId, default: []].append((recordID, session))
         }
       }
+
+      // Track migration errors - only mark complete if all profiles migrate successfully
+      var migrationErrors = 0
 
       // Create new ProfileSessionRecord for each profile
       for (profileId, sessions) in profileSessions {
@@ -103,6 +112,7 @@ class SessionSyncMigration {
             print("SessionSyncMigration: Created ProfileSessionRecord for \(profileId)")
           } catch {
             print("SessionSyncMigration: Failed to create ProfileSessionRecord for \(profileId) - \(error)")
+            migrationErrors += 1
             continue
           }
         }
@@ -113,18 +123,24 @@ class SessionSyncMigration {
             try await privateDatabase.deleteRecord(withID: recordID)
           } catch {
             print("SessionSyncMigration: Failed to delete legacy record \(recordID) - \(error)")
+            migrationErrors += 1
           }
         }
         print("SessionSyncMigration: Deleted \(sessions.count) legacy records for \(profileId)")
       }
 
-      Self.isMigrationComplete = true
-      print("SessionSyncMigration: Migration complete")
+      // Only mark migration complete if no errors occurred
+      if migrationErrors == 0 {
+        isMigrationComplete = true
+        print("SessionSyncMigration: Migration complete")
+      } else {
+        print("SessionSyncMigration: Migration finished with \(migrationErrors) errors, will retry on next sync")
+      }
 
     } catch let error as CKError {
       if error.code == .zoneNotFound || error.code == .unknownItem {
         print("SessionSyncMigration: No sync zone or legacy records found")
-        Self.isMigrationComplete = true
+        isMigrationComplete = true
         return
       }
       print("SessionSyncMigration: Error during migration - \(error)")

--- a/Foqos/CloudKit/SessionSyncMigration.swift
+++ b/Foqos/CloudKit/SessionSyncMigration.swift
@@ -8,7 +8,7 @@ class SessionSyncMigration {
   private let syncZoneID: CKRecordZone.ID
   private let userRecordName: String
 
-  private static let migrationCompleteKeyPrefix = "SessionSyncMigrationComplete_"
+  private static let migrationCompleteKeyPrefix = "family_foqos_session_sync_migration_complete_"
 
   private var migrationCompleteKey: String {
     Self.migrationCompleteKeyPrefix + userRecordName

--- a/Foqos/CloudKit/cloudkit-schema.ckdb
+++ b/Foqos/CloudKit/cloudkit-schema.ckdb
@@ -135,6 +135,7 @@ DEFINE SCHEMA
         GRANT READ TO "_creator"
     );
 
+    // DEPRECATED: Legacy per-device session sync. Replaced by ProfileSession.
     RECORD TYPE SyncedSession (
         "___createTime"   TIMESTAMP QUERYABLE SORTABLE,
         "___createdBy"    REFERENCE QUERYABLE,
@@ -150,6 +151,29 @@ DEFINE SCHEMA
         breakEndTime      TIMESTAMP,
         originDeviceId    STRING QUERYABLE,
         lastModified      TIMESTAMP QUERYABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_creator"
+    );
+
+    // CAS-based single record per profile for session state (replaces SyncedSession)
+    RECORD TYPE ProfileSession (
+        "___createTime"     TIMESTAMP QUERYABLE SORTABLE,
+        "___createdBy"      REFERENCE QUERYABLE,
+        "___etag"           STRING,
+        "___modTime"        TIMESTAMP QUERYABLE SORTABLE,
+        "___modifiedBy"     REFERENCE QUERYABLE,
+        "___recordID"       REFERENCE QUERYABLE,
+        profileId           STRING QUERYABLE SEARCHABLE,
+        isActive            INT64 QUERYABLE,
+        sequenceNumber      INT64 QUERYABLE SORTABLE,
+        startTime           TIMESTAMP QUERYABLE SORTABLE,
+        endTime             TIMESTAMP QUERYABLE SORTABLE,
+        breakStartTime      TIMESTAMP,
+        breakEndTime        TIMESTAMP,
+        lastModifiedBy      STRING,
+        sessionOriginDevice STRING QUERYABLE,
+        lastModified        TIMESTAMP QUERYABLE SORTABLE,
         GRANT WRITE TO "_creator",
         GRANT CREATE TO "_icloud",
         GRANT READ TO "_creator"


### PR DESCRIPTION
## Summary
- Add `ProfileSession` record type to CloudKit schema (missing from PR #7)
- Mark `SyncedSession` as deprecated in schema
- Add UserDefaults flag to skip migration query after completion

## Why
PR #7 introduced CAS-based session sync with a new `ProfileSession` record type but:
1. Didn't update `cloudkit-schema.ckdb`
2. Ran migration query on every sync, even after completion

## Changes
- **Schema**: Add `ProfileSession`, mark `SyncedSession` as deprecated
- **Migration**: Skip CloudKit query entirely once migration completes

## Future cleanup
The migration complete flag enables safe removal of legacy `SyncedSession` code in a future release once users have migrated.

## Test plan
- [ ] Build succeeds
- [ ] Fresh install: migration marks complete after finding no legacy records
- [ ] Existing user with legacy records: migration runs once, then skips

## Summary by Sourcery

Add a migration completion flag for CloudKit session sync and update the CloudKit schema to reflect the new ProfileSession model and deprecated SyncedSession records.

Enhancements:
- Persist a UserDefaults-backed flag to skip re-running the CloudKit session migration after it has successfully completed or found no legacy data.
- Update the CloudKit schema file to include the new ProfileSession record type and mark SyncedSession as deprecated.