### PR TITLE
fix: SharedData cross-process atomicity (flock)

### DIFF
--- a/Foqos/Models/Shared.swift
+++ b/Foqos/Models/Shared.swift
@@ -1,5 +1,6 @@
 import FamilyControls
 import Foundation
+import os
 
 enum SharedData {
     private nonisolated(unsafe) static let suite = UserDefaults(  // SAFETY: UserDefaults is thread-safe per Apple docs
@@ -13,18 +14,31 @@ enum SharedData {
     private static let lockPath: String = containerURL
         .appendingPathComponent(".shared-data.lock").path
 
+    private static let lockLog = Logger(
+        subsystem: "com.cynexia.family-foqos", category: "SharedData"
+    )
+
     /// Cross-process file lock for compound UserDefaults operations.
     /// Uses POSIX flock() — works across app and extension processes.
     /// Lock is automatically released if the process crashes.
+    /// **Not reentrant** — do not call a withLock-wrapped method from inside
+    /// another withLock closure. On BSD/macOS the inner unlock would release
+    /// the process-wide lock while the outer critical section is still running.
     private static func withLock<T>(_ body: () -> T) -> T {
         let fd = open(lockPath, O_CREAT | O_RDWR, 0o644)
-        guard fd >= 0 else { return body() }  // fallback: run unlocked if file can't be opened
+        guard fd >= 0 else {
+            lockLog.warning("SharedData: open() failed, errno \(errno) — proceeding unlocked")
+            return body()
+        }
         defer { close(fd) }
         var ret: Int32
         repeat {
             ret = flock(fd, LOCK_EX)
         } while ret == -1 && errno == EINTR
-        guard ret == 0 else { return body() }  // fallback: run unlocked if lock can't be acquired
+        guard ret == 0 else {
+            lockLog.warning("SharedData: flock() failed, errno \(errno) — proceeding unlocked")
+            return body()
+        }
         defer { flock(fd, LOCK_UN) }
         return body()
     }

--- a/FoqosTests/SharedDataLockTests.swift
+++ b/FoqosTests/SharedDataLockTests.swift
@@ -33,6 +33,11 @@ final class SharedDataLockTests: XCTestCase {
   }
 
   func testConcurrentSnapshotWritesPreserveAllEntries() {
+    // NOTE: Uses GCD to simulate concurrent writes within a single process.
+    // True cross-process testing (main app vs DeviceActivity extension) is
+    // impractical in XCTest, but the POSIX flock() mechanism is identical
+    // in-process and cross-process, so this validates the lock behavior.
+
     // Given: many concurrent writes to different keys
     let count = 50
     let ids = (0..<count).map { _ in UUID() }


### PR DESCRIPTION
Closes #62

## Summary

- Adds POSIX `flock()` cross-process file lock to `SharedData` to prevent data loss from concurrent read-modify-write operations between main app and DeviceActivity extension
- Wraps all mutating methods (snapshot set/remove, session create/end/flush, break times, one-more-minute, deviceSyncId) in the lock
- Reads remain unlocked — UserDefaults individual reads are atomic per Apple docs
- Graceful degradation: falls back to unlocked operation if lock file can't be opened or acquired

## Test plan

- [x] `testSequentialSnapshotOperationsDoNotDeadlock` — verifies lock acquire/release cycle doesn't deadlock
- [x] `testConcurrentSnapshotWritesPreserveAllEntries` — 50 concurrent GCD writes, all entries preserved
- [x] `testEndActiveSharedSessionIsAtomic` — most dangerous compound operation (read active → append completed → clear active) works correctly
- [x] Full test suite passes

## Summary by Sourcery

Add a cross-process file lock around SharedData mutations to ensure atomic UserDefaults updates between app and extensions.

Bug Fixes:
- Prevent data loss and race conditions during concurrent SharedData read-modify-write operations by serializing mutations with a file lock.

Enhancements:
- Introduce a POSIX flock()-based locking helper that gracefully falls back to unlocked behavior if the lock file cannot be opened or acquired.

Tests:
- Add regression tests validating no deadlocks with sequential operations, preservation of all entries under concurrent writes, and atomic completion of active shared sessions.