### PR TITLE
feat(#190): child device heartbeat monitoring

### DIFF
--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -217,8 +217,8 @@ class CloudKitManager: ObservableObject {
     try await networkService.writeHeartbeat(heartbeat)
   }
 
-  func fetchHeartbeats() async throws -> [DeviceHeartbeat] {
-    return try await networkService.fetchHeartbeats()
+  func fetchHeartbeats() async -> [DeviceHeartbeat] {
+    return await networkService.fetchHeartbeats()
   }
 
   func deleteHeartbeat(childUserRecordName: String, deviceIdentifier: String) async throws {

--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -206,6 +206,21 @@ class CloudKitManager: ObservableObject {
     self.familyMembers = result.familyMembers
   }
 
+  // MARK: - Heartbeat
+
+  func writeHeartbeat(_ heartbeat: DeviceHeartbeat) async throws {
+    try await networkService.writeHeartbeat(heartbeat)
+  }
+
+  func fetchHeartbeats() async throws -> [DeviceHeartbeat] {
+    return try await networkService.fetchHeartbeats()
+  }
+
+  func deleteHeartbeat(childUserRecordName: String, deviceIdentifier: String) async throws {
+    try await networkService.deleteHeartbeat(
+      childUserRecordName: childUserRecordName, deviceIdentifier: deviceIdentifier)
+  }
+
   // MARK: - Connection Status
 
   func checkFamilyConnectionStatus() async -> Bool {

--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -162,6 +162,11 @@ class CloudKitManager: ObservableObject {
     let participants = await networkService.refreshShareParticipants()
     self.shareParticipants = participants
     self.isShareOwner = await networkService.getIsShareOwner()
+
+    // Upgrade child permissions to readWrite for heartbeat writes (#190)
+    if isShareOwner {
+      await networkService.upgradeSharePermissionsIfNeeded()
+    }
   }
 
   // MARK: - Share Acceptance

--- a/Foqos/CloudKit/CloudKitNetworkService+Heartbeat.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Heartbeat.swift
@@ -1,0 +1,84 @@
+import CloudKit
+import Foundation
+
+extension CloudKitNetworkService {
+
+  // MARK: - Child: Write Heartbeat
+
+  /// Write heartbeat to the shared zone. Called by child device on profile activation.
+  /// Uses the shared database — child must have readWrite permission on the shared zone.
+  func writeHeartbeat(_ heartbeat: DeviceHeartbeat) async throws {
+    guard let zone = await findSharedZoneByName() else {
+      throw CloudKitError.notConnectedToFamily
+    }
+
+    let record = heartbeat.toCKRecord(in: zone.zoneID)
+
+    let operation = CKModifyRecordsOperation(recordsToSave: [record], recordIDsToDelete: nil)
+    operation.savePolicy = .changedKeys
+
+    let database = self.sharedDatabase
+
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      operation.modifyRecordsResultBlock = { result in
+        switch result {
+        case .success:
+          Log.info("Heartbeat written successfully", category: .cloudKit)
+          continuation.resume()
+        case .failure(let error):
+          Log.warning("Failed to write heartbeat: \(error)", category: .cloudKit)
+          continuation.resume(throwing: error)
+        }
+      }
+      database.add(operation)
+    }
+  }
+
+  // MARK: - Parent: Fetch Heartbeats
+
+  /// Fetch all heartbeat records from the private database. Called by parent device.
+  func fetchHeartbeats() async throws -> [DeviceHeartbeat] {
+    let query = CKQuery(
+      recordType: DeviceHeartbeat.recordType,
+      predicate: NSPredicate(value: true)
+    )
+
+    var allHeartbeats: [DeviceHeartbeat] = []
+
+    if policyZoneVerified {
+      do {
+        let (results, _) = try await privateDatabase.records(
+          matching: query, inZoneWith: policyZoneID)
+
+        for (_, result) in results {
+          if case .success(let record) = result,
+            let heartbeat = DeviceHeartbeat(from: record)
+          {
+            allHeartbeats.append(heartbeat)
+          }
+        }
+      } catch {
+        Log.error("Failed to fetch heartbeats from private DB: \(error)", category: .cloudKit)
+      }
+    }
+
+    return allHeartbeats
+  }
+
+  // MARK: - Parent: Delete Heartbeat
+
+  /// Delete a heartbeat record (when parent removes a device).
+  func deleteHeartbeat(childUserRecordName: String, deviceIdentifier: String) async throws {
+    let recordName = DeviceHeartbeat.recordName(
+      childUserRecordName: childUserRecordName, deviceIdentifier: deviceIdentifier)
+    let recordID = CKRecord.ID(recordName: recordName, zoneID: policyZoneID)
+
+    do {
+      try await privateDatabase.deleteRecord(withID: recordID)
+      Log.info("Deleted heartbeat record: \(recordName)", category: .cloudKit)
+    } catch {
+      Log.error("Failed to delete heartbeat: \(error)", category: .cloudKit)
+      throw CloudKitError.deleteFailed(error)
+    }
+  }
+}

--- a/Foqos/CloudKit/CloudKitNetworkService+Heartbeat.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Heartbeat.swift
@@ -37,7 +37,7 @@ extension CloudKitNetworkService {
   // MARK: - Parent: Fetch Heartbeats
 
   /// Fetch all heartbeat records from the private database. Called by parent device.
-  func fetchHeartbeats() async throws -> [DeviceHeartbeat] {
+  func fetchHeartbeats() async -> [DeviceHeartbeat] {
     let query = CKQuery(
       recordType: DeviceHeartbeat.recordType,
       predicate: NSPredicate(value: true)

--- a/Foqos/CloudKit/CloudKitNetworkService+Heartbeat.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Heartbeat.swift
@@ -36,29 +36,53 @@ extension CloudKitNetworkService {
 
   // MARK: - Parent: Fetch Heartbeats
 
-  /// Fetch all heartbeat records from the private database. Called by parent device.
+  /// Fetch all heartbeat records. Called by parent device.
+  /// Owner reads from private DB; co-parents read from shared DB.
   func fetchHeartbeats() async -> [DeviceHeartbeat] {
-    let query = CKQuery(
-      recordType: DeviceHeartbeat.recordType,
-      predicate: NSPredicate(value: true)
-    )
-
     var allHeartbeats: [DeviceHeartbeat] = []
+    var seenRecordNames: Set<String> = []
 
+    // Owner reads from private DB
     if policyZoneVerified {
+      let query = CKQuery(
+        recordType: DeviceHeartbeat.recordType,
+        predicate: NSPredicate(value: true)
+      )
       do {
         let (results, _) = try await privateDatabase.records(
           matching: query, inZoneWith: policyZoneID)
-
         for (_, result) in results {
           if case .success(let record) = result,
+            let heartbeat = DeviceHeartbeat(from: record)
+          {
+            seenRecordNames.insert(record.recordID.recordName)
+            allHeartbeats.append(heartbeat)
+          }
+        }
+      } catch {
+        Log.error("Failed to fetch heartbeats from private DB: \(error)", category: .cloudKit)
+      }
+    }
+
+    // Co-parent reads from shared DB
+    if let zone = await findSharedZoneByName() {
+      let query = CKQuery(
+        recordType: DeviceHeartbeat.recordType,
+        predicate: NSPredicate(value: true)
+      )
+      do {
+        let (results, _) = try await sharedDatabase.records(
+          matching: query, inZoneWith: zone.zoneID)
+        for (_, result) in results {
+          if case .success(let record) = result,
+            !seenRecordNames.contains(record.recordID.recordName),
             let heartbeat = DeviceHeartbeat(from: record)
           {
             allHeartbeats.append(heartbeat)
           }
         }
       } catch {
-        Log.error("Failed to fetch heartbeats from private DB: \(error)", category: .cloudKit)
+        Log.error("Failed to fetch heartbeats from shared DB: \(error)", category: .cloudKit)
       }
     }
 
@@ -68,16 +92,35 @@ extension CloudKitNetworkService {
   // MARK: - Parent: Delete Heartbeat
 
   /// Delete a heartbeat record (when parent removes a device).
+  /// Tries private DB first (share owner), falls back to shared DB (co-parent).
   func deleteHeartbeat(childUserRecordName: String, deviceIdentifier: String) async throws {
     let recordName = DeviceHeartbeat.recordName(
       childUserRecordName: childUserRecordName, deviceIdentifier: deviceIdentifier)
-    let recordID = CKRecord.ID(recordName: recordName, zoneID: policyZoneID)
 
+    // Try private DB first (share owner)
+    if policyZoneVerified {
+      let recordID = CKRecord.ID(recordName: recordName, zoneID: policyZoneID)
+      do {
+        try await privateDatabase.deleteRecord(withID: recordID)
+        Log.info("Deleted heartbeat record from private DB: \(recordName)", category: .cloudKit)
+        return
+      } catch let error as CKError where error.code == .unknownItem {
+        Log.debug("Heartbeat not in private DB, trying shared DB", category: .cloudKit)
+      } catch {
+        Log.error("Failed to delete heartbeat from private DB: \(error)", category: .cloudKit)
+      }
+    }
+
+    // Fall back to shared DB (co-parent)
+    guard let zone = await findSharedZoneByName() else {
+      throw CloudKitError.notConnectedToFamily
+    }
+    let sharedRecordID = CKRecord.ID(recordName: recordName, zoneID: zone.zoneID)
     do {
-      try await privateDatabase.deleteRecord(withID: recordID)
-      Log.info("Deleted heartbeat record: \(recordName)", category: .cloudKit)
+      try await sharedDatabase.deleteRecord(withID: sharedRecordID)
+      Log.info("Deleted heartbeat record from shared DB: \(recordName)", category: .cloudKit)
     } catch {
-      Log.error("Failed to delete heartbeat: \(error)", category: .cloudKit)
+      Log.error("Failed to delete heartbeat from shared DB: \(error)", category: .cloudKit)
       throw CloudKitError.deleteFailed(error)
     }
   }

--- a/Foqos/CloudKit/CloudKitNetworkService+Sharing.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Sharing.swift
@@ -119,6 +119,40 @@ extension CloudKitNetworkService {
     }
   }
 
+  // MARK: - Share Permission Upgrade
+
+  /// Upgrade share participant permissions from readOnly to readWrite.
+  /// Required for child devices to write heartbeat records.
+  func upgradeSharePermissionsIfNeeded() async {
+    guard let share = activeZoneShare else {
+      Log.debug("No active share to upgrade permissions", category: .cloudKit)
+      return
+    }
+
+    let participants = share.participants.filter { $0.role != .owner }
+    var needsSave = false
+
+    for participant in participants {
+      if participant.permission == .readOnly {
+        participant.permission = .readWrite
+        needsSave = true
+        Log.info(
+          "Upgrading participant permission to readWrite",
+          category: .cloudKit)
+      }
+    }
+
+    guard needsSave else { return }
+
+    do {
+      _ = try await privateDatabase.save(share)
+      self.activeZoneShare = share
+      Log.info("Share permissions upgraded to readWrite", category: .cloudKit)
+    } catch {
+      Log.error("Failed to upgrade share permissions: \(error)", category: .cloudKit)
+    }
+  }
+
   // MARK: - Share Acceptance
 
   func acceptShareDirect(metadata: CKShare.Metadata) async throws {

--- a/Foqos/Components/Parent/DeviceStatusCard.swift
+++ b/Foqos/Components/Parent/DeviceStatusCard.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct DeviceStatusCard: View {
+  let device: MonitoredDevice
+  let onSuppress: () -> Void
+  let onRemove: () -> Void
+
+  private var statusColor: Color {
+    if device.isSuppressed { return .secondary }
+    if device.shouldAlert() { return .red }
+    return .green
+  }
+
+  private var statusText: String {
+    if device.isSuppressed { return "Alerts suppressed" }
+    if device.shouldAlert() { return "Not seen recently" }
+    return "Active"
+  }
+
+  private var lastSeenText: String {
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .short
+    return formatter.localizedString(for: device.lastSeenAt, relativeTo: Date())
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack {
+        Image(systemName: "iphone")
+          .foregroundColor(statusColor)
+        Text(device.deviceName)
+          .font(.subheadline.weight(.medium))
+        Spacer()
+        Circle()
+          .fill(statusColor)
+          .frame(width: 8, height: 8)
+      }
+
+      HStack {
+        Text(statusText)
+          .font(.caption)
+          .foregroundColor(statusColor)
+        Spacer()
+        Text("Last seen \(lastSeenText)")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      }
+
+      HStack(spacing: 12) {
+        Button(device.isSuppressed ? "Unsuppress" : "Suppress") {
+          onSuppress()
+        }
+        .font(.caption)
+
+        Button("Remove", role: .destructive) {
+          onRemove()
+        }
+        .font(.caption)
+      }
+    }
+    .padding()
+    .background(Color(.secondarySystemGroupedBackground))
+    .cornerRadius(12)
+  }
+}

--- a/Foqos/Components/Parent/DeviceStatusCard.swift
+++ b/Foqos/Components/Parent/DeviceStatusCard.swift
@@ -7,13 +7,15 @@ struct DeviceStatusCard: View {
 
   private var statusColor: Color {
     if device.isSuppressed { return .secondary }
-    if device.shouldAlert() { return .red }
+    if device.isAuthRevoked { return .red }
+    if device.isStale() { return .orange }
     return .green
   }
 
   private var statusText: String {
     if device.isSuppressed { return "Alerts suppressed" }
-    if device.shouldAlert() { return "Not seen recently" }
+    if device.isAuthRevoked { return "Permissions revoked" }
+    if device.isStale() { return "Not seen recently" }
     return "Active"
   }
 

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -350,6 +350,10 @@ class AppDelegate: NSObject, UIApplicationDelegate {
       // Handle the notification via ProfileSyncManager
       Task {
         await ProfileSyncManager.shared.handleRemoteNotification()
+        // Refresh heartbeats for parent monitoring (#190)
+        if AppModeManager.shared.currentMode == .parent {
+          await HeartbeatManager.shared.refreshHeartbeats()
+        }
         completionHandler(.newData)
       }
     } else {

--- a/Foqos/Models/DeviceHeartbeat.swift
+++ b/Foqos/Models/DeviceHeartbeat.swift
@@ -1,0 +1,70 @@
+import CloudKit
+import Foundation
+
+/// Heartbeat record written by child devices on profile activation.
+/// Parent monitors freshness to detect permission revocation or app removal.
+struct DeviceHeartbeat: Codable, Identifiable {
+  var id: String {
+    DeviceHeartbeat.recordName(
+      childUserRecordName: childUserRecordName, deviceIdentifier: deviceIdentifier)
+  }
+  var childUserRecordName: String
+  var deviceIdentifier: String
+  var deviceName: String
+  var lastHeartbeatAt: Date
+  var authorizationStatus: String
+
+  static let recordType = "DeviceHeartbeat"
+
+  static func recordName(childUserRecordName: String, deviceIdentifier: String) -> String {
+    "heartbeat-\(childUserRecordName)-\(deviceIdentifier)"
+  }
+}
+
+// MARK: - CloudKit Record Conversion
+
+extension DeviceHeartbeat {
+  private enum RecordKey {
+    static let childUserRecordName = "childUserRecordName"
+    static let deviceIdentifier = "deviceIdentifier"
+    static let deviceName = "deviceName"
+    static let lastHeartbeatAt = "lastHeartbeatAt"
+    static let authorizationStatus = "authorizationStatus"
+  }
+
+  init?(from record: CKRecord) {
+    guard record.recordType == DeviceHeartbeat.recordType,
+      let childUserRecordName = record[RecordKey.childUserRecordName] as? String,
+      let deviceIdentifier = record[RecordKey.deviceIdentifier] as? String,
+      let deviceName = record[RecordKey.deviceName] as? String,
+      let lastHeartbeatAt = record[RecordKey.lastHeartbeatAt] as? Date,
+      let authorizationStatus = record[RecordKey.authorizationStatus] as? String
+    else {
+      return nil
+    }
+
+    self.childUserRecordName = childUserRecordName
+    self.deviceIdentifier = deviceIdentifier
+    self.deviceName = deviceName
+    self.lastHeartbeatAt = lastHeartbeatAt
+    self.authorizationStatus = authorizationStatus
+  }
+
+  func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
+    let recordName = DeviceHeartbeat.recordName(
+      childUserRecordName: childUserRecordName, deviceIdentifier: deviceIdentifier)
+    let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
+    let record = CKRecord(recordType: DeviceHeartbeat.recordType, recordID: recordID)
+
+    record[RecordKey.childUserRecordName] = childUserRecordName
+    record[RecordKey.deviceIdentifier] = deviceIdentifier
+    record[RecordKey.deviceName] = deviceName
+    record[RecordKey.lastHeartbeatAt] = lastHeartbeatAt
+    record[RecordKey.authorizationStatus] = authorizationStatus
+
+    let familyRootID = CKRecord.ID(recordName: "FamilyRoot", zoneID: zoneID)
+    record.parent = CKRecord.Reference(recordID: familyRootID, action: .none)
+
+    return record
+  }
+}

--- a/Foqos/Models/MonitoredDevice.swift
+++ b/Foqos/Models/MonitoredDevice.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Parent-side record tracking a child's device heartbeat status.
 /// Stored in UserDefaults — each parent manages their own list.
 struct MonitoredDevice: Codable, Identifiable {
-  var id: String { deviceIdentifier }
+  var id: String { "\(childUserRecordName)|\(deviceIdentifier)" }
   var deviceIdentifier: String
   var deviceName: String
   var childUserRecordName: String

--- a/Foqos/Models/MonitoredDevice.swift
+++ b/Foqos/Models/MonitoredDevice.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Parent-side record tracking a child's device heartbeat status.
+/// Stored in UserDefaults — each parent manages their own list.
+struct MonitoredDevice: Codable, Identifiable {
+  var id: String { deviceIdentifier }
+  var deviceIdentifier: String
+  var deviceName: String
+  var childUserRecordName: String
+  var lastSeenAt: Date
+  var isSuppressed: Bool
+  var notificationIdentifier: String?
+
+  static let stalenessThreshold: TimeInterval = 24 * 3600  // 24 hours
+
+  func isStale(now: Date = Date()) -> Bool {
+    now.timeIntervalSince(lastSeenAt) >= Self.stalenessThreshold
+  }
+
+  func shouldAlert(now: Date = Date()) -> Bool {
+    !isSuppressed && isStale(now: now)
+  }
+}

--- a/Foqos/Models/MonitoredDevice.swift
+++ b/Foqos/Models/MonitoredDevice.swift
@@ -10,14 +10,19 @@ struct MonitoredDevice: Codable, Identifiable {
   var lastSeenAt: Date
   var isSuppressed: Bool
   var notificationIdentifier: String?
+  var authorizationStatus: String?
 
   static let stalenessThreshold: TimeInterval = 24 * 3600  // 24 hours
+
+  var isAuthRevoked: Bool {
+    authorizationStatus == "denied"
+  }
 
   func isStale(now: Date = Date()) -> Bool {
     now.timeIntervalSince(lastSeenAt) >= Self.stalenessThreshold
   }
 
   func shouldAlert(now: Date = Date()) -> Bool {
-    !isSuppressed && isStale(now: now)
+    !isSuppressed && (isAuthRevoked || isStale(now: now))
   }
 }

--- a/Foqos/Utils/HeartbeatManager.swift
+++ b/Foqos/Utils/HeartbeatManager.swift
@@ -1,0 +1,201 @@
+import FamilyControls
+import Foundation
+import UIKit
+
+/// Manages device heartbeat lifecycle for both child and parent modes.
+@MainActor
+class HeartbeatManager: ObservableObject {
+  static let shared = HeartbeatManager()
+
+  private let userDefaultsKey = "family_foqos_monitored_devices"
+  private let notificationEnabledKey = "family_foqos_heartbeat_notifications_enabled"
+
+  @Published var monitoredDevices: [MonitoredDevice] = []
+
+  @Published var heartbeatNotificationsEnabled: Bool {
+    didSet {
+      UserDefaults.standard.set(heartbeatNotificationsEnabled, forKey: notificationEnabledKey)
+    }
+  }
+
+  private init() {
+    self.heartbeatNotificationsEnabled = UserDefaults.standard.bool(
+      forKey: notificationEnabledKey)
+    self.monitoredDevices = Self.loadDevices()
+  }
+
+  // MARK: - Child Side
+
+  /// Write heartbeat to CloudKit. Fire-and-forget — must not block profile activation.
+  func writeHeartbeat() {
+    let authStatus = AuthorizationCenter.shared.authorizationStatus
+    let statusString: String
+    switch authStatus {
+    case .approved: statusString = "approved"
+    case .denied: statusString = "denied"
+    case .notDetermined: statusString = "notDetermined"
+    @unknown default: statusString = "unknown"
+    }
+
+    guard let userRecordName = CloudKitManager.shared.currentUserRecordID?.recordName else {
+      Log.warning("No user record ID available for heartbeat", category: .cloudKit)
+      return
+    }
+
+    let heartbeat = DeviceHeartbeat(
+      childUserRecordName: userRecordName,
+      deviceIdentifier: UIDevice.current.identifierForVendor?.uuidString ?? "unknown",
+      deviceName: UIDevice.current.name,
+      lastHeartbeatAt: Date(),
+      authorizationStatus: statusString
+    )
+
+    Task {
+      do {
+        try await CloudKitManager.shared.writeHeartbeat(heartbeat)
+      } catch {
+        Log.warning("Heartbeat write failed (non-blocking): \(error)", category: .cloudKit)
+      }
+    }
+  }
+
+  // MARK: - Parent Side
+
+  /// Fetch heartbeats from CloudKit and update local monitored devices.
+  func refreshHeartbeats() async {
+    do {
+      let heartbeats = try await CloudKitManager.shared.fetchHeartbeats()
+
+      for heartbeat in heartbeats {
+        updateOrCreateDevice(from: heartbeat)
+      }
+      saveDevices()
+
+      if heartbeatNotificationsEnabled {
+        scheduleNotifications()
+      }
+    } catch {
+      Log.warning("Failed to refresh heartbeats: \(error)", category: .cloudKit)
+    }
+  }
+
+  /// Remove a device from monitoring and delete its CloudKit record.
+  func removeDevice(_ device: MonitoredDevice) async {
+    cancelNotification(for: device)
+    monitoredDevices.removeAll { $0.deviceIdentifier == device.deviceIdentifier }
+    saveDevices()
+
+    do {
+      try await CloudKitManager.shared.deleteHeartbeat(
+        childUserRecordName: device.childUserRecordName,
+        deviceIdentifier: device.deviceIdentifier
+      )
+    } catch {
+      Log.warning("Failed to delete heartbeat record: \(error)", category: .cloudKit)
+    }
+  }
+
+  /// Toggle suppression for a device.
+  func toggleSuppression(for deviceIdentifier: String) {
+    guard let index = monitoredDevices.firstIndex(where: { $0.deviceIdentifier == deviceIdentifier })
+    else { return }
+
+    monitoredDevices[index].isSuppressed.toggle()
+    saveDevices()
+
+    if monitoredDevices[index].isSuppressed {
+      cancelNotification(for: monitoredDevices[index])
+    } else if heartbeatNotificationsEnabled {
+      scheduleNotification(for: monitoredDevices[index])
+    }
+  }
+
+  // MARK: - Notification Management
+
+  func scheduleNotifications() {
+    for device in monitoredDevices where !device.isSuppressed {
+      scheduleNotification(for: device)
+    }
+  }
+
+  func cancelAllNotifications() {
+    let ids = monitoredDevices.compactMap { $0.notificationIdentifier }
+    UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ids)
+  }
+
+  private func scheduleNotification(for device: MonitoredDevice) {
+    cancelNotification(for: device)
+
+    let notificationId = "heartbeat-\(device.deviceIdentifier)"
+    let content = UNMutableNotificationContent()
+    content.sound = .default
+    content.title = "Device Check-In"
+    content.body =
+      "We haven't heard from \(device.deviceName) in a while. Tap to check their status."
+
+    let triggerDate = device.lastSeenAt.addingTimeInterval(MonitoredDevice.stalenessThreshold)
+
+    // Don't schedule if trigger is in the past (device already stale — banner handles it)
+    guard triggerDate > Date() else { return }
+
+    let interval = triggerDate.timeIntervalSinceNow
+    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: max(interval, 1), repeats: false)
+    let request = UNNotificationRequest(identifier: notificationId, content: content, trigger: trigger)
+
+    UNUserNotificationCenter.current().add(request) { error in
+      if let error {
+        Log.warning("Failed to schedule heartbeat notification: \(error)", category: .cloudKit)
+      }
+    }
+
+    // Update device with notification ID
+    if let index = monitoredDevices.firstIndex(where: {
+      $0.deviceIdentifier == device.deviceIdentifier
+    }) {
+      monitoredDevices[index].notificationIdentifier = notificationId
+      saveDevices()
+    }
+  }
+
+  private func cancelNotification(for device: MonitoredDevice) {
+    if let id = device.notificationIdentifier {
+      UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [id])
+    }
+  }
+
+  // MARK: - Private Helpers
+
+  private func updateOrCreateDevice(from heartbeat: DeviceHeartbeat) {
+    if let index = monitoredDevices.firstIndex(where: {
+      $0.deviceIdentifier == heartbeat.deviceIdentifier
+    }) {
+      monitoredDevices[index].lastSeenAt = heartbeat.lastHeartbeatAt
+      monitoredDevices[index].deviceName = heartbeat.deviceName
+    } else {
+      let device = MonitoredDevice(
+        deviceIdentifier: heartbeat.deviceIdentifier,
+        deviceName: heartbeat.deviceName,
+        childUserRecordName: heartbeat.childUserRecordName,
+        lastSeenAt: heartbeat.lastHeartbeatAt,
+        isSuppressed: false,
+        notificationIdentifier: nil
+      )
+      monitoredDevices.append(device)
+    }
+  }
+
+  private func saveDevices() {
+    if let data = try? JSONEncoder().encode(monitoredDevices) {
+      UserDefaults.standard.set(data, forKey: userDefaultsKey)
+    }
+  }
+
+  private static func loadDevices() -> [MonitoredDevice] {
+    guard let data = UserDefaults.standard.data(forKey: "family_foqos_monitored_devices"),
+      let devices = try? JSONDecoder().decode([MonitoredDevice].self, from: data)
+    else {
+      return []
+    }
+    return devices
+  }
+}

--- a/Foqos/Utils/HeartbeatManager.swift
+++ b/Foqos/Utils/HeartbeatManager.swift
@@ -7,20 +7,25 @@ import UIKit
 class HeartbeatManager: ObservableObject {
   static let shared = HeartbeatManager()
 
-  private let userDefaultsKey = "family_foqos_monitored_devices"
-  private let notificationEnabledKey = "family_foqos_heartbeat_notifications_enabled"
+  private static let userDefaultsKey = "family_foqos_monitored_devices"
+  private static let notificationEnabledKey = "family_foqos_heartbeat_notifications_enabled"
 
   @Published var monitoredDevices: [MonitoredDevice] = []
 
   @Published var heartbeatNotificationsEnabled: Bool {
     didSet {
-      UserDefaults.standard.set(heartbeatNotificationsEnabled, forKey: notificationEnabledKey)
+      UserDefaults.standard.set(heartbeatNotificationsEnabled, forKey: Self.notificationEnabledKey)
+      if heartbeatNotificationsEnabled {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) {
+          _, _ in
+        }
+      }
     }
   }
 
   private init() {
     self.heartbeatNotificationsEnabled = UserDefaults.standard.bool(
-      forKey: notificationEnabledKey)
+      forKey: Self.notificationEnabledKey)
     self.monitoredDevices = Self.loadDevices()
   }
 
@@ -63,19 +68,15 @@ class HeartbeatManager: ObservableObject {
 
   /// Fetch heartbeats from CloudKit and update local monitored devices.
   func refreshHeartbeats() async {
-    do {
-      let heartbeats = try await CloudKitManager.shared.fetchHeartbeats()
+    let heartbeats = await CloudKitManager.shared.fetchHeartbeats()
 
-      for heartbeat in heartbeats {
-        updateOrCreateDevice(from: heartbeat)
-      }
-      saveDevices()
+    for heartbeat in heartbeats {
+      updateOrCreateDevice(from: heartbeat)
+    }
+    saveDevices()
 
-      if heartbeatNotificationsEnabled {
-        scheduleNotifications()
-      }
-    } catch {
-      Log.warning("Failed to refresh heartbeats: \(error)", category: .cloudKit)
+    if heartbeatNotificationsEnabled {
+      scheduleNotifications()
     }
   }
 
@@ -129,11 +130,22 @@ class HeartbeatManager: ObservableObject {
     let notificationId = "heartbeat-\(device.deviceIdentifier)"
     let content = UNMutableNotificationContent()
     content.sound = .default
-    content.title = "Device Check-In"
-    content.body =
-      "We haven't heard from \(device.deviceName) in a while. Tap to check their status."
 
-    let triggerDate = device.lastSeenAt.addingTimeInterval(MonitoredDevice.stalenessThreshold)
+    let triggerDate: Date
+
+    if device.isAuthRevoked {
+      // Auth revoked — fire near-immediately
+      content.title = "Screen Time Permissions Lost"
+      content.body =
+        "\(device.deviceName) has lost Screen Time permissions. Tap to review."
+      triggerDate = Date().addingTimeInterval(1)
+    } else {
+      // Normal staleness countdown
+      content.title = "Device Check-In"
+      content.body =
+        "We haven't heard from \(device.deviceName) in a while. Tap to check their status."
+      triggerDate = device.lastSeenAt.addingTimeInterval(MonitoredDevice.stalenessThreshold)
+    }
 
     // Don't schedule if trigger is in the past (device already stale — banner handles it)
     guard triggerDate > Date() else { return }
@@ -171,6 +183,7 @@ class HeartbeatManager: ObservableObject {
     }) {
       monitoredDevices[index].lastSeenAt = heartbeat.lastHeartbeatAt
       monitoredDevices[index].deviceName = heartbeat.deviceName
+      monitoredDevices[index].authorizationStatus = heartbeat.authorizationStatus
     } else {
       let device = MonitoredDevice(
         deviceIdentifier: heartbeat.deviceIdentifier,
@@ -178,7 +191,8 @@ class HeartbeatManager: ObservableObject {
         childUserRecordName: heartbeat.childUserRecordName,
         lastSeenAt: heartbeat.lastHeartbeatAt,
         isSuppressed: false,
-        notificationIdentifier: nil
+        notificationIdentifier: nil,
+        authorizationStatus: heartbeat.authorizationStatus
       )
       monitoredDevices.append(device)
     }
@@ -186,12 +200,12 @@ class HeartbeatManager: ObservableObject {
 
   private func saveDevices() {
     if let data = try? JSONEncoder().encode(monitoredDevices) {
-      UserDefaults.standard.set(data, forKey: userDefaultsKey)
+      UserDefaults.standard.set(data, forKey: Self.userDefaultsKey)
     }
   }
 
   private static func loadDevices() -> [MonitoredDevice] {
-    guard let data = UserDefaults.standard.data(forKey: "family_foqos_monitored_devices"),
+    guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
       let devices = try? JSONDecoder().decode([MonitoredDevice].self, from: data)
     else {
       return []

--- a/Foqos/Utils/HeartbeatManager.swift
+++ b/Foqos/Utils/HeartbeatManager.swift
@@ -1,6 +1,7 @@
 import FamilyControls
 import Foundation
 import UIKit
+@preconcurrency import UserNotifications
 
 /// Manages device heartbeat lifecycle for both child and parent modes.
 @MainActor
@@ -19,6 +20,9 @@ class HeartbeatManager: ObservableObject {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) {
           _, _ in
         }
+        scheduleNotifications()
+      } else {
+        cancelAllNotifications()
       }
     }
   }

--- a/Foqos/Utils/HeartbeatManager.swift
+++ b/Foqos/Utils/HeartbeatManager.swift
@@ -83,7 +83,7 @@ class HeartbeatManager: ObservableObject {
   /// Remove a device from monitoring and delete its CloudKit record.
   func removeDevice(_ device: MonitoredDevice) async {
     cancelNotification(for: device)
-    monitoredDevices.removeAll { $0.deviceIdentifier == device.deviceIdentifier }
+    monitoredDevices.removeAll { $0.id == device.id }
     saveDevices()
 
     do {
@@ -97,8 +97,8 @@ class HeartbeatManager: ObservableObject {
   }
 
   /// Toggle suppression for a device.
-  func toggleSuppression(for deviceIdentifier: String) {
-    guard let index = monitoredDevices.firstIndex(where: { $0.deviceIdentifier == deviceIdentifier })
+  func toggleSuppression(for deviceId: String) {
+    guard let index = monitoredDevices.firstIndex(where: { $0.id == deviceId })
     else { return }
 
     monitoredDevices[index].isSuppressed.toggle()
@@ -127,7 +127,7 @@ class HeartbeatManager: ObservableObject {
   private func scheduleNotification(for device: MonitoredDevice) {
     cancelNotification(for: device)
 
-    let notificationId = "heartbeat-\(device.deviceIdentifier)"
+    let notificationId = "heartbeat-\(device.id)"
     let content = UNMutableNotificationContent()
     content.sound = .default
 
@@ -162,7 +162,7 @@ class HeartbeatManager: ObservableObject {
 
     // Update device with notification ID
     if let index = monitoredDevices.firstIndex(where: {
-      $0.deviceIdentifier == device.deviceIdentifier
+      $0.id == device.id
     }) {
       monitoredDevices[index].notificationIdentifier = notificationId
       saveDevices()
@@ -179,7 +179,8 @@ class HeartbeatManager: ObservableObject {
 
   private func updateOrCreateDevice(from heartbeat: DeviceHeartbeat) {
     if let index = monitoredDevices.firstIndex(where: {
-      $0.deviceIdentifier == heartbeat.deviceIdentifier
+      $0.childUserRecordName == heartbeat.childUserRecordName
+        && $0.deviceIdentifier == heartbeat.deviceIdentifier
     }) {
       monitoredDevices[index].lastSeenAt = heartbeat.lastHeartbeatAt
       monitoredDevices[index].deviceName = heartbeat.deviceName

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -560,6 +560,11 @@ class StrategyManager: ObservableObject {
     } else {
       Log.warning("No ModelContext available for session sync", category: .strategy)
     }
+
+    // Write heartbeat for child device monitoring (#190)
+    if AppModeManager.shared.currentMode == .child {
+      HeartbeatManager.shared.writeHeartbeat()
+    }
   }
 
   func getStrategy(id: String) -> BlockingStrategy {

--- a/Foqos/Views/Parent/ParentDashboardView.swift
+++ b/Foqos/Views/Parent/ParentDashboardView.swift
@@ -22,6 +22,7 @@ struct ParentDashboardView: View {
   @ObservedObject private var lockCodeManager = LockCodeManager.shared
   @ObservedObject private var strategyManager = StrategyManager.shared
   @ObservedObject private var emergencyManager = EmergencyUnblockManager.shared
+  @ObservedObject private var heartbeatManager = HeartbeatManager.shared
 
   @Environment(\.dismiss) private var dismiss
 
@@ -118,6 +119,13 @@ struct ParentDashboardView: View {
           childrenSection
             .disabled(!parentOperationsEnabled)
             .opacity(parentOperationsEnabled ? 1.0 : 0.5)
+
+          // Device heartbeat monitoring (#190)
+          if !isChildMode {
+            deviceStatusSection
+              .disabled(!parentOperationsEnabled)
+              .opacity(parentOperationsEnabled ? 1.0 : 0.5)
+          }
 
           // Pending members section (accepted share but haven't opened the app yet)
           if !cloudKitManager.pendingParticipants.isEmpty {
@@ -516,6 +524,42 @@ struct ParentDashboardView: View {
             participant: participant,
             onRemove: {
               removeParticipant(participant)
+            }
+          )
+        }
+      }
+    }
+  }
+
+  private var deviceStatusSection: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        Text("Device Status")
+          .font(.headline)
+        Spacer()
+        Toggle("Notify", isOn: $heartbeatManager.heartbeatNotificationsEnabled)
+          .labelsHidden()
+          .toggleStyle(.switch)
+          .scaleEffect(0.8)
+      }
+
+      if heartbeatManager.monitoredDevices.isEmpty {
+        EmptyMemberCard(
+          icon: "antenna.radiowaves.left.and.right",
+          title: "No Devices",
+          description: "Child devices will appear here when they activate a profile"
+        )
+      } else {
+        ForEach(heartbeatManager.monitoredDevices) { device in
+          DeviceStatusCard(
+            device: device,
+            onSuppress: {
+              heartbeatManager.toggleSuppression(for: device.deviceIdentifier)
+            },
+            onRemove: {
+              Task {
+                await heartbeatManager.removeDevice(device)
+              }
             }
           )
         }

--- a/Foqos/Views/Parent/ParentDashboardView.swift
+++ b/Foqos/Views/Parent/ParentDashboardView.swift
@@ -748,6 +748,11 @@ struct ParentDashboardView: View {
 
       _ = try await cloudKitManager.fetchFamilyMembers()
       await lockCodeManager.fetchLockCodes()
+
+      // Refresh heartbeats for device monitoring (#190)
+      if !isChildMode {
+        await HeartbeatManager.shared.refreshHeartbeats()
+      }
     } catch {
       errorMessage = error.localizedDescription
       showError = true

--- a/Foqos/Views/Parent/ParentDashboardView.swift
+++ b/Foqos/Views/Parent/ParentDashboardView.swift
@@ -554,7 +554,7 @@ struct ParentDashboardView: View {
           DeviceStatusCard(
             device: device,
             onSuppress: {
-              heartbeatManager.toggleSuppression(for: device.deviceIdentifier)
+              heartbeatManager.toggleSuppression(for: device.id)
             },
             onRemove: {
               Task {

--- a/FoqosTests/DeviceHeartbeatTests.swift
+++ b/FoqosTests/DeviceHeartbeatTests.swift
@@ -1,0 +1,74 @@
+import CloudKit
+import XCTest
+
+@testable import FamilyFoqos
+
+final class DeviceHeartbeatTests: XCTestCase {
+
+  func testRecordName_isDeterministic() {
+    let name = DeviceHeartbeat.recordName(
+      childUserRecordName: "child123",
+      deviceIdentifier: "device456"
+    )
+    XCTAssertEqual(name, "heartbeat-child123-device456")
+  }
+
+  func testToCKRecord_setsAllFields() {
+    let heartbeat = DeviceHeartbeat(
+      childUserRecordName: "child123",
+      deviceIdentifier: "device456",
+      deviceName: "Emma's iPhone",
+      lastHeartbeatAt: Date(timeIntervalSince1970: 1_000_000),
+      authorizationStatus: "approved"
+    )
+
+    let zoneID = CKRecordZone.ID(
+      zoneName: "FamilyPolicies",
+      ownerName: CKCurrentUserDefaultName
+    )
+    let record = heartbeat.toCKRecord(in: zoneID)
+
+    XCTAssertEqual(record.recordType, "DeviceHeartbeat")
+    XCTAssertEqual(record["childUserRecordName"] as? String, "child123")
+    XCTAssertEqual(record["deviceIdentifier"] as? String, "device456")
+    XCTAssertEqual(record["deviceName"] as? String, "Emma's iPhone")
+    XCTAssertEqual(record["lastHeartbeatAt"] as? Date, Date(timeIntervalSince1970: 1_000_000))
+    XCTAssertEqual(record["authorizationStatus"] as? String, "approved")
+    XCTAssertNotNil(record.parent)
+  }
+
+  func testInitFromCKRecord_roundTrips() {
+    let zoneID = CKRecordZone.ID(
+      zoneName: "FamilyPolicies",
+      ownerName: CKCurrentUserDefaultName
+    )
+    let original = DeviceHeartbeat(
+      childUserRecordName: "child123",
+      deviceIdentifier: "device456",
+      deviceName: "Emma's iPhone",
+      lastHeartbeatAt: Date(timeIntervalSince1970: 1_000_000),
+      authorizationStatus: "denied"
+    )
+    let record = original.toCKRecord(in: zoneID)
+    let decoded = DeviceHeartbeat(from: record)
+
+    XCTAssertNotNil(decoded)
+    XCTAssertEqual(decoded?.childUserRecordName, "child123")
+    XCTAssertEqual(decoded?.deviceIdentifier, "device456")
+    XCTAssertEqual(decoded?.deviceName, "Emma's iPhone")
+    XCTAssertEqual(decoded?.lastHeartbeatAt, Date(timeIntervalSince1970: 1_000_000))
+    XCTAssertEqual(decoded?.authorizationStatus, "denied")
+  }
+
+  func testInitFromCKRecord_returnsNilForMissingFields() {
+    let zoneID = CKRecordZone.ID(
+      zoneName: "FamilyPolicies",
+      ownerName: CKCurrentUserDefaultName
+    )
+    let recordID = CKRecord.ID(recordName: "heartbeat-x-y", zoneID: zoneID)
+    let record = CKRecord(recordType: "DeviceHeartbeat", recordID: recordID)
+    // Missing all fields
+    let decoded = DeviceHeartbeat(from: record)
+    XCTAssertNil(decoded)
+  }
+}

--- a/FoqosTests/MonitoredDeviceTests.swift
+++ b/FoqosTests/MonitoredDeviceTests.swift
@@ -69,6 +69,48 @@ final class MonitoredDeviceTests: XCTestCase {
     XCTAssertTrue(device.shouldAlert(now: now))
   }
 
+  func testShouldAlert_trueWhenAuthRevokedEvenIfNotStale() {
+    let now = Date()
+    let device = MonitoredDevice(
+      deviceIdentifier: "dev1",
+      deviceName: "iPhone",
+      childUserRecordName: "child1",
+      lastSeenAt: now.addingTimeInterval(-1 * 3600),  // 1 hour ago, not stale
+      isSuppressed: false,
+      notificationIdentifier: nil,
+      authorizationStatus: "denied"
+    )
+    XCTAssertTrue(device.shouldAlert(now: now))
+    XCTAssertTrue(device.isAuthRevoked)
+  }
+
+  func testShouldAlert_falseWhenAuthRevokedButSuppressed() {
+    let now = Date()
+    let device = MonitoredDevice(
+      deviceIdentifier: "dev1",
+      deviceName: "iPhone",
+      childUserRecordName: "child1",
+      lastSeenAt: now.addingTimeInterval(-1 * 3600),
+      isSuppressed: true,
+      notificationIdentifier: nil,
+      authorizationStatus: "denied"
+    )
+    XCTAssertFalse(device.shouldAlert(now: now))
+  }
+
+  func testIsAuthRevoked_falseForApproved() {
+    let device = MonitoredDevice(
+      deviceIdentifier: "dev1",
+      deviceName: "iPhone",
+      childUserRecordName: "child1",
+      lastSeenAt: Date(),
+      isSuppressed: false,
+      notificationIdentifier: nil,
+      authorizationStatus: "approved"
+    )
+    XCTAssertFalse(device.isAuthRevoked)
+  }
+
   func testPersistence_roundTrips() throws {
     let device = MonitoredDevice(
       deviceIdentifier: "dev1",
@@ -76,7 +118,8 @@ final class MonitoredDeviceTests: XCTestCase {
       childUserRecordName: "child1",
       lastSeenAt: Date(timeIntervalSince1970: 1_000_000),
       isSuppressed: true,
-      notificationIdentifier: "notif-123"
+      notificationIdentifier: "notif-123",
+      authorizationStatus: "approved"
     )
     let data = try JSONEncoder().encode(device)
     let decoded = try JSONDecoder().decode(MonitoredDevice.self, from: data)
@@ -84,5 +127,19 @@ final class MonitoredDeviceTests: XCTestCase {
     XCTAssertEqual(decoded.deviceIdentifier, "dev1")
     XCTAssertEqual(decoded.isSuppressed, true)
     XCTAssertEqual(decoded.notificationIdentifier, "notif-123")
+    XCTAssertEqual(decoded.authorizationStatus, "approved")
+  }
+
+  func testPersistence_backwardsCompatible_missingAuthStatus() throws {
+    // Simulate a device saved before authorizationStatus was added
+    let json = """
+      {"deviceIdentifier":"dev1","deviceName":"iPhone","childUserRecordName":"child1",
+       "lastSeenAt":1000000,"isSuppressed":false}
+      """
+    let data = json.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(MonitoredDevice.self, from: data)
+
+    XCTAssertNil(decoded.authorizationStatus)
+    XCTAssertFalse(decoded.isAuthRevoked)
   }
 }

--- a/FoqosTests/MonitoredDeviceTests.swift
+++ b/FoqosTests/MonitoredDeviceTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class MonitoredDeviceTests: XCTestCase {
+
+  func testIsStale_returnsTrueWhenOlderThan24Hours() {
+    let now = Date()
+    let device = MonitoredDevice(
+      deviceIdentifier: "dev1",
+      deviceName: "iPhone",
+      childUserRecordName: "child1",
+      lastSeenAt: now.addingTimeInterval(-25 * 3600),
+      isSuppressed: false,
+      notificationIdentifier: nil
+    )
+    XCTAssertTrue(device.isStale(now: now))
+  }
+
+  func testIsStale_returnsFalseWhenWithin24Hours() {
+    let now = Date()
+    let device = MonitoredDevice(
+      deviceIdentifier: "dev1",
+      deviceName: "iPhone",
+      childUserRecordName: "child1",
+      lastSeenAt: now.addingTimeInterval(-23 * 3600),
+      isSuppressed: false,
+      notificationIdentifier: nil
+    )
+    XCTAssertFalse(device.isStale(now: now))
+  }
+
+  func testIsStale_exactlyAt24Hours_returnsTrue() {
+    let now = Date()
+    let device = MonitoredDevice(
+      deviceIdentifier: "dev1",
+      deviceName: "iPhone",
+      childUserRecordName: "child1",
+      lastSeenAt: now.addingTimeInterval(-24 * 3600),
+      isSuppressed: false,
+      notificationIdentifier: nil
+    )
+    XCTAssertTrue(device.isStale(now: now))
+  }
+
+  func testShouldAlert_falseWhenSuppressed() {
+    let now = Date()
+    let device = MonitoredDevice(
+      deviceIdentifier: "dev1",
+      deviceName: "iPhone",
+      childUserRecordName: "child1",
+      lastSeenAt: now.addingTimeInterval(-25 * 3600),
+      isSuppressed: true,
+      notificationIdentifier: nil
+    )
+    XCTAssertFalse(device.shouldAlert(now: now))
+  }
+
+  func testShouldAlert_trueWhenStaleAndNotSuppressed() {
+    let now = Date()
+    let device = MonitoredDevice(
+      deviceIdentifier: "dev1",
+      deviceName: "iPhone",
+      childUserRecordName: "child1",
+      lastSeenAt: now.addingTimeInterval(-25 * 3600),
+      isSuppressed: false,
+      notificationIdentifier: nil
+    )
+    XCTAssertTrue(device.shouldAlert(now: now))
+  }
+
+  func testPersistence_roundTrips() throws {
+    let device = MonitoredDevice(
+      deviceIdentifier: "dev1",
+      deviceName: "iPhone",
+      childUserRecordName: "child1",
+      lastSeenAt: Date(timeIntervalSince1970: 1_000_000),
+      isSuppressed: true,
+      notificationIdentifier: "notif-123"
+    )
+    let data = try JSONEncoder().encode(device)
+    let decoded = try JSONDecoder().decode(MonitoredDevice.self, from: data)
+
+    XCTAssertEqual(decoded.deviceIdentifier, "dev1")
+    XCTAssertEqual(decoded.isSuppressed, true)
+    XCTAssertEqual(decoded.notificationIdentifier, "notif-123")
+  }
+}

--- a/FoqosTests/MonitoredDeviceTests.swift
+++ b/FoqosTests/MonitoredDeviceTests.swift
@@ -4,6 +4,38 @@ import XCTest
 
 final class MonitoredDeviceTests: XCTestCase {
 
+  func testId_isCompositeKey() {
+    let device = MonitoredDevice(
+      deviceIdentifier: "dev1",
+      deviceName: "iPhone",
+      childUserRecordName: "child1",
+      lastSeenAt: Date(),
+      isSuppressed: false,
+      notificationIdentifier: nil
+    )
+    XCTAssertEqual(device.id, "child1|dev1")
+  }
+
+  func testId_distinguishesSameDeviceDifferentChildren() {
+    let device1 = MonitoredDevice(
+      deviceIdentifier: "sharedIPad",
+      deviceName: "iPad",
+      childUserRecordName: "child1",
+      lastSeenAt: Date(),
+      isSuppressed: false,
+      notificationIdentifier: nil
+    )
+    let device2 = MonitoredDevice(
+      deviceIdentifier: "sharedIPad",
+      deviceName: "iPad",
+      childUserRecordName: "child2",
+      lastSeenAt: Date(),
+      isSuppressed: false,
+      notificationIdentifier: nil
+    )
+    XCTAssertNotEqual(device1.id, device2.id)
+  }
+
   func testIsStale_returnsTrueWhenOlderThan24Hours() {
     let now = Date()
     let device = MonitoredDevice(


### PR DESCRIPTION
## Summary
- Child devices write heartbeat records to CloudKit shared zone on every profile activation
- Parent devices monitor heartbeat freshness via in-app Device Status section and opt-in local notifications
- CKShare permissions upgraded from readOnly to readWrite for child participants
- Immediate alert path when child's Screen Time authorization is revoked (`authorizationStatus == denied`)
- Device management UI: suppress/unsuppress/remove per device, notification toggle

## Design
See `docs/plans/2026-03-05-child-device-heartbeat-design.md`

## New files
- `Foqos/Models/DeviceHeartbeat.swift` — CloudKit record model (child → parent)
- `Foqos/Models/MonitoredDevice.swift` — Parent-side device tracking with staleness logic
- `Foqos/CloudKit/CloudKitNetworkService+Heartbeat.swift` — CloudKit read/write/delete ops
- `Foqos/Utils/HeartbeatManager.swift` — Orchestration layer (write on child, refresh on parent)
- `Foqos/Components/Parent/DeviceStatusCard.swift` — Device status UI card

## Test plan
- [x] Unit tests pass (DeviceHeartbeatTests: 4 tests, MonitoredDeviceTests: 10 tests)
- [x] Full test suite passes
- [ ] Manual: child mode activates profile → heartbeat record appears in CloudKit dashboard
- [ ] Manual: parent dashboard shows device status after heartbeat received
- [ ] Manual: suppress/unsuppress/remove device actions work
- [ ] Manual: stale device (>24h) shows orange warning in UI
- [ ] Manual: auth-revoked device shows red 'Permissions revoked' status
- [ ] Manual: notification toggle schedules/cancels local notifications
- [ ] Manual: notification permission prompt appears when toggle enabled

## Summary by Sourcery

Add CloudKit-based heartbeat tracking between child and parent devices to surface device status and alerts in the parent dashboard.

New Features:
- Introduce DeviceHeartbeat CloudKit model and APIs for child devices to write heartbeat records on profile activation.
- Add parent-side MonitoredDevice model, persistence, and HeartbeatManager to track device freshness and authorization state with optional local notifications.
- Expose a Device Status section in the parent dashboard with per-device status cards and suppression/removal actions.

Enhancements:
- Upgrade CloudKit share participant permissions from readOnly to readWrite for child participants to support heartbeat writes.

Tests:
- Add unit tests for DeviceHeartbeat CloudKit record encoding/decoding and MonitoredDevice staleness, alerting, and persistence behavior.