### PR TITLE
Fix crash when SwiftData model deleted during CloudKit sync

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -655,7 +655,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -686,7 +686,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -842,7 +842,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -944,7 +944,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
@@ -970,7 +970,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
@@ -995,7 +995,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
@@ -1020,7 +1020,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
@@ -1046,7 +1046,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1077,7 +1077,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1111,7 +1111,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1144,7 +1144,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;

--- a/Foqos/CloudKit/SyncCoordinator.swift
+++ b/Foqos/CloudKit/SyncCoordinator.swift
@@ -4,6 +4,7 @@ import SwiftData
 
 /// Coordinates between ProfileSyncManager notifications and local SwiftData storage.
 /// Handles incoming synced profiles, sessions, and locations from other devices.
+@MainActor
 class SyncCoordinator: ObservableObject {
   static let shared = SyncCoordinator()
 
@@ -45,9 +46,7 @@ class SyncCoordinator: ObservableObject {
         else {
           return
         }
-        MainActor.assumeIsolated {
-          self?.handleProfileSessionRecords(sessions)
-        }
+        self?.handleProfileSessionRecords(sessions)
       }
       .store(in: &cancellables)
 

--- a/Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift
+++ b/Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift
@@ -35,6 +35,11 @@ struct BlockedProfileCarousel: View {
 
   private var cardHeight: CGFloat = 240
 
+  /// Filtered profiles excluding deleted models
+  private var validProfiles: [BlockedProfiles] {
+    profiles.valid
+  }
+
   private var titleMessage: String {
     return isBlocking ? "Active Profile" : "Profile"
   }
@@ -97,7 +102,7 @@ struct BlockedProfileCarousel: View {
   private func initialSetup() {
     // First priority: active session profile
     if let activeId = activeSessionProfileId,
-      let index = profiles.valid.firstIndex(where: { $0.id == activeId })
+      let index = validProfiles.firstIndex(where: { $0.id == activeId })
     {
       currentIndex = index
       return
@@ -105,14 +110,14 @@ struct BlockedProfileCarousel: View {
 
     // Second priority: starting profile
     if let startingId = startingProfileId,
-      let index = profiles.valid.firstIndex(where: { $0.id == startingId })
+      let index = validProfiles.firstIndex(where: { $0.id == startingId })
     {
       currentIndex = index
       return
     }
 
     // Default: first profile if available
-    if profiles.valid.first != nil {
+    if validProfiles.first != nil {
       currentIndex = 0
       return
     }
@@ -139,37 +144,37 @@ struct BlockedProfileCarousel: View {
             let cardWidth = geometry.size.width - 32  // Padding on sides
 
             HStack(spacing: cardSpacing) {
-              ForEach(profiles.valid.indices, id: \.self) { index in
+              ForEach(validProfiles.indices, id: \.self) { index in
                 BlockedProfileCard(
-                  profile: profiles.valid[index],
-                  isActive: profiles.valid[index].id
+                  profile: validProfiles[index],
+                  isActive: validProfiles[index].id
                     == activeSessionProfileId,
                   isBreakAvailable: isBreakAvailable,
                   isBreakActive: isBreakActive,
                   elapsedTime: elapsedTime,
                   onStartTapped: {
-                    onStartTapped(profiles.valid[index])
+                    onStartTapped(validProfiles[index])
                   },
                   onStopTapped: {
-                    onStopTapped(profiles.valid[index])
+                    onStopTapped(validProfiles[index])
                   },
                   onEditTapped: {
-                    onEditTapped(profiles.valid[index])
+                    onEditTapped(validProfiles[index])
                   },
                   onStatsTapped: {
-                    onStatsTapped(profiles.valid[index])
+                    onStatsTapped(validProfiles[index])
                   },
                   onBreakTapped: {
-                    onBreakTapped(profiles.valid[index])
+                    onBreakTapped(validProfiles[index])
                   },
                   onAppSelectionTapped: {
-                    onAppSelectionTapped(profiles.valid[index])
+                    onAppSelectionTapped(validProfiles[index])
                   },
                   isOneMoreMinuteActive: isOneMoreMinuteActive,
                   isOneMoreMinuteAvailable: isOneMoreMinuteAvailable,
                   oneMoreMinuteTimeRemaining: oneMoreMinuteTimeRemaining,
                   onOneMoreMinuteTapped: {
-                    onOneMoreMinuteTapped(profiles.valid[index])
+                    onOneMoreMinuteTapped(validProfiles[index])
                   }
                 )
                 .frame(width: cardWidth)
@@ -206,7 +211,7 @@ struct BlockedProfileCarousel: View {
                       offsetAmount < -dragThreshold
 
                     if swipedLeft
-                      && currentIndex < profiles.valid.count - 1
+                      && currentIndex < validProfiles.count - 1
                     {
                       currentIndex += 1
                     } else if swipedRight
@@ -226,8 +231,8 @@ struct BlockedProfileCarousel: View {
 
         // Page indicator dots
         HStack(spacing: 8) {
-          if !isBlocking && profiles.valid.count > 1 {
-            ForEach(0..<profiles.valid.count, id: \.self) { index in
+          if !isBlocking && validProfiles.count > 1 {
+            ForEach(0..<validProfiles.count, id: \.self) { index in
               Circle()
                 .fill(
                   index == currentIndex
@@ -240,7 +245,7 @@ struct BlockedProfileCarousel: View {
           }
         }
         .frame(height: 8)
-        .opacity(!isBlocking && profiles.valid.count > 1 ? 1 : 0)
+        .opacity(!isBlocking && validProfiles.count > 1 ? 1 : 0)
         .animation(.easeInOut, value: isBlocking)
       }
     }

--- a/Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift
+++ b/Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift
@@ -97,7 +97,7 @@ struct BlockedProfileCarousel: View {
   private func initialSetup() {
     // First priority: active session profile
     if let activeId = activeSessionProfileId,
-      let index = profiles.firstIndex(where: { $0.id == activeId })
+      let index = profiles.valid.firstIndex(where: { $0.id == activeId })
     {
       currentIndex = index
       return
@@ -105,14 +105,14 @@ struct BlockedProfileCarousel: View {
 
     // Second priority: starting profile
     if let startingId = startingProfileId,
-      let index = profiles.firstIndex(where: { $0.id == startingId })
+      let index = profiles.valid.firstIndex(where: { $0.id == startingId })
     {
       currentIndex = index
       return
     }
 
     // Default: first profile if available
-    if profiles.first != nil {
+    if profiles.valid.first != nil {
       currentIndex = 0
       return
     }
@@ -139,37 +139,37 @@ struct BlockedProfileCarousel: View {
             let cardWidth = geometry.size.width - 32  // Padding on sides
 
             HStack(spacing: cardSpacing) {
-              ForEach(profiles.indices, id: \.self) { index in
+              ForEach(profiles.valid.indices, id: \.self) { index in
                 BlockedProfileCard(
-                  profile: profiles[index],
-                  isActive: profiles[index].id
+                  profile: profiles.valid[index],
+                  isActive: profiles.valid[index].id
                     == activeSessionProfileId,
                   isBreakAvailable: isBreakAvailable,
                   isBreakActive: isBreakActive,
                   elapsedTime: elapsedTime,
                   onStartTapped: {
-                    onStartTapped(profiles[index])
+                    onStartTapped(profiles.valid[index])
                   },
                   onStopTapped: {
-                    onStopTapped(profiles[index])
+                    onStopTapped(profiles.valid[index])
                   },
                   onEditTapped: {
-                    onEditTapped(profiles[index])
+                    onEditTapped(profiles.valid[index])
                   },
                   onStatsTapped: {
-                    onStatsTapped(profiles[index])
+                    onStatsTapped(profiles.valid[index])
                   },
                   onBreakTapped: {
-                    onBreakTapped(profiles[index])
+                    onBreakTapped(profiles.valid[index])
                   },
                   onAppSelectionTapped: {
-                    onAppSelectionTapped(profiles[index])
+                    onAppSelectionTapped(profiles.valid[index])
                   },
                   isOneMoreMinuteActive: isOneMoreMinuteActive,
                   isOneMoreMinuteAvailable: isOneMoreMinuteAvailable,
                   oneMoreMinuteTimeRemaining: oneMoreMinuteTimeRemaining,
                   onOneMoreMinuteTapped: {
-                    onOneMoreMinuteTapped(profiles[index])
+                    onOneMoreMinuteTapped(profiles.valid[index])
                   }
                 )
                 .frame(width: cardWidth)
@@ -206,7 +206,7 @@ struct BlockedProfileCarousel: View {
                       offsetAmount < -dragThreshold
 
                     if swipedLeft
-                      && currentIndex < profiles.count - 1
+                      && currentIndex < profiles.valid.count - 1
                     {
                       currentIndex += 1
                     } else if swipedRight
@@ -226,8 +226,8 @@ struct BlockedProfileCarousel: View {
 
         // Page indicator dots
         HStack(spacing: 8) {
-          if !isBlocking && profiles.count > 1 {
-            ForEach(0..<profiles.count, id: \.self) { index in
+          if !isBlocking && profiles.valid.count > 1 {
+            ForEach(0..<profiles.valid.count, id: \.self) { index in
               Circle()
                 .fill(
                   index == currentIndex
@@ -240,7 +240,7 @@ struct BlockedProfileCarousel: View {
           }
         }
         .frame(height: 8)
-        .opacity(!isBlocking && profiles.count > 1 ? 1 : 0)
+        .opacity(!isBlocking && profiles.valid.count > 1 ? 1 : 0)
         .animation(.easeInOut, value: isBlocking)
       }
     }

--- a/Foqos/Utils/Extensions.swift
+++ b/Foqos/Utils/Extensions.swift
@@ -1,8 +1,21 @@
+import SwiftData
 import SwiftUI
 
 extension Collection {
   // Returns the element at the specified index if it is within bounds, otherwise nil.
   subscript(safe index: Index) -> Element? {
     indices.contains(index) ? self[index] : nil
+  }
+}
+
+// MARK: - SwiftData Model Validation
+
+extension Array where Element: PersistentModel {
+  /// Filters out models that have been deleted from SwiftData but not yet removed from @Query.
+  /// When a SwiftData model is deleted, its `modelContext` becomes nil. Accessing properties
+  /// on such models causes a crash. This defensive filter handles the timing window between
+  /// SwiftData deletion and SwiftUI re-render.
+  var valid: [Element] {
+    filter { $0.modelContext != nil }
   }
 }

--- a/Foqos/Views/BlockedProfileDataExportView.swift
+++ b/Foqos/Views/BlockedProfileDataExportView.swift
@@ -21,6 +21,11 @@ struct BlockedProfileDataExportView: View {
   @State private var isGenerating: Bool = false
   @State private var errorMessage: String? = nil
 
+  /// Filtered profiles excluding deleted models
+  private var validProfiles: [BlockedProfiles] {
+    profiles.valid
+  }
+
   private var isExportDisabled: Bool {
     isGenerating || selectedProfileIDs.isEmpty
   }
@@ -34,11 +39,11 @@ struct BlockedProfileDataExportView: View {
     NavigationStack {
       Form {
         Section(header: Text("Profiles")) {
-          if profiles.valid.isEmpty {
+          if validProfiles.isEmpty {
             Text("No profiles yet")
               .foregroundStyle(.secondary)
           } else {
-            ForEach(profiles.valid) { profile in
+            ForEach(validProfiles) { profile in
               let isSelected = selectedProfileIDs.contains(profile.id)
               HStack {
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")

--- a/Foqos/Views/BlockedProfileDataExportView.swift
+++ b/Foqos/Views/BlockedProfileDataExportView.swift
@@ -34,11 +34,11 @@ struct BlockedProfileDataExportView: View {
     NavigationStack {
       Form {
         Section(header: Text("Profiles")) {
-          if profiles.isEmpty {
+          if profiles.valid.isEmpty {
             Text("No profiles yet")
               .foregroundStyle(.secondary)
           } else {
-            ForEach(profiles) { profile in
+            ForEach(profiles.valid) { profile in
               let isSelected = selectedProfileIDs.contains(profile.id)
               HStack {
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")

--- a/Foqos/Views/BlockedProfileListView.swift
+++ b/Foqos/Views/BlockedProfileListView.swift
@@ -21,7 +21,7 @@ struct BlockedProfileListView: View {
   var body: some View {
     NavigationStack {
       Group {
-        if profiles.isEmpty {
+        if profiles.valid.isEmpty {
           EmptyView(
             iconName: "person.crop.circle.badge.plus",
             headingText:
@@ -29,7 +29,7 @@ struct BlockedProfileListView: View {
           )
         } else {
           List {
-            ForEach(profiles) { profile in
+            ForEach(profiles.valid) { profile in
               ProfileRow(profile: profile)
                 .contentShape(Rectangle())
                 .onTapGesture {

--- a/Foqos/Views/BlockedProfileListView.swift
+++ b/Foqos/Views/BlockedProfileListView.swift
@@ -18,10 +18,15 @@ struct BlockedProfileListView: View {
   @State private var showErrorAlert = false
   @State private var editMode: EditMode = .inactive
 
+  /// Filtered profiles excluding deleted models
+  private var validProfiles: [BlockedProfiles] {
+    profiles.valid
+  }
+
   var body: some View {
     NavigationStack {
       Group {
-        if profiles.valid.isEmpty {
+        if validProfiles.isEmpty {
           EmptyView(
             iconName: "person.crop.circle.badge.plus",
             headingText:
@@ -29,7 +34,7 @@ struct BlockedProfileListView: View {
           )
         } else {
           List {
-            ForEach(profiles.valid) { profile in
+            ForEach(validProfiles) { profile in
               ProfileRow(profile: profile)
                 .contentShape(Rectangle())
                 .onTapGesture {
@@ -58,7 +63,7 @@ struct BlockedProfileListView: View {
               Image(systemName: "checkmark.circle")
             }
           }
-          if !profiles.isEmpty {
+          if !validProfiles.isEmpty {
             Menu {
               Button {
                 editMode = .active
@@ -105,10 +110,11 @@ struct BlockedProfileListView: View {
   private func deleteProfiles(at offsets: IndexSet) {
     let activeSession = BlockedProfileSession.mostRecentActiveSession(
       in: context)
+    let profilesToDelete = validProfiles
 
     // Check if any of the profiles to delete are active
     for index in offsets {
-      let profile = profiles[index]
+      let profile = profilesToDelete[index]
       if profile.id == activeSession?.blockedProfile.id {
         showErrorAlert = true
         return
@@ -118,7 +124,7 @@ struct BlockedProfileListView: View {
     // Delete the profiles and reorder
     do {
       for index in offsets {
-        let profile = profiles[index]
+        let profile = profilesToDelete[index]
         try BlockedProfiles.deleteProfile(profile, in: context)
       }
 
@@ -131,7 +137,7 @@ struct BlockedProfileListView: View {
   }
 
   private func moveProfiles(from source: IndexSet, to destination: Int) {
-    var reorderedProfiles = Array(profiles)
+    var reorderedProfiles = validProfiles
     reorderedProfiles.move(fromOffsets: source, toOffset: destination)
 
     do {

--- a/Foqos/Views/Child/ChildDashboardView.swift
+++ b/Foqos/Views/Child/ChildDashboardView.swift
@@ -23,14 +23,19 @@ struct ChildDashboardView: View {
   @State private var showAuthorizationLostAlert = false
   @State private var isVerifyingAuthorization = false
 
+  /// Filtered profiles excluding deleted models
+  private var validProfiles: [BlockedProfiles] {
+    allProfiles.valid
+  }
+
   /// Profiles that are locked (require code to edit)
   private var lockedProfiles: [BlockedProfiles] {
-    allProfiles.valid.filter { $0.isManaged }
+    validProfiles.filter { $0.isManaged }
   }
 
   /// Profiles that are not locked (child can freely edit)
   private var unlockedProfiles: [BlockedProfiles] {
-    allProfiles.filter { !$0.isManaged }
+    validProfiles.filter { !$0.isManaged }
   }
 
   var body: some View {
@@ -92,7 +97,7 @@ struct ChildDashboardView: View {
         )
       }
       .sheet(isPresented: $showEditLockedProfiles) {
-        EditLockedProfilesSheet(profiles: allProfiles.valid)
+        EditLockedProfilesSheet(profiles: validProfiles)
       }
       .fullScreenCover(isPresented: $showPersonalProfiles) {
         NavigationStack {

--- a/Foqos/Views/Child/ChildDashboardView.swift
+++ b/Foqos/Views/Child/ChildDashboardView.swift
@@ -25,7 +25,7 @@ struct ChildDashboardView: View {
 
   /// Profiles that are locked (require code to edit)
   private var lockedProfiles: [BlockedProfiles] {
-    allProfiles.filter { $0.isManaged }
+    allProfiles.valid.filter { $0.isManaged }
   }
 
   /// Profiles that are not locked (child can freely edit)
@@ -92,7 +92,7 @@ struct ChildDashboardView: View {
         )
       }
       .sheet(isPresented: $showEditLockedProfiles) {
-        EditLockedProfilesSheet(profiles: allProfiles)
+        EditLockedProfilesSheet(profiles: allProfiles.valid)
       }
       .fullScreenCover(isPresented: $showPersonalProfiles) {
         NavigationStack {


### PR DESCRIPTION
## Summary
- Add `@MainActor` to `SyncCoordinator` for Swift 6 compatibility
- Add `.valid` extension on `Array<PersistentModel>` to filter out deleted models
- Apply `.valid` filter to all `ForEach` iterations over `@Query` results
- Document the SwiftData safety pattern in AGENTS.md
- Bump `CURRENT_PROJECT_VERSION` for TestFlight release

## Problem
When a profile was deleted via CloudKit sync while the app was in the background, the app crashed on foreground. The crash occurred because:

1. CloudKit notification triggered profile deletion from SwiftData
2. SwiftUI's `@Query` still held a reference to the deleted model
3. Accessing `profile.selectedActivity` on the deleted model caused `EXC_BREAKPOINT`

**Crash location:** `BlockedProfileCard.swift:123` - accessing `profile.selectedActivity`

**Log evidence:**
```
[01:00:30.313Z] handleSyncedProfiles(_:) - Removing profile 'No games' deleted from remote
[01:00:31.394Z] init() - init() called  ← App crashed and restarted
```

## Solution
When a SwiftData model is deleted, its `modelContext` becomes `nil`. Added a `.valid` extension that filters these out:

```swift
extension Array where Element: PersistentModel {
  var valid: [Element] { filter { $0.modelContext != nil } }
}
```

Applied to all views that iterate `@Query` results with `ForEach`.

## Test Plan
- [x] Build succeeds
- [x] All tests pass
- [ ] Delete a profile on another device while app is backgrounded
- [ ] Return to app - should not crash
- [ ] Verify deleted profile is removed from UI

## Files Changed
| File | Change |
|------|--------|
| `SyncCoordinator.swift` | Add `@MainActor` for Swift 6 |
| `Extensions.swift` | Add `.valid` extension |
| `BlockedProfileCarousel.swift` | Use `profiles.valid` |
| `BlockedProfileListView.swift` | Use `profiles.valid` |
| `ChildDashboardView.swift` | Use `allProfiles.valid` |
| `BlockedProfileDataExportView.swift` | Use `profiles.valid` |
| `AGENTS.md` | Document the pattern |
| `project.pbxproj` | Bump `CURRENT_PROJECT_VERSION` for TestFlight |

## Summary by Sourcery

Prevent crashes when iterating SwiftData query results containing deleted models and align sync coordination with Swift 6 main-actor requirements.

Bug Fixes:
- Avoid crashes when SwiftUI views access SwiftData models that have been deleted during CloudKit sync by filtering out invalid models before iteration.

Enhancements:
- Add a SwiftData model validation helper on arrays of PersistentModel to safely filter out deleted instances before use.
- Mark SyncCoordinator as @MainActor and simplify main-thread handling for Swift 6 compatibility.

Build:
- Bump CURRENT_PROJECT_VERSION for the next TestFlight release.

Documentation:
- Document the SwiftData @Query safety pattern and use of the .valid helper in AGENTS.md.