### PR TITLE
refactor(#137): standardize test naming to Given/When/Then

### DIFF
--- a/FoqosTests/ActiveWindowTests.swift
+++ b/FoqosTests/ActiveWindowTests.swift
@@ -36,7 +36,7 @@ final class ActiveWindowTests: XCTestCase {
 
   // MARK: - Start-only (no stop schedule)
 
-  func testStartOnly_pastStart_returnsToday() {
+  func testGivenStartOnlySchedulePastStart_WhenCheckingActiveWindow_ThenReturnsTodayStart() {
     let start = makeSchedule(hour: 10, minute: 0)
     let now = date(hour: 14, minute: 0)
 
@@ -48,7 +48,7 @@ final class ActiveWindowTests: XCTestCase {
     XCTAssertEqual(c.minute, 0)
   }
 
-  func testStartOnly_beforeStart_returnsNil() {
+  func testGivenStartOnlyScheduleBeforeStart_WhenCheckingActiveWindow_ThenReturnsNil() {
     let start = makeSchedule(hour: 14, minute: 0)
     let now = date(hour: 9, minute: 0)
 
@@ -57,7 +57,7 @@ final class ActiveWindowTests: XCTestCase {
 
   // MARK: - Same-day (start < stop)
 
-  func testSameDay_insideWindow_returnsTodayStart() {
+  func testGivenSameDayScheduleInsideWindow_WhenCheckingActiveWindow_ThenReturnsTodayStart() {
     let start = makeSchedule(hour: 10, minute: 0)
     let stop = makeSchedule(hour: 17, minute: 0)
     let now = date(hour: 14, minute: 0)
@@ -70,7 +70,7 @@ final class ActiveWindowTests: XCTestCase {
     XCTAssertEqual(c.minute, 0)
   }
 
-  func testSameDay_afterStop_returnsNil() {
+  func testGivenSameDayScheduleAfterStop_WhenCheckingActiveWindow_ThenReturnsNil() {
     let start = makeSchedule(hour: 10, minute: 0)
     let stop = makeSchedule(hour: 17, minute: 0)
     let now = date(hour: 18, minute: 0)
@@ -78,7 +78,7 @@ final class ActiveWindowTests: XCTestCase {
     XCTAssertNil(start.activeWindowStart(on: now, stopSchedule: stop, calendar: calendar))
   }
 
-  func testSameDay_beforeStart_returnsNil() {
+  func testGivenSameDayScheduleBeforeStart_WhenCheckingActiveWindow_ThenReturnsNil() {
     let start = makeSchedule(hour: 10, minute: 0)
     let stop = makeSchedule(hour: 17, minute: 0)
     let now = date(hour: 9, minute: 0)
@@ -88,7 +88,7 @@ final class ActiveWindowTests: XCTestCase {
 
   // MARK: - Overnight (start >= stop)
 
-  func testOvernight_afterStart_returnsTodayStart() {
+  func testGivenOvernightScheduleAfterStart_WhenCheckingActiveWindow_ThenReturnsTodayStart() {
     let start = makeSchedule(hour: 22, minute: 0)
     let stop = makeSchedule(hour: 6, minute: 0)
     let now = date(hour: 23, minute: 0)
@@ -101,7 +101,7 @@ final class ActiveWindowTests: XCTestCase {
     XCTAssertEqual(c.minute, 0)
   }
 
-  func testOvernight_earlyMorning_returnsYesterdayStart() {
+  func testGivenOvernightScheduleEarlyMorning_WhenCheckingActiveWindow_ThenReturnsYesterdayStart() {
     let start = makeSchedule(hour: 22, minute: 0)
     let stop = makeSchedule(hour: 6, minute: 0)
     let now = date(hour: 3, minute: 0)
@@ -120,7 +120,7 @@ final class ActiveWindowTests: XCTestCase {
     XCTAssertEqual(c.minute, 0)
   }
 
-  func testOvernight_betweenWindows_returnsNil() {
+  func testGivenOvernightScheduleBetweenWindows_WhenCheckingActiveWindow_ThenReturnsNil() {
     let start = makeSchedule(hour: 22, minute: 0)
     let stop = makeSchedule(hour: 6, minute: 0)
     let now = date(hour: 12, minute: 0)
@@ -128,7 +128,7 @@ final class ActiveWindowTests: XCTestCase {
     XCTAssertNil(start.activeWindowStart(on: now, stopSchedule: stop, calendar: calendar))
   }
 
-  func testOvernight_exactlyAtStop_returnsNil() {
+  func testGivenOvernightScheduleExactlyAtStop_WhenCheckingActiveWindow_ThenReturnsNil() {
     let start = makeSchedule(hour: 22, minute: 0)
     let stop = makeSchedule(hour: 6, minute: 0)
     let now = date(hour: 6, minute: 0)

--- a/FoqosTests/BlockedProfilesMigrationTests.swift
+++ b/FoqosTests/BlockedProfilesMigrationTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 final class BlockedProfilesMigrationTests: XCTestCase {
 
-  func testMigrateV1ToV2SetsSchemaVersion() {
+  func testGivenV1Profile_WhenMigrating_ThenSetsSchemaVersionToV2() {
     let profile = BlockedProfiles(name: "Test")
     profile.profileSchemaVersion = 1
     profile.blockingStrategyId = "ManualBlockingStrategy"
@@ -16,7 +16,7 @@ final class BlockedProfilesMigrationTests: XCTestCase {
     XCTAssertEqual(profile.profileSchemaVersion, 2)
   }
 
-  func testMigrateV1ToV2SetsTriggers() {
+  func testGivenV1NFCProfile_WhenMigrating_ThenSetsNFCTriggers() {
     let profile = BlockedProfiles(name: "Test")
     profile.profileSchemaVersion = 1
     profile.blockingStrategyId = "NFCBlockingStrategy"
@@ -27,7 +27,7 @@ final class BlockedProfilesMigrationTests: XCTestCase {
     XCTAssertTrue(profile.stopConditions.sameNFC)
   }
 
-  func testMigrateV1ToV2MigratesPhysicalUnlock() {
+  func testGivenV1PhysicalUnlockProfile_WhenMigrating_ThenSetsSpecificNFCStop() {
     let profile = BlockedProfiles(name: "Test")
     profile.profileSchemaVersion = 1
     profile.blockingStrategyId = "NFCManualBlockingStrategy"
@@ -40,7 +40,7 @@ final class BlockedProfilesMigrationTests: XCTestCase {
     XCTAssertEqual(profile.stopNFCTagId, "tag-123")
   }
 
-  func testMigrateV1ToV2MigratesSchedule() {
+  func testGivenV1ScheduledProfile_WhenMigrating_ThenSetsStartAndStopSchedules() {
     let profile = BlockedProfiles(name: "Test")
     profile.profileSchemaVersion = 1
     profile.blockingStrategyId = "ManualBlockingStrategy"
@@ -59,7 +59,7 @@ final class BlockedProfilesMigrationTests: XCTestCase {
     XCTAssertEqual(profile.stopSchedule?.hour, 17)
   }
 
-  func testMigrateV2DoesNothing() {
+  func testGivenV2Profile_WhenMigrating_ThenDoesNothing() {
     let profile = BlockedProfiles(name: "Test")
     profile.profileSchemaVersion = 2
     var triggers = profile.startTriggers
@@ -73,19 +73,19 @@ final class BlockedProfilesMigrationTests: XCTestCase {
     XCTAssertTrue(profile.startTriggers.manual)
   }
 
-  func testNeedsMigrationForV1() {
+  func testGivenV1Profile_WhenCheckingNeedsMigration_ThenReturnsTrue() {
     let profile = BlockedProfiles(name: "Test")
     profile.profileSchemaVersion = 1
     XCTAssertTrue(profile.needsMigration)
   }
 
-  func testNeedsMigrationFalseForV2() {
+  func testGivenV2Profile_WhenCheckingNeedsMigration_ThenReturnsFalse() {
     let profile = BlockedProfiles(name: "Test")
     profile.profileSchemaVersion = 2
     XCTAssertFalse(profile.needsMigration)
   }
 
-  func testMigrateSkipsProfileWithActiveSession() {
+  func testGivenActiveSession_WhenMigrating_ThenSkipsProfile() {
     let profile = BlockedProfiles(name: "Active")
     profile.profileSchemaVersion = 1
     profile.blockingStrategyId = "ManualBlockingStrategy"
@@ -96,7 +96,7 @@ final class BlockedProfilesMigrationTests: XCTestCase {
     XCTAssertEqual(profile.profileSchemaVersion, 1)  // Still V1
   }
 
-  func testMigrateV1ScheduleSetsTriggerFlags() {
+  func testGivenV1ScheduledProfile_WhenMigrating_ThenSetsTriggerFlags() {
     let profile = BlockedProfiles(name: "Scheduled")
     profile.profileSchemaVersion = 1
     profile.blockingStrategyId = "ManualBlockingStrategy"
@@ -115,25 +115,25 @@ final class BlockedProfilesMigrationTests: XCTestCase {
     XCTAssertEqual(profile.stopSchedule?.hour, 17)
   }
 
-  func testIsNewerSchemaVersionFalseForCurrentVersion() {
+  func testGivenCurrentSchemaVersion_WhenCheckingIsNewer_ThenReturnsFalse() {
     let profile = BlockedProfiles(name: "Current")
     profile.profileSchemaVersion = 2
     XCTAssertFalse(profile.isNewerSchemaVersion)
   }
 
-  func testIsNewerSchemaVersionFalseForOlderVersion() {
+  func testGivenOlderSchemaVersion_WhenCheckingIsNewer_ThenReturnsFalse() {
     let profile = BlockedProfiles(name: "Old")
     profile.profileSchemaVersion = 1
     XCTAssertFalse(profile.isNewerSchemaVersion)
   }
 
-  func testIsNewerSchemaVersionTrueForFutureVersion() {
+  func testGivenFutureSchemaVersion_WhenCheckingIsNewer_ThenReturnsTrue() {
     let profile = BlockedProfiles(name: "Future")
     profile.profileSchemaVersion = 3
     XCTAssertTrue(profile.isNewerSchemaVersion)
   }
 
-  func testIsNewerSchemaVersionUsesConstant() {
+  func testGivenSchemaVersionConstant_WhenCheckingIsNewer_ThenUsesCurrentSchemaVersion() {
     // Verify the threshold is based on currentSchemaVersion, not a hardcoded value
     let profile = BlockedProfiles(name: "Test")
     profile.profileSchemaVersion = BlockedProfiles.currentSchemaVersion
@@ -143,7 +143,7 @@ final class BlockedProfilesMigrationTests: XCTestCase {
     XCTAssertTrue(profile.isNewerSchemaVersion, "Version above current should be 'newer'")
   }
 
-  func testMigrateRunsWhenNoActiveSession() {
+  func testGivenNoActiveSession_WhenMigrating_ThenMigratesSuccessfully() {
     let profile = BlockedProfiles(name: "Inactive")
     profile.profileSchemaVersion = 1
     profile.blockingStrategyId = "ManualBlockingStrategy"

--- a/FoqosTests/BlockedProfilesTriggersTests.swift
+++ b/FoqosTests/BlockedProfilesTriggersTests.swift
@@ -5,20 +5,20 @@ import XCTest
 
 final class BlockedProfilesTriggersTests: XCTestCase {
 
-  func testNewProfileHasSchemaVersion2() {
+  func testGivenNewProfile_WhenCheckingSchema_ThenReturnsVersion2() {
     let profile = BlockedProfiles(name: "Test")
 
     XCTAssertEqual(profile.profileSchemaVersion, 2)
   }
 
-  func testNewProfileHasEmptyTriggers() {
+  func testGivenNewProfile_WhenCheckingTriggers_ThenBothAreInvalid() {
     let profile = BlockedProfiles(name: "Test")
 
     XCTAssertFalse(profile.startTriggers.isValid)
     XCTAssertFalse(profile.stopConditions.isValid)
   }
 
-  func testCanSetStartTriggers() {
+  func testGivenNewProfile_WhenSettingStartTriggers_ThenTriggersAreStored() {
     let profile = BlockedProfiles(name: "Test")
     var triggers = profile.startTriggers
     triggers.manual = true
@@ -30,7 +30,7 @@ final class BlockedProfilesTriggersTests: XCTestCase {
     XCTAssertTrue(profile.startTriggers.isValid)
   }
 
-  func testCanSetStopConditions() {
+  func testGivenNewProfile_WhenSettingStopConditions_ThenConditionsAreStored() {
     let profile = BlockedProfiles(name: "Test")
     var conditions = profile.stopConditions
     conditions.manual = true
@@ -42,31 +42,31 @@ final class BlockedProfilesTriggersTests: XCTestCase {
     XCTAssertTrue(profile.stopConditions.isValid)
   }
 
-  func testCanSetStartNFCTagId() {
+  func testGivenNewProfile_WhenSettingStartNFCTagId_ThenIdIsStored() {
     let profile = BlockedProfiles(name: "Test")
     profile.startNFCTagId = "tag-123"
     XCTAssertEqual(profile.startNFCTagId, "tag-123")
   }
 
-  func testCanSetStopNFCTagId() {
+  func testGivenNewProfile_WhenSettingStopNFCTagId_ThenIdIsStored() {
     let profile = BlockedProfiles(name: "Test")
     profile.stopNFCTagId = "tag-456"
     XCTAssertEqual(profile.stopNFCTagId, "tag-456")
   }
 
-  func testCanSetStartQRCodeId() {
+  func testGivenNewProfile_WhenSettingStartQRCodeId_ThenIdIsStored() {
     let profile = BlockedProfiles(name: "Test")
     profile.startQRCodeId = "qr-123"
     XCTAssertEqual(profile.startQRCodeId, "qr-123")
   }
 
-  func testCanSetStopQRCodeId() {
+  func testGivenNewProfile_WhenSettingStopQRCodeId_ThenIdIsStored() {
     let profile = BlockedProfiles(name: "Test")
     profile.stopQRCodeId = "qr-456"
     XCTAssertEqual(profile.stopQRCodeId, "qr-456")
   }
 
-  func testCanSetStartSchedule() {
+  func testGivenNewProfile_WhenSettingStartSchedule_ThenScheduleIsStored() {
     let profile = BlockedProfiles(name: "Test")
     let schedule = ProfileScheduleTime(
       days: [.monday, .friday],
@@ -80,7 +80,7 @@ final class BlockedProfilesTriggersTests: XCTestCase {
     XCTAssertEqual(profile.startSchedule?.hour, 9)
   }
 
-  func testCanSetStopSchedule() {
+  func testGivenNewProfile_WhenSettingStopSchedule_ThenScheduleIsStored() {
     let profile = BlockedProfiles(name: "Test")
     let schedule = ProfileScheduleTime(
       days: [.monday, .friday],
@@ -94,7 +94,7 @@ final class BlockedProfilesTriggersTests: XCTestCase {
     XCTAssertEqual(profile.stopSchedule?.hour, 17)
   }
 
-  func testCloneProfileCopiesV2TriggerData() {
+  func testGivenProfileWithV2Triggers_WhenCloning_ThenAllTriggerDataIsCopied() {
     let source = BlockedProfiles(name: "Source")
 
     // Set V2 trigger data on source

--- a/FoqosTests/ConcurrentSessionTests.swift
+++ b/FoqosTests/ConcurrentSessionTests.swift
@@ -12,7 +12,7 @@ final class ConcurrentSessionTests: XCTestCase {
   }
 
   /// Simulates the original bug: stale start after stop
-  func testStaleStartAfterStopIsRejected() async {
+  func testGivenStoppedSession_WhenStaleStartArrives_ThenRejectsIt() async {
     let now = Date()
 
     // Device A starts
@@ -54,7 +54,7 @@ final class ConcurrentSessionTests: XCTestCase {
   }
 
   /// Simulates concurrent schedule triggers
-  func testConcurrentScheduleTriggersFirstWins() async {
+  func testGivenConcurrentScheduleTriggers_WhenBothDevicesStart_ThenFirstWins() async {
     let now = Date()
 
     // Simulate Device A winning the race (Device B gets conflict)
@@ -79,7 +79,7 @@ final class ConcurrentSessionTests: XCTestCase {
   }
 
   /// Simulates multiple devices starting and stopping
-  func testMultiDeviceStartStop() async {
+  func testGivenMultipleDevices_WhenStartingAndStopping_ThenAllSeeStoppedState() async {
     let now = Date()
 
     // Device A starts
@@ -121,7 +121,7 @@ final class ConcurrentSessionTests: XCTestCase {
   }
 
   /// Tests that stopping an already stopped session returns alreadyStopped
-  func testStopAlreadyStoppedSession() async {
+  func testGivenAlreadyStoppedSession_WhenStoppingAgain_ThenReturnsAlreadyStopped() async {
     let now = Date()
 
     // Start and stop
@@ -140,7 +140,7 @@ final class ConcurrentSessionTests: XCTestCase {
   }
 
   /// Tests that stopping a non-existent session returns alreadyStopped
-  func testStopNonExistentSession() async {
+  func testGivenNonExistentSession_WhenStopping_ThenReturnsAlreadyStopped() async {
     let now = Date()
 
     let result = await mockService.stopSession(
@@ -152,7 +152,7 @@ final class ConcurrentSessionTests: XCTestCase {
   }
 
   /// Verifies that the maxRetriesExceeded error case exists and is usable
-  func testMaxRetriesExceededErrorHasDescription() {
+  func testGivenMaxRetriesExceededError_WhenCheckingDescription_ThenContainsRetry() {
     let error = SessionSyncError.maxRetriesExceeded
     XCTAssertNotNil(error.errorDescription)
     XCTAssertTrue(error.errorDescription!.contains("retry"))
@@ -160,7 +160,7 @@ final class ConcurrentSessionTests: XCTestCase {
 
   /// Verifies that simulated CAS conflicts return alreadyActive
   /// to match real-world behavior when another device wins the race
-  func testSimulatedConflictReturnsAlreadyActive() async {
+  func testGivenSimulatedConflict_WhenStarting_ThenReturnsAlreadyActive() async {
     let now = Date()
 
     await mockService.reset()
@@ -181,7 +181,7 @@ final class ConcurrentSessionTests: XCTestCase {
   }
 
   /// Verifies that after conflicts are exhausted, normal behavior resumes
-  func testStartSucceedsAfterConflictsExhausted() async {
+  func testGivenExhaustedConflicts_WhenStarting_ThenSucceedsNormally() async {
     let now = Date()
 
     await mockService.reset()

--- a/FoqosTests/LogTailTests.swift
+++ b/FoqosTests/LogTailTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class LogTailTests: XCTestCase {
 
-  func testGetLogContentTailReturnsLastNLines() {
+  func testGivenLogContent_WhenGettingTail_ThenReturnsAtMostNLines() {
     // Given: Log has content
     _ = Log.shared.getLogContent()
 
@@ -16,7 +16,7 @@ final class LogTailTests: XCTestCase {
     XCTAssertLessThanOrEqual(lineCount, 10)
   }
 
-  func testGetLogContentTailPreservesNewestEntries() {
+  func testGivenRecentLogEntry_WhenGettingTail_ThenPreservesNewestEntries() {
     // Given: We add a unique log entry
     let uniqueMarker = "TAIL_TEST_\(UUID().uuidString)"
     Log.info(uniqueMarker, category: .app)
@@ -28,13 +28,13 @@ final class LogTailTests: XCTestCase {
     XCTAssertTrue(tailedContent.contains(uniqueMarker))
   }
 
-  func testGetLogContentTailWithZeroLinesReturnsEmpty() {
+  func testGivenZeroMaxLines_WhenGettingTail_ThenReturnsEmpty() {
     // Edge case: requesting zero lines should return empty string
     let tailedContent = Log.shared.getLogContentTail(maxLines: 0)
     XCTAssertEqual(tailedContent, "")
   }
 
-  func testGetLogContentTailPreservesChronologicalOrder() {
+  func testGivenMultipleLogEntries_WhenGettingTail_ThenPreservesChronologicalOrder() {
     // Given: We log multiple entries with identifiable order
     let marker1 = "ORDER_TEST_FIRST_\(UUID().uuidString)"
     let marker2 = "ORDER_TEST_SECOND_\(UUID().uuidString)"
@@ -60,7 +60,7 @@ final class LogTailTests: XCTestCase {
     XCTAssertLessThan(pos2, pos3, "Second entry should appear before third entry")
   }
 
-  func testGetLogFileURLsReturnsNonEmptyAfterLogging() {
+  func testGivenLoggedEntry_WhenGettingFileURLs_ThenReturnsNonEmpty() {
     // Given: We log something to ensure a file exists
     let marker = "FILE_URL_TEST_\(UUID().uuidString)"
     Log.info(marker, category: .app)
@@ -77,7 +77,7 @@ final class LogTailTests: XCTestCase {
     }
   }
 
-  func testGetTotalLogSizeReturnsPositiveAfterLogging() {
+  func testGivenLoggedEntry_WhenGettingTotalSize_ThenReturnsPositive() {
     // Given: We log something to ensure files have content
     let marker = "SIZE_TEST_\(UUID().uuidString)"
     Log.info(marker, category: .app)
@@ -89,7 +89,7 @@ final class LogTailTests: XCTestCase {
     XCTAssertGreaterThan(size, 0, "Total log size should be positive after logging")
   }
 
-  func testCopyLogFilesToStagingDirectoryCopiesAllFiles() throws {
+  func testGivenLogFiles_WhenCopyingToStaging_ThenCopiesAllFiles() throws {
     // Given: We log something to ensure files exist
     let marker = "COPY_TEST_\(UUID().uuidString)"
     Log.info(marker, category: .app)

--- a/FoqosTests/OneMoreMinuteTests.swift
+++ b/FoqosTests/OneMoreMinuteTests.swift
@@ -6,7 +6,7 @@ final class OneMoreMinuteTests: XCTestCase {
 
   // MARK: - SessionSnapshot Tests
 
-  func testSessionSnapshotDefaultValues() {
+  func testGivenNewSnapshot_WhenCheckingDefaults_ThenOneMoreMinuteFieldsAreEmpty() {
     // Test that default values are correct for one-more-minute fields
     let snapshot = SharedData.SessionSnapshot(
       id: "test-id",
@@ -20,7 +20,7 @@ final class OneMoreMinuteTests: XCTestCase {
     XCTAssertNil(snapshot.oneMoreMinuteStartTime)
   }
 
-  func testSessionSnapshotWithOneMoreMinuteFields() {
+  func testGivenSnapshotWithOneMoreMinute_WhenCheckingFields_ThenValuesAreSet() {
     let now = Date()
     let snapshot = SharedData.SessionSnapshot(
       id: "test-id",
@@ -36,7 +36,7 @@ final class OneMoreMinuteTests: XCTestCase {
     XCTAssertEqual(snapshot.oneMoreMinuteStartTime, now)
   }
 
-  func testSessionSnapshotEquality() {
+  func testGivenIdenticalSnapshots_WhenComparing_ThenTheyAreEqual() {
     let profileId = UUID()
     let now = Date()
 
@@ -63,7 +63,7 @@ final class OneMoreMinuteTests: XCTestCase {
     XCTAssertEqual(snapshot1, snapshot2)
   }
 
-  func testSessionSnapshotInequalityOnOneMoreMinuteUsed() {
+  func testGivenDifferentOneMoreMinuteUsed_WhenComparing_ThenTheyAreNotEqual() {
     let profileId = UUID()
     let now = Date()
 
@@ -204,7 +204,7 @@ final class OneMoreMinuteTests: XCTestCase {
 
   // MARK: - Time Remaining Calculation Tests
 
-  func testTimeRemainingCalculation() {
+  func testGivenActiveOneMoreMinute_WhenCalculatingRemaining_ThenReturnsCorrectSeconds() {
     let now = Date()
     let startTime = now.addingTimeInterval(-30)
     let elapsed = now.timeIntervalSince(startTime)
@@ -213,7 +213,7 @@ final class OneMoreMinuteTests: XCTestCase {
     XCTAssertEqual(remaining, 30, accuracy: 0.001)
   }
 
-  func testTimeRemainingZeroWhenExpired() {
+  func testGivenExpiredOneMoreMinute_WhenCalculatingRemaining_ThenReturnsZero() {
     let now = Date()
     let startTime = now.addingTimeInterval(-65)
     let elapsed = now.timeIntervalSince(startTime)
@@ -224,14 +224,14 @@ final class OneMoreMinuteTests: XCTestCase {
 
   // MARK: - Content State Widget Tests
 
-  func testContentStateDefaultOneMoreMinuteValues() {
+  func testGivenDefaultContentState_WhenCheckingOneMoreMinute_ThenFieldsAreEmpty() {
     let state = FoqosWidgetAttributes.ContentState(startTime: Date())
 
     XCTAssertFalse(state.isOneMoreMinuteActive)
     XCTAssertNil(state.oneMoreMinuteStartTime)
   }
 
-  func testContentStateWithOneMoreMinuteActive() {
+  func testGivenContentStateWithOneMoreMinute_WhenCheckingActive_ThenReturnsTrue() {
     let now = Date()
     let state = FoqosWidgetAttributes.ContentState(
       startTime: now,
@@ -248,7 +248,7 @@ final class OneMoreMinuteTests: XCTestCase {
 
   // MARK: - SharedData Sync Tests
 
-  func testSetOneMoreMinuteStartTimeSyncsToSharedData() {
+  func testGivenActiveSession_WhenSettingOneMoreMinuteStartTime_ThenSyncsToSharedData() {
     // Setup: Create an active session in SharedData
     let profileId = UUID()
     let initialSnapshot = SharedData.SessionSnapshot(
@@ -280,7 +280,7 @@ final class OneMoreMinuteTests: XCTestCase {
     SharedData.flushActiveSession()
   }
 
-  func testSetOneMoreMinuteStartTimeNoOpWhenNoActiveSession() {
+  func testGivenNoActiveSession_WhenSettingOneMoreMinuteStartTime_ThenNoOp() {
     // Ensure no active session
     SharedData.flushActiveSession()
     XCTAssertNil(SharedData.getActiveSharedSession())

--- a/FoqosTests/PreActivationReminderTests.swift
+++ b/FoqosTests/PreActivationReminderTests.swift
@@ -5,14 +5,14 @@ import XCTest
 final class PreActivationReminderTests: XCTestCase {
   // MARK: - Identifier Tests
 
-  func testPreActivationReminderIdentifier_includesMinutes() {
+  func testGivenProfileAndMinutes_WhenGeneratingIdentifier_ThenIncludesMinutes() {
     let profileId = UUID()
     let identifier = TimersUtil.preActivationReminderIdentifier(for: profileId, minutes: 3)
 
     XCTAssertEqual(identifier, "pre-activation-reminder-\(profileId.uuidString)-3")
   }
 
-  func testPreActivationReminderIdentifier_uniquePerMinuteValue() {
+  func testGivenDifferentMinuteValues_WhenGeneratingIdentifiers_ThenProducesUniqueIds() {
     let profileId = UUID()
     let id1 = TimersUtil.preActivationReminderIdentifier(for: profileId, minutes: 1)
     let id2 = TimersUtil.preActivationReminderIdentifier(for: profileId, minutes: 5)
@@ -20,14 +20,14 @@ final class PreActivationReminderTests: XCTestCase {
     XCTAssertNotEqual(id1, id2)
   }
 
-  func testPreActivationReminderIdentifier_hasCorrectPrefix() {
+  func testGivenProfile_WhenGeneratingIdentifier_ThenHasCorrectPrefix() {
     let profileId = UUID()
     let identifier = TimersUtil.preActivationReminderIdentifier(for: profileId, minutes: 2)
 
     XCTAssertTrue(identifier.hasPrefix(TimersUtil.preActivationReminderPrefix))
   }
 
-  func testAllPreActivationReminderIdentifiers_returns5Ids() {
+  func testGivenProfile_WhenGettingAllIdentifiers_ThenReturnsFiveIds() {
     let profileId = UUID()
     let ids = TimersUtil.allPreActivationReminderIdentifiers(for: profileId)
 
@@ -40,22 +40,22 @@ final class PreActivationReminderTests: XCTestCase {
 
   // MARK: - Profile ID Extraction Tests
 
-  func testProfileIdFromReminderIdentifier_extractsCorrectUUID() {
+  func testGivenValidReminderIdentifier_WhenExtractingProfileId_ThenReturnsCorrectUUID() {
     let profileId = UUID()
     let identifier = TimersUtil.preActivationReminderIdentifier(for: profileId, minutes: 3)
 
     XCTAssertEqual(TimersUtil.profileIdFromReminderIdentifier(identifier), profileId)
   }
 
-  func testProfileIdFromReminderIdentifier_returnsNilForNonReminderIdentifier() {
+  func testGivenNonReminderIdentifier_WhenExtractingProfileId_ThenReturnsNil() {
     XCTAssertNil(TimersUtil.profileIdFromReminderIdentifier("some-other-notification"))
   }
 
-  func testProfileIdFromReminderIdentifier_returnsNilForMalformedIdentifier() {
+  func testGivenMalformedIdentifier_WhenExtractingProfileId_ThenReturnsNil() {
     XCTAssertNil(TimersUtil.profileIdFromReminderIdentifier("pre-activation-reminder-not-a-uuid-3"))
   }
 
-  func testPreActivationReminderThreadIdentifier_format() {
+  func testGivenProfile_WhenGettingThreadIdentifier_ThenFormatsCorrectly() {
     let profileId = UUID()
     let expected = "pre-activation-reminder-\(profileId.uuidString)"
 
@@ -64,28 +64,28 @@ final class PreActivationReminderTests: XCTestCase {
 
   // MARK: - Model Behavior Tests
 
-  func testPreActivationReminderTimes_roundTrip() {
+  func testGivenReminderTimes_WhenSettingAndGetting_ThenRoundTrips() {
     let profile = BlockedProfiles(name: "Test")
     profile.preActivationReminderTimes = [1, 3, 5]
 
     XCTAssertEqual(profile.preActivationReminderTimes, [1, 3, 5])
   }
 
-  func testPreActivationReminderTimes_deduplicatesAndSorts() {
+  func testGivenDuplicateUnsortedTimes_WhenSettingReminderTimes_ThenDeduplicatesAndSorts() {
     let profile = BlockedProfiles(name: "Test")
     profile.preActivationReminderTimes = [5, 1, 5, 3]
 
     XCTAssertEqual(profile.preActivationReminderTimes, [1, 3, 5])
   }
 
-  func testPreActivationReminderTimes_filtersOutOfRangeValues() {
+  func testGivenOutOfRangeValues_WhenSettingReminderTimes_ThenFiltersInvalid() {
     let profile = BlockedProfiles(name: "Test")
     profile.preActivationReminderTimes = [0, 1, 2, 3, 4, 5, 6, 255]
 
     XCTAssertEqual(profile.preActivationReminderTimes, [1, 3, 5])
   }
 
-  func testPreActivationReminderTimes_getterFiltersLegacyPersistedValues() {
+  func testGivenLegacyPersistedData_WhenGettingReminderTimes_ThenFiltersUnsupported() {
     let profile = BlockedProfiles(name: "Test")
     // Bypass the setter by writing directly to the raw data property,
     // simulating legacy persisted data or unfiltered CloudKit sync
@@ -96,14 +96,14 @@ final class PreActivationReminderTests: XCTestCase {
     XCTAssertEqual(profile.preActivationReminderTimes, [1, 3, 5])
   }
 
-  func testPreActivationReminderEnabled_emptyMeansDisabled() {
+  func testGivenEmptyReminderTimes_WhenCheckingEnabled_ThenReturnsFalse() {
     let profile = BlockedProfiles(name: "Test")
     profile.preActivationReminderTimes = []
 
     XCTAssertFalse(profile.preActivationReminderEnabled)
   }
 
-  func testPreActivationReminderEnabled_nonEmptyMeansEnabled() {
+  func testGivenNonEmptyReminderTimes_WhenCheckingEnabled_ThenReturnsTrue() {
     let profile = BlockedProfiles(name: "Test")
     profile.preActivationReminderTimes = [3]
 
@@ -112,7 +112,7 @@ final class PreActivationReminderTests: XCTestCase {
 
   // MARK: - Time Calculation Tests
 
-  func testReminderTimeCalculation() {
+  func testGivenScheduledStartAndMinutes_WhenCalculatingReminderTime_ThenSubtractsCorrectly() {
     let calendar = Calendar(identifier: .gregorian)
     // Use a fixed reference date to avoid midnight/DST boundary issues
     let referenceDate = Date(timeIntervalSince1970: 1_700_000_000)  // 2023-11-14

--- a/FoqosTests/ProfileScheduleTimeTests.swift
+++ b/FoqosTests/ProfileScheduleTimeTests.swift
@@ -27,19 +27,19 @@ final class ProfileScheduleTimeTests: XCTestCase {
     return dayOffset == 0 ? base : calendar.date(byAdding: .day, value: dayOffset, to: base)!
   }
 
-  func testIsActiveWhenDaysNotEmpty() {
+  func testGivenDaysNotEmpty_WhenCheckingIsActive_ThenReturnsTrue() {
     let schedule = ProfileScheduleTime(
       days: [.monday], hour: 9, minute: 0, updatedAt: .distantPast)
     XCTAssertTrue(schedule.isActive)
   }
 
-  func testIsNotActiveWhenDaysEmpty() {
+  func testGivenDaysEmpty_WhenCheckingIsActive_ThenReturnsFalse() {
     let schedule = ProfileScheduleTime(
       days: [], hour: 9, minute: 0, updatedAt: .distantPast)
     XCTAssertFalse(schedule.isActive)
   }
 
-  func testIsTodayScheduled_whenTodayInDays_returnsTrue() {
+  func testGivenTodayInDays_WhenCheckingIsTodayScheduled_ThenReturnsTrue() {
     // referenceDate is Monday
     let schedule = ProfileScheduleTime(
       days: [.monday], hour: 9, minute: 0, updatedAt: .distantPast
@@ -47,7 +47,7 @@ final class ProfileScheduleTimeTests: XCTestCase {
     XCTAssertTrue(schedule.isTodayScheduled(now: referenceDate))
   }
 
-  func testIsTodayScheduled_whenTodayNotInDays_returnsFalse() {
+  func testGivenTodayNotInDays_WhenCheckingIsTodayScheduled_ThenReturnsFalse() {
     // referenceDate is Monday, schedule for Tuesday
     let schedule = ProfileScheduleTime(
       days: [.tuesday], hour: 9, minute: 0, updatedAt: .distantPast
@@ -55,14 +55,14 @@ final class ProfileScheduleTimeTests: XCTestCase {
     XCTAssertFalse(schedule.isTodayScheduled(now: referenceDate))
   }
 
-  func testIsTodayScheduled_whenDaysEmpty_returnsFalse() {
+  func testGivenDaysEmpty_WhenCheckingIsTodayScheduled_ThenReturnsFalse() {
     let schedule = ProfileScheduleTime(
       days: [], hour: 9, minute: 0, updatedAt: .distantPast
     )
     XCTAssertFalse(schedule.isTodayScheduled(now: referenceDate))
   }
 
-  func testOlderThanOneMinute_whenOld_returnsTrue() {
+  func testGivenUpdatedOverOneMinuteAgo_WhenCheckingOlderThanOneMinute_ThenReturnsTrue() {
     let now = referenceDate
     let schedule = ProfileScheduleTime(
       days: [.monday], hour: 9, minute: 0,
@@ -71,7 +71,7 @@ final class ProfileScheduleTimeTests: XCTestCase {
     XCTAssertTrue(schedule.olderThanOneMinute(now: now))
   }
 
-  func testOlderThanOneMinute_whenExactlyOneMinute_returnsFalse() {
+  func testGivenUpdatedExactlyOneMinuteAgo_WhenCheckingOlderThanOneMinute_ThenReturnsFalse() {
     let now = referenceDate
     let schedule = ProfileScheduleTime(
       days: [.monday], hour: 9, minute: 0,
@@ -80,7 +80,7 @@ final class ProfileScheduleTimeTests: XCTestCase {
     XCTAssertFalse(schedule.olderThanOneMinute(now: now))
   }
 
-  func testOlderThanOneMinute_whenRecent_returnsFalse() {
+  func testGivenJustUpdated_WhenCheckingOlderThanOneMinute_ThenReturnsFalse() {
     let now = referenceDate
     let schedule = ProfileScheduleTime(
       days: [.monday], hour: 9, minute: 0, updatedAt: now
@@ -88,28 +88,28 @@ final class ProfileScheduleTimeTests: XCTestCase {
     XCTAssertFalse(schedule.olderThanOneMinute(now: now))
   }
 
-  func testFormattedTime_am() {
+  func testGivenMorningHour_WhenFormatting_ThenShowsAM() {
     let schedule = ProfileScheduleTime(
       days: [.monday], hour: 9, minute: 30, updatedAt: .distantPast
     )
     XCTAssertEqual(schedule.formattedTime, "9:30 AM")
   }
 
-  func testFormattedTime_pm() {
+  func testGivenAfternoonHour_WhenFormatting_ThenShowsPM() {
     let schedule = ProfileScheduleTime(
       days: [.monday], hour: 14, minute: 5, updatedAt: .distantPast
     )
     XCTAssertEqual(schedule.formattedTime, "2:05 PM")
   }
 
-  func testFormattedTime_noon() {
+  func testGivenNoonHour_WhenFormatting_ThenShowsTwelvePM() {
     let schedule = ProfileScheduleTime(
       days: [.monday], hour: 12, minute: 0, updatedAt: .distantPast
     )
     XCTAssertEqual(schedule.formattedTime, "12:00 PM")
   }
 
-  func testFormattedTime_midnight() {
+  func testGivenMidnightHour_WhenFormatting_ThenShowsTwelveAM() {
     let schedule = ProfileScheduleTime(
       days: [.monday], hour: 0, minute: 0, updatedAt: .distantPast
     )
@@ -118,7 +118,7 @@ final class ProfileScheduleTimeTests: XCTestCase {
 
   // MARK: - nextScheduledStartTime tests
 
-  func testNextScheduledStartTime_dailySchedule_beforeStartTime_returnsToday() {
+  func testGivenDailyScheduleBeforeStartTime_WhenGettingNextStart_ThenReturnsToday() {
     // Schedule for every day at 23:00, "now" is 10:00 (before 23:00)
     let schedule = ProfileScheduleTime(
       days: Weekday.allCases,
@@ -143,7 +143,7 @@ final class ProfileScheduleTimeTests: XCTestCase {
     XCTAssertEqual(resultComponents.minute, 0)
   }
 
-  func testNextScheduledStartTime_dailySchedule_afterStartTime_returnsTomorrow() {
+  func testGivenDailyScheduleAfterStartTime_WhenGettingNextStart_ThenReturnsTomorrow() {
     let schedule = ProfileScheduleTime(
       days: Weekday.allCases,
       hour: 14,
@@ -169,7 +169,7 @@ final class ProfileScheduleTimeTests: XCTestCase {
     XCTAssertEqual(resultComponents.minute, 0)
   }
 
-  func testNextScheduledStartTime_weekdaySchedule_skipsNonScheduledDays() {
+  func testGivenWeekdaySchedule_WhenGettingNextStart_ThenSkipsNonScheduledDays() {
     // referenceDate is Monday. Use dayOffset: +2 to get Wednesday at 15:00
     let wednesday = date(hour: 15, minute: 0, dayOffset: 2)
 
@@ -191,7 +191,7 @@ final class ProfileScheduleTimeTests: XCTestCase {
     XCTAssertEqual(resultComponents.minute, 0)
   }
 
-  func testNextScheduledStartTime_emptyDays_returnsNil() {
+  func testGivenEmptyDays_WhenGettingNextStart_ThenReturnsNil() {
     let schedule = ProfileScheduleTime(
       days: [],
       hour: 14,
@@ -201,7 +201,7 @@ final class ProfileScheduleTimeTests: XCTestCase {
     XCTAssertNil(schedule.nextScheduledStartTime(after: referenceDate))
   }
 
-  func testNextScheduledStartTime_exactlyAtStartTime_returnsTomorrow() {
+  func testGivenExactlyAtStartTime_WhenGettingNextStart_ThenReturnsTomorrow() {
     let schedule = ProfileScheduleTime(
       days: Weekday.allCases,
       hour: 14,
@@ -222,7 +222,7 @@ final class ProfileScheduleTimeTests: XCTestCase {
     XCTAssertEqual(resultDay, tomorrowDay)
   }
 
-  func testNextScheduledStartTime_dstSpringForwardGap_returnsNilInsteadOfCrashing() {
+  func testGivenDSTSpringForwardGap_WhenGettingNextStart_ThenDoesNotCrash() {
     // US Eastern: March 9, 2025 at 2:00 AM clocks jump to 3:00 AM
     // So 2:30 AM doesn't exist on that day
     var easternCalendar = Calendar(identifier: .gregorian)
@@ -265,7 +265,7 @@ final class ProfileScheduleTimeTests: XCTestCase {
 
   // MARK: - scheduledStartTime(on:) tests
 
-  func testScheduledStartTime_returnsCorrectTimeForToday() {
+  func testGivenDailySchedule_WhenGettingStartTimeForToday_ThenReturnsCorrectTime() {
     let now = referenceDate
     let schedule = ProfileScheduleTime(
       days: Weekday.allCases, hour: 14, minute: 30, updatedAt: .distantPast
@@ -280,7 +280,7 @@ final class ProfileScheduleTimeTests: XCTestCase {
     XCTAssertEqual(components.second, 0)
   }
 
-  func testScheduledStartTime_preservesDateComponents() {
+  func testGivenSpecificDate_WhenGettingStartTime_ThenPreservesDateComponents() {
     var dateComponents = DateComponents()
     dateComponents.year = 2026
     dateComponents.month = 2
@@ -304,7 +304,7 @@ final class ProfileScheduleTimeTests: XCTestCase {
     XCTAssertEqual(c.minute, 0)
   }
 
-  func testCodableRoundTrip() throws {
+  func testGivenSchedule_WhenEncodingAndDecoding_ThenPreservesValues() throws {
     let original = ProfileScheduleTime(
       days: [.monday, .wednesday, .friday],
       hour: 14,

--- a/FoqosTests/ProfileSessionRecordTests.swift
+++ b/FoqosTests/ProfileSessionRecordTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class ProfileSessionRecordTests: XCTestCase {
 
-  func testRecordIdIsDeterministicPerProfile() {
+  func testGivenSameProfileId_WhenCreatingRecords_ThenRecordIdsMatch() {
     let profileId = UUID()
 
     let record1 = ProfileSessionRecord(profileId: profileId)
@@ -15,7 +15,7 @@ final class ProfileSessionRecordTests: XCTestCase {
     XCTAssertEqual(record1.recordName, "ProfileSession_\(profileId.uuidString)")
   }
 
-  func testApplyUpdateRejectsLowerSequence() {
+  func testGivenHigherSequence_WhenApplyingLowerSequence_ThenRejectsUpdate() {
     var record = ProfileSessionRecord(profileId: UUID())
 
     // Apply start with seq=3
@@ -39,7 +39,7 @@ final class ProfileSessionRecordTests: XCTestCase {
     XCTAssertTrue(record.isActive)  // Still active
   }
 
-  func testApplyUpdateAcceptsHigherSequence() {
+  func testGivenActiveSession_WhenApplyingHigherSequence_ThenAcceptsUpdate() {
     var record = ProfileSessionRecord(profileId: UUID())
 
     // Start
@@ -56,7 +56,7 @@ final class ProfileSessionRecordTests: XCTestCase {
     XCTAssertFalse(record.isActive)
   }
 
-  func testApplyUpdateRejectsEqualSequence() {
+  func testGivenActiveSession_WhenApplyingEqualSequence_ThenRejectsUpdate() {
     var record = ProfileSessionRecord(profileId: UUID())
 
     // Apply start with seq=1
@@ -73,7 +73,7 @@ final class ProfileSessionRecordTests: XCTestCase {
     XCTAssertTrue(record.isActive)  // Still active
   }
 
-  func testResetForNewSession() {
+  func testGivenCompletedSession_WhenResettingForNewSession_ThenClearsAllFields() {
     var record = ProfileSessionRecord(profileId: UUID())
 
     // Start and then stop a session
@@ -92,7 +92,7 @@ final class ProfileSessionRecordTests: XCTestCase {
     XCTAssertNil(record.sessionOriginDevice)
   }
 
-  func testSessionOriginDeviceIsSetOnStart() {
+  func testGivenNewSession_WhenStarting_ThenSetsSessionOriginDevice() {
     var record = ProfileSessionRecord(profileId: UUID())
 
     _ = record.applyUpdate(isActive: true, sequenceNumber: 1, deviceId: "device-a", startTime: Date())
@@ -100,7 +100,7 @@ final class ProfileSessionRecordTests: XCTestCase {
     XCTAssertEqual(record.sessionOriginDevice, "device-a")
   }
 
-  func testBreakTimesAreUpdated() {
+  func testGivenActiveSession_WhenUpdatingBreakTimes_ThenSetsBreakStartAndEnd() {
     var record = ProfileSessionRecord(profileId: UUID())
     let now = Date()
     let breakStart = now

--- a/FoqosTests/ProfileStartTriggersTests.swift
+++ b/FoqosTests/ProfileStartTriggersTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class ProfileStartTriggersTests: XCTestCase {
 
-  func testDefaultTriggersAreAllFalse() {
+  func testGivenNewTriggers_WhenCheckingDefaults_ThenAllFalse() {
     let triggers = ProfileStartTriggers()
     XCTAssertFalse(triggers.manual)
     XCTAssertFalse(triggers.anyNFC)
@@ -16,42 +16,42 @@ final class ProfileStartTriggersTests: XCTestCase {
     XCTAssertFalse(triggers.deepLink)
   }
 
-  func testHasNFCReturnsTrueForAnyNFC() {
+  func testGivenAnyNFCTrue_WhenCheckingHasNFC_ThenReturnsTrue() {
     var triggers = ProfileStartTriggers()
     triggers.anyNFC = true
     XCTAssertTrue(triggers.hasNFC)
   }
 
-  func testHasNFCReturnsTrueForSpecificNFC() {
+  func testGivenSpecificNFCTrue_WhenCheckingHasNFC_ThenReturnsTrue() {
     var triggers = ProfileStartTriggers()
     triggers.specificNFC = true
     XCTAssertTrue(triggers.hasNFC)
   }
 
-  func testHasQRReturnsTrueForAnyQR() {
+  func testGivenAnyQRTrue_WhenCheckingHasQR_ThenReturnsTrue() {
     var triggers = ProfileStartTriggers()
     triggers.anyQR = true
     XCTAssertTrue(triggers.hasQR)
   }
 
-  func testHasQRReturnsTrueForSpecificQR() {
+  func testGivenSpecificQRTrue_WhenCheckingHasQR_ThenReturnsTrue() {
     var triggers = ProfileStartTriggers()
     triggers.specificQR = true
     XCTAssertTrue(triggers.hasQR)
   }
 
-  func testIsValidReturnsFalseWhenEmpty() {
+  func testGivenNoTriggersSet_WhenCheckingIsValid_ThenReturnsFalse() {
     let triggers = ProfileStartTriggers()
     XCTAssertFalse(triggers.isValid)
   }
 
-  func testIsValidReturnsTrueWhenManualSet() {
+  func testGivenManualTriggerSet_WhenCheckingIsValid_ThenReturnsTrue() {
     var triggers = ProfileStartTriggers()
     triggers.manual = true
     XCTAssertTrue(triggers.isValid)
   }
 
-  func testCodableRoundTrip() throws {
+  func testGivenTriggersWithValues_WhenEncodingAndDecoding_ThenRoundTrips() throws {
     var original = ProfileStartTriggers()
     original.manual = true
     original.anyNFC = true

--- a/FoqosTests/ProfileStopConditionsTests.swift
+++ b/FoqosTests/ProfileStopConditionsTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class ProfileStopConditionsTests: XCTestCase {
 
-  func testDefaultConditionsAreAllFalse() {
+  func testGivenNewConditions_WhenCheckingDefaults_ThenAllFalse() {
     let conditions = ProfileStopConditions()
     XCTAssertFalse(conditions.manual)
     XCTAssertFalse(conditions.timer)
@@ -19,24 +19,24 @@ final class ProfileStopConditionsTests: XCTestCase {
     XCTAssertFalse(conditions.deepLink)
   }
 
-  func testIsValidReturnsFalseWhenEmpty() {
+  func testGivenEmptyConditions_WhenCheckingIsValid_ThenFalse() {
     let conditions = ProfileStopConditions()
     XCTAssertFalse(conditions.isValid)
   }
 
-  func testIsValidReturnsTrueWhenManualSet() {
+  func testGivenManualEnabled_WhenCheckingIsValid_ThenTrue() {
     var conditions = ProfileStopConditions()
     conditions.manual = true
     XCTAssertTrue(conditions.isValid)
   }
 
-  func testIsValidReturnsTrueWhenTimerSet() {
+  func testGivenTimerEnabled_WhenCheckingIsValid_ThenTrue() {
     var conditions = ProfileStopConditions()
     conditions.timer = true
     XCTAssertTrue(conditions.isValid)
   }
 
-  func testCodableRoundTrip() throws {
+  func testGivenConditionsWithMultipleFlags_WhenEncodingAndDecoding_ThenRoundTripsCorrectly() throws {
     var original = ProfileStopConditions()
     original.manual = true
     original.sameNFC = true

--- a/FoqosTests/ScheduleSuppressionTests.swift
+++ b/FoqosTests/ScheduleSuppressionTests.swift
@@ -117,7 +117,7 @@ final class ScheduleSuppressionTests: XCTestCase {
 
   /// Stopped at 22:30 yesterday, now 03:00 today. Overnight window started yesterday at 22:00.
   /// Window start (yesterday 22:00) <= stoppedAt (yesterday 22:30) -> suppressed.
-  func testOvernight_stoppedYesterday_earlyMorningToday_suppresses() {
+  func testGivenOvernightStoppedYesterday_WhenEarlyMorningToday_ThenSuppresses() {
     let now = date(hour: 3, minute: 0)
     let stoppedAt = date(hour: 22, minute: 30, dayOffset: -1)
     let start = makeSchedule(hour: 22, minute: 0)
@@ -130,7 +130,7 @@ final class ScheduleSuppressionTests: XCTestCase {
   }
 
   /// Overnight: not stopped, at 03:00. Window started yesterday at 22:00. Should be active.
-  func testOvernight_notStopped_earlyMorningToday_isActive() {
+  func testGivenOvernightNotStopped_WhenEarlyMorningToday_ThenIsActive() {
     let now = date(hour: 3, minute: 0)
     let start = makeSchedule(hour: 22, minute: 0)
     let stop = makeSchedule(hour: 6, minute: 0)

--- a/FoqosTests/SharedDataLockTests.swift
+++ b/FoqosTests/SharedDataLockTests.swift
@@ -12,7 +12,7 @@ final class SharedDataLockTests: XCTestCase {
     _ = SharedData.getAndFlushCompletedSessionsForScheduler()
   }
 
-  func testSequentialSnapshotOperationsDoNotDeadlock() {
+  func testGivenTwoSnapshots_WhenSettingAndRemovingSequentially_ThenNoDeadlock() {
     // Given: two snapshots
     let id1 = UUID()
     let id2 = UUID()
@@ -33,7 +33,7 @@ final class SharedDataLockTests: XCTestCase {
     SharedData.removeSnapshot(for: id2.uuidString)
   }
 
-  func testConcurrentSnapshotWritesPreserveAllEntries() {
+  func testGivenManyConcurrentWrites_WhenWritingSnapshots_ThenPreservesAllEntries() {
     // NOTE: Uses GCD to simulate concurrent writes within a single process.
     // True cross-process testing (main app vs DeviceActivity extension) is
     // impractical in XCTest, but the POSIX flock() mechanism is identical
@@ -68,7 +68,7 @@ final class SharedDataLockTests: XCTestCase {
     }
   }
 
-  func testEndActiveSharedSessionIsAtomic() {
+  func testGivenActiveSession_WhenEndingSession_ThenAtomicallyMovesToCompleted() {
     // Given: an active session
     let profileId = UUID()
     SharedData.createSessionForScheduler(for: profileId)
@@ -84,7 +84,7 @@ final class SharedDataLockTests: XCTestCase {
     XCTAssertEqual(completed.first?.blockedProfileId, profileId)
   }
 
-  func testGetAndFlushCompletedSessionsIsAtomic() {
+  func testGivenTwoCompletedSessions_WhenFlushingAtomically_ThenReturnsBothAndClears() {
     // Given: two completed sessions
     let profileId1 = UUID()
     let profileId2 = UUID()

--- a/FoqosTests/ShouldBeActiveNowTests.swift
+++ b/FoqosTests/ShouldBeActiveNowTests.swift
@@ -42,7 +42,7 @@ final class ShouldBeActiveNowTests: XCTestCase {
 
   // MARK: - Basic window checks
 
-  func testInWindow_notSuppressed_returnsTrue() {
+  func testGivenInWindowNotSuppressed_WhenCheckingActive_ThenReturnsTrue() {
     let start = makeSchedule(hour: 10, minute: 0)
     let now = date(hour: 14, minute: 0)
 
@@ -52,7 +52,7 @@ final class ShouldBeActiveNowTests: XCTestCase {
     )
   }
 
-  func testOutsideWindow_returnsFalse() {
+  func testGivenOutsideWindow_WhenCheckingActive_ThenReturnsFalse() {
     let start = makeSchedule(hour: 14, minute: 0)
     let now = date(hour: 9, minute: 0)
 
@@ -62,7 +62,7 @@ final class ShouldBeActiveNowTests: XCTestCase {
     )
   }
 
-  func testInWindow_suppressed_returnsFalse() {
+  func testGivenInWindowSuppressed_WhenCheckingActive_ThenReturnsFalse() {
     let start = makeSchedule(hour: 10, minute: 0)
     let now = date(hour: 14, minute: 0)
     let stoppedAt = date(hour: 12, minute: 0)
@@ -75,7 +75,7 @@ final class ShouldBeActiveNowTests: XCTestCase {
 
   // MARK: - Age check
 
-  func testTooNew_returnsFalse() {
+  func testGivenScheduleTooNew_WhenCheckingActive_ThenReturnsFalse() {
     let now = date(hour: 14, minute: 0)
     let start = makeSchedule(hour: 10, minute: 0, updatedAt: now)
 
@@ -87,7 +87,7 @@ final class ShouldBeActiveNowTests: XCTestCase {
 
   // MARK: - Day check
 
-  func testNotScheduledDay_returnsFalse() {
+  func testGivenNotScheduledDay_WhenCheckingActive_ThenReturnsFalse() {
     // Reference is Monday (weekday 2). Pick a day that is NOT Monday.
     let otherDay = Weekday.allCases.first { $0.rawValue != referenceWeekday }!
     let start = makeSchedule(hour: 10, minute: 0, days: [otherDay])
@@ -101,7 +101,7 @@ final class ShouldBeActiveNowTests: XCTestCase {
 
   // MARK: - Overnight
 
-  func testOvernight_at2300_notSuppressed_returnsTrue() {
+  func testGivenOvernightAt2300NotSuppressed_WhenCheckingActive_ThenReturnsTrue() {
     let start = makeSchedule(hour: 22, minute: 0)
     let stop = makeSchedule(hour: 6, minute: 0)
     let now = date(hour: 23, minute: 0)
@@ -112,7 +112,7 @@ final class ShouldBeActiveNowTests: XCTestCase {
     )
   }
 
-  func testOvernight_at0300_notSuppressed_returnsTrue() {
+  func testGivenOvernightAt0300NotSuppressed_WhenCheckingActive_ThenReturnsTrue() {
     let start = makeSchedule(hour: 22, minute: 0)
     let stop = makeSchedule(hour: 6, minute: 0)
     let now = date(hour: 3, minute: 0)
@@ -123,7 +123,7 @@ final class ShouldBeActiveNowTests: XCTestCase {
     )
   }
 
-  func testOvernight_at0300_stoppedAt2230Yesterday_returnsFalse() {
+  func testGivenOvernightAt0300StoppedYesterday_WhenCheckingActive_ThenReturnsFalse() {
     let start = makeSchedule(hour: 22, minute: 0)
     let stop = makeSchedule(hour: 6, minute: 0)
     let now = date(hour: 3, minute: 0)
@@ -135,7 +135,7 @@ final class ShouldBeActiveNowTests: XCTestCase {
     )
   }
 
-  func testOvernight_betweenWindows_returnsFalse() {
+  func testGivenOvernightBetweenWindows_WhenCheckingActive_ThenReturnsFalse() {
     let start = makeSchedule(hour: 22, minute: 0)
     let stop = makeSchedule(hour: 6, minute: 0)
     let now = date(hour: 12, minute: 0)
@@ -148,7 +148,7 @@ final class ShouldBeActiveNowTests: XCTestCase {
 
   // MARK: - Same-day with stop
 
-  func testSameDay_insideWindow_returnsTrue() {
+  func testGivenSameDayInsideWindow_WhenCheckingActive_ThenReturnsTrue() {
     let start = makeSchedule(hour: 10, minute: 0)
     let stop = makeSchedule(hour: 17, minute: 0)
     let now = date(hour: 14, minute: 0)
@@ -159,7 +159,7 @@ final class ShouldBeActiveNowTests: XCTestCase {
     )
   }
 
-  func testSameDay_afterStop_returnsFalse() {
+  func testGivenSameDayAfterStop_WhenCheckingActive_ThenReturnsFalse() {
     let start = makeSchedule(hour: 10, minute: 0)
     let stop = makeSchedule(hour: 17, minute: 0)
     let now = date(hour: 18, minute: 0)
@@ -172,7 +172,7 @@ final class ShouldBeActiveNowTests: XCTestCase {
 
   // MARK: - Overnight day check (window started yesterday)
 
-  func testOvernight_at0300_yesterdayNotScheduled_returnsFalse() {
+  func testGivenOvernightAt0300YesterdayNotScheduled_WhenCheckingActive_ThenReturnsFalse() {
     // Reference is Monday. Schedule only for Monday (not Sunday = yesterday).
     let mondayDay = Weekday(rawValue: referenceWeekday)!
     let start = makeSchedule(hour: 22, minute: 0, days: [mondayDay])

--- a/FoqosTests/StrategyManagerStartTests.swift
+++ b/FoqosTests/StrategyManagerStartTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @MainActor
 final class StrategyManagerStartTests: XCTestCase {
 
-  func testDetermineStartActionForManualOnly() {
+  func testGivenManualTriggerOnly_WhenDeterminingStartAction_ThenReturnsStartImmediately() {
     var start = ProfileStartTriggers()
     start.manual = true
 
@@ -15,7 +15,7 @@ final class StrategyManagerStartTests: XCTestCase {
     XCTAssertEqual(action, .startImmediately)
   }
 
-  func testDetermineStartActionForNFCOnly() {
+  func testGivenNFCTriggerOnly_WhenDeterminingStartAction_ThenReturnsScanNFC() {
     var start = ProfileStartTriggers()
     start.anyNFC = true
 
@@ -24,7 +24,7 @@ final class StrategyManagerStartTests: XCTestCase {
     XCTAssertEqual(action, .scanNFC)
   }
 
-  func testDetermineStartActionForQROnly() {
+  func testGivenQRTriggerOnly_WhenDeterminingStartAction_ThenReturnsScanQR() {
     var start = ProfileStartTriggers()
     start.anyQR = true
 
@@ -33,7 +33,7 @@ final class StrategyManagerStartTests: XCTestCase {
     XCTAssertEqual(action, .scanQR)
   }
 
-  func testDetermineStartActionForScheduleOnly() {
+  func testGivenScheduleTriggerOnly_WhenDeterminingStartAction_ThenReturnsWaitForSchedule() {
     var start = ProfileStartTriggers()
     start.schedule = true
 
@@ -42,7 +42,7 @@ final class StrategyManagerStartTests: XCTestCase {
     XCTAssertEqual(action, .waitForSchedule)
   }
 
-  func testDetermineStartActionForDeepLinkOnly() {
+  func testGivenDeepLinkTriggerOnly_WhenDeterminingStartAction_ThenReturnsDeepLinkOnly() {
     var start = ProfileStartTriggers()
     start.deepLink = true
 
@@ -51,7 +51,7 @@ final class StrategyManagerStartTests: XCTestCase {
     XCTAssertEqual(action, .deepLinkOnly)
   }
 
-  func testDetermineStartActionForManualPlusNFC() {
+  func testGivenManualAndNFCTriggers_WhenDeterminingStartAction_ThenShowsPicker() {
     var start = ProfileStartTriggers()
     start.manual = true
     start.anyNFC = true
@@ -61,7 +61,7 @@ final class StrategyManagerStartTests: XCTestCase {
     XCTAssertEqual(action, .showPicker(options: [.startImmediately, .scanNFC]))
   }
 
-  func testDetermineStartActionForNFCPlusQR() {
+  func testGivenNFCAndQRTriggers_WhenDeterminingStartAction_ThenShowsPicker() {
     var start = ProfileStartTriggers()
     start.anyNFC = true
     start.anyQR = true
@@ -71,7 +71,7 @@ final class StrategyManagerStartTests: XCTestCase {
     XCTAssertEqual(action, .showPicker(options: [.scanNFC, .scanQR]))
   }
 
-  func testDetermineStartActionForAllManualOptions() {
+  func testGivenManualNFCAndQRTriggers_WhenDeterminingStartAction_ThenShowsPickerWithAll() {
     var start = ProfileStartTriggers()
     start.manual = true
     start.anyNFC = true
@@ -82,7 +82,7 @@ final class StrategyManagerStartTests: XCTestCase {
     XCTAssertEqual(action, .showPicker(options: [.startImmediately, .scanNFC, .scanQR]))
   }
 
-  func testDetermineStartActionForNoTriggers() {
+  func testGivenNoTriggers_WhenDeterminingStartAction_ThenReturnsCannotStart() {
     let start = ProfileStartTriggers()
 
     let action = StartStopActionResolver.determineStartAction(for: start)
@@ -94,7 +94,7 @@ final class StrategyManagerStartTests: XCTestCase {
     }
   }
 
-  func testDetermineStartActionBlockedByInvalidStopConditions() {
+  func testGivenManualStartWithInvalidStop_WhenDeterminingStartAction_ThenReturnsCannotStart() {
     var start = ProfileStartTriggers()
     start.manual = true
     let stop = ProfileStopConditions()  // all false — invalid
@@ -108,7 +108,7 @@ final class StrategyManagerStartTests: XCTestCase {
     }
   }
 
-  func testDetermineStartActionAllowedWithValidStopConditions() {
+  func testGivenManualStartWithValidStop_WhenDeterminingStartAction_ThenReturnsStartImmediately() {
     var start = ProfileStartTriggers()
     start.manual = true
     var stop = ProfileStopConditions()

--- a/FoqosTests/StrategyManagerStopTests.swift
+++ b/FoqosTests/StrategyManagerStopTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @MainActor
 final class StrategyManagerStopTests: XCTestCase {
 
-  func testCanStopWithManualWhenManualEnabled() {
+  func testGivenManualStopEnabled_WhenStoppingWithManual_ThenAllowed() {
     var stop = ProfileStopConditions()
     stop.manual = true
 
@@ -21,7 +21,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertTrue(result.allowed)
   }
 
-  func testCannotStopWithManualWhenNotEnabled() {
+  func testGivenManualStopDisabled_WhenStoppingWithManual_ThenNotAllowed() {
     var stop = ProfileStopConditions()
     stop.timer = true
 
@@ -36,7 +36,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertFalse(result.allowed)
   }
 
-  func testCanStopWithAnyNFCWhenEnabled() {
+  func testGivenAnyNFCEnabled_WhenStoppingWithNFC_ThenAllowed() {
     var stop = ProfileStopConditions()
     stop.anyNFC = true
 
@@ -51,7 +51,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertTrue(result.allowed)
   }
 
-  func testCanStopWithSpecificNFCWhenMatches() {
+  func testGivenSpecificNFCEnabled_WhenStoppingWithMatchingTag_ThenAllowed() {
     var stop = ProfileStopConditions()
     stop.specificNFC = true
 
@@ -66,7 +66,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertTrue(result.allowed)
   }
 
-  func testCannotStopWithSpecificNFCWhenMismatch() {
+  func testGivenSpecificNFCEnabled_WhenStoppingWithWrongTag_ThenNotAllowed() {
     var stop = ProfileStopConditions()
     stop.specificNFC = true
 
@@ -82,7 +82,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertNotNil(result.errorMessage)
   }
 
-  func testCanStopWithSameNFCWhenSessionTagMatches() {
+  func testGivenSameNFCEnabled_WhenStoppingWithMatchingSessionTag_ThenAllowed() {
     var stop = ProfileStopConditions()
     stop.sameNFC = true
 
@@ -98,7 +98,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertTrue(result.allowed)
   }
 
-  func testCannotStopWithSameNFCWhenSessionTagMismatch() {
+  func testGivenSameNFCEnabled_WhenStoppingWithDifferentTag_ThenNotAllowed() {
     var stop = ProfileStopConditions()
     stop.sameNFC = true
 
@@ -114,7 +114,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertNotNil(result.errorMessage)
   }
 
-  func testCanStopWithSameQRWhenSessionTagMatches() {
+  func testGivenSameQREnabled_WhenStoppingWithMatchingSessionTag_ThenAllowed() {
     var stop = ProfileStopConditions()
     stop.sameQR = true
 
@@ -130,7 +130,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertTrue(result.allowed)
   }
 
-  func testCannotStopWithSameQRWhenSessionTagMismatch() {
+  func testGivenSameQREnabled_WhenStoppingWithDifferentCode_ThenNotAllowed() {
     var stop = ProfileStopConditions()
     stop.sameQR = true
 
@@ -148,7 +148,7 @@ final class StrategyManagerStopTests: XCTestCase {
 
   // MARK: - determineStopAction Tests
 
-  func testDetermineStopActionManualReturnsStopImmediately() {
+  func testGivenManualAndNFC_WhenDeterminingStopAction_ThenStopImmediately() {
     var conditions = ProfileStopConditions()
     conditions.manual = true
     conditions.anyNFC = true  // Even with NFC, manual wins
@@ -158,7 +158,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertEqual(action, .stopImmediately)
   }
 
-  func testDetermineStopActionOnlyAnyNFCReturnsScanNFC() {
+  func testGivenOnlyAnyNFC_WhenDeterminingStopAction_ThenScanNFC() {
     var conditions = ProfileStopConditions()
     conditions.anyNFC = true
 
@@ -167,7 +167,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertEqual(action, .scanNFC)
   }
 
-  func testDetermineStopActionOnlySameNFCReturnsScanNFC() {
+  func testGivenOnlySameNFC_WhenDeterminingStopAction_ThenScanNFC() {
     var conditions = ProfileStopConditions()
     conditions.sameNFC = true
 
@@ -176,7 +176,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertEqual(action, .scanNFC)
   }
 
-  func testDetermineStopActionOnlySpecificNFCReturnsScanNFC() {
+  func testGivenOnlySpecificNFC_WhenDeterminingStopAction_ThenScanNFC() {
     var conditions = ProfileStopConditions()
     conditions.specificNFC = true
 
@@ -185,7 +185,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertEqual(action, .scanNFC)
   }
 
-  func testDetermineStopActionOnlyAnyQRReturnsScanQR() {
+  func testGivenOnlyAnyQR_WhenDeterminingStopAction_ThenScanQR() {
     var conditions = ProfileStopConditions()
     conditions.anyQR = true
 
@@ -194,7 +194,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertEqual(action, .scanQR)
   }
 
-  func testDetermineStopActionOnlySameQRReturnsScanQR() {
+  func testGivenOnlySameQR_WhenDeterminingStopAction_ThenScanQR() {
     var conditions = ProfileStopConditions()
     conditions.sameQR = true
 
@@ -203,7 +203,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertEqual(action, .scanQR)
   }
 
-  func testDetermineStopActionOnlySpecificQRReturnsScanQR() {
+  func testGivenOnlySpecificQR_WhenDeterminingStopAction_ThenScanQR() {
     var conditions = ProfileStopConditions()
     conditions.specificQR = true
 
@@ -212,7 +212,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertEqual(action, .scanQR)
   }
 
-  func testDetermineStopActionBothNFCAndQRReturnsShowPicker() {
+  func testGivenNFCAndQR_WhenDeterminingStopAction_ThenShowPicker() {
     var conditions = ProfileStopConditions()
     conditions.anyNFC = true
     conditions.anyQR = true
@@ -222,7 +222,7 @@ final class StrategyManagerStopTests: XCTestCase {
     XCTAssertEqual(action, .showPicker(options: [.scanNFC, .scanQR]))
   }
 
-  func testDetermineStopActionOnlyTimerReturnsCannotStop() {
+  func testGivenOnlyTimer_WhenDeterminingStopAction_ThenCannotStop() {
     var conditions = ProfileStopConditions()
     conditions.timer = true
 
@@ -235,7 +235,7 @@ final class StrategyManagerStopTests: XCTestCase {
     }
   }
 
-  func testDetermineStopActionOnlyScheduleReturnsCannotStop() {
+  func testGivenOnlySchedule_WhenDeterminingStopAction_ThenCannotStop() {
     var conditions = ProfileStopConditions()
     conditions.schedule = true
 
@@ -248,7 +248,7 @@ final class StrategyManagerStopTests: XCTestCase {
     }
   }
 
-  func testDetermineStopActionEmptyConditionsReturnsCannotStop() {
+  func testGivenEmptyConditions_WhenDeterminingStopAction_ThenCannotStop() {
     let conditions = ProfileStopConditions()
 
     let action = StartStopActionResolver.determineStopAction(for: conditions)
@@ -260,7 +260,7 @@ final class StrategyManagerStopTests: XCTestCase {
     }
   }
 
-  func testDetermineStopActionManualOverridesEverything() {
+  func testGivenAllConditionsEnabled_WhenDeterminingStopAction_ThenManualOverrides() {
     var conditions = ProfileStopConditions()
     conditions.manual = true
     conditions.anyNFC = true

--- a/FoqosTests/SyncConflictManagerTests.swift
+++ b/FoqosTests/SyncConflictManagerTests.swift
@@ -13,13 +13,13 @@ final class SyncConflictManagerTests: XCTestCase {
     }
   }
 
-  func testInitialStateHasNoConflicts() {
+  func testGivenFreshManager_WhenCheckingState_ThenNoConflicts() {
     let manager = SyncConflictManager.shared
     XCTAssertTrue(manager.conflictedProfiles.isEmpty)
     XCTAssertFalse(manager.showConflictBanner)
   }
 
-  func testAddConflictAddsIdAndShowsBanner() {
+  func testGivenNoConflicts_WhenAddingConflict_ThenShowsBanner() {
     let manager = SyncConflictManager.shared
     let profileId = UUID()
 
@@ -29,7 +29,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertTrue(manager.showConflictBanner)
   }
 
-  func testAddMultipleConflicts() {
+  func testGivenNoConflicts_WhenAddingMultiple_ThenAllTracked() {
     let manager = SyncConflictManager.shared
     let id1 = UUID()
     let id2 = UUID()
@@ -43,7 +43,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertTrue(manager.showConflictBanner)
   }
 
-  func testAddSameConflictTwiceDoesNotDuplicate() {
+  func testGivenExistingConflict_WhenAddingSameConflict_ThenNoDuplicate() {
     let manager = SyncConflictManager.shared
     let profileId = UUID()
 
@@ -53,7 +53,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertEqual(manager.conflictedProfiles.count, 1)
   }
 
-  func testDismissBannerHidesBannerButKeepsConflicts() {
+  func testGivenVisibleBanner_WhenDismissing_ThenBannerHiddenButConflictsRemain() {
     let manager = SyncConflictManager.shared
     let profileId = UUID()
 
@@ -64,7 +64,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertNotNil(manager.conflictedProfiles[profileId])
   }
 
-  func testClearConflictRemovesSpecificId() {
+  func testGivenMultipleConflicts_WhenClearingOne_ThenOnlyThatOneRemoved() {
     let manager = SyncConflictManager.shared
     let id1 = UUID()
     let id2 = UUID()
@@ -78,7 +78,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertTrue(manager.showConflictBanner)
   }
 
-  func testClearLastConflictHidesBanner() {
+  func testGivenSingleConflict_WhenClearing_ThenBannerHidden() {
     let manager = SyncConflictManager.shared
     let profileId = UUID()
 
@@ -89,7 +89,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertFalse(manager.showConflictBanner)
   }
 
-  func testClearAllRemovesAllConflictsAndHidesBanner() {
+  func testGivenMultipleConflicts_WhenClearingAll_ThenEmptyAndBannerHidden() {
     let manager = SyncConflictManager.shared
     let id1 = UUID()
     let id2 = UUID()
@@ -102,7 +102,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertFalse(manager.showConflictBanner)
   }
 
-  func testConflictMessageSingularIncludesProfileName() {
+  func testGivenOneConflict_WhenGettingMessage_ThenIncludesProfileName() {
     let manager = SyncConflictManager.shared
     manager.addConflict(profileId: UUID(), profileName: "Work Focus")
 
@@ -112,7 +112,7 @@ final class SyncConflictManagerTests: XCTestCase {
     )
   }
 
-  func testConflictMessagePlural() {
+  func testGivenMultipleConflicts_WhenGettingMessage_ThenUsesPlural() {
     let manager = SyncConflictManager.shared
     manager.addConflict(profileId: UUID(), profileName: "Work Focus")
     manager.addConflict(profileId: UUID(), profileName: "Study Mode")
@@ -125,7 +125,7 @@ final class SyncConflictManagerTests: XCTestCase {
 
   // MARK: - Newer Version Conflict Tests
 
-  func testAddNewerVersionConflictShowsBanner() {
+  func testGivenNoConflicts_WhenAddingNewerVersionConflict_ThenShowsBanner() {
     let manager = SyncConflictManager.shared
     let profileId = UUID()
 
@@ -135,7 +135,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertTrue(manager.showConflictBanner)
   }
 
-  func testNewerVersionConflictTrackedSeparately() {
+  func testGivenBothConflictTypes_WhenChecking_ThenTrackedSeparately() {
     let manager = SyncConflictManager.shared
     let olderId = UUID()
     let newerId = UUID()
@@ -147,7 +147,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertEqual(manager.newerVersionProfiles.count, 1)
   }
 
-  func testNewerVersionMessageSingular() {
+  func testGivenOneNewerVersionConflict_WhenGettingMessage_ThenIncludesProfileName() {
     let manager = SyncConflictManager.shared
     manager.addNewerVersionConflict(profileId: UUID(), profileName: "Work Focus")
 
@@ -157,7 +157,7 @@ final class SyncConflictManagerTests: XCTestCase {
     )
   }
 
-  func testNewerVersionMessagePlural() {
+  func testGivenMultipleNewerVersionConflicts_WhenGettingMessage_ThenUsesPlural() {
     let manager = SyncConflictManager.shared
     manager.addNewerVersionConflict(profileId: UUID(), profileName: "Work Focus")
     manager.addNewerVersionConflict(profileId: UUID(), profileName: "Study Mode")
@@ -168,7 +168,7 @@ final class SyncConflictManagerTests: XCTestCase {
     )
   }
 
-  func testClearConflictClearsNewerVersion() {
+  func testGivenNewerVersionConflict_WhenClearing_ThenRemovedAndBannerHidden() {
     let manager = SyncConflictManager.shared
     let profileId = UUID()
 
@@ -179,7 +179,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertFalse(manager.showConflictBanner)
   }
 
-  func testClearAllClearsNewerVersionConflicts() {
+  func testGivenBothConflictTypes_WhenClearingAll_ThenAllRemovedAndBannerHidden() {
     let manager = SyncConflictManager.shared
     manager.addConflict(profileId: UUID(), profileName: "A")
     manager.addNewerVersionConflict(profileId: UUID(), profileName: "B")
@@ -190,7 +190,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertFalse(manager.showConflictBanner)
   }
 
-  func testBannerStaysWhenOnlyNewerVersionConflictsRemain() {
+  func testGivenBothConflictTypes_WhenClearingOlderOnly_ThenBannerStays() {
     let manager = SyncConflictManager.shared
     let olderId = UUID()
     let newerId = UUID()
@@ -205,7 +205,7 @@ final class SyncConflictManagerTests: XCTestCase {
 
   // MARK: - Computed Banner Visibility Tests
 
-  func testShouldShowNewerVersionBannerWhenConflictsExist() {
+  func testGivenNewerVersionConflicts_WhenCheckingBannerVisibility_ThenShowsNewerOnly() {
     let manager = SyncConflictManager.shared
     manager.addNewerVersionConflict(profileId: UUID(), profileName: "New Version")
 
@@ -213,7 +213,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertFalse(manager.shouldShowOlderDeviceBanner)
   }
 
-  func testShouldShowOlderDeviceBannerWhenConflictsExist() {
+  func testGivenOlderDeviceConflicts_WhenCheckingBannerVisibility_ThenShowsOlderOnly() {
     let manager = SyncConflictManager.shared
     manager.addConflict(profileId: UUID(), profileName: "Old Device")
 
@@ -221,7 +221,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertFalse(manager.shouldShowNewerVersionBanner)
   }
 
-  func testComputedPropertiesFalseWhenBannerDismissed() {
+  func testGivenBothConflictTypes_WhenBannerDismissed_ThenBothComputedPropertiesFalse() {
     let manager = SyncConflictManager.shared
     manager.addConflict(profileId: UUID(), profileName: "Old Device")
     manager.addNewerVersionConflict(profileId: UUID(), profileName: "New Version")
@@ -231,7 +231,7 @@ final class SyncConflictManagerTests: XCTestCase {
     XCTAssertFalse(manager.shouldShowOlderDeviceBanner)
   }
 
-  func testBothComputedPropertiesTrueWhenBothConflictTypesExist() {
+  func testGivenBothConflictTypes_WhenBannerVisible_ThenBothComputedPropertiesTrue() {
     let manager = SyncConflictManager.shared
     manager.addConflict(profileId: UUID(), profileName: "Old Device")
     manager.addNewerVersionConflict(profileId: UUID(), profileName: "New Version")

--- a/FoqosTests/TriggerConfigurationModelTests.swift
+++ b/FoqosTests/TriggerConfigurationModelTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @MainActor
 final class TriggerConfigurationModelTests: XCTestCase {
 
-  func testAutoFixOnStartTriggerChange() {
+  func testGivenSameNFCWithNoNFCStart_WhenStartTriggersChange_ThenAutoFixesStop() {
     let model = TriggerConfigurationModel()
     model.stopConditions.sameNFC = true
 
@@ -17,7 +17,7 @@ final class TriggerConfigurationModelTests: XCTestCase {
     XCTAssertFalse(model.stopConditions.sameNFC)
   }
 
-  func testValidationErrorsUpdateOnChange() {
+  func testGivenEmptyTriggers_WhenValidating_ThenShowsErrorsThatClearWhenValid() {
     let model = TriggerConfigurationModel()
     // Empty triggers should have errors after validation
     model.validate()
@@ -31,7 +31,7 @@ final class TriggerConfigurationModelTests: XCTestCase {
     XCTAssertTrue(model.validationErrors.isEmpty)
   }
 
-  func testIsStopEnabled() {
+  func testGivenNFCStartTrigger_WhenCheckingStopEnabled_ThenSameNFCEnabledSameQRDisabled() {
     let model = TriggerConfigurationModel()
     model.startTriggers.anyNFC = true
 
@@ -39,7 +39,7 @@ final class TriggerConfigurationModelTests: XCTestCase {
     XCTAssertFalse(model.isStopEnabled(.sameQR))
   }
 
-  func testReasonStopDisabled() {
+  func testGivenManualStartOnly_WhenCheckingReasonDisabled_ThenSameNFCHasReasonManualDoesNot() {
     let model = TriggerConfigurationModel()
     model.startTriggers.manual = true
 
@@ -47,7 +47,7 @@ final class TriggerConfigurationModelTests: XCTestCase {
     XCTAssertNil(model.reasonStopDisabled(.manual))
   }
 
-  func testValidationErrorsClearWhenStopConditionAdded() {
+  func testGivenStartWithNoStop_WhenAddingStopCondition_ThenValidationErrorsCleared() {
     let model = TriggerConfigurationModel()
     model.startTriggers.manual = true
     model.startTriggersDidChange()
@@ -68,7 +68,7 @@ final class TriggerConfigurationModelTests: XCTestCase {
     )
   }
 
-  func testValidationErrorsAppearWhenStopConditionRemoved() {
+  func testGivenValidStartAndStop_WhenRemovingStopCondition_ThenValidationErrorAppears() {
     let model = TriggerConfigurationModel()
     model.startTriggers.manual = true
     model.stopConditions.manual = true
@@ -87,7 +87,7 @@ final class TriggerConfigurationModelTests: XCTestCase {
     )
   }
 
-  func testValidationErrorWhenStartAndStopScheduleTimesMatch() {
+  func testGivenMatchingScheduleTimes_WhenValidating_ThenShowsEqualTimeError() {
     let now = Date()
     let model = TriggerConfigurationModel()
     model.startTriggers.schedule = true
@@ -106,7 +106,7 @@ final class TriggerConfigurationModelTests: XCTestCase {
     )
   }
 
-  func testNoValidationErrorWhenScheduleTimesDiffer() {
+  func testGivenDifferentScheduleTimes_WhenValidating_ThenNoEqualTimeError() {
     let now = Date()
     let model = TriggerConfigurationModel()
     model.startTriggers.schedule = true

--- a/FoqosTests/TriggerMigrationTests.swift
+++ b/FoqosTests/TriggerMigrationTests.swift
@@ -7,7 +7,7 @@ final class TriggerMigrationTests: XCTestCase {
 
   // MARK: - ManualBlockingStrategy
 
-  func testMigrateManualStrategy() {
+  func testGivenManualStrategyV1_WhenMigrating_ThenSetsManualTriggers() {
     let (start, stop) = TriggerMigration.migrateFromStrategy("ManualBlockingStrategy")
 
     XCTAssertTrue(start.manual)
@@ -21,7 +21,7 @@ final class TriggerMigrationTests: XCTestCase {
 
   // MARK: - NFCBlockingStrategy
 
-  func testMigrateNFCStrategy() {
+  func testGivenNFCStrategyV1_WhenMigrating_ThenSetsNFCTriggers() {
     let (start, stop) = TriggerMigration.migrateFromStrategy("NFCBlockingStrategy")
 
     XCTAssertTrue(start.anyNFC)
@@ -33,7 +33,7 @@ final class TriggerMigrationTests: XCTestCase {
 
   // MARK: - NFCManualBlockingStrategy
 
-  func testMigrateNFCManualStrategy() {
+  func testGivenNFCManualStrategyV1_WhenMigrating_ThenSetsManualStartAnyNFCStop() {
     let (start, stop) = TriggerMigration.migrateFromStrategy("NFCManualBlockingStrategy")
 
     XCTAssertTrue(start.manual)
@@ -45,7 +45,7 @@ final class TriggerMigrationTests: XCTestCase {
 
   // MARK: - NFCTimerBlockingStrategy
 
-  func testMigrateNFCTimerStrategy() {
+  func testGivenNFCTimerStrategyV1_WhenMigrating_ThenSetsManualStartAnyNFCAndTimerStop() {
     let (start, stop) = TriggerMigration.migrateFromStrategy("NFCTimerBlockingStrategy")
 
     XCTAssertTrue(start.manual)
@@ -56,7 +56,7 @@ final class TriggerMigrationTests: XCTestCase {
 
   // MARK: - QRCodeBlockingStrategy
 
-  func testMigrateQRCodeStrategy() {
+  func testGivenQRCodeStrategyV1_WhenMigrating_ThenSetsQRTriggers() {
     let (start, stop) = TriggerMigration.migrateFromStrategy("QRCodeBlockingStrategy")
 
     XCTAssertTrue(start.anyQR)
@@ -68,7 +68,7 @@ final class TriggerMigrationTests: XCTestCase {
 
   // MARK: - QRManualBlockingStrategy
 
-  func testMigrateQRManualStrategy() {
+  func testGivenQRManualStrategyV1_WhenMigrating_ThenSetsManualStartAnyQRStop() {
     let (start, stop) = TriggerMigration.migrateFromStrategy("QRManualBlockingStrategy")
 
     XCTAssertTrue(start.manual)
@@ -80,7 +80,7 @@ final class TriggerMigrationTests: XCTestCase {
 
   // MARK: - QRTimerBlockingStrategy
 
-  func testMigrateQRTimerStrategy() {
+  func testGivenQRTimerStrategyV1_WhenMigrating_ThenSetsManualStartAnyQRAndTimerStop() {
     let (start, stop) = TriggerMigration.migrateFromStrategy("QRTimerBlockingStrategy")
 
     XCTAssertTrue(start.manual)
@@ -91,7 +91,7 @@ final class TriggerMigrationTests: XCTestCase {
 
   // MARK: - ShortcutTimerBlockingStrategy
 
-  func testMigrateShortcutTimerStrategy() {
+  func testGivenShortcutTimerStrategyV1_WhenMigrating_ThenSetsManualStartTimerStop() {
     let (start, stop) = TriggerMigration.migrateFromStrategy("ShortcutTimerBlockingStrategy")
 
     XCTAssertTrue(start.manual)
@@ -106,7 +106,7 @@ final class TriggerMigrationTests: XCTestCase {
 
   // MARK: - Unknown Strategy
 
-  func testMigrateUnknownStrategyDefaultsToManual() {
+  func testGivenUnknownStrategyV1_WhenMigrating_ThenDefaultsToManual() {
     let (start, stop) = TriggerMigration.migrateFromStrategy("UnknownStrategy")
 
     XCTAssertTrue(start.manual)
@@ -115,7 +115,7 @@ final class TriggerMigrationTests: XCTestCase {
 
   // MARK: - Physical Unlock Migration
 
-  func testMigratePhysicalUnlockNFC() {
+  func testGivenAnyNFCStop_WhenMigratingPhysicalUnlockNFC_ThenSetsSpecificNFC() {
     var stop = ProfileStopConditions()
     stop.anyNFC = true
 
@@ -130,7 +130,7 @@ final class TriggerMigrationTests: XCTestCase {
     XCTAssertEqual(newStopTagId, "nfc-tag-123")
   }
 
-  func testMigratePhysicalUnlockNFCClearsSameNFC() {
+  func testGivenSameNFCStop_WhenMigratingPhysicalUnlockNFC_ThenClearsSameNFC() {
     // Simulates NFCBlockingStrategy migration path: sameNFC is set,
     // then physical unlock adds specificNFC — sameNFC must be cleared
     var stop = ProfileStopConditions()
@@ -147,7 +147,7 @@ final class TriggerMigrationTests: XCTestCase {
     XCTAssertFalse(newStop.anyNFC)
   }
 
-  func testMigratePhysicalUnlockQR() {
+  func testGivenAnyQRStop_WhenMigratingPhysicalUnlockQR_ThenSetsSpecificQR() {
     var stop = ProfileStopConditions()
     stop.anyQR = true
 
@@ -162,7 +162,7 @@ final class TriggerMigrationTests: XCTestCase {
     XCTAssertEqual(newStopCodeId, QRCodeHasher.hash("qr-code-456"))
   }
 
-  func testMigratePhysicalUnlockQRClearsSameQR() {
+  func testGivenSameQRStop_WhenMigratingPhysicalUnlockQR_ThenClearsSameQR() {
     // Simulates QRCodeBlockingStrategy migration path: sameQR is set,
     // then physical unlock adds specificQR — sameQR must be cleared
     var stop = ProfileStopConditions()
@@ -181,7 +181,7 @@ final class TriggerMigrationTests: XCTestCase {
 
   // MARK: - Schedule Migration
 
-  func testMigrateScheduleToStartAndStop() {
+  func testGivenLegacySchedule_WhenMigrating_ThenSplitsIntoStartAndStop() {
     let legacySchedule = BlockedProfileSchedule(
       days: [.monday, .tuesday],
       startHour: 9,
@@ -202,7 +202,7 @@ final class TriggerMigrationTests: XCTestCase {
     XCTAssertEqual(stopSchedule?.minute, 30)
   }
 
-  func testMigrateNilScheduleReturnsNils() {
+  func testGivenNilSchedule_WhenMigrating_ThenReturnsNils() {
     let (startSchedule, stopSchedule) = TriggerMigration.migrateSchedule(nil)
 
     XCTAssertNil(startSchedule)

--- a/FoqosTests/TriggerPickerOptionsTests.swift
+++ b/FoqosTests/TriggerPickerOptionsTests.swift
@@ -7,24 +7,24 @@ final class TriggerPickerOptionsTests: XCTestCase {
 
   // MARK: - NFCStartOption from triggers
 
-  func testNFCStartOptionNoneWhenBothFalse() {
+  func testGivenBothNFCFlagsFalse_WhenGettingNFCStartOption_ThenReturnsNone() {
     let triggers = ProfileStartTriggers()
     XCTAssertEqual(NFCStartOption.from(triggers), .none)
   }
 
-  func testNFCStartOptionAnyWhenAnyNFC() {
+  func testGivenAnyNFCTrue_WhenGettingNFCStartOption_ThenReturnsAny() {
     var triggers = ProfileStartTriggers()
     triggers.anyNFC = true
     XCTAssertEqual(NFCStartOption.from(triggers), .any)
   }
 
-  func testNFCStartOptionSpecificWhenSpecificNFC() {
+  func testGivenSpecificNFCTrue_WhenGettingNFCStartOption_ThenReturnsSpecific() {
     var triggers = ProfileStartTriggers()
     triggers.specificNFC = true
     XCTAssertEqual(NFCStartOption.from(triggers), .specific)
   }
 
-  func testNFCStartOptionAnyWinsBothTrue() {
+  func testGivenBothNFCFlagsTrue_WhenGettingNFCStartOption_ThenAnyWins() {
     var triggers = ProfileStartTriggers()
     triggers.anyNFC = true
     triggers.specificNFC = true
@@ -33,7 +33,7 @@ final class TriggerPickerOptionsTests: XCTestCase {
 
   // MARK: - NFCStartOption apply to triggers
 
-  func testNFCStartOptionNoneApply() {
+  func testGivenNFCStartOptionNone_WhenApplying_ThenClearsBothFlags() {
     var triggers = ProfileStartTriggers()
     triggers.anyNFC = true
     NFCStartOption.none.apply(to: &triggers)
@@ -41,14 +41,14 @@ final class TriggerPickerOptionsTests: XCTestCase {
     XCTAssertFalse(triggers.specificNFC)
   }
 
-  func testNFCStartOptionAnyApply() {
+  func testGivenNFCStartOptionAny_WhenApplying_ThenSetsAnyNFCTrue() {
     var triggers = ProfileStartTriggers()
     NFCStartOption.any.apply(to: &triggers)
     XCTAssertTrue(triggers.anyNFC)
     XCTAssertFalse(triggers.specificNFC)
   }
 
-  func testNFCStartOptionSpecificApply() {
+  func testGivenNFCStartOptionSpecific_WhenApplying_ThenSetsSpecificNFCTrue() {
     var triggers = ProfileStartTriggers()
     NFCStartOption.specific.apply(to: &triggers)
     XCTAssertFalse(triggers.anyNFC)
@@ -57,24 +57,24 @@ final class TriggerPickerOptionsTests: XCTestCase {
 
   // MARK: - QRStartOption from triggers
 
-  func testQRStartOptionNoneWhenBothFalse() {
+  func testGivenBothQRFlagsFalse_WhenGettingQRStartOption_ThenReturnsNone() {
     let triggers = ProfileStartTriggers()
     XCTAssertEqual(QRStartOption.from(triggers), .none)
   }
 
-  func testQRStartOptionAnyWhenAnyQR() {
+  func testGivenAnyQRTrue_WhenGettingQRStartOption_ThenReturnsAny() {
     var triggers = ProfileStartTriggers()
     triggers.anyQR = true
     XCTAssertEqual(QRStartOption.from(triggers), .any)
   }
 
-  func testQRStartOptionSpecificWhenSpecificQR() {
+  func testGivenSpecificQRTrue_WhenGettingQRStartOption_ThenReturnsSpecific() {
     var triggers = ProfileStartTriggers()
     triggers.specificQR = true
     XCTAssertEqual(QRStartOption.from(triggers), .specific)
   }
 
-  func testQRStartOptionAnyWinsBothTrue() {
+  func testGivenBothQRFlagsTrue_WhenGettingQRStartOption_ThenAnyWins() {
     var triggers = ProfileStartTriggers()
     triggers.anyQR = true
     triggers.specificQR = true
@@ -83,7 +83,7 @@ final class TriggerPickerOptionsTests: XCTestCase {
 
   // MARK: - QRStartOption apply to triggers
 
-  func testQRStartOptionNoneApply() {
+  func testGivenQRStartOptionNone_WhenApplying_ThenClearsBothFlags() {
     var triggers = ProfileStartTriggers()
     triggers.anyQR = true
     QRStartOption.none.apply(to: &triggers)
@@ -91,14 +91,14 @@ final class TriggerPickerOptionsTests: XCTestCase {
     XCTAssertFalse(triggers.specificQR)
   }
 
-  func testQRStartOptionAnyApply() {
+  func testGivenQRStartOptionAny_WhenApplying_ThenSetsAnyQRTrue() {
     var triggers = ProfileStartTriggers()
     QRStartOption.any.apply(to: &triggers)
     XCTAssertTrue(triggers.anyQR)
     XCTAssertFalse(triggers.specificQR)
   }
 
-  func testQRStartOptionSpecificApply() {
+  func testGivenQRStartOptionSpecific_WhenApplying_ThenSetsSpecificQRTrue() {
     var triggers = ProfileStartTriggers()
     QRStartOption.specific.apply(to: &triggers)
     XCTAssertFalse(triggers.anyQR)
@@ -107,30 +107,30 @@ final class TriggerPickerOptionsTests: XCTestCase {
 
   // MARK: - NFCStopOption from conditions
 
-  func testNFCStopOptionNoneWhenAllFalse() {
+  func testGivenAllNFCStopFlagsFalse_WhenGettingNFCStopOption_ThenReturnsNone() {
     let conditions = ProfileStopConditions()
     XCTAssertEqual(NFCStopOption.from(conditions), .none)
   }
 
-  func testNFCStopOptionAnyWhenAnyNFC() {
+  func testGivenAnyNFCStopTrue_WhenGettingNFCStopOption_ThenReturnsAny() {
     var conditions = ProfileStopConditions()
     conditions.anyNFC = true
     XCTAssertEqual(NFCStopOption.from(conditions), .any)
   }
 
-  func testNFCStopOptionSameWhenSameNFC() {
+  func testGivenSameNFCTrue_WhenGettingNFCStopOption_ThenReturnsSame() {
     var conditions = ProfileStopConditions()
     conditions.sameNFC = true
     XCTAssertEqual(NFCStopOption.from(conditions), .same)
   }
 
-  func testNFCStopOptionSpecificWhenSpecificNFC() {
+  func testGivenSpecificNFCStopTrue_WhenGettingNFCStopOption_ThenReturnsSpecific() {
     var conditions = ProfileStopConditions()
     conditions.specificNFC = true
     XCTAssertEqual(NFCStopOption.from(conditions), .specific)
   }
 
-  func testNFCStopOptionSameWinsOverAny() {
+  func testGivenSameAndAnyNFCTrue_WhenGettingNFCStopOption_ThenSameWins() {
     // same is more specific than any, matching canStop precedence
     var conditions = ProfileStopConditions()
     conditions.anyNFC = true
@@ -138,7 +138,7 @@ final class TriggerPickerOptionsTests: XCTestCase {
     XCTAssertEqual(NFCStopOption.from(conditions), .same)
   }
 
-  func testNFCStopOptionSpecificWinsOverSame() {
+  func testGivenSpecificAndSameNFCTrue_WhenGettingNFCStopOption_ThenSpecificWins() {
     // specific is highest priority, matching canStop precedence
     var conditions = ProfileStopConditions()
     conditions.sameNFC = true
@@ -148,7 +148,7 @@ final class TriggerPickerOptionsTests: XCTestCase {
 
   // MARK: - NFCStopOption apply to conditions
 
-  func testNFCStopOptionNoneApply() {
+  func testGivenNFCStopOptionNone_WhenApplying_ThenClearsAllFlags() {
     var conditions = ProfileStopConditions()
     conditions.anyNFC = true
     NFCStopOption.none.apply(to: &conditions)
@@ -157,7 +157,7 @@ final class TriggerPickerOptionsTests: XCTestCase {
     XCTAssertFalse(conditions.specificNFC)
   }
 
-  func testNFCStopOptionAnyApply() {
+  func testGivenNFCStopOptionAny_WhenApplying_ThenSetsAnyNFCTrue() {
     var conditions = ProfileStopConditions()
     NFCStopOption.any.apply(to: &conditions)
     XCTAssertTrue(conditions.anyNFC)
@@ -165,7 +165,7 @@ final class TriggerPickerOptionsTests: XCTestCase {
     XCTAssertFalse(conditions.specificNFC)
   }
 
-  func testNFCStopOptionSameApply() {
+  func testGivenNFCStopOptionSame_WhenApplying_ThenSetsSameNFCTrue() {
     var conditions = ProfileStopConditions()
     NFCStopOption.same.apply(to: &conditions)
     XCTAssertFalse(conditions.anyNFC)
@@ -173,7 +173,7 @@ final class TriggerPickerOptionsTests: XCTestCase {
     XCTAssertFalse(conditions.specificNFC)
   }
 
-  func testNFCStopOptionSpecificApply() {
+  func testGivenNFCStopOptionSpecific_WhenApplying_ThenSetsSpecificNFCTrue() {
     var conditions = ProfileStopConditions()
     NFCStopOption.specific.apply(to: &conditions)
     XCTAssertFalse(conditions.anyNFC)
@@ -183,30 +183,30 @@ final class TriggerPickerOptionsTests: XCTestCase {
 
   // MARK: - QRStopOption from conditions
 
-  func testQRStopOptionNoneWhenAllFalse() {
+  func testGivenAllQRStopFlagsFalse_WhenGettingQRStopOption_ThenReturnsNone() {
     let conditions = ProfileStopConditions()
     XCTAssertEqual(QRStopOption.from(conditions), .none)
   }
 
-  func testQRStopOptionAnyWhenAnyQR() {
+  func testGivenAnyQRStopTrue_WhenGettingQRStopOption_ThenReturnsAny() {
     var conditions = ProfileStopConditions()
     conditions.anyQR = true
     XCTAssertEqual(QRStopOption.from(conditions), .any)
   }
 
-  func testQRStopOptionSameWhenSameQR() {
+  func testGivenSameQRTrue_WhenGettingQRStopOption_ThenReturnsSame() {
     var conditions = ProfileStopConditions()
     conditions.sameQR = true
     XCTAssertEqual(QRStopOption.from(conditions), .same)
   }
 
-  func testQRStopOptionSpecificWhenSpecificQR() {
+  func testGivenSpecificQRStopTrue_WhenGettingQRStopOption_ThenReturnsSpecific() {
     var conditions = ProfileStopConditions()
     conditions.specificQR = true
     XCTAssertEqual(QRStopOption.from(conditions), .specific)
   }
 
-  func testQRStopOptionSameWinsOverAny() {
+  func testGivenSameAndAnyQRTrue_WhenGettingQRStopOption_ThenSameWins() {
     // same is more specific than any, matching canStop precedence
     var conditions = ProfileStopConditions()
     conditions.anyQR = true
@@ -214,7 +214,7 @@ final class TriggerPickerOptionsTests: XCTestCase {
     XCTAssertEqual(QRStopOption.from(conditions), .same)
   }
 
-  func testQRStopOptionSpecificWinsOverSame() {
+  func testGivenSpecificAndSameQRTrue_WhenGettingQRStopOption_ThenSpecificWins() {
     // specific is highest priority, matching canStop precedence
     var conditions = ProfileStopConditions()
     conditions.sameQR = true
@@ -224,7 +224,7 @@ final class TriggerPickerOptionsTests: XCTestCase {
 
   // MARK: - QRStopOption apply to conditions
 
-  func testQRStopOptionNoneApply() {
+  func testGivenQRStopOptionNone_WhenApplying_ThenClearsAllFlags() {
     var conditions = ProfileStopConditions()
     conditions.anyQR = true
     QRStopOption.none.apply(to: &conditions)
@@ -233,7 +233,7 @@ final class TriggerPickerOptionsTests: XCTestCase {
     XCTAssertFalse(conditions.specificQR)
   }
 
-  func testQRStopOptionAnyApply() {
+  func testGivenQRStopOptionAny_WhenApplying_ThenSetsAnyQRTrue() {
     var conditions = ProfileStopConditions()
     QRStopOption.any.apply(to: &conditions)
     XCTAssertTrue(conditions.anyQR)
@@ -241,7 +241,7 @@ final class TriggerPickerOptionsTests: XCTestCase {
     XCTAssertFalse(conditions.specificQR)
   }
 
-  func testQRStopOptionSameApply() {
+  func testGivenQRStopOptionSame_WhenApplying_ThenSetsSameQRTrue() {
     var conditions = ProfileStopConditions()
     QRStopOption.same.apply(to: &conditions)
     XCTAssertFalse(conditions.anyQR)
@@ -249,7 +249,7 @@ final class TriggerPickerOptionsTests: XCTestCase {
     XCTAssertFalse(conditions.specificQR)
   }
 
-  func testQRStopOptionSpecificApply() {
+  func testGivenQRStopOptionSpecific_WhenApplying_ThenSetsSpecificQRTrue() {
     var conditions = ProfileStopConditions()
     QRStopOption.specific.apply(to: &conditions)
     XCTAssertFalse(conditions.anyQR)
@@ -259,21 +259,21 @@ final class TriggerPickerOptionsTests: XCTestCase {
 
   // MARK: - NFCStopOption available options
 
-  func testNFCStopAvailableOptionsWithNoNFCStart() {
+  func testGivenNoNFCStart_WhenGettingAvailableNFCStopOptions_ThenExcludesSame() {
     let start = ProfileStartTriggers()
     let options = NFCStopOption.availableOptions(forStart: start)
     XCTAssertEqual(options, [.none, .any, .specific])
     XCTAssertFalse(options.contains(.same))
   }
 
-  func testNFCStopAvailableOptionsWithAnyNFCStart() {
+  func testGivenAnyNFCStart_WhenGettingAvailableNFCStopOptions_ThenIncludesSame() {
     var start = ProfileStartTriggers()
     start.anyNFC = true
     let options = NFCStopOption.availableOptions(forStart: start)
     XCTAssertEqual(options, [.none, .any, .same, .specific])
   }
 
-  func testNFCStopAvailableOptionsWithSpecificNFCStart() {
+  func testGivenSpecificNFCStart_WhenGettingAvailableNFCStopOptions_ThenIncludesSame() {
     var start = ProfileStartTriggers()
     start.specificNFC = true
     let options = NFCStopOption.availableOptions(forStart: start)
@@ -282,20 +282,20 @@ final class TriggerPickerOptionsTests: XCTestCase {
 
   // MARK: - QRStopOption available options
 
-  func testQRStopAvailableOptionsWithNoQRStart() {
+  func testGivenNoQRStart_WhenGettingAvailableQRStopOptions_ThenExcludesSame() {
     let start = ProfileStartTriggers()
     let options = QRStopOption.availableOptions(forStart: start)
     XCTAssertEqual(options, [.none, .any, .specific])
   }
 
-  func testQRStopAvailableOptionsWithAnyQRStart() {
+  func testGivenAnyQRStart_WhenGettingAvailableQRStopOptions_ThenIncludesSame() {
     var start = ProfileStartTriggers()
     start.anyQR = true
     let options = QRStopOption.availableOptions(forStart: start)
     XCTAssertEqual(options, [.none, .any, .same, .specific])
   }
 
-  func testQRStopAvailableOptionsWithSpecificQRStart() {
+  func testGivenSpecificQRStart_WhenGettingAvailableQRStopOptions_ThenIncludesSame() {
     var start = ProfileStartTriggers()
     start.specificQR = true
     let options = QRStopOption.availableOptions(forStart: start)
@@ -304,26 +304,26 @@ final class TriggerPickerOptionsTests: XCTestCase {
 
   // MARK: - Display labels
 
-  func testNFCStartOptionLabels() {
+  func testGivenNFCStartOptions_WhenGettingLabels_ThenReturnsExpectedStrings() {
     XCTAssertEqual(NFCStartOption.none.label, "None")
     XCTAssertEqual(NFCStartOption.any.label, "Any tag")
     XCTAssertEqual(NFCStartOption.specific.label, "Specific tag")
   }
 
-  func testNFCStopOptionLabels() {
+  func testGivenNFCStopOptions_WhenGettingLabels_ThenReturnsExpectedStrings() {
     XCTAssertEqual(NFCStopOption.none.label, "None")
     XCTAssertEqual(NFCStopOption.any.label, "Any tag")
     XCTAssertEqual(NFCStopOption.same.label, "Same tag")
     XCTAssertEqual(NFCStopOption.specific.label, "Specific tag")
   }
 
-  func testQRStartOptionLabels() {
+  func testGivenQRStartOptions_WhenGettingLabels_ThenReturnsExpectedStrings() {
     XCTAssertEqual(QRStartOption.none.label, "None")
     XCTAssertEqual(QRStartOption.any.label, "Any code")
     XCTAssertEqual(QRStartOption.specific.label, "Specific code")
   }
 
-  func testQRStopOptionLabels() {
+  func testGivenQRStopOptions_WhenGettingLabels_ThenReturnsExpectedStrings() {
     XCTAssertEqual(QRStopOption.none.label, "None")
     XCTAssertEqual(QRStopOption.any.label, "Any code")
     XCTAssertEqual(QRStopOption.same.label, "Same code")

--- a/FoqosTests/TriggerValidatorTests.swift
+++ b/FoqosTests/TriggerValidatorTests.swift
@@ -8,49 +8,49 @@ final class TriggerValidatorTests: XCTestCase {
 
   // MARK: - Stop Availability
 
-  func testSameNFCAvailableWhenAnyNFCStart() {
+  func testGivenAnyNFCStart_WhenCheckingSameNFCAvailable_ThenReturnsTrue() {
     var start = ProfileStartTriggers()
     start.anyNFC = true
     XCTAssertTrue(validator.isStopAvailable(.sameNFC, forStart: start))
   }
 
-  func testSameNFCAvailableWhenSpecificNFCStart() {
+  func testGivenSpecificNFCStart_WhenCheckingSameNFCAvailable_ThenReturnsTrue() {
     var start = ProfileStartTriggers()
     start.specificNFC = true
     XCTAssertTrue(validator.isStopAvailable(.sameNFC, forStart: start))
   }
 
-  func testSameNFCNotAvailableWhenNoNFCStart() {
+  func testGivenNoNFCStart_WhenCheckingSameNFCAvailable_ThenReturnsFalse() {
     var start = ProfileStartTriggers()
     start.manual = true
     XCTAssertFalse(validator.isStopAvailable(.sameNFC, forStart: start))
   }
 
-  func testSameQRAvailableWhenAnyQRStart() {
+  func testGivenAnyQRStart_WhenCheckingSameQRAvailable_ThenReturnsTrue() {
     var start = ProfileStartTriggers()
     start.anyQR = true
     XCTAssertTrue(validator.isStopAvailable(.sameQR, forStart: start))
   }
 
-  func testSameQRNotAvailableWhenNoQRStart() {
+  func testGivenNoQRStart_WhenCheckingSameQRAvailable_ThenReturnsFalse() {
     var start = ProfileStartTriggers()
     start.manual = true
     XCTAssertFalse(validator.isStopAvailable(.sameQR, forStart: start))
   }
 
-  func testManualStopAlwaysAvailable() {
+  func testGivenAnyStartTrigger_WhenCheckingManualStopAvailable_ThenReturnsTrue() {
     let start = ProfileStartTriggers()
     XCTAssertTrue(validator.isStopAvailable(.manual, forStart: start))
   }
 
-  func testTimerStopAlwaysAvailable() {
+  func testGivenAnyStartTrigger_WhenCheckingTimerStopAvailable_ThenReturnsTrue() {
     let start = ProfileStartTriggers()
     XCTAssertTrue(validator.isStopAvailable(.timer, forStart: start))
   }
 
   // MARK: - Unavailability Reasons
 
-  func testSameNFCUnavailabilityReason() {
+  func testGivenNoNFCStart_WhenGettingSameNFCReason_ThenMentionsNFC() {
     var start = ProfileStartTriggers()
     start.manual = true
     let reason = validator.unavailabilityReason(.sameNFC, forStart: start)
@@ -58,7 +58,7 @@ final class TriggerValidatorTests: XCTestCase {
     XCTAssertTrue(reason!.contains("NFC"))
   }
 
-  func testSameQRUnavailabilityReason() {
+  func testGivenNoQRStart_WhenGettingSameQRReason_ThenMentionsQR() {
     var start = ProfileStartTriggers()
     start.manual = true
     let reason = validator.unavailabilityReason(.sameQR, forStart: start)
@@ -66,7 +66,7 @@ final class TriggerValidatorTests: XCTestCase {
     XCTAssertTrue(reason!.contains("QR"))
   }
 
-  func testNoReasonWhenAvailable() {
+  func testGivenNFCStartEnabled_WhenGettingSameNFCReason_ThenReturnsNil() {
     var start = ProfileStartTriggers()
     start.anyNFC = true
     XCTAssertNil(validator.unavailabilityReason(.sameNFC, forStart: start))
@@ -74,7 +74,7 @@ final class TriggerValidatorTests: XCTestCase {
 
   // MARK: - Auto-Fix
 
-  func testAutoFixRemovesSameNFCWhenNoNFCStart() {
+  func testGivenNoNFCStart_WhenAutoFixing_ThenRemovesSameNFC() {
     var start = ProfileStartTriggers()
     start.manual = true
     var stop = ProfileStopConditions()
@@ -85,7 +85,7 @@ final class TriggerValidatorTests: XCTestCase {
     XCTAssertFalse(stop.sameNFC)
   }
 
-  func testAutoFixRemovesSameQRWhenNoQRStart() {
+  func testGivenNoQRStart_WhenAutoFixing_ThenRemovesSameQR() {
     var start = ProfileStartTriggers()
     start.manual = true
     var stop = ProfileStopConditions()
@@ -96,7 +96,7 @@ final class TriggerValidatorTests: XCTestCase {
     XCTAssertFalse(stop.sameQR)
   }
 
-  func testAutoFixPreservesSameNFCWhenNFCStart() {
+  func testGivenNFCStartEnabled_WhenAutoFixing_ThenPreservesSameNFC() {
     var start = ProfileStartTriggers()
     start.anyNFC = true
     var stop = ProfileStopConditions()
@@ -109,7 +109,7 @@ final class TriggerValidatorTests: XCTestCase {
 
   // MARK: - Validation Errors
 
-  func testValidateReturnsErrorWhenNoStartTrigger() {
+  func testGivenNoStartTrigger_WhenValidating_ThenReturnsStartError() {
     let start = ProfileStartTriggers()
     var stop = ProfileStopConditions()
     stop.manual = true
@@ -119,7 +119,7 @@ final class TriggerValidatorTests: XCTestCase {
     XCTAssertTrue(errors.contains { $0.contains("start trigger") })
   }
 
-  func testValidateReturnsErrorWhenNoStopCondition() {
+  func testGivenNoStopCondition_WhenValidating_ThenReturnsStopError() {
     var start = ProfileStartTriggers()
     start.manual = true
     let stop = ProfileStopConditions()
@@ -129,7 +129,7 @@ final class TriggerValidatorTests: XCTestCase {
     XCTAssertTrue(errors.contains { $0.contains("stop condition") })
   }
 
-  func testValidateReturnsNoErrorsWhenValid() {
+  func testGivenValidStartAndStop_WhenValidating_ThenReturnsNoErrors() {
     var start = ProfileStartTriggers()
     start.manual = true
     var stop = ProfileStopConditions()

--- a/FoqosTests/WeekdayLocaleOrderTests.swift
+++ b/FoqosTests/WeekdayLocaleOrderTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class WeekdayLocaleOrderTests: XCTestCase {
 
-  func testLocaleOrdered_sundayFirst_returnsSundayFirst() {
+  func testGivenSundayFirstLocale_WhenOrdering_ThenSundayIsFirst() {
     var calendar = Calendar(identifier: .gregorian)
     calendar.firstWeekday = 1  // Sunday
     let ordered = Weekday.localeOrdered(calendar: calendar)
@@ -14,7 +14,7 @@ final class WeekdayLocaleOrderTests: XCTestCase {
     XCTAssertEqual(ordered.count, 7)
   }
 
-  func testLocaleOrdered_mondayFirst_returnsMondayFirst() {
+  func testGivenMondayFirstLocale_WhenOrdering_ThenMondayIsFirst() {
     var calendar = Calendar(identifier: .gregorian)
     calendar.firstWeekday = 2  // Monday
     let ordered = Weekday.localeOrdered(calendar: calendar)
@@ -23,7 +23,7 @@ final class WeekdayLocaleOrderTests: XCTestCase {
     XCTAssertEqual(ordered.count, 7)
   }
 
-  func testLocaleOrdered_saturdayFirst_returnsSaturdayFirst() {
+  func testGivenSaturdayFirstLocale_WhenOrdering_ThenSaturdayIsFirst() {
     var calendar = Calendar(identifier: .gregorian)
     calendar.firstWeekday = 7  // Saturday
     let ordered = Weekday.localeOrdered(calendar: calendar)
@@ -32,14 +32,14 @@ final class WeekdayLocaleOrderTests: XCTestCase {
     XCTAssertEqual(ordered.count, 7)
   }
 
-  func testLocaleOrdered_containsAllDays() {
+  func testGivenAnyLocale_WhenOrdering_ThenContainsAllDays() {
     var calendar = Calendar(identifier: .gregorian)
     calendar.firstWeekday = 2
     let ordered = Weekday.localeOrdered(calendar: calendar)
     XCTAssertEqual(Set(ordered), Set(Weekday.allCases))
   }
 
-  func testLocaleSorted_sortsSubsetByLocaleOrder() {
+  func testGivenMondayFirstLocale_WhenSortingSubset_ThenSortsByLocaleOrder() {
     var calendar = Calendar(identifier: .gregorian)
     calendar.firstWeekday = 2  // Monday-first
 
@@ -49,7 +49,7 @@ final class WeekdayLocaleOrderTests: XCTestCase {
     XCTAssertEqual(sorted, [.monday, .wednesday, .sunday])
   }
 
-  func testLocaleSorted_sundayFirst_sortsSubsetByLocaleOrder() {
+  func testGivenSundayFirstLocale_WhenSortingSubset_ThenSortsByLocaleOrder() {
     var calendar = Calendar(identifier: .gregorian)
     calendar.firstWeekday = 1  // Sunday-first
 
@@ -61,22 +61,22 @@ final class WeekdayLocaleOrderTests: XCTestCase {
 
   // MARK: - compactDaysText
 
-  func testCompactDaysText_allDays_returnsEveryDay() {
+  func testGivenAllDays_WhenGettingCompactText_ThenReturnsEveryDay() {
     let days = Weekday.allCases
     XCTAssertEqual(days.compactDaysText(), "Every day")
   }
 
-  func testCompactDaysText_weekdays_returnsWeekdays() {
+  func testGivenWeekdaysOnly_WhenGettingCompactText_ThenReturnsWeekdays() {
     let days: [Weekday] = [.monday, .tuesday, .wednesday, .thursday, .friday]
     XCTAssertEqual(days.compactDaysText(), "Weekdays")
   }
 
-  func testCompactDaysText_weekends_returnsWeekends() {
+  func testGivenWeekendsOnly_WhenGettingCompactText_ThenReturnsWeekends() {
     let days: [Weekday] = [.saturday, .sunday]
     XCTAssertEqual(days.compactDaysText(), "Weekends")
   }
 
-  func testCompactDaysText_subset_returnsShortLabels() {
+  func testGivenDaySubset_WhenGettingCompactText_ThenReturnsShortLabels() {
     var calendar = Calendar(identifier: .gregorian)
     calendar.firstWeekday = 2  // Monday-first
     let days: [Weekday] = [.sunday, .wednesday, .monday]


### PR DESCRIPTION
## Summary
- Renames 271 test methods across 22 files to follow the `testGivenX_WhenY_ThenZ()` convention from AGENTS.md
- Pure rename refactor — no logic or test body changes
- Closes #137

## Test plan
- [x] All tests pass before rename (green baseline)
- [x] All tests pass after rename (same count, same behavior)
- [x] swift-format applied to all modified files
- [x] Diff verified: every changed line is a `func test` declaration only

## Summary by Sourcery

Enhancements:
- Align test naming in multiple XCTest files with the Given/When/Then pattern for clearer intent and consistency.