### PR TITLE
fix(#101): resolve concurrency warnings in TimersUtil

### DIFF
--- a/Foqos/Utils/TimersUtil.swift
+++ b/Foqos/Utils/TimersUtil.swift
@@ -1,6 +1,6 @@
 import BackgroundTasks
 import Foundation
-import UserNotifications
+@preconcurrency import UserNotifications
 
 // MARK: - Notification Constants
 
@@ -282,14 +282,14 @@ final class TimersUtil: @unchecked Sendable {  // SAFETY: Mutable state (backgro
       .removeAllPendingNotificationRequests()
     // Only remove delivered pre-activation reminders, not other notification types
     // (e.g., geofence-blocked, break/session reminders)
-    let center = UNUserNotificationCenter.current()
-    center.getDeliveredNotifications { notifications in
+    UNUserNotificationCenter.current().getDeliveredNotifications { notifications in
       let preActivationIds =
         notifications
         .map(\.request.identifier)
         .filter { $0.hasPrefix(Self.preActivationReminderPrefix) }
       if !preActivationIds.isEmpty {
-        center.removeDeliveredNotifications(withIdentifiers: preActivationIds)
+        UNUserNotificationCenter.current()
+          .removeDeliveredNotifications(withIdentifiers: preActivationIds)
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add `@preconcurrency import UserNotifications` to suppress Sendable conformance warnings from the framework
- Remove non-Sendable `UNUserNotificationCenter` capture in `cancelAllNotifications()` by inlining `UNUserNotificationCenter.current()` calls

## Test Plan
- [x] Build succeeds with no errors or concurrency warnings
- [x] All existing tests pass

## Summary by Sourcery

Resolve Swift concurrency warnings in TimersUtil related to UserNotifications usage.

Bug Fixes:
- Suppress Sendable conformance warnings from the UserNotifications framework by importing it with @preconcurrency.
- Avoid capturing a non-Sendable UNUserNotificationCenter instance in cancelAllNotifications() by inlining current() calls within the notification callbacks.