### PR TITLE
chore: document intentional duplicate defaults in BlockedProfiles (#75)

### DIFF
--- a/Foqos/Models/BlockedProfiles.swift
+++ b/Foqos/Models/BlockedProfiles.swift
@@ -17,6 +17,9 @@ class BlockedProfiles {
   /// Not written for V2-native profiles. See #59 for future removal.
   var blockingStrategyId: String?
   var strategyData: Data?
+  // Property defaults mirror init() defaults intentionally: property-level defaults
+  // are used by SwiftData/CloudKit when decoding records missing newer fields, while
+  // init() defaults provide caller convenience. See #75.
   var order: Int = 0
 
   var enableLiveActivity: Bool = false


### PR DESCRIPTION
## Summary
- Adds a comment in `BlockedProfiles.swift` explaining why property-level and initializer defaults are intentionally duplicated
- Property defaults are needed for SwiftData/CloudKit decode safety (records missing newer fields)
- Init defaults are needed for caller convenience (50+ call sites rely on them)
- This is not a DRY violation in a SwiftData + CloudKit context

## Test plan
- [ ] Verify comment is clear and accurately describes the dual-default pattern
- [ ] No functional changes — build should pass as-is

Closes #75