### PR TITLE
Add @MainActor to NavigationManager for Swift 6 concurrency safety

### DIFF
--- a/Foqos/Utils/NavigationManager.swift
+++ b/Foqos/Utils/NavigationManager.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 class NavigationManager: ObservableObject {
   @Published var profileId: String? = nil
   @Published var link: URL? = nil


### PR DESCRIPTION
## Summary
- Add `@MainActor` annotation to `NavigationManager` class for Swift 6 strict concurrency compliance
- NavigationManager is a simple leaf node with no dependencies on other managers, no delegate callbacks, and no Combine pipelines

## Test Plan
- [x] Build succeeds with zero warnings related to NavigationManager
- [x] All existing tests pass

## Summary by Sourcery

Enhancements:
- Mark NavigationManager with @MainActor to ensure its published navigation state is accessed on the main thread.