### PR TITLE
fix: strengthen log copy test assertions and clarify doc comment

### DIFF
--- a/Foqos/Utils/Log.swift
+++ b/Foqos/Utils/Log.swift
@@ -305,8 +305,9 @@ final class Log: @unchecked Sendable {  // SAFETY: entries/file I/O protected by
     return queue.sync { _getLogFileURLsUnsafe() }
   }
 
-  /// Copy all log files to a staging directory atomically.
-  /// Runs within the serial queue so no rotation can occur mid-copy.
+  /// Copy all log files to a staging directory as a consistent snapshot.
+  /// Runs within the serial queue so no rotation can occur mid-copy, but does
+  /// not provide an all-or-nothing filesystem transaction if a copy fails.
   /// - Parameter stagingDir: Destination directory (must already exist).
   /// - Throws: If any file copy fails.
   func copyLogFilesToStagingDirectory(_ stagingDir: URL) throws {

--- a/FoqosTests/LogTailTests.swift
+++ b/FoqosTests/LogTailTests.swift
@@ -100,13 +100,21 @@ final class LogTailTests: XCTestCase {
       at: stagingDir, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: stagingDir) }
 
+    // Capture the count of log files before copying
+    let originalCount = Log.shared.getLogFileURLs().count
+
     // When: We copy log files to staging (queue.sync drains pending writes first)
     try Log.shared.copyLogFilesToStagingDirectory(stagingDir)
 
-    // Then: At least one file was copied
+    // Then: All log files were copied
     let copiedFiles = try FileManager.default.contentsOfDirectory(
       at: stagingDir, includingPropertiesForKeys: nil)
     XCTAssertFalse(copiedFiles.isEmpty, "Should have copied at least one log file")
+    XCTAssertEqual(
+      copiedFiles.count,
+      originalCount,
+      "Number of copied log files should match the number of existing log files"
+    )
 
     // And: copied files contain our marker
     let hasMarker = copiedFiles.contains { url in


### PR DESCRIPTION
## Summary
- Recovers orphaned commit `cf72a61` from PR #66 — these changes addressed Copilot review comments but were not pushed before the PR was squash-merged
- Rewords `copyLogFilesToStagingDirectory` doc comment from "atomically" to "consistent snapshot" (multiple `copyItem` calls aren't an all-or-nothing filesystem transaction)
- Strengthens `testCopyLogFilesToStagingDirectory` to assert copied file count matches original log file count, not just "at least one"

## Test plan
- [ ] `xcodebuild test` passes — specifically `LogTailTests.testCopyLogFilesToStagingDirectory`