### PR TITLE
fix(E1): profile save/clone pipeline — #198, #209, #223, #234

### DIFF
--- a/Foqos/Models/BlockedProfiles.swift
+++ b/Foqos/Models/BlockedProfiles.swift
@@ -679,7 +679,18 @@ class BlockedProfiles {
     cloned.startSchedule = source.startSchedule
     cloned.stopSchedule = source.stopSchedule
 
+    // Preserve the source's schema version: init stamps V2 unconditionally,
+    // which would leave a V1 source's clone with all-false triggers that no
+    // migration pass will ever repair. Migrating here translates the copied
+    // blockingStrategyId into startable triggers immediately (#223)
+    cloned.profileSchemaVersion = source.profileSchemaVersion
+    cloned.migrateToV2IfNeeded()
+
     try context.save()
+
+    // Create the snapshot so extensions can read it immediately (#209)
+    updateSnapshot(for: cloned)
+
     return cloned
   }
 

--- a/Foqos/Models/TriggerConfigurationModel.swift
+++ b/Foqos/Models/TriggerConfigurationModel.swift
@@ -109,5 +109,10 @@ final class TriggerConfigurationModel: ObservableObject {
     profile.stopQRCodeId = stopQRCodeId
     profile.startSchedule = startSchedule
     profile.stopSchedule = stopSchedule
+
+    // Refresh the app-group snapshot after trigger persistence — the snapshot
+    // written earlier by createProfile/updateProfile predates these fields, and
+    // the FoqosDeviceMonitor extension enforces schedules purely from it (#198)
+    BlockedProfiles.updateSnapshot(for: profile)
   }
 }

--- a/Foqos/Models/TriggerConfigurationModel.swift
+++ b/Foqos/Models/TriggerConfigurationModel.swift
@@ -110,9 +110,11 @@ final class TriggerConfigurationModel: ObservableObject {
     profile.startSchedule = startSchedule
     profile.stopSchedule = stopSchedule
 
-    // Refresh the app-group snapshot after trigger persistence — the snapshot
-    // written earlier by createProfile/updateProfile predates these fields, and
-    // the FoqosDeviceMonitor extension enforces schedules purely from it (#198)
+    // Refresh the app-group snapshot now that the trigger fields are set on the
+    // in-memory model (SwiftData persistence happens later in the caller) — the
+    // snapshot written earlier by createProfile/updateProfile predates these
+    // fields, and the FoqosDeviceMonitor extension enforces schedules purely
+    // from it (#198)
     BlockedProfiles.updateSnapshot(for: profile)
   }
 }

--- a/Foqos/Utils/LiveActivityManager.swift
+++ b/Foqos/Utils/LiveActivityManager.swift
@@ -201,21 +201,23 @@ class LiveActivityManager: ObservableObject {
   // Activity<T> is not Sendable, so a MainActor-held reference cannot be passed
   // to its nonisolated async update/end methods. Look the activity up by ID in a
   // nonisolated context instead, keeping it out of the main actor's region.
+  private nonisolated static func activity(
+    withId id: String
+  ) -> Activity<FoqosWidgetAttributes>? {
+    Activity<FoqosWidgetAttributes>.activities.first(where: { $0.id == id })
+  }
+
   private nonisolated static func updateActivity(
     withId id: String, to state: FoqosWidgetAttributes.ContentState
   ) async {
-    guard
-      let activity = Activity<FoqosWidgetAttributes>.activities.first(where: { $0.id == id })
-    else { return }
+    guard let activity = activity(withId: id) else { return }
     await activity.update(ActivityContent(state: state, staleDate: nil))
   }
 
   private nonisolated static func endActivity(
     withId id: String, finalState: FoqosWidgetAttributes.ContentState
   ) async {
-    guard
-      let activity = Activity<FoqosWidgetAttributes>.activities.first(where: { $0.id == id })
-    else { return }
+    guard let activity = activity(withId: id) else { return }
     await activity.end(
       ActivityContent(state: finalState, staleDate: nil), dismissalPolicy: .immediate)
   }

--- a/Foqos/Utils/LiveActivityManager.swift
+++ b/Foqos/Utils/LiveActivityManager.swift
@@ -123,10 +123,10 @@ class LiveActivityManager: ObservableObject {
       oneMoreMinuteStartTime: session.oneMoreMinuteStartTime
     )
 
+    let activityId = activity.id
     Task {
-      let content = ActivityContent(state: updatedState, staleDate: nil)
-      await activity.update(content)
-      Log.info("Updated Live Activity with ID: \(activity.id)", category: .liveActivity)
+      await Self.updateActivity(withId: activityId, to: updatedState)
+      Log.info("Updated Live Activity with ID: \(activityId)", category: .liveActivity)
     }
   }
 
@@ -145,10 +145,11 @@ class LiveActivityManager: ObservableObject {
       oneMoreMinuteStartTime: session.oneMoreMinuteStartTime
     )
 
+    let activityId = activity.id
+    let isBreakActive = session.isBreakActive
     Task {
-      let content = ActivityContent(state: updatedState, staleDate: nil)
-      await activity.update(content)
-      Log.info("Updated Live Activity break state: \(session.isBreakActive)", category: .liveActivity)
+      await Self.updateActivity(withId: activityId, to: updatedState)
+      Log.info("Updated Live Activity break state: \(isBreakActive)", category: .liveActivity)
     }
   }
 
@@ -167,9 +168,9 @@ class LiveActivityManager: ObservableObject {
       oneMoreMinuteStartTime: session.oneMoreMinuteStartTime
     )
 
+    let activityId = activity.id
     Task {
-      let content = ActivityContent(state: updatedState, staleDate: nil)
-      await activity.update(content)
+      await Self.updateActivity(withId: activityId, to: updatedState)
       Log.info(
         "Updated Live Activity one-more-minute state", category: .liveActivity)
     }
@@ -186,14 +187,36 @@ class LiveActivityManager: ObservableObject {
       startTime: Date.now
     )
 
+    let activityId = activity.id
     Task {
-      let content = ActivityContent(state: completedState, staleDate: nil)
-      await activity.end(content, dismissalPolicy: .immediate)
+      await Self.endActivity(withId: activityId, finalState: completedState)
       Log.info("Ended Live Activity", category: .liveActivity)
     }
 
     // Remove the stored activity ID when ending the activity
     removeActivityId()
     currentActivity = nil
+  }
+
+  // Activity<T> is not Sendable, so a MainActor-held reference cannot be passed
+  // to its nonisolated async update/end methods. Look the activity up by ID in a
+  // nonisolated context instead, keeping it out of the main actor's region.
+  private nonisolated static func updateActivity(
+    withId id: String, to state: FoqosWidgetAttributes.ContentState
+  ) async {
+    guard
+      let activity = Activity<FoqosWidgetAttributes>.activities.first(where: { $0.id == id })
+    else { return }
+    await activity.update(ActivityContent(state: state, staleDate: nil))
+  }
+
+  private nonisolated static func endActivity(
+    withId id: String, finalState: FoqosWidgetAttributes.ContentState
+  ) async {
+    guard
+      let activity = Activity<FoqosWidgetAttributes>.activities.first(where: { $0.id == id })
+    else { return }
+    await activity.end(
+      ActivityContent(state: finalState, staleDate: nil), dismissalPolicy: .immediate)
   }
 }

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -483,6 +483,12 @@ struct BlockedProfileView: View {
                 .disabled(isBlocking)
                 .font(.subheadline)
                 .foregroundColor(.secondary)
+                .onChange(of: reminderTimeInMinutes) { _, newValue in
+                  let clamped = min(max(newValue, 0), Self.maxReminderTimeInMinutes)
+                  if clamped != newValue {
+                    reminderTimeInMinutes = clamped
+                  }
+                }
 
                 Text("minutes")
                   .font(.subheadline)
@@ -728,6 +734,7 @@ struct BlockedProfileView: View {
                     source, in: modelContext, newName: trimmed
                   )
                   DeviceActivityCenterUtil.scheduleTimerActivity(for: clonedProfile)
+                  SyncCoordinator.shared.pushProfile(clonedProfile)
                 }
               } catch {
                 showError(message: error.localizedDescription)
@@ -816,6 +823,20 @@ struct BlockedProfileView: View {
     }
   }
 
+  /// Largest minutes value whose seconds representation fits in UInt32.
+  /// Any previously savable value stays within these bounds — the clamp only
+  /// rejects input that would have trapped, never rewrites stored settings.
+  static let maxReminderTimeInMinutes = Int(UInt32.max) / 60
+
+  /// Clamped conversion of free-form minutes input to reminder seconds.
+  /// UInt32(_:) traps on negative or overflowing values, so unchecked input
+  /// from the reminder TextField must never reach it directly (#234).
+  static func reminderTimeSeconds(enabled: Bool, minutes: Int) -> UInt32? {
+    guard enabled else { return nil }
+    let clampedMinutes = min(max(minutes, 0), maxReminderTimeInMinutes)
+    return UInt32(clampedMinutes * 60)
+  }
+
   private func showError(message: String) {
     alertIdentifier = AlertIdentifier(id: .error, errorMessage: message)
   }
@@ -879,8 +900,8 @@ struct BlockedProfileView: View {
 
     do {
       // Calculate reminder time in seconds or nil if disabled
-      let reminderTimeSeconds: UInt32? =
-        enableReminder ? UInt32(reminderTimeInMinutes * 60) : nil
+      let reminderTimeSeconds = Self.reminderTimeSeconds(
+        enabled: enableReminder, minutes: reminderTimeInMinutes)
 
       // Only set managedByChildId on child devices - this identifies which child owns this profile
       let managedChildId: String? =

--- a/FoqosTests/CloneProfileTests.swift
+++ b/FoqosTests/CloneProfileTests.swift
@@ -1,0 +1,145 @@
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+/// Regression tests for issues #209 and #223 in BlockedProfiles.cloneProfile:
+/// - #209: the clone must get its own SharedData snapshot so the FoqosDeviceMonitor
+///   extension can resolve it when its DeviceActivity schedule fires.
+/// - #223: cloning an unmigrated V1 profile must not stamp the clone as V2 with
+///   all-false triggers; the clone must carry migrated, startable triggers.
+@MainActor
+final class CloneProfileTests: XCTestCase {
+
+  private var container: ModelContainer!
+  private var context: ModelContext!
+  private var testSuiteName: String!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    testSuiteName = "CloneProfileTests-\(UUID().uuidString)"
+    SharedData.configure(
+      suite: UserDefaults(suiteName: testSuiteName)!
+    )
+    container = try TestModelContainer.create()
+    context = container.mainContext
+  }
+
+  override func tearDown() async throws {
+    UserDefaults().removePersistentDomain(forName: testSuiteName)
+    try await super.tearDown()
+  }
+
+  private func makeScheduledProfile(now: Date) throws -> BlockedProfiles {
+    let profile = try BlockedProfiles.createProfile(in: context, name: "School Hours")
+    var startTriggers = profile.startTriggers
+    startTriggers.schedule = true
+    profile.startTriggers = startTriggers
+    var stopConditions = profile.stopConditions
+    stopConditions.schedule = true
+    profile.stopConditions = stopConditions
+    profile.startSchedule = ProfileScheduleTime(days: [.monday], hour: 21, minute: 0, updatedAt: now)
+    profile.stopSchedule = ProfileScheduleTime(days: [.monday], hour: 7, minute: 0, updatedAt: now)
+    try context.save()
+    return profile
+  }
+
+  // MARK: - #209: clone snapshot
+
+  func testGivenScheduledProfile_WhenCloned_ThenCloneSnapshotExists() throws {
+    let now = Date()
+    let source = try makeScheduledProfile(now: now)
+
+    let cloned = try BlockedProfiles.cloneProfile(source, in: context, newName: "School Hours Copy")
+
+    let snapshot = SharedData.snapshot(for: cloned.id.uuidString)
+    XCTAssertNotNil(snapshot, "Clone must have a SharedData snapshot so extensions can read it")
+    XCTAssertEqual(snapshot?.id, cloned.id)
+    XCTAssertEqual(snapshot?.name, "School Hours Copy")
+  }
+
+  func testGivenScheduledProfile_WhenCloned_ThenCloneSnapshotReflectsTriggerSchedule() throws {
+    let now = Date()
+    let source = try makeScheduledProfile(now: now)
+
+    let cloned = try BlockedProfiles.cloneProfile(source, in: context, newName: "School Hours Copy")
+
+    let snapshot = SharedData.snapshot(for: cloned.id.uuidString)
+    XCTAssertEqual(snapshot?.startTriggersSchedule, true)
+    XCTAssertEqual(snapshot?.startSchedule?.hour, 21)
+    XCTAssertEqual(snapshot?.stopConditionsSchedule, true)
+    XCTAssertEqual(snapshot?.stopSchedule?.hour, 7)
+  }
+
+  func testGivenScheduledProfile_WhenCloned_ThenSourceSnapshotUntouched() throws {
+    let now = Date()
+    let source = try makeScheduledProfile(now: now)
+
+    _ = try BlockedProfiles.cloneProfile(source, in: context, newName: "School Hours Copy")
+
+    let sourceSnapshot = SharedData.snapshot(for: source.id.uuidString)
+    XCTAssertEqual(sourceSnapshot?.id, source.id)
+    XCTAssertEqual(sourceSnapshot?.name, "School Hours")
+  }
+
+  // MARK: - #223: cloning an unmigrated V1 profile
+
+  func testGivenUnmigratedV1NFCProfile_WhenCloned_ThenCloneIsV2WithMigratedTriggers() throws {
+    let source = BlockedProfiles(name: "V1 NFC")
+    source.profileSchemaVersion = 1
+    source.blockingStrategyId = "NFCBlockingStrategy"
+    context.insert(source)
+    try context.save()
+
+    let cloned = try BlockedProfiles.cloneProfile(source, in: context, newName: "V1 NFC Copy")
+
+    XCTAssertEqual(cloned.profileSchemaVersion, 2)
+    XCTAssertTrue(cloned.startTriggers.anyNFC, "NFC strategy must migrate to NFC start trigger")
+    XCTAssertTrue(cloned.stopConditions.sameNFC, "NFC strategy must migrate to same-NFC stop")
+    XCTAssertTrue(cloned.stopConditions.isValid, "Clone must be startable")
+  }
+
+  func testGivenUnmigratedV1PhysicalUnlockProfile_WhenCloned_ThenCloneGetsSpecificNFCStop() throws {
+    let source = BlockedProfiles(name: "V1 Physical")
+    source.profileSchemaVersion = 1
+    source.blockingStrategyId = "NFCManualBlockingStrategy"
+    source.physicalUnblockNFCTagId = "tag-123"
+    context.insert(source)
+    try context.save()
+
+    let cloned = try BlockedProfiles.cloneProfile(source, in: context, newName: "V1 Physical Copy")
+
+    XCTAssertTrue(cloned.stopConditions.specificNFC)
+    XCTAssertEqual(cloned.stopNFCTagId, "tag-123")
+  }
+
+  func testGivenUnmigratedV1Profile_WhenCloned_ThenSourceRemainsV1() throws {
+    let source = BlockedProfiles(name: "V1 NFC")
+    source.profileSchemaVersion = 1
+    source.blockingStrategyId = "NFCBlockingStrategy"
+    context.insert(source)
+    try context.save()
+
+    _ = try BlockedProfiles.cloneProfile(source, in: context, newName: "V1 NFC Copy")
+
+    XCTAssertEqual(source.profileSchemaVersion, 1, "Cloning must not migrate the source")
+    XCTAssertTrue(source.needsMigration, "Source must stay eligible for the normal migration pass")
+  }
+
+  func testGivenV2ProfileWithManualTriggers_WhenCloned_ThenTriggersCopiedUnchanged() throws {
+    let source = try BlockedProfiles.createProfile(in: context, name: "Manual")
+    var startTriggers = source.startTriggers
+    startTriggers.manual = true
+    source.startTriggers = startTriggers
+    var stopConditions = source.stopConditions
+    stopConditions.manual = true
+    source.stopConditions = stopConditions
+    try context.save()
+
+    let cloned = try BlockedProfiles.cloneProfile(source, in: context, newName: "Manual Copy")
+
+    XCTAssertEqual(cloned.profileSchemaVersion, 2)
+    XCTAssertTrue(cloned.startTriggers.manual)
+    XCTAssertTrue(cloned.stopConditions.manual)
+  }
+}

--- a/FoqosTests/ProfileSaveSnapshotTests.swift
+++ b/FoqosTests/ProfileSaveSnapshotTests.swift
@@ -1,0 +1,96 @@
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+/// Regression tests for issue #198: the app-group ProfileSnapshot must reflect
+/// trigger/schedule edits persisted via TriggerConfigurationModel.saveToProfile,
+/// otherwise the FoqosDeviceMonitor extension enforces from a stale snapshot and
+/// scheduled blocking never starts in the background.
+@MainActor
+final class ProfileSaveSnapshotTests: XCTestCase {
+
+  private var container: ModelContainer!
+  private var context: ModelContext!
+  private var testSuiteName: String!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    testSuiteName = "ProfileSaveSnapshotTests-\(UUID().uuidString)"
+    SharedData.configure(
+      suite: UserDefaults(suiteName: testSuiteName)!
+    )
+    container = try TestModelContainer.create()
+    context = container.mainContext
+  }
+
+  override func tearDown() async throws {
+    UserDefaults().removePersistentDomain(forName: testSuiteName)
+    try await super.tearDown()
+  }
+
+  func testGivenNewProfileWithScheduleStartTrigger_WhenTriggerConfigSaved_ThenSnapshotContainsStartSchedule()
+    throws
+  {
+    let now = Date()
+    let profile = try BlockedProfiles.createProfile(in: context, name: "Evening")
+
+    let config = TriggerConfigurationModel()
+    config.loadFromProfile(profile)
+    config.startTriggers.schedule = true
+    config.stopConditions.schedule = true
+    config.startSchedule = ProfileScheduleTime(days: [.monday], hour: 21, minute: 0, updatedAt: now)
+    config.stopSchedule = ProfileScheduleTime(days: [.monday], hour: 7, minute: 0, updatedAt: now)
+
+    config.saveToProfile(profile)
+
+    let snapshot = SharedData.snapshot(for: profile.id.uuidString)
+    XCTAssertEqual(snapshot?.startTriggersSchedule, true)
+    XCTAssertEqual(snapshot?.startSchedule?.hour, 21)
+    XCTAssertEqual(snapshot?.startSchedule?.minute, 0)
+  }
+
+  func testGivenProfileWithStopSchedule_WhenTriggerConfigSaved_ThenSnapshotContainsStopSchedule()
+    throws
+  {
+    let now = Date()
+    let profile = try BlockedProfiles.createProfile(in: context, name: "Evening")
+
+    let config = TriggerConfigurationModel()
+    config.loadFromProfile(profile)
+    config.startTriggers.schedule = true
+    config.stopConditions.schedule = true
+    config.startSchedule = ProfileScheduleTime(days: [.monday], hour: 21, minute: 0, updatedAt: now)
+    config.stopSchedule = ProfileScheduleTime(days: [.monday], hour: 7, minute: 30, updatedAt: now)
+
+    config.saveToProfile(profile)
+
+    let snapshot = SharedData.snapshot(for: profile.id.uuidString)
+    XCTAssertEqual(snapshot?.stopConditionsSchedule, true)
+    XCTAssertEqual(snapshot?.stopSchedule?.hour, 7)
+    XCTAssertEqual(snapshot?.stopSchedule?.minute, 30)
+  }
+
+  func testGivenExistingProfileScheduleEdited_WhenTriggerConfigSaved_ThenSnapshotReflectsNewTime()
+    throws
+  {
+    let now = Date()
+    let profile = try BlockedProfiles.createProfile(in: context, name: "Evening")
+
+    let config = TriggerConfigurationModel()
+    config.loadFromProfile(profile)
+    config.startTriggers.schedule = true
+    config.stopConditions.schedule = true
+    config.startSchedule = ProfileScheduleTime(days: [.monday], hour: 21, minute: 0, updatedAt: now)
+    config.stopSchedule = ProfileScheduleTime(days: [.monday], hour: 7, minute: 0, updatedAt: now)
+    config.saveToProfile(profile)
+
+    // User edits the start time in a later editing session
+    config.startSchedule = ProfileScheduleTime(days: [.monday], hour: 22, minute: 30, updatedAt: now)
+    config.saveToProfile(profile)
+
+    let snapshot = SharedData.snapshot(for: profile.id.uuidString)
+    XCTAssertEqual(snapshot?.startSchedule?.hour, 22)
+    XCTAssertEqual(snapshot?.startSchedule?.minute, 30)
+  }
+}

--- a/FoqosTests/ReminderTimeConversionTests.swift
+++ b/FoqosTests/ReminderTimeConversionTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+/// Regression tests for issue #234: the reminder-minutes field is free-form Int
+/// input; converting it to UInt32 seconds must clamp instead of trapping on
+/// large or negative values.
+@MainActor
+final class ReminderTimeConversionTests: XCTestCase {
+
+  func testGivenReminderDisabled_WhenComputingSeconds_ThenReturnsNil() {
+    XCTAssertNil(BlockedProfileView.reminderTimeSeconds(enabled: false, minutes: 15))
+  }
+
+  func testGivenTypicalMinutes_WhenComputingSeconds_ThenReturnsMinutesTimesSixty() {
+    XCTAssertEqual(BlockedProfileView.reminderTimeSeconds(enabled: true, minutes: 15), 900)
+  }
+
+  func testGivenNineDigitMinutes_WhenComputingSeconds_ThenClampsInsteadOfTrapping() {
+    // 100,000,000 minutes * 60 overflows UInt32 — must clamp, not crash (#234)
+    XCTAssertEqual(
+      BlockedProfileView.reminderTimeSeconds(enabled: true, minutes: 100_000_000),
+      UInt32(BlockedProfileView.maxReminderTimeInMinutes * 60)
+    )
+  }
+
+  func testGivenNegativeMinutes_WhenComputingSeconds_ThenClampsToZero() {
+    XCTAssertEqual(BlockedProfileView.reminderTimeSeconds(enabled: true, minutes: -15), 0)
+  }
+
+  func testGivenMaximumAllowedMinutes_WhenComputingSeconds_ThenReturnsExactSeconds() {
+    XCTAssertEqual(
+      BlockedProfileView.reminderTimeSeconds(
+        enabled: true, minutes: BlockedProfileView.maxReminderTimeInMinutes),
+      UInt32(BlockedProfileView.maxReminderTimeInMinutes * 60)
+    )
+  }
+
+  func testGivenPreviouslyValidLargeMinutes_WhenComputingSeconds_ThenValuePreservedUnclamped() {
+    // A weekly reminder (10080 min) was valid before the clamp existed and must
+    // survive an edit-and-save round trip unchanged
+    XCTAssertEqual(
+      BlockedProfileView.reminderTimeSeconds(enabled: true, minutes: 10_080), 604_800)
+  }
+
+  func testGivenMaxBound_WhenConvertedToSeconds_ThenFitsUInt32() {
+    // The clamp bound itself must never trap
+    XCTAssertNotNil(
+      UInt32(exactly: BlockedProfileView.maxReminderTimeInMinutes * 60),
+      "maxReminderTimeInMinutes * 60 must fit in UInt32"
+    )
+  }
+}


### PR DESCRIPTION
## E1 · Profile save/clone pipeline (Wave 1, epic #263)

Fixes #198
Fixes #209
Fixes #223
Fixes #234

All four defects were re-verified against current `main` by independent adversarial verification agents before fixing (every handover line citation still held). Fixes follow TDD: each regression test was written first and observed failing for the expected reason.

### #198 (critical) — stale snapshot breaks background scheduled blocking
`TriggerConfigurationModel.saveToProfile` now refreshes the app-group `ProfileSnapshot` after writing trigger/schedule fields onto the model. Previously `createProfile`/`updateProfile` snapshotted **before** `finalizeSave` applied trigger edits, so the `FoqosDeviceMonitor` extension read a stale snapshot at interval start (`ScheduleTimerActivity` logs "no schedule found") and scheduled blocking silently never started until the app was foregrounded. `saveToProfile`'s only call site is `finalizeSave`, so the placement is behavior-identical to snapshotting in the view but unit-testable.

### #209 (high) — cloned profile never gets a snapshot or sync push
`cloneProfile` now writes the clone's snapshot (after trigger copy and migration, after a successful `context.save()`), matching `createProfile`'s "so extensions can read it immediately" behavior. The Duplicate flow additionally pushes the clone via `SyncCoordinator.shared.pushProfile`, mirroring the existing save and delete flows, so the clone reaches CloudKit before its first manual edit.

### #223 (medium) — cloning an unmigrated V1 profile produced a permanently broken clone
`cloneProfile` now copies `source.profileSchemaVersion` and runs `migrateToV2IfNeeded()`, so a V1 source's `blockingStrategyId` is translated into startable triggers on the clone immediately. For V2 sources this is a no-op; V3+ sources now keep their version on the clone (previously stamped V2 — strictly more correct). The source is intentionally left unmigrated for the normal launch-time pass. Migration runs before the #209 snapshot write so the snapshot reflects migrated triggers.

### #234 (medium) — reminder minutes field could crash saveProfile
The minutes→seconds conversion goes through `BlockedProfileView.reminderTimeSeconds(enabled:minutes:)`, clamped to `0...UInt32.max/60`, plus a matching `.onChange` clamp on the TextField (mirroring the adjacent reminder-message clamp). Bounds were chosen deliberately after review: they preserve **every previously savable value** (e.g. a weekly 10 080-minute reminder survives unchanged) and only clamp input that would have trapped `UInt32(_:)` — negative values or ≥ 71 582 789 minutes.

### Preliminary commit — Xcode 26.6 build break (pre-existing)
`xcodebuild test` fails on unmodified `main` under Xcode 26.6: four Swift 6 `sending 'activity' risks causing data races` errors in `LiveActivityManager`. Commit 1 fixes this by looking the `Activity` up by ID inside nonisolated static helpers (the pattern `restoreExistingActivity` already uses) so the non-Sendable reference never leaves the main actor. Without it no tests can build or run on current toolchains.

## Testing

- New regression tests (TDD, RED observed before each fix): `ProfileSaveSnapshotTests` (3), `CloneProfileTests` (7, incl. pinning tests that the source profile and V2 clones are untouched), `ReminderTimeConversionTests` (7).
- Full `FoqosTests` suite green on iPhone 17 simulator: **429 passed, 0 failed**.
- `swift-format lint` clean on all touched files.

## Review

A 7-agent adversarial review (per-fix dimensions, concurrency, regression sweep, test quality; findings adversarially verified) ran before commit. Its one confirmed finding — the original 1440-minute clamp silently rewriting legitimate pre-existing reminder values — was fixed (see #234 above, bounds `0...UInt32.max/60`). Human review requested per AGENTS.md.

## Out of scope / follow-up

- `SyncModels.swift:198-199` performs the same unchecked `UInt32(reminderInt)` conversion on inbound CloudKit record data — same defect class as #234, worth its own issue.
- V1→V2 migration paths (`ProfileMigrationUtil`, post-session migration) still don't re-snapshot after mutating trigger fields — same class as #198, largely masked by the legacy-schedule fallback (low severity, flagged by review but not confirmed as user-visible).

## Summary by Sourcery

Strengthen the profile save and clone pipeline, fixing snapshot, migration, sync, and reminder-time issues and updating live activity handling for Swift 6 toolchains.

Bug Fixes:
- Ensure profile trigger/schedule changes refresh the shared snapshot so background blocking uses up-to-date data.
- Guarantee cloned profiles are migrated appropriately from legacy schemas and receive immediate snapshots and sync pushes.
- Prevent crashes when saving reminder times by clamping free-form minute input to a safe UInt32 range.

Enhancements:
- Adjust live activity update/end handling to satisfy Swift 6 sendability rules while keeping activity references confined to the main actor context.

Tests:
- Add regression test suites covering snapshot updates on trigger saves, cloning behavior across schema versions, and reminder time conversion edge cases.