### PR TITLE
fix(#178): iCloud shown as not available for users without family share

### DIFF
--- a/Foqos/CloudKit/CloudKitNetworkService+Verification.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Verification.swift
@@ -65,17 +65,11 @@ extension CloudKitNetworkService {
     Log.info("verifySelfFamilyMember: starting", category: .cloudKit)
 
     guard let zone = await findSharedZoneByName() else {
-      // No shared zone, but still check if iCloud account is available
-      // so the UI doesn't show "iCloud Not Available" for signed-in users.
-      let accountResult = await checkAccountStatus()
       Log.info(
-        "verifySelfFamilyMember: no shared zone, signed in: \(accountResult.isSignedIn) (\(String(format: "%.2f", CFAbsoluteTimeGetCurrent() - start))s)",
+        "verifySelfFamilyMember: no shared zone (\(String(format: "%.2f", CFAbsoluteTimeGetCurrent() - start))s)",
         category: .cloudKit)
       return VerificationResult(
-        isConnected: false,
-        userRecordID: accountResult.userRecordID ?? cachedUserRecordID,
-        isSignedIn: accountResult.isSignedIn,
-        enforcedMode: nil)
+        isConnected: false, userRecordID: cachedUserRecordID, isSignedIn: nil, enforcedMode: nil)
     }
     Log.info(
       "verifySelfFamilyMember: found zone (\(String(format: "%.2f", CFAbsoluteTimeGetCurrent() - start))s)",

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -129,6 +129,8 @@ struct FoqosApp: App {
           Log.debug("scenePhase changed from \(oldPhase) to \(newPhase)", category: .app)
           if newPhase == .active {
             Task {
+              // Determine iCloud sign-in status (independent of family sharing)
+              await CloudKitManager.shared.checkAccountStatus()
               // Enforce CloudKit FamilyMember role as local app mode (must complete before auth check)
               await CloudKitManager.shared.verifySelfFamilyMemberRecord()
               // Verify child authorization when app becomes active


### PR DESCRIPTION
## Summary
- Fixes #178 — "iCloud not available" banner showing on ParentDashboardView for signed-in users
- `CloudKitManager.isSignedIn` defaulted to `false` and was never updated when user had no family shared zone, because `checkAccountStatus()` was never called in the app lifecycle
- Added `checkAccountStatus()` as a dedicated step in the scene-active handler, giving iCloud sign-in status its own lifecycle independent of family member verification
- Also fixes the "Connected"/"Not Connected" status display in ChildDashboardView, which reads the same property

## Test plan
- [ ] Build succeeds (verified locally)
- [ ] All tests pass (verified locally)
- [ ] On a device signed into iCloud without a family share, the "iCloud Not Available" banner no longer appears on ParentDashboardView
- [ ] On a device NOT signed into iCloud, the banner still correctly appears
- [ ] ChildDashboardView shows "Connected" for signed-in users without a family share

## Summary by Sourcery

Ensure iCloud account status is checked when the app becomes active so dashboard views show accurate connectivity state.

Bug Fixes:
- Prevent falsely showing the 'iCloud not available' banner for users who are signed into iCloud but do not have family sharing enabled.
- Correct the iCloud 'Connected'/'Not Connected' status display in the child dashboard for signed-in users without a family share.