### PR TITLE
Add @MainActor to RatingManager for Swift 6 concurrency safety

### DIFF
--- a/Foqos/Utils/RatingManager.swift
+++ b/Foqos/Utils/RatingManager.swift
@@ -1,6 +1,7 @@
 import StoreKit
 import SwiftUI
 
+@MainActor
 class RatingManager: ObservableObject {
   @AppStorage("launchCount") private var launchCount = 0
   @AppStorage("lastVersionPromptedForReview") private var lastVersionPromptedForReview: String?


### PR DESCRIPTION
## Summary
- Add `@MainActor` to RatingManager class for Swift 6 concurrency safety
- RatingManager accesses `UIApplication.shared` which requires main thread
- Leaf node with no dependencies on other managers

Part of incremental Swift 6 strict concurrency migration.

## Test plan
- [x] Build succeeds with strict concurrency checking
- [x] Unit tests pass

## Summary by Sourcery

Enhancements:
- Annotate RatingManager with @MainActor to ensure its UI-related state and API access occur on the main thread under Swift concurrency.