### PR TITLE
Add @MainActor to CloudKitManager and ShareCoordinator for Swift 6 concurrency safety

### DIFF
--- a/Foqos/Utils/AuthorizationVerifier.swift
+++ b/Foqos/Utils/AuthorizationVerifier.swift
@@ -148,7 +148,7 @@ class AuthorizationVerifier: ObservableObject {
     Log.info("Handling authorization loss", category: .authorization)
 
     // Clear CloudKit shared state first
-    await cloudKitManager.clearSharedState()
+    cloudKitManager.clearSharedState()
 
     // Clear local authorization state
     clearAuthorizationState()


### PR DESCRIPTION
## Summary
- Add `@MainActor` to CloudKitManager (T2 manager) and ShareCoordinator (T3 manager)
- Remove 25+ redundant `await MainActor.run { }` wrappers from CloudKitManager
- Remove redundant MainActor wrappers from ShareCoordinator
- Simplify `clearSharedState()` from async to sync method
- Fix redundant await in AuthorizationVerifier.handleAuthorizationLoss()

Note: AuthorizationVerifier was already `@MainActor` from PR #24. SyncCoordinator (T5) was also already `@MainActor`.

## Test Plan
- [x] Build succeeds with zero warnings for migrated files
- [x] All existing tests pass
- [ ] Manual testing of CloudKit share flow (Parent creates share → Child accepts)

⚠️ MANUAL TESTING REQUIRED: CloudKitManager - Test share flow end-to-end: Parent device creates share and sends invitation, Child device accepts share, verify lock codes sync to child

## Summary by Sourcery

Annotate CloudKitManager and ShareCoordinator with @MainActor to align with Swift 6 concurrency expectations and simplify shared-state handling.

Bug Fixes:
- Prevent redundant awaiting of a main-actor-isolated clearSharedState in AuthorizationVerifier.handleAuthorizationLoss().

Enhancements:
- Mark CloudKitManager as @MainActor and treat its published properties and shared state as main-actor isolated.
- Mark ShareCoordinator as @MainActor to ensure its UI-related state is updated on the main actor.
- Simplify CloudKitManager clearSharedState from async to synchronous now that it is main-actor isolated.
- Remove now-unnecessary MainActor.run wrappers and Task-based main-actor hops around CloudKitManager and ShareCoordinator state updates.