### PR TITLE
fix: lock code should only gate editing/deleting, not stopping (#47)

### DIFF
--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -261,28 +261,10 @@ class StrategyManager: ObservableObject {
     showGeofenceStartWarning = false
   }
 
-  /// Check if the current blocking session can be stopped
-  /// Note: This is a synchronous check and doesn't verify geofence rules.
-  /// Lock codes no longer gate stopping — they only gate editing/deleting profiles.
-  func canStopBlocking() -> Bool {
-    return true
-  }
-
   /// Check if the profile has geofence restrictions
   func hasGeofenceRestrictions() -> Bool {
     guard let session = activeSession else { return false }
     return session.blockedProfile.geofenceRule?.hasLocations == true
-  }
-
-  /// Get the reason why stopping is blocked
-  func getStopBlockedReason() -> String? {
-    guard let session = activeSession else { return nil }
-
-    if session.blockedProfile.geofenceRule?.hasLocations == true {
-      return "This profile has location restrictions. You must be at the required location to stop."
-    }
-
-    return nil
   }
 
   func toggleBreak(context: ModelContext) {


### PR DESCRIPTION
## Summary
- Removed lock code guards from `toggleBlocking()`, `canStopBlocking()`, `getStopBlockedReason()`, and `emergencyUnblock()` in `StrategyManager.swift`
- Lock codes no longer prevent children from stopping active sessions or using emergency unblock
- Lock code checks remain in profile editing (`BlockedProfileView`) and deletion flows where they belong
- Cleaned up unused `appModeManager` and `lockCodeManager` properties

## Test Plan
- [ ] In child mode, start a managed (locked) profile — verify it starts normally
- [ ] In child mode, stop a managed profile — verify it stops without requiring lock code
- [ ] In child mode, use emergency unblock on a managed profile — verify it works without lock code
- [ ] In child mode, try to edit a managed profile — verify lock code is still required
- [ ] In child mode, try to delete a managed profile — verify lock code is still required
- [ ] Verify geofence restrictions still work independently of lock code changes

Closes #47

## Summary by Sourcery

Relax lock code enforcement so it only protects profile editing and deletion, not stopping or emergency-unblocking active sessions.

Bug Fixes:
- Allow children to stop active managed blocking sessions without requiring a lock code.
- Allow emergency unblock for managed profiles without being blocked by lock code checks.

Enhancements:
- Remove obsolete lock code gating logic and unused manager dependencies from the blocking strategy manager.