### PR TITLE
fix: lock code should only gate editing/deleting, not stopping (#33)

### DIFF
--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -6,8 +6,6 @@ import WidgetKit
 class StrategyManager: ObservableObject {
   static let shared = StrategyManager()
 
-  private let appModeManager = AppModeManager.shared
-  private let lockCodeManager = LockCodeManager.shared
   private let locationManager = LocationManager.shared
 
   static let availableStrategies: [BlockingStrategy] = [
@@ -115,17 +113,6 @@ class StrategyManager: ObservableObject {
 
   func toggleBlocking(context: ModelContext, activeProfile: BlockedProfiles?) {
     if isBlocking {
-      // Check if the active profile is managed and requires unlock
-      if let session = activeSession,
-        session.blockedProfile.isManaged,
-        appModeManager.currentMode == .child,
-        !lockCodeManager.isUnlocked(session.blockedProfile.id)
-      {
-        Log.info("Manual stop blocked: Managed profile requires lock code", category: .strategy)
-        errorMessage = "This profile is parent-controlled. Enter the lock code to stop blocking."
-        return
-      }
-
       // Check geofence rule if one exists
       if let session = activeSession,
         let geofenceRule = session.blockedProfile.geofenceRule,
@@ -289,40 +276,10 @@ class StrategyManager: ObservableObject {
     showGeofenceStartWarning = false
   }
 
-  /// Check if the current blocking session can be stopped (for managed profiles)
-  /// Note: This is a synchronous check and doesn't verify geofence rules
-  func canStopBlocking() -> Bool {
-    guard let session = activeSession else { return true }
-
-    // If it's a managed profile on a child device, check if unlocked
-    if session.blockedProfile.isManaged && appModeManager.currentMode == .child {
-      return lockCodeManager.isUnlocked(session.blockedProfile.id)
-    }
-
-    return true
-  }
-
   /// Check if the profile has geofence restrictions
   func hasGeofenceRestrictions() -> Bool {
     guard let session = activeSession else { return false }
     return session.blockedProfile.geofenceRule?.hasLocations == true
-  }
-
-  /// Get the reason why stopping is blocked
-  func getStopBlockedReason() -> String? {
-    guard let session = activeSession else { return nil }
-
-    if session.blockedProfile.isManaged && appModeManager.currentMode == .child
-      && !lockCodeManager.isUnlocked(session.blockedProfile.id)
-    {
-      return "This profile is parent-controlled. Enter the lock code to stop blocking."
-    }
-
-    if session.blockedProfile.geofenceRule?.hasLocations == true {
-      return "This profile has location restrictions. You must be at the required location to stop."
-    }
-
-    return nil
   }
 
   func toggleBreak(context: ModelContext) {
@@ -691,17 +648,6 @@ class StrategyManager: ObservableObject {
 
     // Do not allow emergency unblocks if there is no active session
     guard let activeSession = getActiveSession(context: context) else {
-      return
-    }
-
-    // Check if the active profile is managed and requires unlock
-    if activeSession.blockedProfile.isManaged,
-      appModeManager.currentMode == .child,
-      !lockCodeManager.isUnlocked(activeSession.blockedProfile.id)
-    {
-      Log.info("Emergency unblock blocked: Managed profile requires lock code", category: .strategy)
-      errorMessage =
-        "This profile is parent-controlled. Enter the lock code to use emergency unblock."
       return
     }
 

--- a/Foqos/Views/HomeView.swift
+++ b/Foqos/Views/HomeView.swift
@@ -66,9 +66,6 @@ struct HomeView: View {
   @ObservedObject private var appModeManager = AppModeManager.shared
   @State private var showModeSelection = false
 
-  // Lock code manager (for stop flow lock check)
-  private let lockCodeManager = LockCodeManager.shared
-
   // Sync conflict manager
   @ObservedObject private var syncConflictManager = SyncConflictManager.shared
 
@@ -499,17 +496,6 @@ struct HomeView: View {
   }
 
   private func handleStopTap(_ profile: BlockedProfiles) {
-    // Check if managed profile requires unlock (moved from toggleBlocking)
-    if let session = strategyManager.activeSession,
-      session.blockedProfile.isManaged,
-      appModeManager.currentMode == .child,
-      !lockCodeManager.isUnlocked(session.blockedProfile.id)
-    {
-      strategyManager.errorMessage =
-        "This profile is parent-controlled. Enter the lock code to stop blocking."
-      return
-    }
-
     let action = StrategyManager.determineStopAction(
       for: profile.stopConditions
     )


### PR DESCRIPTION
## Summary
- Removed lock code guards from `toggleBlocking()`, `emergencyUnblock()`, and `handleStopTap()` so children can stop sessions and use emergency unblock without a lock code
- Removed unused `canStopBlocking()` and `getStopBlockedReason()` methods from StrategyManager
- Cleaned up unused `appModeManager` and `lockCodeManager` properties from StrategyManager, and `lockCodeManager` from HomeView
- Lock code checks remain in profile editing (`BlockedProfileView`) and deletion flows where they belong

Equivalent of PR #50 on the v1 branch, plus HomeView cleanup that v1 didn't need.

## Test plan
- [ ] In child mode, start a managed (locked) profile — verify it starts normally
- [ ] In child mode, stop a managed profile — verify it stops without requiring lock code
- [ ] In child mode, use emergency unblock on a managed profile — verify it works without lock code
- [ ] In child mode, try to edit a managed profile — verify lock code is still required
- [ ] In child mode, try to delete a managed profile — verify lock code is still required
- [ ] Verify geofence restrictions still work independently of lock code changes

Closes #33

## Summary by Sourcery

Relax lock-code restrictions so that only profile editing and deletion are gated, and clean up related unused strategy and home view code.

Bug Fixes:
- Allow child-mode users to stop managed blocking sessions and use emergency unblock without requiring a lock code while preserving geofence checks.

Enhancements:
- Remove unused lock-code-related helpers and dependencies from StrategyManager and HomeView.