### PR TITLE
fix: initialize isAuthorized from system auth status

### DIFF
--- a/Foqos/Utils/RequestAuthorizer.swift
+++ b/Foqos/Utils/RequestAuthorizer.swift
@@ -5,7 +5,8 @@ import SwiftUI
 
 @MainActor
 class RequestAuthorizer: ObservableObject {
-  @Published var isAuthorized = false
+  @Published var isAuthorized =
+    AuthorizationCenter.shared.authorizationStatus == .approved
   @Published var authorizationError: String?
 
   /// Request authorization for the current app mode


### PR DESCRIPTION
## Summary

Fixes #83 — users were shown the onboarding workflow on every app launch.

**Root cause:** `RequestAuthorizer.isAuthorized` was hardcoded to `false` on init, never checking the actual `AuthorizationCenter.shared.authorizationStatus`. The safety net added in #77 (`HomeView.onAppearApp()`) checks `!requestAuthorizer.isAuthorized && !showIntroScreen && !showModeSelection` — since `isAuthorized` was always `false` at startup, this fired every launch for already-authorized users, re-showing the intro screen.

**Fix:** Initialize `isAuthorized` from `AuthorizationCenter.shared.authorizationStatus == .approved` so it reflects reality from the start.

## Test plan

- [x] Build succeeds
- [x] All tests pass
- [x] Exhaustive state machine trace of all 8 onboarding scenarios (fresh install, authorized relaunch, killed mid-onboarding, auth revoked, foreground from background, etc.) — all correct
- [ ] Manual: authorized user relaunches app → should go straight to HomeView (no intro screen)
- [ ] Manual: fresh install → should show intro screen as normal

## Summary by Sourcery

Bug Fixes:
- Correct the initial isAuthorized flag to reflect the current AuthorizationCenter authorization status, preventing already-authorized users from repeatedly seeing the onboarding flow.