### PR TITLE
docs(#267): sync-engine design (converged, 9 adversarial rounds) + A1 acceptance corpus

### DIFF
--- a/docs/plans/2026-07-02-reset-sync-a1-acceptance-corpus.md
+++ b/docs/plans/2026-07-02-reset-sync-a1-acceptance-corpus.md
@@ -1,0 +1,147 @@
+# A1 acceptance corpus — reset-sync failure scenarios for the #267 sync-engine replacement
+
+- **Status:** authoritative acceptance suite for issue #267 (change-token sync engine).
+- **Provenance:** bundle A1 (#195/#202) went through four design revisions and three
+  independent adversarial verification rounds (65 findings). Maintainer decision
+  (2026-07-02, recorded on #267): no live users exist, so the query-based sync layer is
+  replaced, not patched. This corpus preserves everything learned; **every scenario below
+  must be shown safe or impossible-by-construction under the #267 design** (corpus-mapping
+  table is a required deliverable of that design).
+- **Files in this corpus:**
+  - `2026-07-02-reset-sync-a1-design-rev1.md` … `rev4.md` — the four design revisions,
+    each annotated with why it fell.
+  - `2026-07-02-reset-sync-a1-interleavings-round1.md` (27 findings, vs rev 2),
+    `…-round2.md` (20 findings, vs rev 3), `…-round3.md` (18 findings, vs rev 4) —
+    verbatim, machine-extracted verifier output. The canonical scenarios below cite these
+    as `rN/<lens>-<i>`.
+
+## 1. The structural result
+
+Three rounds converged on one root cause: **the sync layer infers deletions from absence in
+eventually-consistent CKQuery results.** Under that model:
+
+- *Absence is not evidence of deletion* — it is indistinguishable from mid-wipe, mid-re-push,
+  index lag, or a failed push.
+- *Presence is not evidence of durability* — a pull can show stale presence of wiped records,
+  and a push ack can be undone by a concurrent snapshot-based wipe.
+- Therefore **no client-observable event can safely end a protection window early**, and any
+  time-boxed window is either born-expired for stragglers (anchored to the reset) or
+  clock-defeatable (anchored to local time).
+
+**The vacuous-reconciliation proof (r2/crashChurn-2, r2/readVerification-3).** Rev 3 tried
+"resume deletions once a pass proves the zone contains everything this device could
+re-create" (`remoteIds ⊇ {local: syncVersion > 0 ∧ ¬isNewerSchemaVersion}`). But
+reconciliation's deletable set is `{local: syncVersion > 0 ∧ ¬isNewerSchemaVersion ∧
+id ∉ remoteIds}` — a subset of the restorable set, hence **empty whenever the proof
+passes**. Evidence-based early exit either authorizes nothing (proof passes ⇒ nothing to
+delete) or is unsafe (proof fails ⇒ any deletion may be a not-yet-re-pushed record). This is
+why deletions must arrive as **explicit events** (tombstones / `recordWithIDWasDeleted`),
+which is the core of #267.
+
+## 2. Canonical acceptance scenarios
+
+Grouped by root-cause class. Sources cite the verbatim appendix findings; several scenarios
+were independently discovered by multiple lenses. The #267 design's corpus-mapping table
+must give each ID a verdict: **impossible-by-construction** (preferred), **safe** (with the
+protecting mechanism named), or **accepted-residual** (with honest preconditions — "narrow"
+is not a verdict).
+
+### Class A — deletion-by-absence vs. reset/wipe races
+
+| ID | Scenario | Sources |
+|----|----------|---------|
+| A-1 | Wipe runs before any marker exists; another device pulls an empty/partial zone with no marker and mass-deletes local profiles (original #195; also the guard at `SyncCoordinator.swift:179` covering only decode failures) | handover #195; r1 problem stmt |
+| A-2 | Wipe throws mid-way before the marker is saved: durable marker-less wiped zone; every later sync on every device wipes local data | handover #195.3 |
+| A-3 | Marker seen, re-push dispatched async, the *same* pass continues into pullProfiles and reconciles against the partial zone | handover #195.4 |
+| A-4 | A *subsequent* pass (manual "Sync Now", crash-relaunch, follow-up sync) reconciles against the still-partial zone after per-device processing state has already advanced | r1/interleavings-3, r1/crashRecovery-4, r2/cloudkitOps-1 |
+| A-5 | Push ack ≠ durability: records acked by device B are deleted moments later by the origin's snapshot-based wipe; B's "clean re-push" evidence is false | r1/interleavings-1, r1/cloudkit-1 |
+| A-6 | Not read-your-writes: the pass right after a clean re-push pulls a set missing the just-pushed records and self-deletes them locally | r1/crashRecovery-1 |
+| A-7 | Stale **presence**: a pull shows the pre-wipe zone, clearing/satisfying protection while the zone is genuinely wiped; the next truthful pull deletes | r2/crashChurn-1, r2/cloudkitOps-5 |
+| A-8 | Stale **absence** of the marker: the marker exists but a pass's marker query misses it while the same pass's data query already reflects the wipe (includes the partial-chunk variant r3/stateMachine-6) | r1 row 14 class; r2/readVerification-1; r3/stateMachine-6 |
+| A-9 | Vacuous reconciliation: any evidence gate that passes has an empty deletion set (see §1); "verify then resume" resumes nothing and its clearing write is a new race surface | r2/crashChurn-2, r2/readVerification-3 |
+| A-10 | Concurrent passes (no reentrancy guard on `performFullSync`): one pass's protection-clear is consumed by another in-flight pass holding a stale pulled set | r2/cloudkitOps-1, r2/specReview-1 |
+| A-11 | Sole-copy data: reconciliation deletes local records **before** the end-of-pass push runs; if no other device holds them, loss is permanent (not "self-healing with selection loss") | r1/crashRecovery-2, r1/cloudkit-4, r3/temporal-1 |
+| A-12 | `isNewerSchemaVersion` profiles: never pushable by this device (filtered at `SyncCoordinator.swift:64/:567`) yet deletion-eligible; no re-push can ever restore them | r1/interleavings-4, r1/crashRecovery-7 |
+| A-13 | Locations mirror every scenario above (`handleSyncedLocations`, `SyncCoordinator.swift:479-499`); note location `syncVersion` is **pull-confirmed** (set only on receipt, incl. the `max(syncVersion,1)` "seen from remote" path at `:454`), unlike push-optimistic profile `syncVersion` (`pushProfile` increments before network) | rev 2 §#195.5; r2/specReview-3 |
+| A-14 | Deleting the *last* remaining profile/location: an empty-remote guard blocks propagation and blanket re-push resurrects it; conversely, no guard means an empty pull is a mass-delete. Any design must state which side it takes and why | rev 2 A2 discussion; r4 intentional changes |
+
+### Class B — reset-command (marker) lifecycle (#202)
+
+| ID | Scenario | Sources |
+|----|----------|---------|
+| B-1 | Consume-on-first-read: first non-origin device deletes the command; devices 3..N never receive it | handover #202.1 |
+| B-2 | Origin never cleans up; single-device account: command lingers forever; a device enabling sync a year later processes it and wipes app selections | handover #202.2/.3 |
+| B-3 | Two near-simultaneous resets mutually delete each other's markers (each wipe excludes only its own); third devices lose both delivery and protection | r1/interleavings-2, r1/crashRecovery-3, r1/cloudkit-2 |
+| B-4 | >400 records of one type: single `modifyRecords` fails `limitExceeded` deterministically **after** the marker broadcast; reset can never complete while every retry re-clears selections family-wide | r1/cloudkit-3 |
+| B-5 | Undecodable / future-schema / per-record-`.failure` marker records: protection and GC must both be defined for them; rev 4 protected on raw-recordID sight but had **no GC path**, making one corrupt record suppress deletion propagation family-wide **forever** (profiles become undeletable) | r2/readVerification-4, r2/cloudkitOps-4, r3/temporal-2 |
+| B-6 | Background cold-launch (`content-available` push) processes the command with `modelContext == nil`: `handleSyncReset` silently no-ops, yet the command is marked processed — consumed without ever being applied | r3/stateMachine-2 |
+| B-7 | Same-device double-dispatch: classify-then-mark spans an await (e.g. a GC network call); two concurrent passes both dispatch the same command | r3/stateMachine-4, r3/specReview-2 |
+| B-8 | Command supersession: multiple pending resets — newest must win; a superseded older command must not be applied after a newer one; tie-break at equal timestamps must be defined | rev 4 B5; r3/specReview-3 |
+
+### Class C — clocks (a screen-time app must assume children manipulate device clocks)
+
+| ID | Scenario | Sources |
+|----|----------|---------|
+| C-1 | Origin clock skew: client-written timestamps (e.g. `requestedAt`) poison any date-ordered processing; server-assigned metadata (`CKRecord.creationDate`) is the only skew-immune ordinal | r1/interleavings-5, r2 B2 |
+| C-2 | Receiver clock **fast** by more than (gcTTL − processTTL): GCs a live command inside other devices' delivery window (rev 3 claimed a 14d margin but had 7d: GC fires at real age ≥ gcTTL − F) | r2/cloudkitOps-3 |
+| C-3 | Receiver clock **slow**: any date-comparison idempotency (watermark, even capped at now+slack) re-processes the same command every pass — infinite loop of selection-clearing + full re-push, self-sustaining past every throttle. Idempotency must be by **identity**, never by time | r2/readVerification-2, r2/crashChurn-3, r2/cloudkitOps-2 |
+| C-4 | Protection window anchored to the *event's* date is **born expired** for a device that first syncs ≥ window after the event — exactly the straggler whose data nobody re-pushed; anchoring to *local receipt* time instead is defeated by C-5 | r3/temporal-1, r3/stateMachine-1 |
+| C-5 | Forward clock roll during an active local-time window silently ends it (fails toward delete, violating fail-toward-keep) | r3/temporal-3 |
+| C-6 | Pruning local idempotency memory by local clock while the remote command outlives it: a ≥(prune-window)-slow clock re-processes an expired command after the prune | r3/stateMachine-3 |
+
+### Class D — process & state hygiene
+
+| ID | Scenario | Sources |
+|----|----------|---------|
+| D-1 | SIGKILL between any two statements: the order of persisted writes must fail toward "re-process idempotently *with* protection", never "skip *without* protection" | r1/interleavings-6, r1/crashRecovery-5, r2/crashChurn (ordering) |
+| D-2 | Pass-abort coupling: if fetching sync-commands fails, no later step of the same pass may act destructively; today this holds only via an incidental `try` chain — it must be an explicit invariant | r2/crashChurn-4, r3/specReview-1 |
+| D-3 | iCloud account switch: per-device persisted sync state (tokens, processed-command ids, windows) must be account-scoped or provably harmless across accounts (precedent: `legacyCleanupKey(for: userRecordName)`) | r2/cloudkitOps-7, r3/specReview-4 |
+| D-4 | Sync disable → re-enable mid-operation (the `$isEnabled` sink calls `setupSync` → full sync immediately) | r1/crashRecovery (8a); rev 4 constraints |
+| D-5 | The 5-minute notification throttle (`ProfileSyncManager.swift:882-900`): missed notifications must degrade to latency, never to lost state transitions (#200 is absorbed by #267 for this reason) | r3/stateMachine (throttle lens); #267 scope |
+| D-6 | Zone deleted externally (iCloud settings) and recreated: subscriptions, tokens, and local state must all survive or re-bootstrap deliberately (today: `zoneNotFound` early-returns mask this) | r3 brief (§zone), #267 req 3 |
+| D-7 | All compound persisted state updates must follow the `SharedData.withLock` convention (non-reentrant flock) or document why MainActor serialization suffices | r2/specReview-4 |
+
+### Class E — product semantics to preserve or consciously re-decide
+
+| ID | Item | Sources |
+|----|------|---------|
+| E-1 | `FamilyActivitySelection` never syncs (device-local tokens); recreated profiles arrive `needsAppSelection = true` and enforce nothing until re-selected — this is why "husk resurrection" is *silent blocking failure*, the top-severity outcome | handovers; deviation-report |
+| E-2 | Reset Sync UI contract (`SettingsView.swift:389-419`): copy describes effects on *other* devices only, yet the origin also clears its own selections via the direct `didReceiveSyncReset` call (`ProfileSyncManager.swift:848`) — pre-existing mismatch, follow-up issue; #267's reset re-design should resolve it deliberately | r1 context sweep |
+| E-3 | Safety asymmetry (maintainer-endorsed): wrongly deleting profiles/selections is catastrophic and silent; wrongly keeping/resurrecting one is minor and visible. Ambiguity resolves toward "keep" | rev 1–4 |
+| E-4 | Normal deletion propagation must keep working: with no reset in flight, deleting a profile on one device removes it on others (the regression tests of every rev) | rev 1–4 test plans |
+
+## 3. Rev 4 residual table — what the best query-based design still could not close
+
+Rev 4 (monotonic ~8-day suppression window + identity-based processed-ids) was the
+strongest patch found. Round 3 still produced `has-holes` on all lenses. Its residuals,
+with **real** preconditions — these are the specific items #267 must close (or accept with
+eyes open):
+
+| # | Residual | Real precondition | Round-3 source |
+|---|----------|-------------------|----------------|
+| R1 | Born-expired window: device first sighting a ≥8d-old marker gets zero suppression, `.skipExpired` skips the re-push, and the same pass reconcile-deletes its sole-copy data before its own push runs | An 8-day sync gap (vacation iPad) — no failures, no skew needed | temporal-1, stateMachine-1 |
+| R2 | One undecodable marker ⇒ suppression extended from `now` on every sight, and no GC path (GC needs decode) ⇒ deletion propagation dead family-wide, forever; profiles undeletable | One corrupt/future-schema marker record | temporal-2 |
+| R3 | Forward clock roll ≥ remaining window re-opens the wipe for that device | Clock set forward once, mid-window | temporal-3 |
+| R4 | Reset consumed-but-never-applied on background cold-launch (`modelContext == nil` no-op, id still marked processed) | A content-available push before first foreground | stateMachine-2 |
+| R5 | ≥14d-slow clock + 21d local prune re-processes an expired reset (selection re-clear) | Constant slow clock + dormant origin | stateMachine-3 |
+| R6 | No-sight-ever + partial non-empty zone ⇒ reconcile-deletes not-yet-re-pushed data (permanent for sole copies) | Marker query-invisible on *every* pass the device ran since the reset | carried from r1 row 14 / r2 row 20 |
+| R7 | Intentional cost: deletion propagation suspended ~8 days after every reset; deletions made in the window are resurrected by blanket re-push | Any reset (by design) | rev 4 intentional changes |
+| R8 | >14d-fast receiver clock GCs a live marker: delivery broken for devices that never sighted it | Pathological clock | rev 4 row 14/15 (corrected arithmetic) |
+
+#267's change-token model should make R1–R3, R6, R7 **impossible by construction**
+(deletions are explicit events; no windows, no absence inference). R4, R5, D-* remain real
+design obligations for the new engine (they are about command processing and state hygiene,
+not about absence inference).
+
+## 4. Obligations this corpus places on the #267 design
+
+1. A **corpus-mapping table**: every ID above → *impossible-by-construction* / *safe
+   (mechanism named)* / *accepted-residual (honest preconditions)*. No "narrow window"
+   verdicts.
+2. The design must pass the same adversarial process that produced this corpus: independent
+   skeptic rounds until a full round yields no breaking interleaving.
+3. Token lifecycle is in scope of the mapping: bootstrap (no token), `changeTokenExpired`,
+   zone deleted/recreated (D-6), account switch (D-3) — each is an opportunity to
+   reintroduce a full-requery path, which is where Class A comes back from the dead.
+4. Reset Sync re-designed on the new transport must be mapped against **all of Class B**,
+   and E-2 resolved deliberately.

--- a/docs/plans/2026-07-02-reset-sync-a1-design-rev1.md
+++ b/docs/plans/2026-07-02-reset-sync-a1-design-rev1.md
@@ -1,0 +1,252 @@
+> **SUPERSEDED (2026-07-02):** rev 1 of the A1 design, authored by a prior session and never
+> committed. Preserved as part of the A1 acceptance corpus for #267 — see
+> `2026-07-02-reset-sync-a1-acceptance-corpus.md`. Rev 1 was revised (before any adversarial
+> round ran) because re-derivation found three holes: unprotected *location* reconciliation;
+> the stateless per-pass A3 flag not surviving the re-push window (manual "Sync Now" or
+> crash-relaunch mid-re-push could still wipe); undocumented reliance on CloudKit zone
+> atomicity.
+
+# Design: Reset-Sync Safety (SyncResetRequest lifecycle)
+
+- **Bundle:** A1 (epic #263)
+- **Issues:** #195 (critical) reset race wipes local profiles; #202 (high) reset consumed by first device / never GC'd
+- **Date:** 2026-07-02
+- **Files:** `Foqos/CloudKit/ProfileSyncManager.swift`, `Foqos/CloudKit/SyncCoordinator.swift`,
+  `Foqos/CloudKit/SyncModels.swift`, `Foqos/CloudKit/SyncEventDelegate.swift`,
+  `Packages/FoqosShared/Sources/FoqosShared/SharedData.swift`
+
+## Problem (re-verified against current `main`, 2026-07-02)
+
+Two independent defects in the `SyncResetRequest` lifecycle. Both confirmed by re-tracing
+the code, not just the handover.
+
+### #195 — Reset race / partial-failure wipes all local profiles on other devices
+
+1. **Ordering.** `resetSync` (`ProfileSyncManager.swift:823`) calls `deleteAllSyncedData()`
+   (line 831) — which deletes `SyncedProfile` records first (record-type order line 859) —
+   **before** saving the `SyncResetRequest` (line 839). Zone deletions fire the zone
+   subscription (`setupSubscriptions`, line 210) on other devices.
+2. **Reconciliation gap.** A device that syncs in that window runs `performFullSync`:
+   `pullResetRequests` (line 345) sees no request yet, `pullProfiles` (line 348) sees an
+   empty zone, and delivers `([], remoteProfileIds: [])` to
+   `SyncCoordinator.handleSyncedProfiles`. The guard at `SyncCoordinator.swift:179`
+   (`remoteProfileIds.isEmpty && !syncedProfiles.isEmpty`) only covers the decode-failure
+   case; with **both** empty it falls through and deletes every local profile with
+   `syncVersion > 0` (line 195) via `BlockedProfiles.deleteProfile`.
+3. **Persistent partial-failure variant.** If `deleteAllSyncedData` throws mid-way
+   (`modifyRecords` limitExceeded, line 873), `resetSync` aborts before the request is ever
+   saved. The zone is left wiped with no reset marker — **any** later sync on **any** device
+   deterministically wipes its local profiles. Not a race; a durable landmine.
+4. **Intra-pass re-push race.** Even when the reset request *is* seen first,
+   `handleSyncReset` (`SyncCoordinator.swift:552`) re-pushes in a detached `Task` while the
+   **same** `performFullSync` continues synchronously into `pullProfiles`. The single query
+   beats N sequential re-push round-trips, so reconciliation runs against a partial remote
+   set and deletes the not-yet-re-pushed remainder. Re-pushed profiles keep `syncVersion > 0`,
+   so the `syncVersion` guard does not protect them.
+
+**Impact:** local profiles, app selections, session history destroyed on the innocent
+device; profiles later recreated from the origin arrive `needsAppSelection = true`, so
+blocking silently stops enforcing apps.
+
+### #202 — Reset consumed by first reader; origin never GCs; no TTL
+
+1. **Consume-on-first-read.** `pullResetRequests` deletes the record immediately after the
+   **first** non-origin device processes it (line 402). In a 3+ device family the remaining
+   devices never receive the reset.
+2. **Origin never cleans up.** The origin skips its own request via `continue` (line 387)
+   and never deletes it. On a single-device account the record lingers **forever**.
+3. **No TTL.** `requestedAt` is written but never read. A device that enables sync months
+   later processes the stale request and executes `handleSyncReset(clearAppSelections: true)`
+   (`SyncCoordinator.swift:535`), clearing `selectedActivity` on every profile — blocking
+   silently stops.
+
+## Constraints & design forces
+
+- **No CloudKit mock exists.** `ProfileSyncManager` calls `privateDatabase` (a real
+  `CKDatabase`) directly; there is no injectable seam. Introducing a CK abstraction is a
+  large, risky refactor and out of scope for a "minimal fix" bundle. Therefore: keep the CK
+  plumbing as-is, and **extract every decision into pure, injectable-`now` helpers** that are
+  unit-testable.
+- **The destructive act is testable.** `SyncCoordinator.handleSyncedProfiles` takes plain
+  arrays + an in-memory `ModelContext`, reachable through the `didReceiveSyncedProfiles`
+  delegate method. This is the last line of defence for #195 and where its fix is proven.
+- **CloudKit query indexes are eventually consistent.** A record saved before another can
+  still be *read back* after it. We cannot rely on "saved the marker first ⇒ every reader
+  sees the marker before the deletions." Defence must not depend on query ordering alone.
+- **Safety asymmetry.** Wrongly deleting all local profiles + app selections (silent
+  blocking failure) is catastrophic and hard to notice. Wrongly *keeping* a profile that was
+  legitimately deleted elsewhere is a minor, recoverable staleness. Every ambiguous case must
+  resolve toward "keep."
+- **AGENTS.md:** feature branch, TDD, `Log.<level>(_,category:)`, no `print`, pin `now` in
+  tests, swift-format, no behaviour change outside the defect scope.
+
+## Approach
+
+Two cooperating mechanisms — **reconciliation gating** (fixes #195, the destructive path)
+and **request lifecycle** (fixes #202, delivery + cleanup) — plus an **ordering fix** that
+turns a failed reset from a data-wipe into a no-op.
+
+### Part A — Reconciliation gating (#195)
+
+**A1. Order: marker before wipe, and never wipe the current marker.**
+In `resetSync`, save the `SyncResetRequest` **first**, capture its `recordID`, then call
+`deleteAllSyncedData(excluding: [currentRequestRecordID])`. Consequence: a reset that fails
+at the network layer now leaves *all* CloudKit data intact (the wipe never started) instead
+of leaving a wiped, marker-less zone. This alone neutralises the persistent partial-failure
+landmine (#195.3).
+
+**A2. Empty-pull is never authoritative for deletions.**
+Widen the guard in `handleSyncedProfiles`: **skip deletion reconciliation whenever
+`remoteProfileIds.isEmpty`**, regardless of how many profiles decoded. An empty remote
+profile set is indistinguishable from a reset-in-flight / partial-wipe / index-lag
+transient, and the safety asymmetry makes "skip" the only correct choice. (Closes #195.2, the
+primary path.)
+
+**A3. A pass that processed a reset does not reconcile deletions.**
+`pullResetRequests` returns whether it processed a non-origin reset this pass;
+`performFullSync` threads that boolean through `pullProfiles` into
+`didReceiveSyncedProfiles(..., resetProcessedThisPass:)`. When true, `handleSyncedProfiles`
+skips deletion reconciliation. This is **stateless across passes** (computed fresh each
+pass — no flag can leak or get stuck), and it closes #195.4 (intra-pass re-push race) without
+depending on re-push timing.
+
+**A4. Await the re-push before the follow-up sync.**
+`handleSyncReset` already chains `rePushLocalSyncedData` then `performFullSync` inside one
+`Task`; keep that ordering (re-push completes before the follow-up full sync pulls), so the
+follow-up pass reconciles against a fully-rebuilt remote. A3 already makes the *triggering*
+pass safe; A4 makes the *follow-up* pass accurate.
+
+Normal deletion propagation is preserved: a non-empty, reset-free pull that is missing one
+profile still reconciles that profile away (regression-guarded by test).
+
+### Part B — Request lifecycle (#202)
+
+Replace consume-on-first-read with **per-device idempotent processing + TTL + cooperative
+garbage collection**. No device roster or per-device ack list (brittle — would need to know
+every device that exists).
+
+**B1. Per-device processed watermark.**
+Add `SharedData.lastProcessedResetAt: Date` (app-group, per device, default `.distantPast`).
+A device processes a request only if `requestedAt > lastProcessedResetAt`; after processing,
+it advances the watermark to that `requestedAt`. Idempotent (never reprocesses), O(1)
+storage, monotonic (an older reset seen after a newer one is correctly skipped — the newer
+one supersedes).
+
+**B2. TTL.**
+`SyncResetRequest.isExpired(now:ttl:)` using the existing `requestedAt`. Requests older than
+`ttl` are ignored by all devices. `ttl = 7 days` (constant `SyncResetRequest.defaultTTL`):
+long enough that all family devices realistically sync within it; short enough that stale
+resets don't haunt a device months later. A device offline longer than the TTL still
+full-syncs current data on return and merely keeps its app selections — the safe default.
+(Closes #202.3, the fresh-device-processes-year-old-reset scenario.)
+
+**B3. Cooperative GC.**
+Any device that sees a request past its TTL deletes it (a past-TTL request is globally inert,
+so deletion is always safe and self-healing even if the origin is gone). This closes #202.2
+(origin/single-device lingering) without needing the origin to be online.
+
+**B4. Do not delete within-TTL requests after processing.**
+Deletion of a live request is what breaks 3+ device delivery. Within-TTL requests are left in
+place; the per-device watermark (B1) prevents reprocessing. They are removed later by
+cooperative TTL-GC (B3). (Closes #202.1.)
+
+**B5. Pure classifier.**
+`SyncResetRequest.classify(deviceId:watermark:now:ttl:) -> ResetAction` returning one of
+`.skipOwnOrigin`, `.skipAlreadyProcessed`, `.expiredCollect` (skip **and** GC),
+`.process`. `pullResetRequests` becomes a thin loop: classify → act. All the #202 logic lives
+in this pure, `now`-injected function and is exhaustively unit-tested.
+
+**B6. Watermark advance prevents an infinite reset loop.**
+Because within-TTL requests are no longer deleted (B4), the watermark is the *only* thing
+stopping re-processing. `pullResetRequests` must advance `lastProcessedResetAt` to the
+request's `requestedAt` **synchronously, in the same loop iteration** that classifies it
+`.process` — before `handleSyncReset` spawns its re-push + follow-up `performFullSync`. That
+follow-up pass re-runs `pullResetRequests`, now sees `.skipAlreadyProcessed`, and does not
+re-trigger the reset. Advancing the watermark inside the async re-push `Task` instead would
+race the follow-up pass and can loop. This is the single most correctness-critical ordering in
+Part B.
+
+## Data flow (post-fix)
+
+```
+resetSync(origin):
+  save SyncResetRequest  ──► deleteAllSyncedData(excluding: current request)
+                             └► didReceiveSyncReset ──► rePush(local) ──► performFullSync
+
+performFullSync(any device):
+  resetProcessed = pullResetRequests()          # classify each: skip / process / expire-GC
+  pullProfiles(resetProcessed:) ──► didReceiveSyncedProfiles(profiles, remoteIds, resetProcessedThisPass)
+      handleSyncedProfiles:
+        apply upserts (unchanged)
+        reconcile deletions  ONLY IF  !remoteIds.isEmpty  &&  !resetProcessedThisPass
+```
+
+## Partial-failure interleaving analysis
+
+Every interleaving considered; the design's response shown. "Converges" = all devices end
+with the union of local data, no silent blocking loss.
+
+### resetSync (origin)
+
+| # | Interleaving | Outcome |
+|---|---|---|
+| 1 | Save request ✓, crash before wipe | Request present (within TTL); no data wiped anywhere. Receivers gated + re-push. Origin re-pushes its local data next sync. **Converges.** |
+| 2 | Save ✓, wipe partial, crash | Request present. Receivers gated (A3) / empty-skip (A2). Origin re-pushes all local next full sync (`didRequestLocalDataPush`), restoring purged CK records. **Converges.** |
+| 3 | Save request **throws** (network) | Wipe is *after* save, so nothing is wiped. UI shows error. **No data loss** — a failed reset is now a no-op (was: durable wipe). |
+| 4 | Save ✓, wipe ✓, app killed before re-push runs | CK holds only the marker, zero profiles. Receivers pull empty → empty-skip (A2). Origin re-pushes local next sync. Origin's SwiftData never touched. **Converges.** |
+| 5 | Remote notification fires during resetSync awaits | Concurrent `performFullSync` on origin pulls its own mid-wipe empty zone → empty-skip (A2). Origin's own request skipped (`originDeviceId`). **Safe.** |
+
+### pullResetRequests (receiver)
+
+| # | Interleaving | Outcome |
+|---|---|---|
+| 6 | Apply ✓, watermark ✓, GC delete of an expired other fails | Harmless; retried next pass. |
+| 7 | Apply ✓, crash before watermark advance | Next pass reprocesses the **same** request. `handleSyncReset` is idempotent (re-clear already-cleared selections; re-push overwrites). Wasteful, safe. |
+| 8 | Fresh device (watermark `.distantPast`) sees within-TTL reset | Processes once — correct delivery. Sees past-TTL reset → skip + GC (B2/B3). Closes #202.3. |
+| 9 | Two receivers process same within-TTL request concurrently | Both apply (idempotent), advance own watermark. Neither deletes (within TTL) → no delete race. |
+| 10 | `requestedAt` far in future (clock skew) | Treated within TTL, processed; watermark jumps forward → a legit reset in that window could be skipped. Rare; accepted; noted. |
+
+### handleSyncedProfiles reconciliation
+
+| # | Interleaving | Outcome |
+|---|---|---|
+| 11 | remoteIds empty, decoded empty (scenario 1) | Skip (A2). Closes #195 primary. |
+| 12 | remoteIds empty, decoded non-empty (decode failures) | Skip (existing guard, retained). |
+| 13 | remoteIds non-empty partial + resetProcessedThisPass | Skip (A3). Closes #195.4. |
+| 14 | remoteIds non-empty partial + reset **not** seen this pass (CloudKit index lag) | **Residual:** reconciles → may delete not-yet-re-pushed profiles. Mitigated: origin re-push makes them reappear next pass and `createLocalProfile` recreates them (self-healing, was permanent). Narrow window; documented accepted risk. Fully closing it needs per-delete tombstones — out of scope (A3-wave conflict semantics). |
+| 15 | Non-empty, complete, no reset, one profile deleted remotely | Reconciles + deletes locally — **normal propagation preserved** (regression test). |
+
+## Intentional behaviour changes (documented)
+
+- **Deleting the *last* remaining profile no longer propagates via reconciliation.** With the
+  zone empty, other devices skip reconciliation (A2) and re-push their copy, effectively
+  resurrecting the last profile. Deleting a *non-last* profile still propagates normally
+  (remote non-empty). Accepted: resurrecting one profile is vastly safer than wiping all.
+  Explicit deletes still delete the CK record via `deleteProfileFromSync`; only the
+  reconciliation *inference* is gated.
+
+## Test plan (TDD)
+
+Pure / in-memory — no CloudKit:
+
+1. **`SyncResetRequest.classify` / `isExpired`** (issue #202, the bulk): own-origin skip;
+   already-processed skip (watermark); expired → `.expiredCollect`; fresh within-TTL →
+   `.process`; boundary at exactly `ttl`; future `requestedAt`. All with a single injected
+   `now`.
+2. **`handleSyncedProfiles` gating** (issue #195) via `didReceiveSyncedProfiles`, seeded
+   in-memory `ModelContext`, `MockSessionController`:
+   - empty remote + empty decoded ⇒ local profiles (syncVersion>0) **retained**;
+   - non-empty partial + `resetProcessedThisPass = true` ⇒ **retained**;
+   - non-empty complete + no reset, one missing ⇒ that one **deleted** (regression guard);
+   - `syncVersion == 0` local ⇒ never deleted (unchanged).
+3. **`SharedData.lastProcessedResetAt`** round-trip + `.distantPast` default.
+
+CloudKit-plumbing (`resetSync` ordering, `pullResetRequests` loop) verified by code
+inspection; their *decisions* are covered by the pure classifier (1).
+
+## Out of scope
+
+- Per-delete tombstones for the general (non-reset) deletion path (interleaving #14 residual).
+- Introducing a CloudKit mock / `CKDatabase` abstraction.
+- Any change to session, location, or emergency-settings sync beyond what these two issues
+  touch.

--- a/docs/plans/2026-07-02-reset-sync-a1-design-rev2.md
+++ b/docs/plans/2026-07-02-reset-sync-a1-design-rev2.md
@@ -1,0 +1,168 @@
+> **SUPERSEDED (2026-07-02):** rev 2 of the A1 design. Broken by adversarial round 1 (see
+> `2026-07-02-reset-sync-a1-interleavings-round1.md`, 27 findings): the "clear gate on
+> zero-failure push" rule is unsound (push acks race the origin's snapshot wipe; the
+> follow-up pull is not read-your-writes; stale/pre-reset push tasks clear a newer reset's
+> gate; never-pushable newer-schema profiles make "zero failures" a lie), and two concurrent
+> resets mutually annihilate each other's markers. Preserved as part of the A1 acceptance
+> corpus for #267 — see `2026-07-02-reset-sync-a1-acceptance-corpus.md`.
+
+# Design: Reset-Sync Safety (SyncResetRequest lifecycle)
+
+- **Bundle:** A1 (epic #263)
+- **Issues:** #195 (critical) reset race wipes local profiles; #202 (high) reset consumed by first device / never GC'd
+- **Date:** 2026-07-02 (rev 2 — adds persistent re-push gate, location gating; supersedes the per-pass flag of rev 1)
+- **Files:** `Foqos/CloudKit/ProfileSyncManager.swift`, `Foqos/CloudKit/SyncCoordinator.swift`,
+  `Foqos/CloudKit/SyncModels.swift`,
+  `Packages/FoqosShared/Sources/FoqosShared/SharedData.swift`
+
+## Problem (re-verified against current `main`, 2026-07-02, post-PR #264)
+
+*(identical to rev 1's problem statement, with one addition:)*
+
+**#195.5 — Same defect for locations.** `handleSyncedLocations` (`SyncCoordinator.swift:479-499`)
+runs the identical delete-on-absence reconciliation for `SavedLocation`, and
+`deleteAllSyncedData` wipes `SyncedLocation` records too. Every #195 scenario also destroys
+local saved locations. (Sessions and emergency settings have no absence-based deletion, so
+they are not exposed.)
+
+## Constraints & design forces
+
+As rev 1, plus:
+
+- **CloudKit custom zones are atomic per operation.** `deleteAllSyncedData` issues one
+  `modifyRecords` per record type, so within a type the deletion is all-or-nothing (a
+  `limitExceeded` failure deletes nothing). Partial wipes are therefore partial *across
+  types*, never within `SyncedProfile`. This bounds — but must not carry — the failure
+  analysis; the gates below hold even if a within-type partial state somehow occurred.
+- **`pushLocalData` re-pushes all local profiles and locations at the end of every full
+  sync pass** (`SyncCoordinator.swift:45-100`, via `didRequestLocalDataPush`). Convergence
+  after any failure therefore does not depend on a special retry path; it only requires that
+  reconciliation not destroy local data before a re-push has happened.
+
+## Approach
+
+Two cooperating mechanisms — **reconciliation gating** (fixes #195, the destructive path)
+and **request lifecycle** (fixes #202, delivery + cleanup) — plus an **ordering fix** that
+turns a failed reset from a data-wipe into a no-op.
+
+### Part A — Reconciliation gating (#195)
+
+**A1. Order: marker before wipe, and never wipe the current marker.**
+In `resetSync`, save the `SyncResetRequest` **first**, capture its `recordID`, then call
+`deleteAllSyncedData(excluding: currentRequestRecordID)`. A reset that fails at the network
+layer now leaves *all* CloudKit data intact instead of a wiped, marker-less zone (closes
+#195.3). Excluding only the current request means older `SyncResetRequest` records are still
+wiped by the reset itself (part of #202 cleanup). *(Round 1 showed this exclusion rule is
+itself a hole: two concurrent resets delete each other's markers.)*
+
+**A2. Empty-pull is never authoritative for deletions.**
+Skip deletion reconciliation whenever `remoteProfileIds.isEmpty`, regardless of how many
+profiles decoded; same for `remoteLocationIds.isEmpty`. (Closes #195.2.)
+
+**A3. Persistent re-push gate: no deletion reconciliation until this device's post-reset
+re-push has completed.**
+A per-device, *persisted* marker `SharedData.resetRePushPendingSince: Date?`:
+
+- **Set** (to the request's `requestedAt`) synchronously *before* the reset is applied:
+  by `pullResetRequests` when it classifies a request `.process`, before invoking
+  `didReceiveSyncReset`; and by `resetSync` on the origin, before `deleteAllSyncedData`.
+- **While set (and within TTL)**: `handleSyncedProfiles` and `handleSyncedLocations` skip
+  deletion reconciliation (upserts still apply).
+- **Cleared** when a complete local re-push finishes with **zero per-record failures** —
+  both `rePushLocalSyncedData` (the reset path) and `pushLocalData` (every full sync pass)
+  report success/failure counts and clear the flag on a clean run. If some pushes failed,
+  the flag stays set and the next pass's push retries.
+- **TTL backstop:** a pending flag older than `SyncResetRequest.defaultTTL` (7 days) is
+  ignored (reconciliation resumes) and cleared.
+
+Rationale vs rev 1's per-pass boolean: the destructive window is not one pass wide. After a
+device processes a reset, its watermark (B1/B6) has already advanced, so a *subsequent*
+pass — a manual "Sync Now" seconds later, or an app relaunch after a crash mid-re-push —
+would classify the request `.skipAlreadyProcessed`, reconcile against the still-partial
+zone, and delete local data that was never re-pushed. A persisted gate closes
+process-crash-relaunch, concurrent manual sync, and the origin's own crash-after-wipe.
+*(Round 1 proved the CLEARING rule wrong, not the persistence idea: "zero per-record
+failures" is push-ack evidence, which proves nothing about the zone under a concurrent
+snapshot wipe, is not read-your-writes for the follow-up pull, can be produced by a
+pre-reset stale task, and silently excludes never-pushable `isNewerSchemaVersion` profiles.)*
+
+**A4. Re-push before the follow-up sync.**
+`handleSyncReset` already chains `rePushLocalSyncedData` then `performFullSync` inside one
+`Task`; keep that ordering.
+
+### Part B — Request lifecycle (#202)
+
+As rev 1 (B1 watermark, B2 TTL = 7 days, B3 cooperative GC, B4 no-delete-within-TTL,
+B5 pure classifier with `.expiredCollect` checked first, B6 synchronous watermark advance),
+with the addition that the gate (A3) covers the crash window B6 leaves open: a crash between
+watermark advance and re-push completion is covered by the persisted gate.
+
+### Interplay
+
+- A2 protects devices that **cannot see** the marker yet (mid-wipe, index lag, marker save
+  in flight): an empty pull deletes nothing.
+- A3 protects devices that **have seen** the marker, across the entire re-push window,
+  including crashes and concurrent passes.
+- B1–B6 make delivery reach every device exactly once and make cleanup independent of any
+  single device's survival.
+
+## Data flow (post-fix)
+
+```
+resetSync(origin):
+  save SyncResetRequest ──► set resetRePushPendingSince ──► deleteAllSyncedData(excluding: current)
+      └► didReceiveSyncReset ──► clear selections (if flag) ──► rePush(local)
+                                     └► on zero failures: clear gate ──► performFullSync
+
+performFullSync(any device):
+  pullResetRequests()                    # classify each: expiredCollect / skip / process
+      .process ⇒ advance watermark; set gate; didReceiveSyncReset (as above)
+  pullProfiles ──► didReceiveSyncedProfiles(profiles, remoteIds)
+      handleSyncedProfiles:
+        apply upserts (unchanged)
+        reconcile deletions ONLY IF !remoteIds.isEmpty && gate not set/expired
+  pullLocations ──► (same gating)
+  didRequestLocalDataPush ──► pushLocalData ──► on zero failures: clear gate
+```
+
+## Partial-failure interleaving analysis (as claimed at the time — several rows were REFUTED in round 1)
+
+### resetSync (origin)
+
+| # | Interleaving | Claimed outcome (annotations from round 1) |
+|---|---|---|
+| 1 | Save request **throws** | No data loss — a failed reset is a no-op. *(Held.)* |
+| 2 | Save ✓, crash before gate set / before wipe | Converges. *(Held.)* |
+| 3 | Save ✓, gate ✓, wipe partial, crash | Converges via gate + re-push. *(Held, modulo the clearing-rule holes.)* |
+| 4 | Save ✓, gate ✓, wipe ✓, killed before re-push | Converges via A2 + gate. *(Held.)* |
+| 5 | Concurrent pass on origin mid-reset | Safe. *(Held.)* |
+| 6 | Two devices reset near-simultaneously | "At least the later wipe's marker survives … **Converges**." **REFUTED (round 1):** each wipe's `SyncResetRequest` snapshot can include the other origin's marker (the type is wiped last), so BOTH markers are deleted; a third device then reconciles a partially re-seeded zone with zero protection. |
+
+### pullResetRequests (receiver)
+
+| # | Interleaving | Claimed outcome (annotations from round 1) |
+|---|---|---|
+| 7 | Gate ✓, watermark ✓, apply ✓, re-push ✓, GC delete fails | Harmless. *(Held.)* |
+| 8 | Gate ✓, watermark ✓, crash before/during apply or mid-re-push | Converges via persisted gate. *(Partially held — but see clearing-rule holes.)* |
+| 9 | Manual "Sync Now" while another pass's re-push is in flight | "Gate still set ⇒ skip. Closes the rev-1 hole." **REFUTED (round 1):** a pre-reset `pushLocalData` task straddling the wipe completes "clean" and clears the gate a later reset set (no CAS/attribution); also a receiver's clean re-push racing the origin's still-in-flight wipe clears the gate while the zone is about to lose the re-pushed records. |
+| 10 | Fresh device sees within-TTL reset | Delivery correct; stale (>TTL) skipped + GC'd. *(Held.)* |
+| 11 | Two receivers process the same request concurrently | Both apply; no delete race. *(Held.)* |
+| 12 | `requestedAt` far in future (clock skew) | "Watermark jumps forward → a legit reset could be skipped. Rare; accepted." **REFUTED as under-stated (round 1):** a poisoned watermark disarms the gate for a later legitimate reset — data loss, not just a skipped selection-clear. |
+| 13 | Re-push permanently failing | Gate suppression bounded by 7-day backstop. **REFUTED as mis-anchored (round 1):** the gate stores the request's `requestedAt`, so a device processing a 6.9-day-old reset gets a gate that expires in ~2 hours; and on expiry the same pass reconciles BEFORE its push, deleting own-only data permanently. |
+
+### handleSyncedProfiles / handleSyncedLocations reconciliation
+
+| # | Interleaving | Claimed outcome (annotations from round 1) |
+|---|---|---|
+| 14 | remoteIds empty, decoded empty | Skip (A2). *(Held.)* |
+| 15 | remoteIds empty, decoded non-empty | Skip (A2 subsumes old guard). *(Held.)* |
+| 16 | remoteIds non-empty partial + gate set | "Skip (A3). Closes #195.4 and the multi-pass window." **REFUTED (round 1):** the design's own zero-failure clear rule removes the gate while the origin's wipe is still in flight (ack-race); `isNewerSchemaVersion` profiles are never re-pushed yet remain deletion-eligible, so a "clean" re-push clears the gate without their data in the zone and reconciliation then deletes them. |
+| 17 | remoteIds non-empty partial, no marker visible (index lag), no gate | Residual, "narrow". **Round 1: mischaracterised** — marker and data-record indexes are independent; and own-only profiles deleted before the end-of-pass push are lost permanently, not "self-healed with selection loss". |
+| 18 | Non-empty, complete, no reset/gate, one deleted remotely | Normal propagation preserved. *(Held.)* |
+
+## Intentional behaviour changes / test plan / out of scope
+
+As rev 1, plus: reset requests persist (within TTL) instead of being consumed; gate-lifecycle
+tests (set-before-dispatch; cleared on zero-failure push; retained on partial failure;
+TTL-expiry) — *round 1 additionally showed "zero per-record failures" is ambiguous (zero-attempt
+early-return paths count as clean) and the gate/watermark write order was unspecified.*

--- a/docs/plans/2026-07-02-reset-sync-a1-design-rev3.md
+++ b/docs/plans/2026-07-02-reset-sync-a1-design-rev3.md
@@ -1,0 +1,194 @@
+> **SUPERSEDED (2026-07-02):** rev 3 of the A1 design. Broken by adversarial round 2 (see
+> `2026-07-02-reset-sync-a1-interleavings-round2.md`, 20 findings), most importantly:
+> (a) the **vacuous-reconciliation proof** — a pass whose read-verification passes has a
+> provably empty deletion set, so "verify, then resume deleting" never actually resumes
+> propagation; (b) the hold is edge-triggered (cleared by a possibly stale-presence pull,
+> not re-armed by a stale-absent marker query) while the danger is level-triggered;
+> (c) concurrent passes leak one pass's hold-clear into another pass's stale reconciliation;
+> (d) the `now + 1h` watermark cap re-introduces an **infinite reprocessing loop**
+> (repeated family-wide selection clearing) for receivers with slow clocks; (e) the 14-day
+> gcTTL gives only a 7-day skew margin, not the claimed 14. Preserved as part of the A1
+> acceptance corpus for #267 — see `2026-07-02-reset-sync-a1-acceptance-corpus.md`.
+
+# Design: Reset-Sync Safety (SyncResetRequest lifecycle)
+
+- **Bundle:** A1 (epic #263)
+- **Issues:** #195 (critical) reset race wipes local profiles; #202 (high) reset consumed by first device / never GC'd
+- **Date:** 2026-07-02 (rev 3 — read-verified reconciliation holds; supersedes rev 2's
+  push-ack-cleared gate, which adversarial verification broke in three independent ways)
+- **Files:** `Foqos/CloudKit/ProfileSyncManager.swift`, `Foqos/CloudKit/SyncCoordinator.swift`,
+  `Foqos/CloudKit/SyncModels.swift`,
+  `Packages/FoqosShared/Sources/FoqosShared/SharedData.swift`
+
+## Problem
+
+*(identical to rev 2's problem statement — #195.1–.5 and #202.1–.3.)*
+
+## Constraints & design forces
+
+As rev 2, with these sharpened:
+
+- **CloudKit query indexes are eventually consistent, with no cross-record-type ordering.**
+  No safety decision may rely on a write being query-visible; only positive query evidence
+  counts. *(Rev 3's own failure: it treated positive evidence as trustworthy, but positive
+  evidence can be stale-presence.)*
+- **A push ack is not durability against a concurrent wipe** (deletes by recordID from a
+  fetched snapshot land after the ack). This is what broke rev 2.
+- **CloudKit custom zones are atomic per operation, and operations are capped at 400
+  records** — `deleteAllSyncedData` must chunk.
+- **Device clocks are not trustworthy** — prefer server-assigned `CKRecord.creationDate`;
+  clock rules must fail toward "keep data / keep marker."
+
+## Approach
+
+One safety invariant, one delivery mechanism, one ordering fix.
+
+> **Invariant (I): while any reset marker is visible (or a hold persists from one), a device
+> may reconcile deletions only in a pass whose own pull proves the zone contains every
+> record this device could re-create.** Positive evidence, read in the same pass, decides —
+> never push acks, never timers alone, never classification state.
+
+### Part A — Reconciliation holds (#195)
+
+**A1. Order: marker before wipe; never wipe markers; chunked deletes.**
+`resetSync`: (1) save the new `SyncResetRequest` (failure aborts with the zone intact);
+(2) advance the origin's watermark; (3) set both reconciliation holds; (4)
+`deleteAllSyncedData` — **excluding the `SyncResetRequest` type entirely** (fixes rev 2's
+mutual-marker-annihilation) and chunked ≤400 recordIDs per op; (5) fire `didReceiveSyncReset`
+as today.
+
+**A2. Reconciliation holds, set on sight, cleared only by read-verification.**
+Two persisted per-device dates: `profileReconciliationHoldSince` and
+`locationReconciliationHoldSince`.
+
+- **Set** (to local `now`, only if nil) by `pullResetRequests` whenever its query result
+  contains **any** `SyncResetRequest` record — regardless of classification — and by
+  `resetSync` before its wipe. Set before `didReceiveSyncReset` dispatch and before any
+  watermark advance.
+- **While a hold is set**, the corresponding handler skips deletion reconciliation — unless
+  cleared in that same pass by read-verification. Upserts always apply. The hold is read
+  fresh inside the reconciliation branch.
+- **Read-verification (the only clearing rule):** if the pull's `remoteProfileIds` ⊇
+  {local profiles with `syncVersion > 0` and `!isNewerSchemaVersion`}, clear the hold and
+  reconcile normally **using that same pulled set**. Locations mirror with
+  `remoteLocationIds` ⊇ {local locations with `syncVersion > 0`}. Each hold clears
+  independently.
+- **Backstop:** a hold older than 14 days is cleared **and that pass still skips
+  reconciliation** (the end-of-pass push restores anything missing before the next pass
+  reconciles).
+
+*(Round 2 refuted the clearing rule from both directions: stale-presence pulls clear the
+hold while the zone is genuinely wiped; stale-absence marker queries then fail to re-arm it;
+a concurrent pass's clear leaks into another pass's stale pulled set; and — decisively — a
+passing superset check has a provably empty deletion set, so the machinery could only ever
+authorize vacuous reconciliation.)*
+
+**A3. Empty-pull is never authoritative for deletions** (profiles and locations).
+
+**A4. Newer-schema profiles are exempt from deletion reconciliation.** They are read-only
+holdings this device can never re-push; treat like `syncVersion == 0`.
+
+### Part B — Request lifecycle (#202)
+
+**B1. Per-device processed watermark** `lastProcessedResetAt` (default `.distantPast`);
+advance **capped at `now + 1 hour`** to bound skew poisoning. *(Round 2: the cap breaks
+idempotency for receivers >1h slow — infinite reprocessing loop with repeated
+selection-clearing; idempotency must be by request identity, not time.)*
+
+**B2. Effective date & processing TTL.** `effectiveDate = CKRecord.creationDate ??
+requestedAt`; requests older than `processTTL = 7 days` are not processed.
+
+**B3. Cooperative GC with a skew margin.** Any device deletes markers older than
+`gcTTL = 14 days` (= 2 × processTTL). *(Round 2: margin arithmetic wrong — a receiver
+>7 days fast, not >14, can GC a live marker: it GCs at real age ≥ 14 − F.)*
+
+**B4. Process the newest, once.** Pure classifier
+`classify(effectiveDate:originIsSelf:watermark:now:)` →
+`.process | .skipOwnOrigin | .skipAlreadyProcessed | .skipExpired | .expiredCollect`;
+process only the newest `.process` candidate per pass; within-TTL markers never deleted
+after processing.
+
+**B5. Ordering inside `.process`**: holds already set (on sight) → advance watermark
+synchronously → dispatch `didReceiveSyncReset`. A kill anywhere leaves holds set.
+
+### Interplay
+
+- A3 protects devices that cannot see the marker **when the zone is fully wiped**.
+- A2 protects every device that *can* see the marker (or ever saw one), for exactly as long
+  as the zone lacks data that device could restore — and not a pass longer. *(Round 2:
+  false — protection can end on a stale-presence read while the zone still lacks the data,
+  and does not resume on a stale-absent one.)*
+- A4 protects data no push path can restore.
+- B1–B5 make delivery reach every syncing device within the processing TTL, exactly once
+  per device, with cleanup that needs no particular device to survive.
+
+## Data flow (post-fix)
+
+```
+resetSync(origin):
+  save SyncResetRequest ─► advance watermark ─► set both holds
+    ─► chunked wipe of data types (never SyncResetRequest, ≤400/op)
+    ─► didReceiveSyncReset ─► clear own selections (if flag) ─► rePush(local)
+                                 ─► performFullSync            [always, success or not]
+
+performFullSync(any device):
+  pullResetRequests:
+      any marker fetched        ⇒ set holds (if nil)
+      classify all; age>14d     ⇒ GC-delete
+      newest .process candidate ⇒ advance watermark ─► didReceiveSyncReset (as above)
+  pullProfiles ─► handleSyncedProfiles:
+      apply upserts (always)
+      deletion reconciliation IFF remoteIds nonempty
+        AND (hold nil  OR  remoteIds ⊇ local restorable ids → clear hold, reconcile)
+        AND skipping isNewerSchemaVersion + syncVersion==0 profiles
+  pullLocations ─► handleSyncedLocations: same shape, location hold
+  didRequestLocalDataPush ─► pushLocalData   [pushes restorable local data; never clears holds]
+```
+
+## Partial-failure interleaving analysis (as claimed — rows 5, 9, 10, 13, 14, 15, 16, 19, 20 were refuted or shown mis-stated in round 2)
+
+### resetSync (origin)
+
+| # | Interleaving | Claimed outcome |
+|---|---|---|
+| 1 | Marker save **throws** | No data loss — failed reset is a no-op. |
+| 2 | Marker ✓, crash before watermark/holds/wipe | Converges (receivers process idempotently; origin re-verifies). |
+| 3 | Marker ✓, watermark ✓, holds ✓, wipe partial, crash | Converges (holds + superset proof fails on partial zone). |
+| 4 | Wipe ✓, killed before re-push | Converges (A3 + holds; origin's next pass pushes; verification clears). |
+| 5 | Concurrent pass on origin mid-reset | Safe. **(Refuted: a manual pass can verify-clear the origin's holds against its pre-wipe pull before the wipe lands.)** |
+| 6 | Two devices reset near-simultaneously | Both markers survive (wipes never touch markers); newest processed once; converges. |
+| 7 | >400 records of one type | Chunked deletes; mid-chunk failure = row 3. |
+
+### pullResetRequests (receiver)
+
+| # | Interleaving | Claimed outcome |
+|---|---|---|
+| 8 | Sight ✓, holds ✓, killed before watermark advance | Reprocess idempotently; safe by holds-before-watermark ordering. |
+| 9 | Watermark ✓, killed before/during apply or mid-re-push | Converges via persisted holds + re-sight. **(Refuted: re-sight depends on a query that can be stale-absent after a stale-presence verification-clear.)** |
+| 10 | Any pass while a re-push is in flight | Superset proof fails exactly while anything is missing. **(Refuted for the cleared-hold case and the concurrent-pass clear leak.)** |
+| 11 | Fresh device | Delivery within 7d; 7–14d grace `.skipExpired`; >14d collected. |
+| 12 | Two receivers process the same marker concurrently | Both apply; no delete race. |
+| 13 | Origin clock skew (future dates) | Bounded by `creationDate` preference + 1h cap. **(Refuted: cap breaks idempotency for slow receivers — infinite loop.)** |
+| 14 | Receiver clock 7–14 days fast | `.skipExpired`, not GC'd, sighted ⇒ holds. **(Refuted: GCs at real age ≥ 14 − F, so >7d-fast destroys live markers.)** |
+| 15 | Receiver clock >14 days fast | Residual: GCs a live marker. **(Precondition wrong — >7d suffices.)** |
+| 16 | Re-push failing persistently | Deferred propagation bounded by 14-day backstop. **(Refuted as stated: loss also occurs when the finally-successful push is not yet query-visible at the first post-backstop reconcile; and gcTTL == backstop removes marker re-sight protection at exactly that moment.)** |
+
+### handleSyncedProfiles / handleSyncedLocations
+
+| # | Interleaving | Claimed outcome |
+|---|---|---|
+| 17 | remoteIds empty | Skip (A3). |
+| 18 | remoteIds non-empty, hold set, superset fails | Skip. |
+| 19 | remoteIds non-empty, hold set, superset holds | Clear hold; reconcile same pass. **(Refuted as vacuous: the deletion set in such a pass is provably empty; "same-pass resume" resumes nothing.)** |
+| 20 | Partial zone, marker never sighted, no hold | Residual (index lag). **(Precondition wrong: a device that DID sight the marker loses data the same way after a stale-presence clear + stale-absent re-sight.)** |
+| 21 | Non-empty, no marker, no hold, one deleted remotely | Normal propagation preserved. |
+| 22 | `isNewerSchemaVersion` absent from remote | Never deleted (A4). |
+
+## Test plan / out of scope
+
+As rev 2 amended: classifier boundary tests; newest-only; hold lifecycle (set-if-nil,
+independent clears, fresh read); `handleSyncedLocations` mirror; SharedData round-trips.
+*(Round 2 additionally showed: test 4.3 "same-pass deletion after verification-clear" is
+unsatisfiable — a hint the mechanism was vacuous; location `syncVersion` is pull-confirmed,
+not push-optimistic, so "restorable" differs between types; no locking discipline was
+specified for the new compound SharedData writes; 7d/14d boundary operators unpinned.)*

--- a/docs/plans/2026-07-02-reset-sync-a1-design-rev4.md
+++ b/docs/plans/2026-07-02-reset-sync-a1-design-rev4.md
@@ -1,0 +1,372 @@
+> **SUPERSEDED (2026-07-02):** final A1 design (rev 4). Implementation was stopped by maintainer decision in favour of #267 (change-token sync engine). Preserved as part of the A1 acceptance corpus — see `2026-07-02-reset-sync-a1-acceptance-corpus.md`. Round-3 verification found further breaks in THIS design too (see `...-interleavings-round3.md`): born-expired suppression for late sighters; undecodable-marker permanent suppression; forward-clock-roll gate bypass.
+
+# Design: Reset-Sync Safety (SyncResetRequest lifecycle)
+
+- **Bundle:** A1 (epic #263)
+- **Issues:** #195 (critical) reset race wipes local profiles; #202 (high) reset consumed by first device / never GC'd
+- **Date:** 2026-07-02 (rev 4 — time-boxed deletion-reconciliation suppression + identity-based
+  processing. Supersedes rev 3's read-verified holds, which adversarial verification proved
+  vacuous-when-passing and racy-when-clearing, and rev 2's push-ack-cleared gate.)
+- **Files:** `Foqos/CloudKit/ProfileSyncManager.swift`, `Foqos/CloudKit/SyncCoordinator.swift`,
+  `Foqos/CloudKit/SyncModels.swift`,
+  `Packages/FoqosShared/Sources/FoqosShared/SharedData.swift`
+
+## Problem (re-verified against current `main`, 2026-07-02, post-PR #264)
+
+Two independent defects in the `SyncResetRequest` lifecycle. Both confirmed by re-tracing
+the code, not just the handover.
+
+### #195 — Reset race / partial-failure wipes all local profiles on other devices
+
+1. **Ordering.** `resetSync` (`ProfileSyncManager.swift:823`) calls `deleteAllSyncedData()`
+   (line 831) **before** saving the `SyncResetRequest` (line 839). Zone deletions fire the
+   zone subscription (line 210) on other devices while no marker exists.
+2. **Reconciliation gap.** A device syncing in that window sees no reset request and an
+   empty zone; the guard at `SyncCoordinator.swift:179` only covers the decode-failure case
+   (`remoteProfileIds.isEmpty && !syncedProfiles.isEmpty`), so a legitimately empty pull
+   falls through and deletes every local profile with `syncVersion > 0` (line 195).
+3. **Persistent partial-failure variant.** If `deleteAllSyncedData` throws mid-way,
+   `resetSync` aborts before the request is ever saved: a wiped, marker-less zone. Any later
+   sync on any device deterministically wipes its local profiles. A durable landmine, not a
+   race.
+4. **Intra-pass re-push race.** Even when the marker *is* seen, `handleSyncReset`
+   (`SyncCoordinator.swift:552`) re-pushes in a detached `Task` while the same
+   `performFullSync` continues into `pullProfiles`; reconciliation runs against a partial
+   remote set and deletes the not-yet-re-pushed remainder.
+5. **Same defect for locations.** `handleSyncedLocations` (`SyncCoordinator.swift:479-499`)
+   runs identical delete-on-absence reconciliation, and the wipe removes `SyncedLocation`
+   records too. (Sessions and emergency settings have no absence-based deletion.)
+
+**Impact:** local profiles, app selections, session history, saved locations destroyed on
+the innocent device; recreated profiles arrive `needsAppSelection = true`, so blocking
+silently stops enforcing.
+
+### #202 — Reset consumed by first reader; origin never GCs; no TTL
+
+1. **Consume-on-first-read** (`ProfileSyncManager.swift:402`): in a 3+ device family, only
+   the first non-origin device ever receives the reset.
+2. **Origin never cleans up** (skip via `continue`, line 387): on a single-device account
+   the record lingers forever.
+3. **No TTL:** `requestedAt` is never read. A device enabling sync months later processes
+   the stale request and clears `selectedActivity` on every profile
+   (`SyncCoordinator.swift:535`) — blocking silently stops.
+
+## Constraints & design forces
+
+- **No CloudKit mock exists**; keep the CK plumbing as-is and extract every decision into
+  pure, injectable-`now` helpers that are unit-testable.
+- **CKQuery results may lag ANY write arbitrarily, in both directions** — stale absence of
+  existing records and stale presence of deleted ones. **No safety decision may rely on any
+  single query observation being fresh**, including this device's own acked writes.
+  (General index-lag reconciliation risk is #219; this design must not depend on freshness,
+  and must not pretend to more protection than that allows.)
+- **A push ack proves nothing about the zone's later contents** (a concurrent wipe deletes
+  by recordID from its own snapshot). Broke rev 2.
+- **A "verified" pull proves nothing about the next pull**, and a passing superset check
+  has a provably empty deletion set — so "verify, then resume deleting" is either vacuous
+  or unsafe. Broke rev 3. The consequence is structural, not incidental: **while a reset
+  may be in flight, absence-based deletion inference is meaningless and must simply be
+  suspended for a time window.** No client-observable evidence ends the window early.
+- **CloudKit custom zones are atomic per operation; 400-record cap per op** — bulk deletes
+  must be chunked or a large type wedges the reset forever.
+- **`pushLocalData` pushes local profiles and locations at the end of every full sync pass**
+  (via `didRequestLocalDataPush`), except never-pushable `isNewerSchemaVersion` profiles
+  (filtered at `SyncCoordinator.swift:64`, `:567`). Post-failure convergence rides on this.
+- **Device clocks are untrustworthy** (users set them wrong; a screen-time app must assume
+  children roll clocks back). Server-assigned `CKRecord.creationDate` is preferred where
+  available; every clock-dependent rule must fail toward "keep data / keep marker", and no
+  date comparison may create an unbounded loop.
+- **Concurrent passes exist.** `performFullSync` has no reentrancy guard; manual "Sync Now",
+  remote notifications, setup, and the reset follow-up can overlap at await points. Any new
+  state must be safe when read/written by interleaved passes (monotonic, no check-then-act
+  clears).
+- **Safety asymmetry.** Wrongly deleting all local profiles (silent blocking failure) is
+  catastrophic; wrongly keeping or resurrecting one is minor and recoverable. Ambiguity
+  resolves toward "keep".
+- **AGENTS.md:** feature branch, TDD, `Log`, pinned `now` in tests, swift-format, no
+  behaviour change outside the defect scope.
+
+## Approach
+
+Three mechanisms, each with one job:
+
+- **Suppression window (A)** — fixes #195's destructive path: absence-based deletion
+  reconciliation is suspended, per device, for a bounded time window around any observed
+  reset. Monotonic persisted state; nothing ever clears it early; it just expires.
+- **Marker lifecycle (B)** — fixes #202: markers persist, every device processes each reset
+  exactly once (by request **identity**, not by time), expiry is TTL'd, GC is cooperative
+  with an honest skew margin.
+- **Ordering & plumbing fixes (C)** — marker-before-wipe, never wipe markers, chunked
+  deletes, exempt never-pushable profiles from deletion inference.
+
+### Part A — Time-boxed suppression of deletion reconciliation (#195)
+
+**A1. One persisted date:** `SharedData.syncDeletionSuppressedUntil: Date?` (default nil).
+Updated **only** by monotonic max (never cleared, never decreased; expiry is just the clock
+passing it):
+
+```
+extendSuppression(basis) := suppressedUntil = max(suppressedUntil ?? .distantPast,
+                                                  min(basis, now) + suppressionWindow)
+```
+
+`suppressionWindow = 8 days` (`processTTL + 1 day` of slack: a device may legitimately
+process a 7-day-old marker and start re-pushing; others must stay suppressed while that
+convergence completes). The `min(basis, now)` clamp means a future-dated basis can never
+suppress for more than `suppressionWindow` from now.
+
+**Extended (basis = marker's effective date, or `now` when unknown) when:**
+- `resetSync` runs on the origin — synchronously **before** the wipe starts;
+- `pullResetRequests`' fetch returns **any** `SyncResetRequest` recordID — including
+  per-record `.failure` results and records that fail to decode (basis `now` for those).
+  Sight is judged on raw recordIDs *before* decoding or classification, mirroring how
+  `pullProfiles` builds `allRemoteProfileIds`; a corrupt or future-schema marker still
+  protects.
+
+**A2. The reconciliation rule** (in `handleSyncedProfiles` *and* `handleSyncedLocations`):
+deletion reconciliation runs **iff**
+1. the remote ID set is non-empty (empty pulls are never authoritative — subsumes the
+   existing decode-failure guard; closes #195.2), **and**
+2. `now ≥ syncDeletionSuppressedUntil` (read fresh from `SharedData` inside the
+   reconciliation branch; `nil` passes), **and**
+3. per record: `syncVersion > 0` (unchanged) and, for profiles, `!isNewerSchemaVersion`
+   (**A3**).
+
+Upserts always apply regardless — merging is always safe. There is no per-pass flag, no
+clearing write, no verification read: interleaved passes cannot race a monotonic date.
+
+**A3. Newer-schema profiles are exempt from deletion inference.** They are read-only
+holdings this device can never re-push; their authoritative copy may be offline for days.
+Without this, any suppression scheme is unsound for them (nothing this device does can
+restore their zone record). Symmetric with the existing push-side filter.
+
+**A4. Why time, not evidence.** Two adversarial-verification rounds showed every
+evidence-based early exit is unsound or empty: push acks race the wipe (rev 2); a passing
+superset check *cannot* delete anything the device holds, so it never actually resumes
+propagation, while its clearing write races concurrent passes and stale reads in both
+directions (rev 3). A monotonic time window is the strongest honest guarantee available on
+top of absence-inference. The consequences are stated plainly under *Intentional behaviour
+changes*.
+
+### Part B — Marker lifecycle (#202)
+
+**B1. Identity-based idempotency.** `SharedData.processedResetRequestIds: [UUID: Date]`
+(requestId → processed-at, pruned when `processed-at` older than `gcTTL`). A request whose
+`requestId` is in the map is never processed again — no date arithmetic, no clock
+dependence, no reprocessing loop regardless of skew. (Replaces rev 3's date watermark,
+whose skew cap created an infinite clear-selections loop for slow-clocked receivers.)
+
+**B2. Effective date & processing TTL.** `effectiveDate = CKRecord.creationDate ??
+requestedAt` (server-assigned when available). `age = now − min(effectiveDate, now)`
+(future dates clamp to age 0 — fail toward "fresh"). A request is processable **iff
+`age ≤ processTTL` (7 days)**; boundary inclusive on the process side. Older requests are
+never processed (closes #202.3 — the year-later stale-reset wipe).
+
+**B3. Cooperative GC with an honest margin.** Any device deletes markers with
+**`age > gcTTL` (21 days)**. Margin against a fast receiver clock is
+`gcTTL − processTTL = 14 days`: a receiver must be *more than 14 days fast* before it can
+GC a marker inside another device's processing window. GC is the **only** deletion path
+for markers; GC failures are logged and retried next pass, and never affect suppression or
+processing state. (Closes #202.2 without needing the origin alive.)
+
+**B4. Classification (pure).**
+`SyncResetRequest.classify(effectiveDate:isOwnOrigin:isProcessed:now:)` →
+`.expiredCollect` (age > 21d) | `.skipExpired` (7d < age ≤ 21d) | `.skipOwnOrigin` |
+`.skipAlreadyProcessed` | `.process`, checked in that order. Exhaustively unit-tested with
+pinned `now`, including both boundaries exactly (7d ⇒ `.process`-eligible; 21d ⇒
+`.skipExpired`; 21d+1s ⇒ `.expiredCollect`) and future dates (⇒ `.process`-eligible when
+unprocessed).
+
+**B5. Process the newest, once; retire the rest.** Per pass: among `.process` candidates,
+dispatch **only the newest** (by effectiveDate); mark **all** `.process` candidates'
+requestIds as processed (older ones are retired-without-applying — "last reset wins",
+selection-clearing intent of a superseded reset is intentionally dropped).
+Ordering inside the pass, single most correctness-critical sequence:
+1. suppression already extended (A1, on sight, before anything else);
+2. dispatch `didReceiveSyncReset(clearAppSelections:)` — its synchronous part clears
+   selections; it then chains re-push → follow-up `performFullSync` on the pushTask chain;
+3. mark requestIds processed (synchronously, same iteration, before any suspension point).
+
+A kill before (3) re-processes on relaunch — idempotent re-clear/re-push, safe direction. A
+follow-up pass after (3) sees `.skipAlreadyProcessed` — no loop. The follow-up sync runs
+**unconditionally** after the re-push, success or not (today's behaviour, kept).
+
+**B6. Never delete live markers outside GC.** `deleteAllSyncedData` excludes the
+`SyncResetRequest` type **entirely** (rev 2's exclude-only-mine let two concurrent resets
+annihilate each other's markers). `resetSync` also inserts its own requestId into
+`processedResetRequestIds` at creation (belt) in addition to the `.skipOwnOrigin`
+classification (braces).
+
+### Part C — resetSync ordering & plumbing
+
+`resetSync` becomes:
+1. Save the new `SyncResetRequest` (failure ⇒ abort with the zone fully intact — a failed
+   reset is now a no-op; closes #195.3);
+2. `extendSuppression(now)` + mark own requestId processed (persisted before anything
+   destructive);
+3. `deleteAllSyncedData` — excluding `SyncResetRequest`, deleting in **chunks of ≤ 400
+   recordIDs per `modifyRecords`** (a >400-record type otherwise fails `limitExceeded`
+   deterministically, wedging every retry after the marker is already live);
+4. Fire `didReceiveSyncReset` exactly as today — the origin's local behaviour, including
+   clearing its own selections when the flag is set, is intentionally unchanged — which
+   chains re-push → follow-up sync.
+
+**Pass-abort commitment:** `performFullSync` must keep `pullResetRequests` as the first
+pull, and **any `pullResetRequests` failure must abort the pass** before any pull whose
+handler can reconcile deletions (today's `try` chain already does this; the
+`zoneNotFound`/`unknownItem` swallow is acceptable only because `pullProfiles` swallows the
+same codes without delivering). A future "log and continue" refactor here would silently
+reopen #195 — called out for code review.
+
+## Data flow (post-fix)
+
+```
+resetSync(origin):
+  save SyncResetRequest ─► extendSuppression(now); mark own id processed
+    ─► chunked wipe of data types (never SyncResetRequest, ≤400/op)
+    ─► didReceiveSyncReset ─► clear own selections (if flag) ─► rePush(local)
+                                 ─► performFullSync            [always, success or not]
+
+performFullSync(any device):
+  pullResetRequests:                        [failure ⇒ abort pass]
+      any recordID fetched (even undecodable) ⇒ extendSuppression(effectiveDate | now)
+      classify all decoded; age>21d ⇒ GC-delete (failures ignored)
+      newest .process ⇒ didReceiveSyncReset ─► mark ALL .process ids processed
+  pullProfiles ─► handleSyncedProfiles:
+      apply upserts (always)
+      deletion reconciliation IFF remoteIds nonempty
+                              AND now ≥ suppressedUntil        [fresh read]
+                              AND per-profile: syncVersion>0 ∧ !isNewerSchemaVersion
+  pullLocations ─► handleSyncedLocations: same, minus the schema clause
+  didRequestLocalDataPush ─► pushLocalData  [unchanged; never touches suppression]
+```
+
+## Partial-failure interleaving analysis
+
+"Converges" = all devices end with the union of local data; no deletion or selection loss
+outside genuine remote deletions (post-window) and the reset's own opt-in selection
+clearing. "Suppressed" = `now < syncDeletionSuppressedUntil` on that device.
+
+### resetSync (origin)
+
+| # | Interleaving | Outcome |
+|---|---|---|
+| 1 | Marker save **throws** | Nothing wiped, no state changed, UI error. **No data loss** (was: durable landmine). |
+| 2 | Marker ✓, crash before step 2 | Zone intact + live marker. Receivers process it (idempotent clear + re-push). Origin relaunch: sights own marker ⇒ suppression extends; own id unprocessed but `.skipOwnOrigin` ⇒ never self-processed via pull. Zone complete; suppression merely delays deletion propagation ≤ 8d. **Converges.** |
+| 3 | Steps 1–2 ✓, wipe partial (across types/chunks), crash | Marker live; every device that sights it is suppressed; devices that don't sight it: wiped types pull empty ⇒ A2.1 skips. Origin relaunch: suppressed (persisted); its every-pass push restores its data. **Converges.** |
+| 4 | Wipe ✓, killed before re-push | Zone = marker only. All pulls empty ⇒ A2.1 everywhere + suppression. Origin's next pass pushes everything. **Converges.** |
+| 5 | Concurrent pass on origin mid-reset | Suppression persisted at step 2 before the wipe; monotonic — no concurrent pass can clear it (nothing clears it). Empty/partial pulls also A2.1-skipped where empty. **Safe.** |
+| 6 | Two devices reset near-simultaneously | Wipes never touch markers (B6) ⇒ **both markers survive**. Each origin: own id pre-processed; processes the other's (newer wins per pass). Receivers sight ≥1 marker ⇒ suppressed; process newest; older ids retired (B5). Double re-push idempotent. Older reset's selection-intent superseded — accepted. **Converges.** |
+| 7 | >400 records of one type | Chunked ≤400/op; mid-sequence failure ⇒ row 3. No deterministic wedge. Each retry is a new marker ⇒ re-clears selections family-wide when the flag is set — unchanged from intent (each retry is a new reset command); retries now actually succeed. |
+
+### pullResetRequests (receiver)
+
+| # | Interleaving | Outcome |
+|---|---|---|
+| 8 | Sight ✓ (suppression extended), killed before dispatch or before marking processed | Relaunch: re-sighted ⇒ suppression re-extended; id unprocessed ⇒ `.process` again ⇒ idempotent re-apply. Safe direction by construction (suppress-first, mark-last). |
+| 9 | Marked processed ✓, killed mid-re-push | Relaunch: `.skipAlreadyProcessed`, **suppression persists** (monotonic, ~8d) ⇒ no deletion inference while the zone is rebuilt; every-pass push restores this device's data. Selection-clearing already applied (synchronous, step B5.2 precedes B5.3). **Converges.** |
+| 10 | Any pass while any re-push (own or others') is in flight | Suppressed — by sight on this device, persisted, un-clearable. Closes rev 1's multi-pass hole, rev 2's ack-race/stale-task holes, rev 3's stale-presence-clear + stale-absence-no-re-arm hole, and the concurrent-pass clear leak. |
+| 11 | Fresh device (empty processed map) | Marker age ≤ 7d: processes once — 3+ device delivery (#202.1). 7–21d: `.skipExpired` (no processing, no GC), but sighted ⇒ suppressed — protected while others converge. >21d: `.expiredCollect`. A device with pre-existing local profiles joining sync within 7 days of a clear-selections reset clears its selections — visible via `needsAppSelection` UI; within reset semantics; accepted. |
+| 12 | Two receivers process the same marker concurrently | Both apply (idempotent); ids marked on each; marker not deleted. No race. |
+| 13 | Origin clock skew (any direction) | `effectiveDate` prefers server `creationDate` (skew-immune). On the `requestedAt` fallback: future dates clamp to age 0 (processed once — id-idempotent, **no loop possible by construction**, unlike rev 3's capped watermark); past-skewed dates age out early (missed delivery — UX miss, no data risk: suppression is sight-based, not classification-based). |
+| 14 | Receiver clock fast | ≤14d fast: cannot GC a live (≤7d) marker (B3 margin); may classify it `.skipExpired` (missed selection-clearing — UX), but sight ⇒ suppression still protects its data. >14d fast: can GC a live marker — family delivery broken for devices that never sighted it, and those devices retain only A2.1 (empty-pull) protection. Residual; requires a pathologically wrong clock; accepted & documented honestly (was mis-stated as ">14d" with a 14d gcTTL in rev 3; arithmetic now consistent: margin = gcTTL − processTTL = 14d). |
+| 15 | Receiver clock slow | Marker appears future ⇒ age clamps to 0 ⇒ processed once (id-idempotent), suppression extends from `min(basis, now) = now` ⇒ normal 8d window. No loop, no extended suppression. |
+| 16 | Marker present but undecodable / per-record fetch failure | Sight counts raw recordIDs ⇒ suppression extends (basis `now`). No processing (nothing decoded), no GC. Protected. (Pinned by test.) |
+| 17 | `pullResetRequests` throws (network) | Pass aborts before any reconciling pull (Part C commitment). No sight, but also no reconciliation. Safe. |
+
+### handleSyncedProfiles / handleSyncedLocations
+
+| # | Interleaving | Outcome |
+|---|---|---|
+| 18 | remoteIds empty (any decode state) | Skip (A2.1). Closes #195.2 for profiles **and** locations. |
+| 19 | remoteIds non-empty, suppressed | Skip. Closes #195.4 and every mid-window partial-zone case for devices that ever sighted the marker (or originated the reset). |
+| 20 | remoteIds non-empty partial, device **never** sighted any marker and window closed/never opened | **Residual:** reconciles → may delete not-yet-re-pushed profiles, including own-only ones (permanent if no other device holds them). Requires the marker to be query-invisible on every pass this device ran since the reset, while data-record deletions are visible. Same staleness class as #219; accepted, stated honestly: the precondition is *no sight ever*, not "narrow window" — one sight suppresses for 8 days. |
+| 21 | Non-empty, no marker sighted ≤8d, suppression expired, one profile deleted remotely | Reconciles + deletes locally — **normal propagation preserved** (regression test). |
+| 22 | `isNewerSchemaVersion` local profile absent from remote | Never deleted by inference (A3), suppression state irrelevant. Zone copy reappears when the newer-app device pushes. Stale husks possible if that device never returns — accepted (read-only placeholders). |
+| 23 | Suppression expires while one local record's push has failed for 8+ days | Next reconciling pass may delete that record locally (and its zone copy is absent) — genuine residual, bounded: requires ≥8 days of continuous push failure for that record *and* no marker re-sight. Also inherits the generic #219 stale-absence risk on the first post-window pass. Accepted & documented. |
+
+## Intentional behaviour changes (documented)
+
+- **Absence-based deletion propagation is suspended for ~8 days after any reset** (per
+  device, from its last marker sighting basis). Deletions made anywhere during a device's
+  suppression window are **not applied on that device until its window closes — and because
+  every device re-pushes all its local data every pass, such deletions are typically
+  resurrected zone-wide** (the deleting user will see the item return; deleting it again
+  after the window sticks). This is the honest price of making reset-as-re-seed safe with
+  absence-inference; it was already partially true today for any device that hadn't synced
+  a deletion before a reset. Explicit record deletes (`deleteProfileFromSync`) still remove
+  the CK record immediately; only the *inference* on other devices is windowed.
+- **Deleting the last remaining profile (or location) no longer propagates via
+  reconciliation** (empty remote ⇒ skip; other devices resurrect it by re-push). Non-last
+  deletions propagate normally outside suppression windows.
+- **Reset markers persist up to ~21 days** (tiny records; one per reset) instead of being
+  consumed; every device syncing within 7 days receives the reset; GC is cooperative.
+- **Newer-schema profiles are never deleted by absence-inference** (A3); stale read-only
+  husks may linger if the newer-app device disappears — accepted.
+- **Unchanged (noted, not changed):** the origin also clears its *own* app selections when
+  "Clear App Selections" is chosen, though the alert copy (`SettingsView.swift:417-419`)
+  describes only other devices. Pre-existing; follow-up issue candidate.
+- **Account switching:** `processedResetRequestIds` are UUIDs (cannot collide across
+  accounts — no cross-account suppression of delivery); `syncDeletionSuppressedUntil` may
+  carry ≤8 days across an account switch (blocks only deletions — safe direction). Neither
+  needs account-scoping.
+
+## Concurrency & storage discipline
+
+- Both new SharedData values are **compound read-modify-write** operations
+  (`extendSuppression` = read-max-write; processed-id insert/prune = decode-merge-encode):
+  each must be wrapped in a single `SharedData.withLock` block, matching the existing
+  convention (`SharedData.swift:69-96`); `withLock` is not reentrant — no nesting.
+- `syncDeletionSuppressedUntil` is **monotonic** (max-only). `processedResetRequestIds` is
+  insert + prune-by-age only. Neither has a clearing operation; interleaved MainActor passes
+  and cross-process readers cannot observe a protection downgrade.
+- All comparisons take an injected `now` so tests pin time (AGENTS.md).
+
+## Test plan (TDD)
+
+Pure / in-memory — no CloudKit:
+
+1. **`SyncResetRequest.classify`** (#202): precedence order; `.expiredCollect` iff
+   age > 21d (boundary: exactly 21d ⇒ `.skipExpired`); `.skipExpired` iff 7d < age ≤ 21d
+   (boundary: exactly 7d ⇒ processable); own-origin; already-processed (by id, regardless
+   of dates); future effectiveDate ⇒ age 0 ⇒ `.process` when unprocessed;
+   `creationDate`-preferred-over-`requestedAt`. Single pinned `now` per test.
+2. **Newest-only + retire-the-rest** (B5): several `.process` candidates ⇒ exactly the
+   newest dispatched, **all** their ids marked processed (pure helper).
+3. **`extendSuppression`** (A1): monotonic max; `min(basis, now)` clamp for future basis;
+   nil start; never decreases.
+4. **`handleSyncedProfiles` gating** (#195) via `didReceiveSyncedProfiles`, seeded
+   in-memory `ModelContext`, `MockSessionController`, injected suppression state + `now`:
+   - empty remote (with and without decoded profiles) ⇒ synced locals **retained**;
+   - non-empty remote, suppressed ⇒ missing locals **retained**; upserts still applied;
+   - non-empty remote, suppression expired (or nil), one missing ⇒ **deleted** (regression
+     for normal propagation, row 21);
+   - `syncVersion == 0` ⇒ never deleted; `isNewerSchemaVersion` ⇒ never deleted even
+     unsuppressed (A3).
+5. **`handleSyncedLocations` gating**: mirror of (4) minus the schema clause. Location
+   `syncVersion` is pull-confirmed (set only in `handleSyncedLocations`,
+   `SyncCoordinator.swift:441/454`), unlike push-optimistic profile `syncVersion` — seed it
+   directly in tests; no push round-trip needed.
+6. **Processed-id map**: insert, idempotent re-insert, prune at > 21d, bounded growth.
+7. **`SharedData` round-trips**: both new keys, defaults, `withLock`-wrapped compound ops
+   (reuse the ephemeral-suite pattern from `SharedDataLockTests`).
+
+Code-inspection commitments (not unit-testable without a CK seam; each called out in the PR
+description for review):
+- `resetSync` step order (C.1–4), including suppression + own-id persisted before the wipe;
+- suppression extended on **raw recordID sight** before decode/classify (B/A1), and
+  `didReceiveSyncReset` dispatched before ids are marked (B5 order);
+- chunking ≤ 400; wipe excludes `SyncResetRequest`; GC failures ignored;
+- pass-abort: `pullResetRequests` failure prevents all reconciling pulls (Part C).
+
+## Out of scope
+
+- Tombstones / change-token (`CKFetchRecordZoneChangesOperation`) sync — the correct
+  long-term fix for rows 20/23 and #219.
+- Introducing a CloudKit mock / `CKDatabase` abstraction.
+- Any change to session or emergency-settings sync.
+- The origin self-clear vs. alert-copy mismatch (follow-up issue).
+- A reentrancy guard for `performFullSync` (concurrent passes are made safe *for this
+  design* by monotonic state; serializing passes generally is a separate improvement).
+- CloudKit schema changes: none — no new record fields (`creationDate` is system metadata);
+  no new query predicates.

--- a/docs/plans/2026-07-02-reset-sync-a1-interleavings-round1.md
+++ b/docs/plans/2026-07-02-reset-sync-a1-interleavings-round1.md
@@ -1,0 +1,451 @@
+# A1 adversarial verification — round 1 findings (verbatim)
+
+- **Target design:** rev 2 (persisted gate cleared on zero-failure push)
+- **Context:** acceptance corpus for #267; see `2026-07-02-reset-sync-a1-acceptance-corpus.md`.
+- **Provenance:** machine-extracted, unedited output of the independent verifier agents.
+
+## Lens: interleavings — verdict: has-holes
+
+**Verifier reasoning:**
+
+> Method: read the spec (/Users/rob/Downloads/git/family-foqos/docs/superpowers/specs/2026-07-02-reset-sync-safety-design.md) and the pre-fix implementation it modifies (/Users/rob/Downloads/git/family-foqos/Foqos/CloudKit/ProfileSyncManager.swift — resetSync:823-877, pullResetRequests:373-417, pushSyncedProfile:430-465; /Users/rob/Downloads/git/family-foqos/Foqos/CloudKit/SyncCoordinator.swift — handleSyncedProfiles:104-209, handleSyncedLocations:423-507, handleSyncReset:529-560, rePushLocalSyncedData:563-593, pushLocalData:45-100, pushTask chaining; /Users/rob/Downloads/git/family-foqos/Foqos/CloudKit/SyncModels.swift — SyncResetRequest:543-599; SyncEventDelegate.swift; isNewerSchemaVersion at /Users/rob/Downloads/git/family-foqos/Foqos/Models/BlockedProfiles.swift:712). I then walked the POST-fix protocol (marker save → gate set → typed wipe → delegate → re-push → conditional gate clear → follow-up sync; and the classify loop) and at every await point injected: origin crash, concurrent performFullSync, a second reset from a third device, pre-existing in-flight push tasks, and clock skew, checking each of the spec's 18 interleaving rows.
+> 
+> The design's two guards (A2 empty-pull skip; A3 persistent gate) are individually correct for the cases the spec tables enumerate, but the composition has a structural flaw: THE GATE-CLEAR CONDITION IS UNSOUND. 'A complete local re-push finished with zero per-record failures' is treated as proof that this device's data is back in the zone, but a CloudKit push ack does not survive a concurrent snapshot-based wipe — the origin's deleteAllSyncedData (or a second origin's) can delete acked records after the ack. Every path that clears the gate while any wipe/re-push is in flight reopens exactly the #195 window the design set out to close: (1) receiver re-push racing the origin's own wipe — no second reset, no index lag, no crash needed; (3) a clean push attributed to reset N (or to a pre-reset pushLocalData task) clearing the gate reset N+1 just set — the spec specifies no CAS semantics. Additionally (2) spec row 6 is factually wrong: near-simultaneous resets mutually delete each other's markers (SyncResetRequest is wiped LAST, giving both markers time to be query-visible to the other wipe), leaving third devices with no marker, no gate, and a partial zone — mass local deletion plus a delivery/liveness break. (4) The isNewerSchemaVersion filter in both push paths means read-only newer-schema profiles are never re-pushed yet stay deletion-eligible, so a device's own 'clean' re-push disarms its gate and the follow-up pass deletes them — this also falsifies the spec's stated constraint that pushLocalData re-pushes ALL local profiles. (5) Row 12's accepted clock-skew outcome actually includes full data loss (a poisoned watermark classifies a later live reset .skipAlreadyProcessed, so no gate is set during its destructive window), not just a skipped selection-clear.
+> 
+> What survives: A1 (marker-before-wipe) genuinely kills the durable-landmine variant (#195.3); A2 is sound for truly-empty pulls; B1-B6 deliver-to-all/GC/no-loop liveness holds except for the mutual-marker-annihilation case in finding 2; rows 1-5, 7, 10-11, 13-15, 18 check out as claimed; the watermark-advance-before-task rule (B6) does prevent the reset loop.
+> 
+> Cross-cutting fix that closes findings 1, 3, and 5 with one rule: suppress deletion reconciliation in any pass whose pullResetRequests observed ANY within-TTL reset marker, regardless of classification — markers persist ≤7 days by design (B4), so protection spans the whole wipe+re-push window without depending on gate-clear timing; the cost (deletion propagation deferred ≤TTL after a reset) is the trade the spec's own safety asymmetry endorses. Finding 2 needs the wipe to exclude ALL non-expired markers (not just its own); finding 4 needs isNewerSchemaVersion profiles exempted from reconciliation deletion. Verdict: has-holes — four concrete safety-breaking interleavings against the post-fix design as written, two of which (1 and 2) require no exotic conditions at all.
+
+### interleavings-1 [breaks-safety] Receiver's clean re-push races the origin's still-in-flight wipe: gate clears, next pass reconciles against a partial zone and deletes local profiles
+
+**Violated:**
+
+Safety property (P1 was never genuinely deleted anywhere; loss is not covered by exception (a) or (b)). Contradicts spec row 16 ('remoteIds non-empty partial + gate set ⇒ Skip (A3)') and A3's claim that the gate protects 'across the entire re-push window' — the design's own zero-failure clear rule removes the gate while the origin's wipe is still in flight. Root cause: a successful push ack does not mean the record is durably in the zone when a snapshot-based wipe is concurrent; 'zero per-record failures' is the wrong clear condition. This is NOT spec row 17's acknowledged index-lag residual — the marker was seen and processed; no index lag is required.
+
+**Interleaving:**
+
+Devices: A (origin), B (receiver). B owns profiles P1, P2, both previously synced (syncVersion > 0).
+1. A: resetSync — saves marker M (CloudKit save ✓; the zone subscription push fires to B immediately). A sets its gate. A begins deleteAllSyncedData: fetches the SyncedProfile ID snapshot S = {P1, P2, ...} (await).
+2. B: handleRemoteNotification → performFullSync pass k. pullResetRequests returns M (query index happens to be fresh — 'may lag' permits fresh), classify = .process → watermark := M.requestedAt; gate_B := M.requestedAt; didReceiveSyncReset → handleSyncReset spawns re-push task T1. Rest of pass k: gate set ⇒ upserts only. So far exactly per spec rows 9/16.
+3. B/T1: pushSyncedProfile(P1) — fetch + save succeed (server ack).
+4. A: its modifyRecords(deleting: S) now executes → deletes P1 and P2 records. Deletes by recordID succeed regardless of B's newer save; B's acked push of P1 is silently undone.
+5. B/T1: pushSyncedProfile(P2) — fetch → .unknownItem → creates fresh record → save ✓ (survives; A's delete already ran).
+6. B/T1: zero per-record failures ⇒ per A3 it CLEARS gate_B, then continues into its follow-up performFullSync (pass k+1).
+7. B pass k+1: pullResetRequests sees M → .skipAlreadyProcessed (watermark equal) ⇒ gate NOT re-set. pullProfiles → remoteIds = {P2} (non-empty, so A2 does not fire). handleSyncedProfiles: remoteIds non-empty AND gate not set ⇒ deletion reconciliation runs → P1 (syncVersion > 0) ∉ remoteIds → BlockedProfiles.deleteProfile(P1) on B. Local P1 and its FamilyActivitySelection destroyed; when A's re-push later restores P1, B recreates it with needsAppSelection = true — silent blocking failure.
+Timing is realistic: A's wipe is 6 record types × ≥2 round-trips (seconds); B is push-notified the instant M is saved, and each of B's pushes is only 2 round-trips.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Do not treat push acks as evidence the device's data is in the zone. Add a pass-level rule: whenever pullResetRequests observes ANY within-TTL SyncResetRequest (regardless of classification — .process, .skipAlreadyProcessed, or .skipOwnOrigin), suppress deletion reconciliation for that pass. Markers persist ≤7 days (B4), so this keeps devices safe through the whole wipe + re-push window at the cost of deferring deletion propagation for ≤TTL after a reset — the exact trade the spec's safety asymmetry already endorses (optionally use a shorter 'settling period' constant than the full 7-day TTL). Keep the persistent gate as defense-in-depth for the marker-not-yet-visible window.
+
+### interleavings-2 [breaks-safety] Row 6 is wrong: two near-simultaneous resets can mutually delete each other's markers, leaving a third device with zero protection against the re-push window
+
+**Violated:**
+
+Spec row 6 claims 'At least the later wipe's marker survives; devices process the newest surviving request … Converges.' False: each wipe's SyncResetRequest snapshot can include the other origin's marker (the reset-request type is wiped last, giving the other marker ample time to be visible), so both markers are deleted. Safety property violated on D; liveness (delivery to every device) violated too. The spec also underestimates the marker's role: it is not just 'selection-clearing intent' — it is the trigger that sets receivers' gates.
+
+**Interleaving:**
+
+Devices: A and B both run resetSync near-simultaneously; D is a third device with synced profiles.
+1. A: saves M_A ✓, sets gate_A, wipes types in order (SyncedProfile first). SyncResetRequest is the LAST type wiped, so by the time A's wipe reaches it, B's marker has had seconds to become query-visible: A's fetch returns {M_A, M_B} → A deletes M_B (excluding only its own M_A, per A1).
+2. B: saves M_B ✓, sets gate_B, wipes; its SyncResetRequest fetch returns {M_A} (M_A still exists — only B ever deletes it) → B deletes M_A (excluding only M_B, which A already deleted).
+3. Zone state: ZERO reset markers; all SyncedProfile records wiped. A and B start their re-pushes (each protected locally by its own gate).
+4. D: performFullSync. pullResetRequests → no records at all → no gate set, watermark untouched, nothing to classify. pullProfiles → remoteIds = A's partially re-pushed set (say 2 of 6 profiles) → non-empty, so A2 does not fire; no gate ⇒ deletion reconciliation runs → D deletes every local synced profile not among those 2 — near-total local wipe on D, selections lost on later recreation (needsAppSelection = true).
+Also breaks liveness: neither reset's marker survives to reach D at all, violating 'resets reach every device that syncs within the TTL'.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+deleteAllSyncedData must exclude ALL non-expired SyncResetRequest records, not just the current one. Expired markers are still collected (cooperative GC, B3, handles cleanup), so #202's cleanup goal is preserved. With any live marker guaranteed to survive, D would classify it .process, set its gate, and be protected.
+
+### interleavings-3 [breaks-safety] Gate clear has no CAS/freshness semantics: a clean push belonging to reset N (or to a pre-reset pushLocalData) clears the gate that reset N+1 just set
+
+**Violated:**
+
+Safety property; rows 9 and 11 implicitly assume the gate set for a reset stays set until THAT reset's re-push completes — the spec's clear rule doesn't distinguish which reset (or which pre-reset push) a completing task belongs to. This is the exact hole the spec's rev-1→rev-2 change was meant to close, reopened one level up.
+
+**Interleaving:**
+
+Devices: B (receiver), C (origin of reset N+1). B earlier processed reset N; its re-push task T1 (multi-profile, slow) is still in flight.
+1. B, pass k: processed N → watermark = N, gate_B = N.requestedAt, T1 spawned on the pushTask chain.
+2. C: resetSync N+1 — saves M_{N+1}, sets gate_C, wipes the zone (deleting the records B's T1 already pushed), starts C's own re-push.
+3. B, pass k+1 (manual 'Sync Now', or the subscription push from M_{N+1}): pullResetRequests sees M_{N+1} → .process → watermark := N+1; gate_B := (N+1).requestedAt; spawns T2 (chained after T1 on pushTask). pullProfiles: gate set ⇒ skip. Correct so far.
+4. B/T1 finishes its last push with zero per-record failures → clears gate_B. The spec ('Cleared when a complete local re-push finishes with zero per-record failures') specifies no comparison against the current gate value, so the clear lands even though the gate now belongs to N+1. T1 then runs its follow-up performFullSync — which executes BEFORE T2, because T2 is chained after T1 on pushTask.
+5. B, T1's follow-up pass: pullResetRequests → M_{N+1} → .skipAlreadyProcessed (watermark already N+1) ⇒ no gate. pullProfiles → C's partial re-push (non-empty), missing B's profiles (wiped in step 2) → reconciliation deletes B's local profiles. T2's later re-push cannot restore them — they are gone from B's local store.
+Variant needing no second manual pass: a pushLocalData task spawned in the pass BEFORE the reset was known (pushes still in flight when the marker is processed) completes cleanly after the gate is set and clears a gate whose reset it knows nothing about — same outcome within a single marker-processing pass.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Minimum: clear the gate only via compare-and-swap (record the gate value when the push task starts; clear only if unchanged) and never let a push task that started before the gate was set clear it. Note this only narrows the race — finding 1 shows a correctly-attributed clean push still can't witness a concurrent wipe — so the pass-level 'within-TTL marker visible ⇒ no deletion reconciliation' rule from finding 1 is the actually-sound layer; CAS is defense-in-depth.
+
+### interleavings-4 [breaks-safety] Newer-schema (read-only) profiles are skipped by every re-push but remain deletion-eligible: 'zero failures' clears the gate without their data being in the zone, and reconciliation then deletes them
+
+**Violated:**
+
+Safety property. Also invalidates the spec's stated constraint 'pushLocalData re-pushes ALL local profiles' (it doesn't — it filters isNewerSchemaVersion) and A3's invariant 'gate set ⇒ no deletions until my data is back in the zone': schema-filtered profiles are never re-pushed yet remain fully deletion-eligible in reconciliation.
+
+**Interleaving:**
+
+Devices: V (newer app, profile schema S+1) owns profile P; B (current app) holds a read-only local copy (handleSyncedProfiles sets profileSchemaVersion = S+1 and syncVersion = synced.version > 0 — SyncCoordinator.swift:157-159; isNewerSchemaVersion is true, BlockedProfiles.swift:712).
+1. Any device runs resetSync: marker M saved, zone wiped (P's record deleted), origin re-push begins (P re-pushed late, or the origin isn't V and doesn't push P at all — pushLocalData/rePushLocalSyncedData filter `where !profile.isNewerSchemaVersion`, SyncCoordinator.swift:64 and :567).
+2. B syncs: M → .process → gate set → handleSyncReset → rePushLocalSyncedData SKIPS P (schema filter) and pushes B's other profiles; zero per-record failures — a skipped profile is not a failure — ⇒ gate cleared.
+3. B's follow-up pass: M → .skipAlreadyProcessed; pullProfiles → remoteIds = B's re-pushed profiles + origin's partial set, P absent → non-empty, no gate ⇒ reconciliation deletes local P — a profile the schema logic explicitly treats as authoritative-elsewhere and read-only.
+4. If V later re-pushes P, B recreates it with needsAppSelection = true (selection loss). If the reset was issued precisely because V was retired/replaced, P is lost on B permanently — no device ever re-pushes it.
+Note this is near-deterministic once the precondition (mixed app versions, which the project's V1/V2 branch strategy explicitly anticipates) holds: B's own clean re-push is what disarms its gate.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Exempt isNewerSchemaVersion profiles from deletion reconciliation entirely (treat them like syncVersion == 0 — they are read-only on this device, so this device must never infer their deletion). Alternatively/additionally, count schema-skipped profiles as non-clean for gate-clear purposes, but the reconciliation exemption is the correct-by-construction fix.
+
+### interleavings-5 [weakens] Row 12 understates clock-skew impact: a poisoned watermark disarms the A3 gate for a later legitimate reset — data loss, not just a skipped selection-clear
+
+**Violated:**
+
+Spec row 12 claims the cost is only that 'a legit reset issued in that window could be skipped … self-heals; accepted.' Skipping a live reset does not merely miss its selection-clearing — it removes the A3 gate exactly when the destructive wipe/re-push window is open, leaving only A2, which does not cover the partial (non-empty) re-push state. The accepted row therefore accepts silent data loss, not a UX miss.
+
+**Interleaving:**
+
+1. Device C's clock is 30 days fast. C issues reset R1 (requestedAt = T+30d; per row 12, future requestedAt is treated as within TTL and processed). Every device processes R1 and advances its watermark to T+30d.
+2. At real time T+2d, device A (correct clock) issues a legitimate reset R2 (requestedAt = T+2d): marker saved, zone wiped, A's re-push begins.
+3. Device B syncs during R2's wipe/re-push window: pullResetRequests sees R2 → requestedAt < watermark → .skipAlreadyProcessed ⇒ NO gate set, no selection handling. pullProfiles → A's partial re-push (non-empty) → reconciliation deletes B's local profiles absent from the partial set — the full #195 outcome, on every device in the family with the poisoned watermark, for the whole 30-day skew window.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Cap the watermark advance at min(requestedAt, now + small slack) so a skewed request cannot poison future classification; the pass-level 'within-TTL marker visible ⇒ suppress deletion reconciliation' rule (finding 1) independently protects the wipe window regardless of watermark state, since R2's marker IS visible to B.
+
+### interleavings-6 [nit] Gate-set vs watermark-advance write order is unspecified; row 8's guarantee silently depends on gate-first
+
+**Violated:**
+
+Spec row 8 ('crash before/during handleSyncReset … gate is persisted') — only true under gate-before-watermark ordering, which the spec never states.
+
+**Interleaving:**
+
+B6 says the watermark is advanced 'synchronously, in the same loop iteration' that classifies .process; A3 says the gate is set 'before invoking didReceiveSyncReset'. Neither pins their relative order. If an implementation writes watermark-then-gate and the process is killed between the two writes (both are synchronous SharedData/UserDefaults writes — a SIGKILL between adjacent statements is real even though it is outside the stated 'kills at await points' model, and UserDefaults persistence on kill is itself not guaranteed), relaunch classifies the request .skipAlreadyProcessed with NO persisted gate — row 8's 'but gate is persisted ⇒ no reconciliation' claim fails, and a partial (non-empty) pull then reconciles destructively.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Pin the order in the spec: set resetRePushPendingSince FIRST, then advance lastProcessedResetAt, then dispatch didReceiveSyncReset. A kill between the writes then leaves gate-set/watermark-old → the request is reprocessed (idempotent) instead of skipped-unprotected.
+
+## Lens: crashRecovery — verdict: has-holes
+
+**Verifier reasoning:**
+
+> Human Meatbag — adversarial verification of /Users/rob/Downloads/git/family-foqos/docs/superpowers/specs/2026-07-02-reset-sync-safety-design.md against the pre-fix code in /Users/rob/Downloads/git/family-foqos/Foqos/CloudKit/ProfileSyncManager.swift, /Users/rob/Downloads/git/family-foqos/Foqos/CloudKit/SyncCoordinator.swift, /Users/rob/Downloads/git/family-foqos/Foqos/CloudKit/SyncModels.swift (SyncResetRequest:543), /Users/rob/Downloads/git/family-foqos/Foqos/CloudKit/SyncEventDelegate.swift, plus SharedData.swift (flock model), FoqosApp.swift (relaunch ordering: setModelContext → setupSync → performFullSync, and the modelContext-less background-notification path at line 352), and BlockedProfiles.deleteProfile (confirms reconcile-deletion also destroys sessions and the enforcement snapshot).
+> 
+> The design is a genuine improvement — A1 ordering kills the durable-landmine variant, A2 kills the primary empty-pull wipe, B1–B6 fix delivery/GC — but it does not meet the stated safety property. The root defect is one wrong witness used twice: the gate's clear condition treats push ACKNOWLEDGEMENT as proof that 'my data is back in the zone', while the spec's own stated assumption (and its Constraints section) says CKQuery reads lag writes arbitrarily. Finding 1 (gate cleared, immediate follow-up performFullSync pulls a stale index missing the just-re-pushed records, reconciliation deletes them) breaks rows 8/9 under the spec's own assumptions and is practically likely, since the follow-up pull runs milliseconds after the pushes. Finding 4 is the same root via pushTask chaining with no compare-and-clear. Finding 2 breaks row 13 and row 8's convergence claim through the crash-recovery lens specifically requested: the TTL backstop clears the gate at pull-time within a pass whose push runs after the pulls, so a device killed mid-re-push and left unlaunched >7 days reconcile-deletes its own only-copy data on relaunch (resets inherently make the pushing device the sole holder of any profile the origin hadn't pulled) — and the spec's test plan enshrines that deletion as a regression test. Finding 3 shows row 6's 'at least the later marker survives' is simply false for overlapping wipes (SyncResetRequest is wiped LAST in the type loop, maximizing mutual visibility), which also breaks delivery liveness. Findings 5–8 are narrower: the diagram's watermark-before-gate write order contradicts B6's own crash justification (real SIGKILL between two persisted writes, outside the stated await-only kill model); receiver-side clock skew lets one device GC a live marker for the whole family; unpushable isNewerSchemaVersion profiles can never satisfy the gate invariant; and 'clean run'/gate-read-freshness are implementation traps (notably the modelContext-nil background-launch path).
+> 
+> Answers to the specific lens questions: gate freshness is fine on MainActor iff read inside the reconciliation branch (pinned as finding 8b); SharedData's flock is moot for the new keys — only the main app's MainActor writes them, no extension runs sync code (verified by grep); disable/re-enable mid-window is safe because both markers persist in SharedData, EXCEPT that early-return paths must not clear the gate (finding 8a) and a >TTL disabled span collapses into finding 2; context.save failure after selection-clearing leaves the enforcement snapshot cleared while the model keeps selections — a pre-existing wart outside A1 scope and covered by exception (b), so noted but not filed. Acknowledged residuals I did NOT double-count: row 17 (marker-invisible index lag, punted to #219) is honestly labeled; B6's crash-skips-selection-clearing UX miss is real but is only a UX miss as claimed; row 4's 'Origin's SwiftData never touched' is inaccurate when clearAppSelections=true (handleSyncReset clears selections synchronously before the re-push Task), but the behavior is excepted by (b). Liveness otherwise holds: watermark+B4 deliver to every device within TTL, .expiredCollect is checked first so origins GC their own requests, and gate suppression is TTL-bounded — except where findings 3 and 6 destroy live markers.
+> 
+> Verdict: has-holes — four concrete breaks-safety interleavings, two of which (findings 1 and 2) are single-fault and realistic, and three of which falsify rows the spec claims converge (6, 8/9, 13). The good news: one repair closes most of it — clear the gate by read-verification (pulled remoteIds ⊇ local synced ids, reconcile with that same set) instead of push-ack, never wipe live foreign markers, set the gate before the watermark, and set it to max(now, requestedAt) with expiry deferring reconciliation to the pass after a clean push.
+
+### crashRecovery-1 [breaks-safety] Gate cleared on push-ack, but follow-up pull is not read-your-writes: reconciliation deletes the profiles that were just re-pushed
+
+**Violated:**
+
+Safety property (local BlockedProfiles/SavedLocation deleted with an unexpired reset in flight — neither exception applies); spec rows 8 and 9 ('Converges', 'Closes the rev-1 hole'); A3's invariant 'gate set ⇒ no deletions until my data is back in the zone' — the spec forbids relying on query freshness for the marker (Constraints §3) but its gate-clear condition relies on exactly that for the re-pushed data.
+
+**Interleaving:**
+
+Devices A (origin) and B; B holds P1..Pn with syncVersion>0. (1) A: resetSync — saves marker, sets gate_A, wipes zone (P1..Pn CK records deleted), re-pushes its own set cleanly. (2) B pass 1: pullResetRequests classifies marker .process → watermark advanced, gate_B set → handleSyncReset spawns Task_R; pass 1's pulls skip reconciliation (gate set). (3) Task_R: rePushLocalSyncedData pushes P1..Pn, every save server-acked, zero failures → per A3 clears gate_B → immediately calls performFullSync (pass 2), exactly the ordering in the spec's data-flow diagram ('on zero failures: clear gate ──► performFullSync'). (4) Pass 2 pullProfiles runs milliseconds after the saves; the CKQuery index has not ingested P1..Pn yet (stated assumption: 'CKQuery results may lag writes arbitrarily'), so the result is A's profiles only — remoteProfileIds non-empty, gate_B cleared. (5) handleSyncedProfiles reconciliation: P1..Pn are local, syncVersion>0, absent from remoteIds → BlockedProfiles.deleteProfile each (SyncCoordinator.swift:186-197; deleteProfile also destroys all sessions and the SharedData snapshot, BlockedProfiles.swift:469-494). (6) Later passes re-pull the still-existing CK records and recreate husks via createLocalProfile with needsAppSelection=true — selections and session history lost even on a 'Keep App Selections' reset. Same interleaving applies verbatim to pushLocalData's end-of-pass gate clear followed by a manual 'Sync Now' seconds later, and to handleSyncedLocations.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Clear the gate by READ, not write-ack: while the gate is set, a pass that pulls remoteProfileIds ⊇ {local ids with syncVersion>0} (and the location analogue) clears the gate and reconciles using that same pulled set (deletions are then vacuous by construction); a clean push alone never clears. Equivalently: keep the gate through the follow-up pass and clear it only after a pull self-verifies the device's records are query-visible.
+
+### crashRecovery-2 [breaks-safety] TTL backstop resumes reconciliation at pull-time, before the same pass's push — a device dark >7 days after processing a reset deletes its own only-copy profiles permanently
+
+**Violated:**
+
+Safety property (deletion not covered by exception (a) — the item was never deleted by a user — nor (b)); row 13's characterization ('suppression only delays deletions; the backstop bounds the delay' — it does not merely delay foreign deletions, it deletes this device's own never-re-pushed data); row 8's 'Converges'; test-plan item 2 bullet 4 ('non-empty partial + gate expired ⇒ missing one deleted (backstop regression)') encodes the destructive outcome as desired behavior.
+
+**Interleaving:**
+
+(1) Device B creates profile P and pushes it (syncVersion=1); origin A has not pulled P yet. (2) A: resetSync — marker saved, zone wiped: P's CK record is deleted, so B now holds the ONLY copy (inherent to reset-as-re-seed: every not-yet-pulled profile's remote copy is destroyed). A re-pushes its own set cleanly. (3) B syncs same day: marker .process → watermark advanced, gate_B set to requestedAt, handleSyncReset spawns re-push Task; app is killed at an await inside rePushLocalSyncedData before P is pushed — this is spec row 8's exact scenario, claimed 'Converges' via the persisted gate. (4) B's app is not launched for 8 days (> defaultTTL); no pass runs. (5) Day-8 relaunch: FoqosApp.onAppear → setupSync → performFullSync. pullResetRequests: marker now .expiredCollect (GC'd, not reprocessed). pullProfiles: remote = A's set, non-empty; gate_B is older than TTL ⇒ per A3 'ignored (reconciliation resumes) and cleared'. (6) Reconciliation deletes P locally. pushLocalData runs AFTER the pulls in the pass and no longer contains P. P is gone from every device and from CloudKit — unrecoverable. Aggravator: the gate is set to the request's requestedAt, not to when this device set it — a device that legitimately processes a 6.9-day-old reset gets a gate that expires ~2 hours later, so even a short crash-then-relaunch gap reproduces this. Same hole for a device whose one record persistently fails to push for 7 days (row 13): after the backstop, reconciliation deletes exactly the record that could not be pushed.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+On gate expiry: skip deletion reconciliation for that pass, clear the gate only after that pass's clean full push (or the read-verified clear from finding 1, which subsumes this). Set the gate to max(now, requestedAt) — or simply now — so its TTL runs from when THIS device entered the window.
+
+### crashRecovery-3 [breaks-safety] Row 6 is wrong: near-simultaneous resets can annihilate BOTH markers, leaving third devices ungated against the double-wiped zone
+
+**Violated:**
+
+Row 6 ('At least the later wipe's marker survives ... Converges'); safety property; liveness claim 'resets reach every device that syncs within the 7-day TTL'.
+
+**Interleaving:**
+
+Devices A, B, C. C pushed profile P_C yesterday; A and B have not pulled it. (1) t1: A saves marker m_A, sets gate_A. (2) t2: B saves marker m_B, sets gate_B. Both markers are query-visible by t3 (deleteAllSyncedData wipes SyncResetRequest LAST in its 6-type loop, leaving ample time). (3) A's wipe reaches the SyncResetRequest type at t5: fetch sees {m_A, m_B}, excludes only its own m_A (A1: 'Excluding only the current request') → deletes m_B. P_C's record was already deleted in the SyncedProfile pass. (4) B's wipe reaches SyncResetRequest at t6: sees {m_A} → deletes m_A. The zone now contains NO reset marker. (5) A and B re-push their local sets; neither contains P_C. (6) C's next pass: pullResetRequests returns nothing → no watermark change, no gate. pullProfiles: remote = A∪B, non-empty, no marker, no gate → reconciliation deletes P_C locally (syncVersion>0, absent). P_C's CK record was already wiped → lost everywhere, permanently. C also never receives either reset (delivery liveness broken). The spec's claim 'At least the later wipe's marker survives' only holds if the two resets are strictly serialized; row 6's own premise is 'near-simultaneously'.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Never wipe live foreign markers: deleteAllSyncedData should delete only SyncResetRequest records past TTL. Live foreign markers are inert to re-processing (B1 watermark) and are GC'd by B3, so leaving them costs nothing and each origin then processes the other's reset (idempotent double re-push, as row 6 already accepts).
+
+### crashRecovery-4 [breaks-safety] No compare-and-clear on the gate: a pre-reset pushLocalData task straddling the wipe completes 'clean' and clears the gate a later reset set
+
+**Violated:**
+
+A3's clear condition and row 9's claim that the gate 'cleared only on clean re-push completion' closes the concurrent-pass hole — here a clean run of a PRE-reset push clears the POST-reset gate; safety property.
+
+**Interleaving:**
+
+Device B. (1) Pass 0 (no reset): pushLocalData synchronously snapshots P1..Pn and chains Task_P0 on pushTask (SyncCoordinator.swift:72-96); network is slow, Task_P0 pushes one record at a time. (2) Task_P0 pushes P1 (server-acked). Origin A now runs resetSync: marker saved, wipe's SyncedProfile fetch runs after P1's save → P1's record is deleted; P2..Pn haven't been pushed yet. (3) B pass 1: marker .process → watermark advanced, gate_B set → handleSyncReset chains Task_R AFTER Task_P0 on pushTask. Pass 1's pulls skip reconciliation (gate). (4) Task_P0 resumes: pushes P2..Pn, which land after the wipe fetch and survive. Task_P0 finishes with zero per-record failures → per A3 ('pushLocalData ... clear the flag on a clean run') it clears gate_B — while the zone lacks P1 and Task_R has not yet run. (5) User taps Sync Now (pass 2) before Task_R executes (MainActor interleaves at Task_R's awaits): pullProfiles → remote non-empty, missing P1; gate cleared → reconciliation deletes P1 locally. (6) Task_R then runs rePushLocalSyncedData, fetches profiles at execution time — P1 is already gone locally, its CK record wiped → never restored. Permanent loss of P1, its sessions, and its selection.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Compare-and-clear: capture the gate value (or an epoch counter) when the push task's snapshot is taken; on clean completion clear only if the gate still equals the captured value AND the snapshot was taken after the gate was set. The read-verified clear from finding 1 subsumes this entirely.
+
+### crashRecovery-5 [weakens] Spec-internal contradiction: data-flow diagram advances the watermark BEFORE setting the gate, but B6's crash argument assumes the gate is 'already set'
+
+**Violated:**
+
+B6's stated justification vs the data-flow diagram ordering; under real (non-model) kills, the safety property.
+
+**Interleaving:**
+
+Per the diagram ('.process ⇒ advance watermark; set gate; didReceiveSyncReset'), pullResetRequests performs two separate persisted SharedData writes: (w1) lastProcessedResetAt := requestedAt, then (w2) resetRePushPendingSince := requestedAt. A SIGKILL/jetsam lands between w1 and w2 (no await separates them, so this is outside the stated 'kills at await points' model — but real kills do not respect that model, and B6 explicitly claims crash coverage: 'A crash between watermark advance and re-push completion is covered by the A3 gate (already set, persisted)', which is only true if the gate is written FIRST, contradicting the diagram). Relaunch while origin's re-push is still incomplete: pullResetRequests → .skipAlreadyProcessed (watermark persisted); gate is nil; pullProfiles returns the partial, non-empty zone → reconciliation deletes local not-yet-re-pushed profiles — the exact wipe A3 exists to prevent.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Pin the order: set resetRePushPendingSince BEFORE advancing lastProcessedResetAt (a kill between them then re-processes the reset idempotently — safe direction), ideally as one flock-guarded compound SharedData write. One sentence in A3/B6 fixes the spec.
+
+### crashRecovery-6 [weakens] A receiver with a fast clock (>TTL skew) classifies a live reset expired: it skips protection for itself AND GC-deletes the marker for every other device
+
+**Violated:**
+
+B3's safety claim for cooperative GC; safety property and delivery liveness under a single skewed device.
+
+**Interleaving:**
+
+Devices A (origin), B (clock +8 days — user-set wrong date or dead RTC battery), C. (1) A resets: marker saved, zone wiped, A mid-re-push. (2) B syncs first: classify(now_B) → requestedAt appears 8 days old → .expiredCollect: B does not process (no gate, no watermark advance) and DELETES the live marker (B3: 'a past-TTL request is globally inert, so deletion is always safe' — false under clock skew). (3) B's same pass: pullProfiles returns A's partial re-push, non-empty; B has no gate → reconciliation deletes B's local profiles absent from the partial set. (4) C syncs later: the marker no longer exists → C never gates, never processes the reset, and reconciles against whatever partial state it pulls — same exposure; delivery liveness to C is broken. Row 12 considers only ORIGIN-side skew (future requestedAt); receiver-side fast clocks are unexamined and are strictly worse because .expiredCollect is checked first and destroys the marker for everyone.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+GC foreign markers only when expired by a margin (e.g., 2×TTL); a merely-expired-looking foreign marker is skipped but not deleted. Optionally compare against the CKRecord's server-set creationDate instead of the client-written requestedAt to remove origin skew from classification.
+
+### crashRecovery-7 [weakens] isNewerSchemaVersion profiles are excluded from every push but not from deletion reconciliation — the gate invariant is unsatisfiable for them
+
+**Violated:**
+
+Safety property (deletion during an unexpired reset, no exception applies); A3's invariant, which assumes a clean push restores everything the device holds.
+
+**Interleaving:**
+
+(1) Device B holds P_new received from newer-app device D: isNewerSchemaVersion=true, syncVersion>0 (set at SyncCoordinator.swift:159). (2) Any reset wipes P_new's CK record. (3) B processes the reset: gate set; rePushLocalSyncedData and pushLocalData both filter `!isNewerSchemaVersion` (SyncCoordinator.swift:64, 567), so P_new is never pushed; the push of the remaining set completes with zero failures → gate cleared ('my data is back in the zone' is structurally false for P_new). (4) D has not synced yet (offline for days, or retired). (5) B's next pass: remote non-empty, P_new absent → reconciliation deletes P_new locally (only syncVersion>0 is checked, SyncCoordinator.swift:189). If D never returns, the profile is lost permanently; if D returns, B gets a needsAppSelection husk.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Skip profiles with isNewerSchemaVersion in deletion reconciliation — they are read-only holdings whose authoritative copy lives on the newer device, symmetric with the existing push-side filter.
+
+### crashRecovery-8 [nit] 'Clean run' and gate-read timing are underspecified — early-return paths must not count as zero-failure pushes, and the gate must be read at reconcile time
+
+**Violated:**
+
+A3's clear condition as written ('zero per-record failures') and test-plan item 4's coverage gap.
+
+**Interleaving:**
+
+(a) Background CloudKit push launches the app without the SwiftUI scene appearing: handleRemoteNotification → performFullSync runs before FoqosApp.onAppear ever calls syncCoordinator.setModelContext (FoqosApp.swift:227 vs 352), so pushLocalData hits `guard let context ... return` (SyncCoordinator.swift:51) having pushed nothing with zero recorded failures; same shape for `guard syncManager.isEnabled` after a mid-window sync disable, and for fetchProfiles throwing in rePushLocalSyncedData's outer catch. If 'zero per-record failures' is implemented as failures==0 ⇒ clear, the gate clears with nothing pushed and the next pass reconciles against the partial zone. (b) If a pass captures the gate value at pass start instead of reading SharedData inside handleSyncedProfiles/handleSyncedLocations at reconciliation time, a concurrent pass's freshly-set gate is missed; MainActor only guarantees freshness for a late read. Neither is pinned by the spec; test-plan item 4 covers zero-failure vs partial-failure but not zero-attempt, and item 2 doesn't pin read placement.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Define clean run as 'the full local synced set was enumerated and every record acked' (early returns are not clean); require the gate check to be a fresh SharedData read inside the reconciliation branch; add tests for the zero-attempt paths.
+
+## Lens: cloudkit — verdict: has-holes
+
+**Verifier reasoning:**
+
+> Human Meatbag: I attacked the post-fix protocol through the CloudKit-semantics lens as instructed, verifying each mechanism against the actual code (ProfileSyncManager.swift, SyncCoordinator.swift, SyncModels.swift, SyncEventDelegate.swift) and the spec's data flow. The design's two big ideas — A2 (empty pull is never authoritative) and the persisted A3 gate — are sound as far as they go, and most table rows hold: rows 1-5 (origin failure ladder), row 8 (crash mid-re-push), row 10 (fresh device), row 18 (normal propagation), the B1/B6 watermark loop-prevention, and the marker-save-notification-vs-throttle interaction all survived attack. limitExceeded is also data-safe post-A1, exactly as claimed.
+> 
+> The load-bearing flaw is the gate's CLEAR condition. The spec's own rationale states the invariant as 'no deletions until my data is back in the zone', but the mechanism clears on 'my re-push reported zero failures' — a strictly weaker fact. Three independent gaps exploit the difference: (a) the origin's wipe deletes by recordID with no conflict check, and pushSyncedProfile reuses profileId-keyed record IDs, so a receiver's completed, 'clean' re-push is silently destroyed by a wipe still in flight (app suspension of the origin between marker save and wipe stretches this race from seconds to minutes — well within the stated fault model); (b) the receiver's own follow-up query is not read-your-writes (the spec concedes this), so fresh re-creates can be invisible while wipe deletions are ingested; (c) deterministically, isNewerSchemaVersion profiles are never pushed but have syncVersion>0, so 'zero failures' is satisfied while their absence from the rebuilt zone is guaranteed. In all three, the design's own follow-up performFullSync then reconciles ungated against a genuinely-partial zone and deletes local profiles/locations — including selection loss when clearRemoteAppSelections=false (outside exception (b)) and permanent loss of victim-only items (outside exception (a)). This falsifies the coverage claimed by rows 9 and 16.
+> 
+> Secondary breaks: row 6's 'at least the later wipe's marker survives' is provably wrong — SyncResetRequest is wiped last and each wipe excludes only its OWN marker, so overlapping resets mutually annihilate both markers, leaving third devices to reconcile ungated against a partially-reseeded zone. Row 17's accepted residual is real but its acceptance rationale is false on both counts: the window is an ordinary independent per-type index-lag combination (not a 'narrow inverted index order'), and the self-heal claim fails for victim-only data, which is permanently destroyed because reconciliation deletes it before the end-of-pass push. On liveness: a >400-record type makes the single-call wipe deterministically un-completable after the marker is already broadcast (selection-clearing fires family-wide on every retry), and cooperative GC trusts per-device clocks, so one fast-clocked device deletes a live marker for everyone — reintroducing the consume-before-delivery defect (#202.1) this design exists to fix.
+> 
+> Verdict: has-holes. The gating architecture is salvageable — the fixes are localized (evidence-based gate clearing, don't wipe other markers, chunked deletes, server-timestamp TTL) — but as specified the design still loses data under interleavings inside its own stated fault model, and four of its table rows (6, 9, 16, 17) claim outcomes the design does not deliver.
+
+### cloudkit-1 [breaks-safety] Gate cleared on 'clean re-push' while the reset is still in flight — follow-up pass reconciles against a genuinely partial zone and mass-deletes local data
+
+**Violated:**
+
+SAFETY PROPERTY exceptions (a)/(b) — deletion during an in-flight reset with clearRemoteAppSelections=false; spec rows 9 and 16 ('gate still set ⇒ skips reconciliation' — here the gate is legitimately cleared by the design's own rule); A3's stated invariant 'gate set ⇒ no deletions until my data is back in the zone' — the mechanism actually tests 'my push once reported success', which is strictly weaker: the origin's still-in-flight wipe can delete the re-pushed records afterward, and skipped (newer-schema) profiles were never pushed at all.
+
+**Interleaving:**
+
+Devices: O (origin) and B, both hold profiles p1..p6 (syncVersion>0); B also holds B-only profile p7, pushed 2 days ago while O was offline (O never pulled it). Reset uses clearRemoteAppSelections=false. (1) O: resetSync saves marker M(T); iOS suspends O's app at the very next await (user locked the phone — milder than the crash-at-await the spec's model allows). (2) B receives the zone push fired by the marker save itself; last sync >5 min ago so the throttle passes. performFullSync#1: pullResetRequests sees M, classifies .process → watermark_B:=T, gate_B set, handleSyncReset spawns TaskA={rePush; performFullSync}. (3) Pass#1 pullProfiles sees the full pre-wipe set (O hasn't wiped yet); gate set → no reconciliation; fine. (4) TaskA rePushLocalSyncedData: p1..p7 fetch+save all succeed (records still exist — these are updates to the SAME record IDs, since pushSyncedProfile keys records by profileId). Zero failures → per spec A3/data-flow, gate_B is CLEARED. (5) O resumes 10 minutes later: sets gate_O, deleteAllSyncedData fetches SyncedProfile IDs {p1..p7} and modifyRecords-deletes them — deletes are by recordID with no change-tag check, so B's just-re-pushed records are destroyed too. Wipe finishes; O begins its sequential re-push and has saved only p1,p2,p3 so far. (6) B: user taps Sync Now (or a zone push arrives; throttle window has passed). performFullSync: pullResetRequests → M is .skipAlreadyProcessed (watermark_B=T). pullProfiles → the zone GENUINELY contains only {p1,p2,p3} — no index lag needed — remoteIds non-empty, gate_B cleared → reconciliation deletes local p4,p5,p6,p7 via BlockedProfiles.deleteProfile (session history cascades, selections destroyed). (7) O finishes re-pushing p4..p6; B recreates them with needsAppSelection=true → app selections silently lost on B although clearRemoteAppSelections was FALSE (outside exception (b)); p7 is PERMANENTLY lost — its CK record was wiped in step 5 and B deleted its only local copy in step 6, before B's end-of-pass push. Two independent variants reach the same state without app suspension: (i) own-write query-index lag — B's follow-up pull simply doesn't yet index B's fresh post-wipe re-creates (the spec itself disclaims query read-your-writes) while the wipe deletions are indexed → same partial remoteIds; (ii) deterministic, no race at all: a profile with isNewerSchemaVersion is skipped by rePushLocalSyncedData yet has syncVersion>0, so the 'zero per-record failures' clear condition is met while that profile is guaranteed absent from the rebuilt zone → the follow-up pass always deletes it locally. pushLocalData clearing the gate has the identical flaw (spec says both sites clear it).
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Make the gate-clear condition evidence-based instead of push-based: clear only when, within a single pass, the pull's remoteProfileIds/remoteLocationIds are a superset of this device's own pushable local synced IDs (proof the zone currently reflects this device's data), optionally AND the triggering marker is older than a short quarantine so the origin's wipe has landed. Independently, exempt isNewerSchemaVersion profiles (never pushable by this device) from reconciliation deletion, since re-push can never restore them.
+
+### cloudkit-2 [breaks-safety] Row 6 is wrong: two near-simultaneous resets can mutually annihilate BOTH markers, leaving a wiped/partially-reseeded zone with no reset marker for third devices
+
+**Violated:**
+
+Spec row 6 ('At least the later wipe's marker survives; devices process the newest surviving request... Converges') and the SAFETY PROPERTY — a third device deletes local BlockedProfiles/SavedLocation data during an in-flight reset with no marker visible, outside exceptions (a)/(b).
+
+**Interleaving:**
+
+(1) O1: resetSync saves M1(T1), begins deleteAllSyncedData — SyncResetRequest is the LAST type in the recordTypes array, so its fetch runs latest. (2) 30s later O2: resetSync saves M2(T2), begins its wipe. (3) O1's wipe reaches the SyncResetRequest type: fetch returns M1 (excluded, per A1 'excluding only the current request') and M2 (saved 30s earlier, index-visible) → deletes M2. (4) O2's wipe reaches SyncResetRequest: fetch returns M2 (excluded) and M1 → deletes M1. Both deletes are unconditional by recordID; both succeed. Zone now contains ZERO reset markers while both origins' wipes have destroyed all SyncedProfile/SyncedLocation records; both origins start re-pushing. (5) Device C, which had not synced since before step 1 (throttled/asleep) and holds C-only profile P (pushed last week, syncVersion>0; neither origin pulled it recently): performFullSync → pullResetRequests finds nothing → no gate, no watermark change. pullProfiles → zone contains O1's partially-re-pushed subset → remoteIds NON-EMPTY (A2 does not fire) → reconciliation deletes every C-local profile absent from the subset, including P. P's CK record was wiped in steps 1-2 and neither origin holds it, so P is permanently lost; C's copies of the origins' not-yet-re-pushed profiles are deleted and later recreated with needsAppSelection=true (selection loss even if both resets had clearRemoteAppSelections=false). Row 6's claimed outcome — 'At least the later wipe's marker survives' — is refuted: each wipe's reset-request fetch runs after the other's marker save whenever the two resetSync calls overlap within the wipe duration, which is exactly the 'near-simultaneous' case the row claims to handle.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Never delete other devices' within-TTL SyncResetRequest records in deleteAllSyncedData — exclude the whole SyncResetRequest type from the wipe (expired ones are already handled by cooperative GC B3, fresh ones by watermarks B1). Old markers being superseded is exactly what the watermark already handles; wiping them buys nothing and creates the annihilation window.
+
+### cloudkit-3 [breaks-liveness] >400 records of one type makes the wipe deterministically fail AFTER the marker is live: reset can never complete, yet every attempt clears app selections family-wide
+
+**Violated:**
+
+LIVENESS ('resets reach every device' presumes a reset can complete; here the wipe never can) and the spec's partial-failure table, which analyzes limitExceeded only as a one-shot transient (rows 1, 3) — it never considers that a >400-record type makes the failure deterministic and repeatable after the marker is already broadcast.
+
+**Interleaving:**
+
+(1) Zone contains 450 records of one type — e.g. LegacySyncedSession from a long-time v1 user whose per-record legacy cleanup (ProfileSyncManager.cleanupLegacySessionsIfNeeded) was interrupted and never completed for this account. (2) O: resetSync(clearRemoteAppSelections: true) → saves marker M (zone push fans out to the family) → sets gate → deleteAllSyncedData: SyncedProfile deletes fine, then LegacySyncedSession: fetchAllRecords returns 450 IDs and ONE modifyRecords(saving:[], deleting: 450 IDs) is issued — over CloudKit's 400-records-per-operation limit → CKError.limitExceeded, atomic op deletes nothing, resetSync throws; UI shows 'Reset failed'. (3) Meanwhile every family device processes M (it is a genuine, unexpired marker): clears selectedActivity on ALL profiles, sets needsAppSelection=true, re-pushes, advances watermark. (4) User retries → new marker M2 → identical deterministic failure at the same type → selections cleared family-wide AGAIN; the wipe NEVER succeeds no matter how many retries. Data converges (rows 1/3 hold), but the reset operation itself is permanently un-completable while its most disruptive side effect fires on every attempt.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Chunk deleteAllSyncedData into batches of ≤400 record IDs per modifyRecords call (CK's documented guidance for limitExceeded is to split). The spec's constraint section already states the gates must hold 'even if a within-type partial state somehow occurred', so per-batch atomicity is compatible with the rest of the design.
+
+### cloudkit-4 [breaks-safety] Row 17's residual is mischaracterized: the window is not 'narrow' and the self-heal claim is false for victim-only data (permanent loss, not selection loss)
+
+**Violated:**
+
+SAFETY PROPERTY (deletion during in-flight reset, outside exceptions (a)/(b)) — acknowledged by the spec as a residual, but row 17's claimed outcome ('narrow... self-heals: origin's re-push recreates them; app selections lost') is WRONG on both the window characterization and the recovery claim.
+
+**Interleaving:**
+
+(1) O: resetSync saves marker M, then wipes SyncedProfile. (2) B syncs during the wipe window: pullResetRequests queries the SyncResetRequest type — M is a seconds-old record whose query index has not ingested it yet, so B sees no reset (this does NOT require 'inverted index order' within one index, as the spec claims: SyncResetRequest and SyncedProfile live in independent per-type query indexes, and a fresh write lagging its index while a different type's deletions are already ingested is an ordinary, uncorrelated combination — not a narrow inversion). (3) B's pullProfiles returns a non-empty partial set (wipe deletions partially ingested) → no gate, no A2 → reconciliation deletes B's local profiles absent from the partial view — including B-only profile P (created on B, pushed, syncVersion>0, never pulled by O). (4) The spec's claimed self-heal — 'origin's re-push recreates them' — cannot apply to P: O never held P, and B deleted its only local copy in step 3, BEFORE B's end-of-pass pushLocalData runs, so nothing ever re-pushes it. P and its session history are permanently destroyed, and the same holds for B-only SavedLocations. The row's accepted-risk rationale ('narrow window, self-heals with only selection loss') rests on two false claims; the actual exposure is a common-case index-lag combination with permanent-loss outcomes.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+If full tombstones stay out of scope (#219), at minimum bound the blast radius: treat a pull in which previously-seen remote IDs shrink by more than a small fraction (e.g. >50%) in a single pass as reset-suspect and skip deletion reconciliation for that pass (a shrink-rate circuit breaker), and re-word row 17 to state the true impact so the risk acceptance is honest.
+
+### cloudkit-5 [weakens] TTL/GC decisions trust per-device wall clocks: one fast-clocked device GC-deletes a live marker for the whole family; a slow origin clock disables the receiver gate
+
+**Violated:**
+
+B3's claim 'a past-TTL request is globally inert, so deletion is always safe and self-healing'; LIVENESS ('resets reach every device that syncs within the 7-day TTL'); and, downstream, the SAFETY PROPERTY via the ungated wipe window in cases A/B.
+
+**Interleaving:**
+
+Case A: device D's clock is 7+ days fast (manually set date — a known failure mode on user devices). (1) O: resetSync saves M(requestedAt = real now), wipes, starts re-pushing. (2) D syncs first: classify(M) computes age = now_D - requestedAt > 7d → .expiredCollect → D DELETES the fresh marker (B3: 'a past-TTL request is globally inert, so deletion is always safe' — false: inertness is judged on each device's clock). (3) Devices B, C sync minutes later: no marker → no gate, no watermark → they hit the mid-re-push zone exactly as in finding 2 step 5: non-empty partial remoteIds → reconciliation deletes local profiles → needsAppSelection loss, permanent loss of any B/C-only items; additionally the reset never 'reaches every device' (liveness claim broken by consume-before-delivery, the very #202.1 defect this design set out to fix). Case B: origin's clock is 7+ days slow → every receiver classifies M .expiredCollect immediately, GCs it, and syncs through the wipe/re-seed window entirely ungated (deterministic row-17 exposure). Case C (sub-TTL skew): origin 6d23h slow → receivers process M but set gate := requestedAt, which their local clock judges ~1h from the 7-day cutoff — the gate's intended 7-day backstop shrinks to minutes if the re-push stalls. Row 12 considers only a future-skewed origin; none of these three cases appear in the tables.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Base expiry and GC on the server-assigned CKRecord.creationDate (systemFields metadata, immune to device clocks) instead of the client-written requestedAt, and only GC at a slack multiple (e.g. 2x TTL) of the processing cutoff so borderline skew can never delete a marker other devices still need. Set the receiver gate to the receiver's own now at processing time, not the origin's requestedAt.
+
+### cloudkit-6 [nit] Spec does not pin gate-set before watermark-advance ordering
+
+**Violated:**
+
+B6's own justification ('covered by the A3 gate (already set, persisted)') — an assumption the spec never mandates.
+
+**Interleaving:**
+
+A3 says the gate is set 'before invoking didReceiveSyncReset'; B6 says the watermark advances 'synchronously, in the same loop iteration'; their mutual order is unspecified, yet B6's crash argument parenthetically assumes the gate is 'already set'. If an implementer writes watermark-first and the process dies between the two SharedData writes (outside the stated awaits-only fault model, but a real kill -9 can land between any two statements), relaunch classifies the request .skipAlreadyProcessed with NO gate → the device reconciles ungated against the mid-reset zone.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+State explicitly in A3/B6: persist resetRePushPendingSince BEFORE advancing lastProcessedResetAt, so any kill between the two writes fails safe (reprocessing is idempotent; an unwatermarked-but-gated state is harmless, the reverse is not).
+
+## Lens: specReview — verdict: has-holes
+
+**Verifier reasoning:**
+
+> Read the full spec (325 lines). It is unusually disciplined for cross-referencing (issue-number tags #195.x/#202.x match consistently between the Problem section and every later citation; interleaving-table rows 1-18 mostly track the mechanism definitions correctly; test-plan items 1-3 correctly mirror A2/A3's stated logic). No literal TODO/TBD/placeholder markers exist. However, systematic cross-checking of every interleaving row against the mechanism text, the data-flow diagram, and the test plan surfaced seven real issues: one edge case that plausibly defeats the core safety mechanism (A3 gate anchored to `requestedAt` rather than local processing time, so a device that comes back online near the 7-day TTL boundary gets almost no protected re-push window — exactly the deferred-sync scenario the rev-2 gate was introduced to cover); an underspecified 'zero per-record failures' clearing condition for a gate shared by two unrelated data types; a critical liveness-preventing ordering guarantee (B6, 'prevents an infinite reset loop') that has no dedicated test and falls outside the explicit code-inspection disclaimer's named scope; two interleaving-table rows (6, 7) that are asserted safe/harmless but have no corresponding test item and aren't listed under 'Out of scope' the way row 17 is; a documentation overclaim in 'Interplay' ('delivery reach every device exactly once') that directly contradicts A1's own text and B4's own caveat about a later reset's wipe deleting an unprocessed request; a diagram-vs-prose ambiguity about whether `performFullSync` runs unconditionally after a failed re-push (A4 says yes, the diagram's arrow notation reads as conditional, and row 13 requires the unconditional reading); and an undefined 'partial' vs 'complete' remote-set vocabulary used only in the interleaving table / test plan that has no counterpart in the Part A mechanism definitions (which only ever branch on `.isEmpty` and gate state, never on any partial/complete distinction). None of these amount to the design being fundamentally broken — the accepted-risk framing (row 17, the safety-asymmetry principle) is honest and mostly closes the loop — but several are more than nits: finding 1 in particular can reintroduce data loss + lost app selections through an everyday scenario (a device that was offline for most of the TTL window), not just the 'narrow' index-lag race the spec believes is its only residual risk.
+
+### specReview-1 [breaks-safety] A3 gate is anchored to the request's requestedAt, not to local processing time — TTL backstop can expire the gate almost immediately for a delayed-sync device
+
+**Violated:**
+
+Contradicts the rev-2 rationale given at lines 134-140 ('the destructive window is not one pass wide... A persisted gate closes the whole window: process-crash-relaunch, concurrent manual sync, and the origin's own crash-after-wipe all land in gate set ⇒ no deletions until my data is back in the zone') and undermines the 'Converges' outcome claimed for row 8 (line 251), which assumes the gate stays set 'until pushLocalData completes cleanly.' Also widens interleaving row 17's 'narrow' residual-risk description (line 265) far beyond what the spec believes is the only unclosed gap.
+
+**Interleaving:**
+
+Quote (line 118): "Set (to the request's requestedAt) synchronously before the reset is applied". Quote (lines 128-129): "TTL backstop: a pending flag older than SyncResetRequest.defaultTTL (7 days) is ignored (reconciliation resumes) and cleared." Concrete scenario: Day 0, origin creates SyncResetRequest R1 (requestedAt = Day 0), TTL = 7 days. Device D is offline until Day 6.9. At Day 6.9, D runs pullResetRequests; classify(R1, watermark=.distantPast, now=Day6.9, ttl=7d) is not expired (age 6.9d < 7d) so returns .process. Per A3, D sets resetRePushPendingSince = R1.requestedAt = Day 0 (not Day 6.9). D begins clearing selections and re-pushing its (possibly many) local profiles/locations. At Day 7.0 — only ~2.4 hours later — the backstop check computes gate age = now - gate = 7.0d ≥ 7d TTL and treats the gate as expired, re-enabling deletion reconciliation, even though D's re-push may still be incomplete (network delay, large profile count, transient failures). A subsequent pull in that ~2.4-hour window with a non-empty-but-partial remote set (because D's own data isn't fully re-pushed yet) now reconciles instead of skipping, deleting D's own not-yet-repushed local profiles — exactly the catastrophic outcome (lost profiles, needsAppSelection=true, silent blocking failure) the whole design exists to prevent.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Clarify in the spec whether the gate should store requestedAt (as written) or local now-at-set-time; if requestedAt is intentional, add an interleaving row and a test case for a device processing a within-TTL-but-near-expiry request, and state the resulting (reduced) protection window explicitly.
+
+### specReview-2 [weakens] "Zero per-record failures" clearing condition is underspecified: scope of 'per-record' and cross-type coupling of the single gate are both ambiguous
+
+**Violated:**
+
+No explicit row or test resolves either question; A3's own bullet (lines 124-127) is the only source and doesn't disambiguate.
+
+**Interleaving:**
+
+Quote (lines 124-127): "Cleared when a complete local re-push finishes with zero per-record failures — both rePushLocalSyncedData (the reset path) and pushLocalData (runs at the end of every full sync pass) report success/failure counts and clear the flag on a clean run. If some pushes failed, the flag stays set and the next pass's push retries." Two concrete ambiguities: (a) row 7 (line 250) describes 'GC delete of an expired other fails' as merely 'harmless; retried next pass' — but it is unspecified whether a failed cooperative-GC deletion counts toward the 'per-record failure' total that keeps the single shared gate set, i.e. whether an unrelated stale record from a third device could indefinitely block this device's own gate from clearing. (b) A3 states there is one resetRePushPendingSince flag gating both handleSyncedProfiles and handleSyncedLocations (line 122); if pushLocalData's profile-push succeeds cleanly but its location-push keeps failing (or vice versa), it is unspecified whether the single flag's clear condition requires BOTH to be clean (blocking the unrelated, successfully-pushed data type's reconciliation too) or clears per-type independently despite there being only one flag.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+State explicitly that GC-delete failures never count toward the push failure total, and either split the gate per data-type or state explicitly that a failure in one type's push blocks reconciliation for both types until resolved.
+
+### specReview-3 [weakens] B6's watermark-advance-before-Task-spawn ordering (the sole fix for the infinite reset loop) has no dedicated test and falls outside the named code-inspection scope
+
+**Violated:**
+
+Test-plan completeness relative to a fix explicitly framed (line 189 heading) as preventing 'an infinite reset loop' — the single most severe liveness property in Part B.
+
+**Interleaving:**
+
+B6 (lines 189-199) states this ordering is the *only* thing preventing an infinite reprocessing loop: "Advancing the watermark inside the async re-push Task instead would race the follow-up pass and can loop." The Test Plan's item 4 (lines 307-309) is titled 'Gate lifecycle' and only covers resetRePushPendingSince timing ("set-on-process happens before delegate dispatch; cleared on zero-failure push..."), never lastProcessedResetAt's ordering relative to the async Task spawn. Item 5 (lines 310-311) is a bare persistence round-trip test. The closing disclaimer (lines 313-314) says 'CloudKit-plumbing (resetSync ordering, pullResetRequests loop) verified by code inspection; their decisions are covered by the pure classifier (1) and gate lifecycle (4)' — B6's watermark-advance timing is neither a classify 'decision' (classify takes watermark as an input, per B5's signature, and never mutates it) nor part of item 4's gate-lifecycle scope, so it is left uncovered by both the automated tests and the explicit inspection commitment.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Add an explicit test-plan line (or an explicit code-inspection callout naming B6 specifically) asserting that lastProcessedResetAt is advanced synchronously in the same loop iteration, before the re-push Task is spawned.
+
+### specReview-4 [weakens] Interleaving rows 6 and 7 are asserted safe but have no corresponding test item and are not listed under 'Out of scope' (unlike row 17)
+
+**Violated:**
+
+Test-plan completeness relative to the interleaving-analysis table's own claims (Part 'resetSync (origin)' and 'pullResetRequests (receiver)' sections).
+
+**Interleaving:**
+
+Row 6 (line 244): "Two devices reset near-simultaneously | Each saves its own marker first; each wipe deletes the other's marker... Converges." Row 7 (line 250): "GC delete of an expired other fails | Harmless; retried next pass." Row 17 (line 265) is the only interleaving explicitly carried into the 'Out of scope' section (line 318-319: "Per-delete tombstones for the general (non-reset) deletion path (interleaving #17 residual...)"). Rows 6 and 7 receive no equivalent treatment: they aren't exercised by any of the five test-plan items (1-5, lines 292-311), and they aren't declared out of scope, leaving their claimed outcomes ('Converges' / 'Harmless') asserted but unverified by either the pure-function tests or the stated code-inspection commitment.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Add a test (e.g. simulate two SyncResetRequest saves each excluding only its own recordID) for row 6's marker-survival logic, and either add a GC-delete-failure test or explicitly list row 7 as accepted/out of scope alongside row 17.
+
+### specReview-5 [weakens] "Interplay" section overclaims delivery guarantee that A1 and B4 themselves qualify
+
+**Violated:**
+
+Line 207 vs. lines 104-105, 179-180, and row 6 (line 244) — direct textual tension between a summary claim and the mechanism's own documented exception.
+
+**Interleaving:**
+
+Quote (line 207): "B1–B6 make delivery reach every device exactly once and make cleanup independent of any single device's survival." This is stated unconditionally. But A1 (lines 104-105) states: "Excluding only the current request means older SyncResetRequest records are still wiped by the reset itself (part of #202 cleanup)" and B4 (lines 179-180) explicitly concedes within-TTL requests are "removed later by cooperative TTL-GC (B3) or by the next reset's wipe (A1)" — i.e. a second reset can delete a first reset's still-live, not-yet-delivered request. Row 6 (line 244) directly confirms the consequence: "Selection-clearing intent of a deleted marker can be lost — last reset wins; accepted." So delivery to every device is only guaranteed absent an intervening reset; the Interplay bullet states the guarantee without that qualification.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Qualify line 207, e.g. 'assuming no intervening reset wipes the request first (see A1, row 6)', or cross-reference the caveat explicitly.
+
+### specReview-6 [weakens] Data-flow diagram's "on zero failures: clear gate ──► performFullSync" arrow is ambiguous about whether performFullSync runs unconditionally after re-push
+
+**Violated:**
+
+A4's prose (lines 142-146) and row 13's outcome (line 256) vs. the diagram notation (lines 215-216).
+
+**Interleaving:**
+
+Diagram (lines 215-216 and 226): "rePush(local) └► on zero failures: clear gate ──► performFullSync" and "pushLocalData ──► on zero failures: clear gate" (no explicit continuation after this one). A4 (lines 142-146) states unconditionally: "handleSyncReset already chains rePushLocalSyncedData then performFullSync inside one Task; keep that ordering" — implying performFullSync always follows re-push, success or not. Row 13 (line 256) requires this: "Re-push permanently failing... Upserts and pushes of other records continue throughout," which is only true if the follow-up performFullSync (and its own end-of-pass pushLocalData) keeps running despite failures. But the diagram's linear arrow places performFullSync directly after 'on zero failures: clear gate,' which a reader can plausibly interpret as performFullSync being gated behind the success branch rather than running regardless.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Redraw or annotate the diagram to show performFullSync as unconditional (e.g. 'rePush(local) [always]──► performFullSync; separately, on zero failures ⇒ clear gate') so it can't be read as conditional.
+
+### specReview-7 [nit] "Partial" vs "complete" remote-set terminology used in the interleaving table and test plan is never defined by the Part A mechanism, which only branches on isEmpty + gate state
+
+**Violated:**
+
+Test-plan/interleaving-table vocabulary vs. mechanism definitions in Part A (A2/A3) — the algorithm has no 'partial vs complete' input, only isEmpty + gate.
+
+**Interleaving:**
+
+Test item 2 (lines 298-304) lists, as apparently distinct scenario categories: "non-empty partial + gate set ⇒ retained", "non-empty partial + gate expired... ⇒ deleted (backstop regression)", and "non-empty complete + no gate, one missing ⇒ that one deleted (regression guard)". Row 18 (line 266) likewise uses "Non-empty, complete, no reset, no gate, one profile deleted remotely." But Part A's actual mechanism definitions (A2, line 108-112, and A3, lines 114-132) only ever check `remoteProfileIds.isEmpty` and the gate's set/expired state — there is no code-level notion of a remote set being 'partial' vs 'complete' (both 'partial' and 'complete, one missing' describe the identical shape of data: a non-empty remote array missing one profile the local side has). The word 'complete' never appears anywhere in Part A's mechanism text at all.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Replace 'partial'/'complete' with the actual determining factor (gate state) in the test-plan bullets and row 18, or add a one-line definition in Part A clarifying that these terms describe test-scenario setup only, not an algorithmic input.

--- a/docs/plans/2026-07-02-reset-sync-a1-interleavings-round2.md
+++ b/docs/plans/2026-07-02-reset-sync-a1-interleavings-round2.md
@@ -1,0 +1,331 @@
+# A1 adversarial verification — round 2 findings (verbatim)
+
+- **Target design:** rev 3 (read-verified clearable holds + date watermark)
+- **Context:** acceptance corpus for #267; see `2026-07-02-reset-sync-a1-acceptance-corpus.md`.
+- **Provenance:** machine-extracted, unedited output of the independent verifier agents.
+
+## Lens: readVerification — verdict: has-holes
+
+**Verifier reasoning:**
+
+> Rev 3's core invariant is much stronger than rev 2 — I confirmed it defeats all seven rev-2 breaks it was built against: holds-on-sight + same-pass superset verification correctly neutralizes push-ack races, non-read-your-writes follow-up pulls, stale push tasks, mutual marker deletion (wipes exclude markers), >400 wedges (chunking), origin-clock TTL anchoring (server creationDate), and 7-14d-fast receiver clocks (.skipExpired grace band + sight-based holds). Rows 15 and 16 and the intentional-behaviour-changes section are honest as stated (their preconditions are genuinely required, modulo the pre-existing #219 index-lag class the design legitimately carves out). I also verified pull ordering: pullResetRequests failures abort performFullSync before pullProfiles, and the zoneNotFound/unknownItem early-returns are matched by identical early-returns in pullProfiles/pullLocations, so no reconciliation runs without a marker fetch attempt; no other caller reaches the reconciliation handlers. However, the design has one real safety hole and one real liveness hole. Safety: the hold is a one-shot clearable flag while the danger (in-flight wipe, marker lifetime) is a window; after any legitimate verification-clear (e.g., a pass that races ahead of the wipe against a genuinely-complete zone), re-protection depends entirely on re-sighting the marker via a CKQuery that may be stale-absent — one such stale query (the exact same staleness budget row 20 accepts) lets a device that DID sight the marker reconcile against the post-wipe zone and permanently delete its own-only profiles/locations. This falsifies the interplay claim ('...or ever saw one ... not a pass longer') and shows row 20's precondition ('marker never sighted') is not actually required, i.e., that acceptance is stated too narrowly. The stale-presence direction additionally lets verification itself pass on false evidence, and an origin-side variant falsifies row 5. Liveness: the B1 watermark cap (now+1h) directly contradicts B5's loop-prevention whenever effectiveDate > receiver-now+1h (receiver clock >1h slow — squarely inside the stated skew-up-to-days model, and realistic for a screen-time app whose users manipulate clocks): the marker re-classifies .process every pass, and since each processing chains rePush + performFullSync, the loop is self-sustaining for ~(skew−1h), re-clearing user app selections every cycle, including past the 7-day exception window. Both holes have targeted fixes that preserve the design's shape (a persisted 7-day verification window keyed to last marker sight instead of a clearable hold; processed-request identity alongside the watermark). Plus two spec-consistency nits (unsatisfiable test 4.3/row 19; decode-independence of hold-set) whose main risk is an implementer 'fixing' the spec the wrong way. Verdict: has-holes — the invariant needs the window/identity amendments before implementation, but the overall architecture (sight-based protection + same-pass read-verification + persistent markers + watermark) is the right shape and survives everything else I threw at it.
+
+### readVerification-1 [breaks-safety] Hold-clear is edge-triggered but the danger window is level-triggered: one stale-absent marker query after a legitimate verification-clear deletes real data
+
+**Violated:**
+
+The safety property (deletion of local BlockedProfiles/SavedLocation during a reset, outside all stated exceptions) and the spec's interplay claim: 'A2 protects every device that can see the marker (or ever saw one), for exactly as long as the zone lacks data that device could restore — and not a pass longer.' After a legitimate clear, re-protection depends entirely on per-pass re-sighting through a query that can be stale-absent — the exact staleness budget (one marker-invisible + deletions-visible query) that row 20 accepts, but row 20's stated precondition 'marker never sighted by this device' is NOT actually required: a device that sighted the marker and had its hold correctly set loses data the same way. Row 20's acceptance is therefore stated dishonestly-by-incompleteness, and rows 5 and 19's outcome claims are false under this interleaving.
+
+**Interleaving:**
+
+Setup: devices A (origin) and B. Profile P was created on B, pushed (syncVersion>0, normal schema), and A has NOT synced since — P exists only on B and in the zone. STEP 1 (t1): A runs resetSync: saves marker M; A's wipe has not landed yet (chunked wipe over multiple ops takes time). STEP 2 (t2): B runs performFullSync pass 1: pullResetRequests sights M -> both holds set, M classified .process, watermark advanced, didReceiveSyncReset dispatched (spawns re-push + follow-up-sync task). pullProfiles returns the still-complete pre-wipe zone -> remoteIds ⊇ B's restorable ids -> read-verification legitimately PASSES -> hold CLEARED, reconcile is a no-op. STEP 3 (t3): A's wipe executes. Its per-type snapshot contains P's recordID (recordIDs are stable = profileId), so P is deleted — including the copy B just re-pushed. A then re-pushes A's local data, which does not include P. STEP 4 (t4): B's follow-up sync (or a later notification-triggered pass): pullResetRequests query is STALE-ABSENT for M (index lag hiding a minutes-old record — explicitly permitted) -> zero markers sighted -> hold stays nil (set-if-nil never fires). pullProfiles now shows the true post-wipe zone: remoteIds = A's re-pushed set, non-empty (A3 doesn't fire), P absent, hold nil, backstop irrelevant -> reconciliation deletes P locally via BlockedProfiles.deleteProfile. The end-of-pass pushLocalData runs AFTER reconciliation, fetches local profiles post-deletion, and no longer includes P. P (and its selection/sessions) is permanently lost — no device or zone copy exists. The same trace works verbatim for SavedLocation with the location hold. Two variants use the same skeleton: (a) pass-1 verification passes on STALE PRESENCE of records the wipe already deleted (the superset check trusts positive query evidence, which the design's own constraint says can lag deletions); (b) origin-side: a manual performFullSync interleaved at resetSync's awaits verify-clears the origin's own step-3 holds against its pre-wipe pull before the wipe lands, falsifying row 5's outcome, after which one stale-absent sighting of its own marker exposes the origin's not-yet-re-pushed data mid-re-push.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Make protection a persisted time window, not a clearable flag: persist lastSightedResetAt (per data type if desired), set/refreshed by resetSync and by every marker sighting; require read-verification (superset proof, same-pass pulled set) for EVERY deletion reconciliation while now < lastSightedResetAt + processTTL (7d, with the same fail-toward-keep clamps), regardless of whether the current pass's query returned any marker. Verification passing every pass in a healthy zone preserves the same-pass-resume liveness goal, but a stale-absent marker query can no longer strip protection because the window outlives any single query. Optionally harden variant (a) by proving presence via fetch-by-recordID (record store, not the query index) for the device's restorable ids.
+
+### readVerification-2 [breaks-liveness] Watermark cap at now+1h reintroduces the infinite reprocessing loop B5 claims to prevent whenever the receiver clock is >1h slow
+
+**Violated:**
+
+Liveness requirement 'no infinite reprocessing loops' and B5's own claim: 'The synchronous watermark advance prevents the follow-up pass from re-processing (infinite reset loop)' — the B1 cap and the B5 loop-prevention are mutually contradictory whenever effectiveDate > now+1h, and the cap's stated rationale (processing future-dated markers via the requestedAt fallback) confirms future-dated markers are intended to be processed. Secondary safety-exception overrun: repeated selection-clearing continues beyond the 7-day-old-reset allowance of exception (b) in wall-clock terms.
+
+**Interleaving:**
+
+Setup: receiver B's clock is s > 1h slow relative to server time (model allows days; kids rolling clocks back is a realistic threat for a screen-time app). Origin A resets with clearRemoteAppSelections=true; marker M has server creationDate E, so effectiveDate = E. STEP 1: B syncs at receiver-time n0 = E − s. classify: not own, age = n0 − E < 0 (not expired), E > watermark -> .process. B5: watermark advance is capped at min(E, n0+1h) = n0+1h < E (cap engages because E > now+1h). didReceiveSyncReset dispatched -> handleSyncReset clears ALL app selections, then chains Task { rePushLocalSyncedData (every profile + location, one CK call each); performFullSync }. STEP 2: that chained performFullSync re-runs pullResetRequests: M still classifies .process (E > watermark = now+1h, still capped) -> selections cleared AGAIN, full re-push AGAIN, another chained performFullSync. STEP 3: the chain is self-sustaining (it does not go through handleRemoteNotification, so the 5-minute throttle never applies) and loops continuously until receiver-clock now+1h catches up to E — duration ≈ s − 1h (days of continuous full-sync + full-re-push cycles for day-scale skew), or until the marker expires/GCs at receiver-relative E+7d / E+14d. Every cycle re-sets needsAppSelection=true and wipes selectedActivity on every profile, so any apps the user re-selects between cycles are cleared again; with s > 0 this re-clearing also continues past the point where the reset is more than 7 wall-clock days old (exceeding exception (b)'s window).
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Add idempotency by identity, not only by time: persist the processed request's requestId (e.g., SharedData.lastProcessedResetId, or the set of processed ids seen within gcTTL) alongside the watermark, and have classify return .skipAlreadyProcessed when requestId matches regardless of effectiveDate-vs-watermark. Keep the now+1h cap solely for cross-request delivery ordering. Also define classify's expected output for future effectiveDates explicitly in the test plan (it is currently listed as a test input with no specified outcome).
+
+### readVerification-3 [nit] Test plan 4.3 and row 19 are internally inconsistent: same-pass deletion after a verification-clear is provably unsatisfiable
+
+**Violated:**
+
+Internal consistency of the spec (invariant I vs. test plan item 4.3 and row 19). Risk: a TDD implementer forced to make 4.3 green may redefine 'restorable' more narrowly than 'deletable' (e.g., only records this device originated), which would silently reopen the #195 hole the invariant closes.
+
+**Interleaving:**
+
+Derivation, not a runtime trace: a verification-clearing pass requires remoteIds ⊇ {local ids with syncVersion>0 ∧ !isNewerSchemaVersion}. Reconciliation's deletable set is {local ids with syncVersion>0 ∧ id ∉ remoteIds}, minus isNewerSchemaVersion (A4) and syncVersion==0. Any deletable candidate is therefore restorable, hence in remoteIds — contradiction. So in the pass that clears the hold, no locally-held record can ever be deleted; test bullet 4.3's expected outcome 'one non-held remote-only deletion ⇒ hold cleared, absent local DELETED (same-pass resume)' cannot occur, and row 19's 'normal propagation resumes in the same pass' is misleading (real remote-deletion propagation resumes at the earliest the next hold-free pass, and per the intentional-changes section is usually reversed first by this device's every-pass push resurrecting the deleted record).
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Reword 4.3 to assert the no-op: 'non-empty remote, hold set, remote ⊇ restorable locals, one remote-only id with no local counterpart ⇒ hold cleared, nothing deleted, reconciliation branch executed'; reword row 19 to say deletion propagation resumes from the next pass (and is typically preceded by re-push resurrection), and state explicitly that restorable ⊇ deletable must hold by construction.
+
+### readVerification-4 [nit] Hold-set-on-sight is underspecified for undecodable marker records
+
+**Violated:**
+
+A2's stated intent ('no ... state ... can leave a device unprotected while a marker it can see exists') — the wording 'whenever its query result contains any SyncResetRequest record' is right, but the design's own decode/classify pipeline makes the decoded interpretation the natural implementation, and the failure direction is the catastrophic one.
+
+**Interleaving:**
+
+A future app version (or a corrupted write) produces a SyncResetRequest record that SyncResetRequest(from:) fails to decode, or fetchAllRecords returns it as a .failure per-record result. Origin wipes the zone under that marker. Receiver B's pullResetRequests fetches the record, but if the implementation counts only DECODED markers when setting holds (the spec's 'regardless of classification' is post-decode language, and classification is defined over decoded requests), B sets no hold, sees a partial mid-re-push zone in pullProfiles (non-empty, A3 silent), and reconciles-deletes its not-yet-re-pushed data with no protection.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+State explicitly (and pin with a test) that holds are set when the raw fetched result set for record type SyncResetRequest is non-empty — counting .failure results and decode-nil records — before any decoding or classification runs.
+
+## Lens: crashChurn — verdict: has-holes
+
+**Verifier reasoning:**
+
+> Human Meatbag — rev 3 is a real improvement over rev 2 (marker-before-wipe kills the durable landmine; wipes never touching markers kills mutual annihilation; chunking kills the >400 wedge; sight-based holds close the rev-2 ack races it set out to close; rows 11, 14, 15 and the last-deletion/newer-schema behaviour changes are honestly stated). But it has holes in exactly the new machinery. (1) Read-verification is itself a query-freshness bet: stale PRESENCE of wiped records falsely clears the hold, and the re-latch on the next pass depends on the marker being query-visible — stale absence there (the very lag row 20 is built on) leaves a previously-sighted device unprotected while deletions ARE visible, wiping its own-only data. The same shape breaks the 14-day backstop (clear-then-trust-next-pass relies on the previous pass's push being query-visible, violating the spec's own 'no safety decision may rely on a write being query-visible' constraint) and row 5 on the origin. Rows 16 and 20's acceptances are therefore not honest — their stated preconditions (persistent push FAILURE; marker NEVER sighted) are not required. (2) The clearing rule is self-defeating: verification passing implies the deletion set is empty (remoteIds ⊇ restorable-locals is precisely the no-deletions condition, and everything else is exempt), and every pass re-sights the persisted marker and re-sets the hold, so 'propagation resumes in the same pass' is vacuous, test-plan 4.3 is unsatisfiable, and genuine deletions during the ~14-day marker window are not deferred but reverted family-wide by every-pass pushes. (3) The now+1h watermark cap defeats B4/B5 idempotency whenever effectiveDate > now+1h (receiver ≥1h slow, or the requestedAt fallback with a fast origin): the follow-up sync re-classifies the same marker .process forever until the clock catches up — an infinite reprocess loop that re-clears selections for hours or days. (4) A weaker spec omission: fail-closed pass-abort on pullResetRequests failure is load-bearing but unstated. Verification method: full read of the spec and the three pre-fix files; grep confirmed all reconciliation-reaching paths flow through performFullSync with pullResetRequests first (SettingsView.swift:176/394/407, FoqosApp.swift:352, setupSync), so the error-path analysis in finding 4 is exhaustive over current callers. I could not break: resetSync crash rows 1–4/7 (marker-first ordering plus A3 genuinely holds under SIGKILL at every step boundary), hold-set-before-watermark B5 kill ordering (rows 8–9 honest), concurrent double resets (row 6, markers survive), the 7–14d skipExpired grace band (row 14 honest), sync disable/re-enable within the marker window (re-sight re-protects), and A4. Fixes for (1)+(2) point the same direction: replace the clearable latch + vacuous verification with a persisted quiet-period keyed to last marker sight, and state the resulting 7–14-day deletion-propagation suspension honestly; fix (3) with requestId-based idempotency.
+
+### crashChurn-1 [breaks-safety] Hold latch falsely cleared by stale-presence verification, then never re-latched by stale-absent marker query — a device that DID sight the marker still wipes its own-only data (rows 16/20 acceptances state preconditions that are not actually required; A2 interplay claim and row 5 refuted)
+
+**Violated:**
+
+Safety property: local BlockedProfiles/SavedLocation deletion and FamilyActivitySelection loss on a device with no genuine remote deletion in flight, outside the honest scope of accepted residuals — rows 16 and 20 state preconditions ('14 straight days of failed pushes', 'marker never sighted by this device') that these interleavings show are not required, so exception (c) does not cover them. Also falsifies the spec's A2 interplay claim, row 5, and the constraint that no new index-freshness dependencies be added.
+
+**Interleaving:**
+
+Variant 1a (stale-presence clear): (1) Origin A runs resetSync: marker saved, watermark advanced, holds set, zone wiped, A re-pushes A's profiles. (2) Device B (holds own-only profiles P*, syncVersion>0) runs performFullSync pass 1: pullResetRequests sights the marker → profile hold set. (3) pullProfiles' CKQuery returns STALE PRESENCE — index has not caught up to the wipe, so remoteProfileIds still contains all of B's restorable ids. Read-verification (remoteIds ⊇ restorable locals) PASSES → hold CLEARED, reconciliation vacuous, end-of-pass push re-pushes P* (acked). (4) Pass 2: pullResetRequests suffers STALE ABSENCE of the still-existing marker (explicitly allowed: 'CKQuery results may lag ANY write arbitrarily... stale absence for existing ones' — the same lag the spec itself relies on in row 20) → zero sightings → hold stays nil. (5) pullProfiles now reflects the wipe plus A's re-push but NOT B's pass-1 pushes (not read-your-writes): remoteIds non-empty (A's records), P* absent. No hold, no marker, remoteIds non-empty → reconciliation runs → B deletes P* locally via BlockedProfiles.deleteProfile: FamilyActivitySelection and session history destroyed; P* returns later only as needsAppSelection husks (or never, if the pass-1 pushes had failed). Row 20's acceptance requires 'marker never sighted by this device' — B sighted it; the precondition is not actually required, so the acceptance is not honest and this interleaving falls outside it. Variant 1b (backstop clear): device D's hold set at day 0, sync disabled, re-enabled day 15. Pass 1: marker already GC'd (day 14) → no sight; hold age >14d → backstop clears it and skips reconciliation; end-of-pass push of D's data is ACKED. Pass 2: marker gone (GC'd — re-sight impossible, unlike the normal churn case), pull shows stale absence of D's just-pushed records (the spec's own constraint: 'a write this device just made (even server-acked) may be missing from the next query') → no hold → reconcile → D's own-only profiles deleted. Row 16 claims this residual requires '14 straight days of FAILED pushes' — here every push succeeded; only index lag was needed. Variant 1c (row 5): a notification-triggered performFullSync on the origin issues its pullProfiles query before the wipe; the result (pre-wipe snapshot = stale presence) arrives after resetSync set the holds mid-wipe → verification passes against the pre-wipe snapshot → origin's hold cleared DURING its own wipe, contradicting row 5's 'Holds already set ⇒ no reconciliation'. All three variants refute the interplay claim 'A2 protects every device that can see the marker (or ever saw one), for exactly as long as the zone lacks data that device could restore — and not a pass longer': protection ends the moment one query lies, and read-verification is itself a new dependency on index freshness, which the constraints section forbids ('this design merely must not add new dependencies on index freshness').
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Stop treating the hold as a clearable latch. Persist lastMarkerSightAt (updated on every sight, and set by resetSync) and suppress deletion reconciliation for the full gcTTL window after the last sight, independent of any per-pass query evidence; drop read-verification-as-clearing entirely (per the next finding it only ever authorizes vacuous reconciliation, so nothing real is lost). For the backstop/offline case: after the quiet period expires, the first reconciling pass must still require remoteIds ⊇ restorable-locals in THAT pass whenever the previous pass pushed records absent from its own pull — or more simply, require one additional pass between 'this pass pushed missing data' and 'reconciliation allowed'. Restate rows 5, 16, 20 and the A2 interplay claim honestly if any residual is retained.
+
+### crashChurn-2 [breaks-liveness] Read-verification-passing passes have a provably empty deletion set: 'same-pass resume' is vacuous, deletion propagation is actually suspended for the whole ~14-day marker lifetime, genuine deletions in the window are actively REVERTED, and test-plan item 4 bullet 3 is unsatisfiable
+
+**Violated:**
+
+Liveness requirement 'deletion propagation resumes after read-verification, bounded by the 14-day backstop' — it never resumes via read-verification (only via the accidental row-20 stale-absence window, i.e. propagation during the window depends on the exact index-lag event the design elsewhere treats as its dangerous residual); plus internal spec consistency (row 19, intentional-change bullet 1, test plan 4.3 contradict A2's own definitions).
+
+**Interleaving:**
+
+Proof of vacuousness: reconciliation deletes a local profile iff syncVersion>0 ∧ ¬isNewerSchemaVersion ∧ id ∉ remoteIds. That is exactly the 'restorable' set; verification passing means remoteIds ⊇ restorable ids. Therefore in every pass where the hold is cleared by verification, the deletion set is empty by definition (A4 and the syncVersion==0 rule exempt everything else). Since every subsequent pass re-sights the still-persisted marker and re-sets the cleared hold ('set... whenever its query result contains ANY SyncResetRequest record — regardless of classification'), every pass during the marker's ≤14-day life is a hold pass, and the only reconciliations permitted are these vacuous ones. Reversion interleaving: (1) Reset day 0, marker persists to day 14. (2) Day 2: device C deletes profile P locally and via deleteProfileFromSync removes its CK record — a genuine deletion with the reset long converged. (3) Device B (holds P, syncVersion>0) syncs: sights marker → hold set; pullProfiles: P absent → verification FAILS (P is restorable and missing) → reconciliation skipped; end-of-pass pushLocalData pushes ALL local profiles including P → P re-created in the zone. (4) C's next pass: 'upserts always apply' → createLocalProfile resurrects P on C as a needsAppSelection husk. (5) This repeats every pass until the marker is GC'd at day 14 (and indefinitely if the family resets more often than every 14 days). Consequences: row 19's outcome ('one non-held remote-only deletion ⇒ hold cleared, absent local deleted... Normal propagation resumes in the same pass; no timer wait') is mathematically impossible — an absent restorable local makes verification fail, and non-restorable locals are never deleted; test-plan item 4 bullet 3 encodes this impossible case and cannot be made to pass by any implementation satisfying the rest of the spec; the intentional-change bullet 'Non-last deletions propagate normally' is false for 14 days after every reset; and the liveness claim 'post-reset deletion propagation resumes within one pass, not after a timer' is false — real resumption is at marker GC + hold lapse, and deletions attempted in the window are not deferred but undone.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Accept and state the true behavior: while any marker is within gcTTL of last sight, deletion reconciliation is suspended, deletions made in that window may be resurrected by other devices' every-pass pushes, and propagation resumes only after the quiet period — then delete the vacuous same-pass-resume machinery and the unsatisfiable test case. If 14-day suspension after every reset is unacceptable, shorten the suspension by keying it to processTTL (7d) rather than gcTTL, or gate the every-pass pushLocalData so it does not re-push records that were present in this pass's own pull baseline and then vanished (requires remembering the last verified pull set — a partial tombstone substitute), acknowledging that a real fix is the out-of-scope change-token/tombstone sync.
+
+### crashChurn-3 [breaks-liveness] Watermark cap (now+1h) breaks processing idempotency under receiver-slow clock ≥1h: infinite reset-reprocessing loop with repeated selection clearing, falsifying B5's no-infinite-loop claim
+
+**Violated:**
+
+Liveness: 'no infinite reprocessing loops' and B4 'process the newest, once'; secondarily the repeated destruction of user-restored FamilyActivitySelections stretches exception (b) far beyond a one-shot clear that is 'part of' the reset.
+
+**Interleaving:**
+
+(1) Receiver R's clock is 24h slow (clock skew 'up to days' is in scope; the same trace works with an honest receiver and a future-skewed requestedAt on the creationDate-nil fallback path). Marker effectiveDate = server creationDate S; R's now = S − 24h. (2) classify: not own-origin, not expired (age negative < 7d), effectiveDate > watermark → .process. (3) B5: advance watermark = min(S, now + 1h) = S − 23h, which is STILL < S. (4) didReceiveSyncReset dispatched → handleSyncReset clears app selections (flag=true), spawns rePushLocalSyncedData + follow-up performFullSync. (5) Follow-up pass: pullResetRequests sights the same marker; classify: effectiveDate S > watermark S − 23h → .process AGAIN → watermark 're-advanced' to now+1h (no progress) → selections cleared again → another re-push + another follow-up performFullSync. (6) Self-sustaining loop of full CloudKit sync passes, selection wipes, and full re-pushes, continuing ~23 hours until R's clock passes S − 1h; any app selections the user restores during that window are destroyed on the next iteration, and the loop also runs on every remote-notification and manual sync. B5's claim 'the synchronous watermark advance prevents the follow-up pass from re-processing (infinite reset loop)' is false whenever effectiveDate > now + 1h — the cap, introduced to protect delivery, silently sacrifices the idempotency B4/B5 depend on, and the spec's classification rules give no other skip for this marker (the test plan lists 'future effectiveDate' as a case but never states its required outcome).
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Make idempotency identity-based, not date-based: persist lastProcessedResetRequestId (or a small pruned set of processed requestIds) in SharedData and classify .skipAlreadyProcessed on id match regardless of watermark; keep the capped watermark solely for retiring older markers and delivery ordering. Alternatively, cap the classification comparison symmetrically (compare min(effectiveDate, now+1h) against the watermark) so the advanced watermark is always ≥ the processed marker's comparison date. Specify the required outcome of the 'future effectiveDate' test.
+
+### crashChurn-4 [weakens] Sight-protection's fail-closed dependency on pullResetRequests aborting the pass is never stated as a requirement
+
+**Violated:**
+
+Invariant (I) — its enforcement depends on an unstated ordering/abort property; the spec's own 'code-inspection commitments' section (the designated home for such non-unit-testable requirements) omits it.
+
+**Interleaving:**
+
+All sight-based protection assumes pullResetRequests runs, surfaces markers, and — on failure — prevents pullProfiles/pullLocations from reconciling. Today this holds only incidentally: performFullSync's try-chain aborts the whole pass when pullResetRequests throws (ProfileSyncManager.swift:345), and the zoneNotFound/unknownItem swallow inside pullResetRequests (line 411) is benign only because a zoneNotFound would equally empty pullProfiles' own catch and unknownItem-with-markers-present is practically impossible. The spec's data-flow diagram shows the ordering but neither the design text nor the 'code-inspection commitments' list requires that a pullResetRequests failure abort the pass. Interleaving after a plausible future refactor (e.g. 'log and continue so profile sync is not blocked by a flaky marker query'): (1) origin resets, marker saved, zone wiped; (2) receiver's pullResetRequests throws (CK throttling) and is caught-and-continued → no sight, no hold; (3) pullProfiles returns the partially re-pushed zone → non-empty remoteIds, no hold → reconciliation deletes the receiver's not-yet-re-pushed profiles. Exactly the #195 wipe, restored by an error-handling change the spec does not forbid — and it would strip protection precisely during CloudKit flakiness, when mid-reset zones are most likely to be observed.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Add to the code-inspection commitments: 'any pullResetRequests failure (other than a provably-empty result) must abort the pass before any pull whose handler can reconcile deletions; the zoneNotFound/unknownItem swallow is acceptable only while pullProfiles/pullLocations swallow the same codes without delivering.' Ideally also add a regression test asserting handleSyncedProfiles is never invoked in a pass where marker fetching failed (injectable seam permitting).
+
+## Lens: cloudkitOps — verdict: has-holes
+
+**Verifier reasoning:**
+
+> Human Meatbag — verdict: has-holes. Rev 3's core invariant (same-pass read-verified reconciliation) is a genuine improvement over rev 2 and survives most of the attacks that killed its predecessor: I could not break marker-before-wipe ordering, the never-wipe-markers rule (two concurrent resets now coexist, row 6 holds), chunked deletes (row 7 holds), A3's empty-pull skip, A4's newer-schema exemption, or B5's holds-before-watermark crash ordering (rows 8/9 verified against the code paths — end-of-pass pushLocalData really does cover the killed-mid-re-push case). pushSyncedProfile's fetch-then-save racing a wipe fails safe (save policy rejects, local data untouched). Rows 15/16/20's acceptances were checked for honesty rather than reported as new findings — and two of the three turned out to be stated with preconditions narrower than the truth (findings 3 and 6; finding 5 shows row 20's 'never sighted' is likewise not the real precondition), which per my brief is reportable.
+> 
+> The design breaks in one confirmed safety hole and two liveness holes. (1) The fatal one: holds are global per-device state, cleared by whichever pass verifies first, but performFullSync is not serialized (verified: four unguarded call paths, including the follow-up sync the design itself spawns inside handleSyncReset) and the spec mandates reading the hold 'fresh, never captured at pass start' — so a slow/stale pull from pass1 reconciles unverified after pass2 clears the hold, deleting everything the partial set lacks. Invariant (I) only gates passes that observe a hold; it says nothing about a pass whose hold was consumed by a sibling. This needs pass-scoped clearing or pass serialization before implementation. (2) The now+1h watermark cap fires on the server-assigned creationDate (which cannot be skew-poisoned and never needed capping), so any receiver >1h slow re-processes the same marker forever in the self-chaining follow-up loop — including re-clearing selections every iteration for days. (3) The GC margin is 7 days, not the 14 rows 14/15 claim — B3's own prose admits it — so the delivery guarantee's clock carve-out is off by half.
+> 
+> The weakens-level findings are spec-hardening and honesty items: hold-set must count recordIDs (not decoded records) or a per-record fetch failure on the marker silently disarms protection in the most dangerous pass; the Interplay 'ever saw one' latching claim is false under stale-presence verification; row 16's residual also occurs when the final push succeeds but isn't query-visible, aggravated by gcTTL equaling the backstop. The account-switch nit fails safe for data. Out of scope but noted: external zone deletion via iCloud settings destroys markers and the subscription and can still yield partial-reseed deletions with A3-only protection — pre-existing behavior, not introduced or claimed-fixed by this design.
+
+### cloudkitOps-1 [breaks-safety] Concurrent-pass hold-clear race: one pass's read-verification clears the hold, a second in-flight pass then reconciles an older/staler partial pull with no hold and no verification
+
+**Violated:**
+
+Invariant (I): pass1 reconciles deletions in a pass whose own pull proved nothing — the hold was consumed by a different pass with a different pulled set. Rows 10/19 implicitly assume the verifying set and the reconciling set belong to the same pass; the fresh-read rule makes clears (not just sets) visible cross-pass. Safety property: local BlockedProfiles/SavedLocation deleted while a reset is in flight, outside all exceptions.
+
+**Interleaving:**
+
+Device B (non-origin) already processed reset marker M in an earlier pass: hold set, B's data re-pushed, zone now converging. (1) Pass1 starts on B (zone-change notification, >5min after last completed sync): pullResetRequests sights M (hold already set, .skipAlreadyProcessed), then issues its pullProfiles query Q1. Q1 is slow, or is served by a stale index replica, and reflects the mid-wipe/mid-re-push zone: {P1} only, missing P2..Pn which B holds with syncVersion>0. Pass1 suspends at the await. (2) Pass2 starts on B (any of: the reset follow-up performFullSync spawned at SyncCoordinator.swift:558, setupSync:172, or the manual button — performFullSync has no reentrancy guard and never checks isSyncing). Pass2's pullProfiles returns the fresh full set S ⊇ B's restorable ids. In pass2's handleSyncedProfiles the hold is set, read-verification passes, the HOLD IS CLEARED (spec: 'the only clearing rule'), and pass2 reconciles harmlessly with S. (3) Q1 finally resolves; pass1's handleSyncedProfiles runs with remoteIds={P1}: non-empty, and the hold — explicitly 'read fresh (from SharedData) inside the reconciliation branch, never captured at pass start' — is now NIL, so no superset check runs at all. Pass1 deletes every local profile with syncVersion>0 not in {P1}: P2..Pn destroyed, including B-only profiles whose zone copies were wiped and not yet visible — permanent loss of those profiles plus all selections/session history. The identical race exists for the location hold. Note the design manufactures the overlap itself: the outer pass that processes M continues into pullProfiles while handleSyncReset's task chain (re-push → performFullSync) runs pass2 at the outer pass's awaits.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Serialize performFullSync per device (guard on isSyncing / an async queue — drop or queue overlapping passes, including the handleSyncReset follow-up), AND/OR make hold-clearing pass-scoped: reconciliation may proceed only if (hold was nil when THIS pass's pull was issued) or (THIS pass's own pull passed the superset check). E.g., store the hold with a monotonically increasing pull-sequence number; a pass records its sequence at pull time and may not treat a hold as cleared unless it cleared it itself.
+
+### cloudkitOps-2 [breaks-liveness] Watermark cap at now+1h with a receiver clock >1h slow turns the reset follow-up into a self-sustaining infinite reprocessing loop (with repeated selection-clearing)
+
+**Violated:**
+
+Liveness: 'no infinite reprocessing loops'; B4 'process the newest, once'; B5's explicit no-loop claim. Also erodes the spirit of safety exception (b): selection-clearing is repeated indefinitely, not applied once per device.
+
+**Interleaving:**
+
+Receiver B's clock is 90 minutes behind server time (auto-set-time off — well within the 'clock skew up to days' envelope). (1) Origin resets; marker M has effectiveDate = server creationDate ≈ T. (2) B syncs at real T+5m: sight → hold; classify: effectiveDate T > watermark, age < 7d → .process. Watermark advance is capped: min(T, B.now+1h) = T−30m < effectiveDate. (3) didReceiveSyncReset runs: clears ALL app selections (flag true), re-pushes everything, then runs the built-in follow-up performFullSync. (4) Follow-up pass: pullResetRequests sights M again; classify: effectiveDate T > watermark (T−30m) → .process AGAIN → clear selections again → full re-push again → another follow-up pass. The loop is direct performFullSync calls, so the 5-minute notification throttle never applies. It self-sustains for (skew − 1h) of wall time — days for multi-day skew — burning battery/network with continuous full syncs and full re-pushes, and re-clearing FamilyActivitySelection on every iteration so the user's re-selections are destroyed within minutes of being made, for days. B5's claim that 'the synchronous watermark advance prevents the follow-up pass from re-processing (infinite reset loop)' is false whenever the cap keeps the watermark below effectiveDate; the cap fires on the trustworthy server-assigned creationDate, not just the skew-poisonable requestedAt fallback it was designed for.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Apply the +1h cap only when effectiveDate came from the requestedAt fallback (server creationDate cannot be poisoned by any device clock, so advancing the watermark fully to it is safe), and additionally persist the last-processed requestId so classify returns .skipAlreadyProcessed for an identical requestId regardless of date comparisons.
+
+### cloudkitOps-3 [breaks-liveness] GC skew margin is 7 days, not 14: a receiver clock >7d fast destroys live markers; rows 14/15 and the liveness carve-out state the wrong threshold
+
+**Violated:**
+
+Liveness property as stated: 'resets reach every device syncing within 7 days (absent >14d-fast receiver clocks)' — broken by an 8d-fast clock. Honesty of accepted residuals: row 15's claimed precondition (>14d-fast) is not actually required (>7d suffices), and row 14's 'B3 margin protects the family' is false over time for that band.
+
+**Interleaving:**
+
+Family: device C's clock is 8 days fast (F=8d, under the documented >14d threshold) and syncs hourly; device D syncs every ~6.5 days. (1) Origin resets at T; marker M, effectiveDate T. (2) C at T+1h: perceived age 8d → 7–14d band → .skipExpired; row 14 asserts 'not GC'd (B3 margin protects the family)'. (3) C keeps syncing; at real T+6d its perceived age reaches 14d → .expiredCollect → C deletes M at real age 6 days, inside the 7-day processTTL. (4) D syncs at T+6d12h: no marker exists → reset never delivered to D (selection-clearing missed), and D never sights it, so D gets no hold — if the zone is still partial (any device's re-push failing), D reconciles with only A3 protection, i.e., row 15's harm materializes at F=8d. Arithmetic: a device F days fast GCs at real age ≥ 14−F, so any F>7 destroys a marker inside its live window — which B3's own prose concedes ('must be >7 days fast before it can destroy a marker other devices still need'), directly contradicting row 14's protection claim for the 7–14d band and row 15's '>14 days fast' precondition.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Either raise gcTTL to processTTL + the skew margin actually claimed (21d for a true 14d margin), or gate .expiredCollect on the marker having been perceptibly expired across ≥7d of the GC-ing device's own elapsed time since first sight (age at first sight is skew; growth since sight is skew-free). At minimum, correct rows 14/15 and the property carve-out from '>14d' to '>7d'.
+
+### cloudkitOps-4 [weakens] Hold-set trigger is underspecified for per-record fetch failures and decode-nil markers — the natural implementation (mirroring existing .success-only code) leaves a device unprotected while its query returned the marker's recordID
+
+**Violated:**
+
+A2's guarantee that 'no watermark state, clock skew, or crash history can leave a device unprotected while a marker it can see exists' — the device's query literally returned the marker's recordID. Safety property via the row-20 deletion path without row-20's precondition.
+
+**Interleaving:**
+
+Origin wiped the zone at T; marker M is present. (1) Device B syncs at T+1m: pullResetRequests' query SUCCEEDS but returns [(M.recordID, .failure(...))] — a per-record fetch failure, which does not throw — or M's record decodes nil in SyncResetRequest(from:) (corrupt write, or a record from a future client). The spec says holds are set 'whenever its query result contains any SyncResetRequest record — regardless of classification', but classification presupposes a decoded request; the existing code pattern (pullResetRequests, ProfileSyncManager.swift:382-384) inspects only .success + decoded records, so the obvious port sees 'no markers', sets no hold, and returns normally. (2) The pass continues to pullProfiles, which returns the mid-wipe partial set {P1}. (3) handleSyncedProfiles: remoteIds non-empty, hold nil → reconciliation deletes P2..Pn locally. Unlike accepted row 20, this needs NO index-lag invisibility of the marker — the marker was returned by the query; only its payload fetch/decode failed.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Specify explicitly (and test): holds are set when the SyncResetRequest query returns ANY recordID for that record type — success, per-record failure, or decode-nil — exactly mirroring how allRemoteProfileIds is built from recordIDs before decode filtering in pullProfiles.
+
+### cloudkitOps-5 [weakens] Stale-presence pulls can clear the hold while the zone is genuinely wiped — the Interplay claim ('protects every device that ever saw one, for exactly as long as the zone lacks data') and row 20's precondition ('marker never sighted') are both overstated
+
+**Violated:**
+
+Honesty of row 20's acceptance and of the Interplay paragraph ('A2 protects every device that can see the marker (or ever saw one), for exactly as long as the zone lacks data that device could restore — and not a pass longer'). Protection can end while the zone still lacks the data.
+
+**Interleaving:**
+
+(1) Origin A resets at T: marker M saved, wipe completes. (2) B pass1 at T+2m: sights M → hold set; its pullProfiles is served by a stale index replica showing the full pre-wipe set → read-verification passes → hold CLEARED (and same-pass reconcile deletes nothing) — although the zone truly contains none of B's data. (3) B pass2 at T+10m: pullResetRequests hits a replica that has not indexed M (stale absence — permitted arbitrarily) → no sight, no hold; pullProfiles returns the true partial state {P1} (A mid-re-push) → hold nil → B deletes P2..Pn, including B-only profiles = permanent loss. B DID sight the marker, so row 20's stated precondition ('marker never sighted by this device') is not required; the true requirement is only 'no hold present and marker not sighted in the reconciling pass', which a stale-presence verification-clear can manufacture after a sight. Net damage window is the same index-lag class as accepted row 20, so this is an honesty defect rather than a new mechanism — but the design's central 'holds latch until the zone is provably healthy' story is not what the mechanism delivers: verification trusts a single possibly-stale read, and holds do not latch.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Reword row 20 and Interplay to the true precondition ('no hold and no sight in the reconciling pass; sights do not latch because verification may pass on a stale-presence read'). Optionally harden: only clear a hold when the verifying pull is at least N seconds newer than the hold's set-time, or require the marker to have been sighted in the same pass that verifies (markers persist 14d, so a healthy verifying pass normally sees it; a marker-absent + full-superset pass is exactly the stale-read signature).
+
+### cloudkitOps-6 [weakens] Row 16 / backstop honesty: loss does not require 'the push keeps failing' — the first successful push after backstop expiry can be eaten by ordinary index lag, on the design's own axiom; gcTTL == backstop (14d) removes marker re-sight protection at exactly the worst moment
+
+**Violated:**
+
+Honesty of row 16's accepted residual (its stated precondition — persistent push failure — is not required), and internal consistency with the constraint 'no safety decision may rely on a write being query-visible'.
+
+**Interleaving:**
+
+(1) B's pushes of profile X (syncVersion>0) fail for 14 days (e.g., app killed before the detached pushTask completes each pass). The hold set at reset time T never verifies (X absent from every pull). (2) At T+14d the backstop pass clears the hold and skips reconciliation; this pass's end-of-pass push of X SUCCEEDS (network recovered). (3) Around the same time, marker M reaches gcTTL (also 14d) and is GC'd — so no re-sight can re-arm the hold. (4) Next pass at T+14d+10m: no marker → no hold; pullProfiles does not yet show the minutes-old X write (the design's own constraint: 'a write this device just made (even server-acked) may be missing from the next query') → remoteIds non-empty, missing X → X deleted locally; selections and session history lost, husk re-created later. Row 16 accepts residual loss only 'if the push keeps failing'; here the push succeeded. The backstop's stated safety story ('the end-of-pass push then restores anything missing before the next pass reconciles') relies on write→query visibility, which the design elsewhere forbids as a safety dependency.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+State the acceptance honestly (loss also occurs if the finally-successful push is not yet query-visible at the first post-backstop reconcile). Mechanically: make gcTTL strictly greater than the hold backstop (e.g., 21d vs 14d) so a live marker re-arms the hold after backstop expiry, and/or have the backstop pass arm a one-pass grace (skip reconciliation for one additional verified-or-not pass).
+
+### cloudkitOps-7 [nit] SharedData reset state (watermark, holds) is not iCloud-account-scoped: after account switching, a stale watermark silently suppresses the new account's reset delivery
+
+**Violated:**
+
+Liveness: 'resets reach every device syncing within 7 days' for the post-switch account; the design is silent on account scoping despite persisting cross-account state.
+
+**Interleaving:**
+
+(1) On account A1, B processes a reset at T1 → lastProcessedResetAt ≈ T1. (2) User switches to account A2 (different private DB/zone). A2's zone contains a live reset marker with effectiveDate T0 < T1. (3) B syncs A2's zone: marker sighted → hold set (safe), but classify → .skipAlreadyProcessed against A1's watermark → the reset's selection-clearing is never applied on B, permanently, with no indication. Conversely, a stale hold from A1 defers deletion propagation on A2 until verification passes there. Fails safe for data (holds only ever block deletions) — delivery/UX miss only. The codebase already has the per-account pattern (legacyCleanupKey(for: userRecordName)).
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Key lastProcessedResetAt and both reconciliation holds by userRecordID (as legacy cleanup already does), clearing or namespacing them on account change.
+
+## Lens: specReview — verdict: has-holes
+
+**Verifier reasoning:**
+
+> Read the full REVISION 3 spec (361 lines) plus the actual source it's built against: Foqos/CloudKit/SyncCoordinator.swift (handleSyncedProfiles, handleSyncedLocations, pushLocalData, handleSyncReset), Foqos/CloudKit/ProfileSyncManager.swift (resetSync, pullResetRequests, performFullSync, deleteAllSyncedData, pushLocation/pushSyncedLocation), Foqos/Models/SavedLocation.swift, and Packages/FoqosShared/Sources/FoqosShared/SharedData.swift. Verified every line-number citation in the spec's Problem section against current main (all accurate — resetSync:823/831/839, pullResetRequests:345/402/387, pullProfiles:348, handleSyncedProfiles guard:179/195, handleSyncedLocations:479-499, deleteAllSyncedData chunking:873, isNewerSchemaVersion filters:64/567 — all match, so the factual re-verification claims in the Problem section hold up).
+> 
+> No literal placeholders/TBDs exist (only an unrelated use of the English word "placeholders" at line 313).
+> 
+> Cross-checked every row of all four interleaving tables (rows 1-22) against A1-A4/B1-B5 and the data-flow diagram; most are internally consistent. Two genuine problems surfaced:
+> 
+> (a) Invariant (I) says a device "may reconcile deletions only in a pass whose own pull proves the zone contains every record this device could re-create" — evidence must be "read in the same pass." But the hold is modeled as single global per-device SharedData state, read fresh "inside the reconciliation branch, never captured at pass start" (A2). ProfileSyncManager.performFullSync() has no re-entrancy guard (confirmed: no `isSyncing` check at entry, just an unconditional `self.isSyncing = true`), and SettingsView's "Sync Now" button plus notification-triggered handleRemoteNotification can both invoke it independently — the spec's own table acknowledges concurrent passes occur (rows 5, 10). Under that acknowledged concurrency, a pass with a stale/incomplete pull can observe hold==nil because a *different*, more-current concurrent pass satisfied read-verification and cleared it moments earlier — then reconcile against its own stale pull without ever itself proving the superset. That is a different pass's evidence deciding, which directly contradicts "read in the same pass, decides." No interleaving row analyzes this specific case (row 5/10 only cover holds staying *set* during concurrent passes, not one pass benefiting from another's clear).
+> 
+> (b) A2's Backstop bullet and two other spots (test-plan item 4's 4th bullet, row 16) all state the 14-day-expired-hold case "clears... and that pass still skips reconciliation." But the Data-flow diagram's literal reconciliation formula is `deletion reconciliation IFF remoteIds nonempty AND (hold nil OR remoteIds ⊇ local restorable ids → clear hold, reconcile)` — a two-way disjunction with no third branch for "hold was set-but-expired → clear anyway but still skip." As written, once the backstop clears the hold, "hold nil" is true and the diagram's own formula says reconcile — contradicting the prose. The diagram doesn't show which component performs the backstop check either (pullResetRequests' diagram bullets only cover marker GC, not hold GC), so it's genuinely unclear where/how the "clear-but-skip" branch is meant to be structured.
+> 
+> Checked the location syncVersion mechanics specifically requested: handleSyncedLocations sets `existingLocation.syncVersion = max(existingLocation.syncVersion, 1) + 1` only on remote-newer update, and `= max(existingLocation.syncVersion, 1)` (no +1) on "seen from remote, not newer." Crucially, pushLocation/pushSyncedLocation (ProfileSyncManager) never touch local `location.syncVersion` — unlike pushProfile (SyncCoordinator:610, `profile.syncVersion += 1` before the network call). So for locations, syncVersion > 0 is set *only* by pull-confirmed evidence (this device's own push reflecting back, since handleSyncedLocations has no origin-device filter, unlike handleSyncedProfiles' line 117 check), whereas for profiles it's set optimistically by the *push attempt itself*. The spec (A2) states the profile and location superset predicates as parallel ("local profiles with syncVersion > 0 ... local locations with syncVersion > 0") and the test plan (item 5) calls the location tests a "mirror of (4) minus the schema case" — but no test explicitly exercises the location-only "seen from remote, not updated" merge path, despite it being the specific mechanism that governs when a location becomes eligible for the superset check at all.
+> 
+> Checked "same-pass clear-then-reconcile when profile hold clears but location hold doesn't": SavedLocation has no SwiftData `@Relationship` to BlockedProfiles (geofenceRule is a plain Codable struct, not a relationship), and handleSyncedProfiles/handleSyncedLocations read/write entirely separate SharedData keys with no cross-references in the code paths — so this particular coupling is actually well-defined; I did not find a contradiction here specifically (documenting a negative result, not raising it as a finding).
+> 
+> Checked SharedData.swift: existing pattern wraps every compound check-then-set operation (deviceSyncId generation, snapshot map mutations, session snapshot mutations) in a cross-process POSIX-flock `withLock`. The spec introduces three new keys with explicitly compound, TOCTOU-prone semantics ("Set... only if currently nil", conditional clearing) but the word "lock" never appears anywhere in the design doc, and no locking/atomicity discipline is specified for the new keys, despite SharedData.swift being listed as an in-scope file.
+> 
+> Checked exact comparison-operator boundaries: B2 says "Requests older than processTTL = 7 days are not processed" and B3 says "deletes markers older than gcTTL (14 days)" — "older than" is used for both, but the spec never states whether age==7d/14d exactly falls on the process/skip side or the skipExpired/expiredCollect side (`<` vs `<=`). Test-plan item 1 claims "boundaries at exactly 7d/14d" will be tested, but since the doc never states the correct classification at those exact boundaries, the test's own expected assertions are undefined by the spec as written.
+> 
+> Overall verdict: has-holes. The two breaks-safety items are grounded in an acknowledged design premise (concurrent passes exist) combined with real code facts (no re-entrancy guard) and a literal reading of the diagram vs. prose; the remaining items are real ambiguities that a competent implementer would have to resolve by guessing, undermining the doc's own "extract every decision into pure, injectable-now helpers" and "positive evidence... never classification state" commitments.
+
+### specReview-1 [breaks-safety] Global per-device hold lets a stale concurrent pass reconcile on another pass's evidence
+
+**Violated:**
+
+Invariant (I), lines 105-108: 'a device may reconcile deletions only in a pass whose own pull proves the zone contains every record this device could re-create. Positive evidence, read in the same pass, decides — never push acks, never timers alone, never classification state.' Pass A's decision here is decided by Pass B's evidence, not its own, in the same pass.
+
+**Interleaving:**
+
+Pass A (e.g. triggered by a remote CK notification) starts pulling profiles while a reset's re-push is still landing; its `remoteProfileIds` snapshot is missing a record R that this device holds. Concurrently, Pass B (e.g. the user taps 'Sync Now' — `SettingsView.swift:176` calls `profileSyncManager.performFullSync()` directly, and `ProfileSyncManager.performFullSync()` at `ProfileSyncManager.swift:337` has no re-entrancy guard: it unconditionally sets `self.isSyncing = true` with no check that a sync is already running) runs slightly later, after R has fully landed, and its own pull proves the superset — Pass B clears `profileReconciliationHoldSince` per A2's read-verification rule and reconciles safely using Pass B's own (complete) pulled set. Because 'The hold is read fresh (from SharedData) inside the reconciliation branch, never captured at pass start' (spec lines 141-143), if Pass A reaches its own reconciliation branch after Pass B's clear, Pass A reads hold==nil and — per the diagram's own formula '(hold nil OR remoteIds ⊇ local restorable ids → clear hold, reconcile)' (lines 246-248) — proceeds to reconcile using Pass A's own stale, incomplete `remoteProfileIds`, deleting local profile R even though it currently exists in the zone.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Rows 5 and 10 of the interleaving table assert concurrent passes are safe but only analyze the case where the hold stays set throughout; neither row (nor any other) analyzes the cross-pass 'one pass's clear leaks into another pass's stale reconciliation' interleaving. This needs to be added to the interleaving table and resolved (e.g. by making the hold-clear-and-reconcile decision per-pass-local rather than a globally shared SharedData boolean) before implementation, since `performFullSync` genuinely has no re-entrancy guard today.
+
+### specReview-2 [breaks-safety] Backstop's 'clear but still skip' behavior contradicts the data-flow diagram's reconciliation formula
+
+**Violated:**
+
+A2 Backstop bullet (lines 152-154) vs. the Data-flow diagram (lines 244-248); also Invariant (I)'s 'never timers alone' framing, since a diagram-literal implementation would let a 14-day timer expiry alone trigger reconciliation against unverified data on that pass.
+
+**Interleaving:**
+
+A hold has been set for >14 days (superset proof has never succeeded — e.g. row 16's persistently-failing re-push). Per A2's Backstop bullet (lines 152-156): 'a hold older than `SyncResetRequest.gcTTL` (14 days...) is cleared **and that pass still skips reconciliation**.' Test-plan item 4's fourth bullet (line 337) and row 16 (line 283) both restate the same 'cleared, but still skipped this pass' outcome. But the Data-flow diagram's literal reconciliation gate (lines 244-248) is: `deletion reconciliation IFF remoteIds nonempty AND (hold nil OR remoteIds ⊇ local restorable ids → clear hold, reconcile) AND skipping isNewerSchemaVersion + syncVersion==0 profiles.` This is a two-way disjunction with no third arm for 'hold was set-but-backstop-expired.' If the backstop clears the hold before/at the point this formula is evaluated, `hold nil` is true and the diagram says reconcile — using this device's own (already known-incomplete, per row 16) pulled set — which is exactly the outcome A2's prose says must NOT happen on the backstop-expiry pass.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+The diagram never states which component performs the 14-day hold-expiry check (pullResetRequests' diagram bullets at lines 240-243 only show marker GC — a different 14-day check on `SyncResetRequest` records, not on the hold timestamps) or how a 'cleared but not reconciled' outcome is distinguished in code from a 'cleared and reconciled' outcome. The diagram needs an explicit third branch (or the backstop needs to be modeled as leaving reconciliation gated by an independent flag, not solely by hold==nil) before this can be implemented consistently with the prose.
+
+### specReview-3 [weakens] "Local restorable ids" means mechanically different things for profiles vs. locations, but the test plan treats location tests as a plain mirror
+
+**Violated:**
+
+Consistency between A2's parallel phrasing for profiles/locations and the actual mechanism in `SyncCoordinator.swift`; test-plan completeness for item 5 relative to the claimed #195.5 location fix.
+
+**Interleaving:**
+
+For profiles, `SyncCoordinator.pushProfile()` (`SyncCoordinator.swift:610`, `profile.syncVersion += 1`) sets syncVersion>0 optimistically at push-attempt time, before any network confirmation. For locations, neither `pushLocation` nor `pushSyncedLocation` (`ProfileSyncManager.swift:623-666`) ever touches local `location.syncVersion` — it is set to >0 *only* inside `handleSyncedLocations` on receipt from a pull: `existingLocation.syncVersion = max(existingLocation.syncVersion, 1) + 1` when remote is newer (`SyncCoordinator.swift:441`), or `existingLocation.syncVersion = max(existingLocation.syncVersion, 1)` when merely 'seen from remote' without being newer (`SyncCoordinator.swift:454`) — and `handleSyncedLocations` has no origin-device filter (unlike `handleSyncedProfiles`'s `if syncedProfile.originDeviceId == deviceId { continue }` at line 117), so a location only becomes 'restorable' once this device's own push has round-tripped back through a subsequent pull. A2 states the profile predicate ('local profiles with syncVersion > 0 and !isNewerSchemaVersion', lines 145-146) and the location predicate ('local locations with syncVersion > 0', lines 149-150) as parallel statements, and test-plan item 5 (line 341) says location gating tests are simply a 'mirror of (4) minus the schema case.' No listed test case exercises the location-specific 'seen from remote, not newer' merge path (the bare `max(syncVersion,1)`, no +1) that is unique to how a location's restorable-status is established.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+State explicitly in A2 (or a dedicated note) that location syncVersion semantics are pull-confirmed-only (not push-optimistic like profiles), and add an explicit test case for the 'seen from remote but not updated' merge path feeding the superset check, rather than folding it into an unqualified 'mirror of (4)'.
+
+### specReview-4 [weakens] No locking/atomicity discipline specified for the three new SharedData keys
+
+**Violated:**
+
+No specific mechanism name is violated — this is an omission relative to the doc's own file scope and the codebase's established SharedData concurrency-safety convention.
+
+**Interleaving:**
+
+A2/B1 introduce three new compound, check-then-act SharedData operations: 'Set (to local now, only if currently nil)' for both holds (lines 131-133), and the per-device processed watermark advance (B1, lines 184-189). `SharedData.swift`'s existing pattern wraps every comparable compound operation (deviceSyncId generation at lines 469-481, all snapshot/session mutations) in `withLock`, a cross-process POSIX `flock` explicitly built for 'compound UserDefaults operations' (`SharedData.swift:69-74`). The word 'lock' does not appear anywhere in the design doc (grep confirms zero matches beyond unrelated clock/keep-data language), and `SharedData.swift` is listed in the spec's Files header as an in-scope file to modify.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Specify whether the new `set-if-nil` and `clear` operations on the two hold keys, and the watermark advance, must be wrapped in `withLock` (matching existing SharedData conventions), and clarify whether the same-process MainActor interleaving discussed in the concurrent-pass finding above is intended to be the only protection, or whether additional atomicity is required.
+
+### specReview-5 [weakens] processTTL/gcTTL boundary comparison operators (7d, 14d) are never pinned down
+
+**Violated:**
+
+Design constraint 'extract every decision into pure, injectable-now helpers that are unit-testable' (Constraints section) — a boundary that isn't specified can't be correctly unit-tested, only arbitrarily coded and then retroactively asserted.
+
+**Interleaving:**
+
+B2 (line 193): 'Requests older than `processTTL = 7 days` are not processed.' B3 (line 197): 'Any device deletes markers older than `gcTTL` (14 days...).' Both use 'older than' without stating whether age exactly equal to 7d/14d falls on the processed/kept side or the expired/GC'd side (i.e. `age > 7d` vs `age >= 7d` for the process/skipExpired boundary, and similarly for skipExpired/expiredCollect at 14d). Test-plan item 1 (lines 323-326) explicitly lists 'boundaries at exactly 7d/14d' as something that will be tested, but since the spec gives no ground-truth classification for those exact instants, the boundary tests' own expected assertions are undefined by the design as written.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+State the exact inequality direction for both boundaries (e.g. 'processed iff age <= 7d', 'GC iff age > 14d') so the classify() truth table and its tests have an unambiguous target, consistent with the 'fail toward keep data / keep marker' clock-skew principle already stated in the Constraints section.

--- a/docs/plans/2026-07-02-reset-sync-a1-interleavings-round3.md
+++ b/docs/plans/2026-07-02-reset-sync-a1-interleavings-round3.md
@@ -1,0 +1,308 @@
+# A1 adversarial verification — round 3 findings (verbatim)
+
+- **Target design:** rev 4 (time-boxed suppression + id idempotency)
+- **Context:** acceptance corpus for #267; see `2026-07-02-reset-sync-a1-acceptance-corpus.md`.
+- **Provenance:** machine-extracted, unedited output of the independent verifier agents.
+
+## Lens: temporal — verdict: has-holes
+
+**Verifier reasoning:**
+
+> Human Meatbag — adversarial verification of rev 4, temporal-arithmetic lens, verdict: has-holes.
+> 
+> What I verified holds: (a) the identity-based processed map genuinely kills the rev-3 reprocessing loop in every clock configuration I could construct — future-clamped bases, slow/fast receivers, roll-forward/roll-back — every reprocess cycle costs >= 21d of local clock and terminates (worst case exactly one extra clear for >14d-slow clocks, finding 4; never unbounded); (b) marker-before-wipe with suppression+own-id persisted at step C.2 closes every resetSync crash row I attacked (rows 1-7 check out, including double-reset marker survival via B6 and chunked <=400 deletes); (c) B5's suppress-on-sight -> dispatch -> mark-last ordering is crash-safe in the claimed direction at every SIGKILL point (rows 8-9); (d) monotonic max-only suppression is immune to concurrent-pass downgrades; (e) the GC margin arithmetic (21d - 7d = 14d) is now stated correctly; (f) account-switch reasoning holds (UUIDs can't collide; carried suppression blocks only deletions).
+> 
+> What breaks: the core temporal defect is that A1 anchors suppression to the marker's effectiveDate (window = effectiveDate+8d for every sighter), not to each device's first contact. The devices most at risk — stragglers first syncing at age 7-21d, whose data nobody else re-pushed since the wipe — therefore receive between <1 day and exactly ZERO protection from sighting the marker, while the same pass's pull-before-push ordering deletes their syncVersion>0 profiles before pushLocalData can restore them. Rows 11, 14 and 20 all assert 'sight => suppressed/protected', which is arithmetically false at first sight age >= 8d local; that makes finding 1 a reportable safety break, not an accepted residual (rows 20/23 preconditions — 'never sighted' / '>=8d continuous push failure' — do not cover it; the marker IS sighted and no push failure is required, just an 8-day sync gap spanning the reset, e.g. new-phone reset + old phone in a drawer). Note also that re-sighting a decodable marker NEVER extends protection (min(basis,now)+8d with basis=effectiveDate is a no-op after day 8), so row 23's 'no marker re-sight' precondition is mechanically meaningless.
+> 
+> Second, the undecodable-marker path (row 16) combines 'basis=now on every sight' with 'no GC without decode' into unbounded per-device suppression plus an immortal marker: any normally-syncing device never exits suppression, deletion propagation dies family-wide, and every explicit profile delete resurrects via other devices' every-pass re-push — a direct violation of three stated liveness requirements, fixable cheaply because CKRecord.creationDate is system metadata available without custom-field decode.
+> 
+> Findings 3-6 are honestly-graded weakeners/nits: forward clock rolls defeat the active window (the gate fails toward delete, contradicting the design's own fail-toward-keep constraint and its child-adversary clock model — unstated residual); the 21d prune vs 21d GC symmetry leaves a >14d-slow twin of the accepted >14d-fast residual unstated (one extra selection-clear of a ~3-week-old reset); B5's last-reset-wins is only intra-pass under the spec's own query-staleness assumption; and marking ids processed when the dispatch no-ops (nil modelContext) can permanently forfeit delivery on a device.
+> 
+> I did not re-report the accepted residuals (14 fast-clock GC, 20, 22, 23, intentional-behaviour changes) except where their stated preconditions are provably wrong, as licensed: rows 11/14/20 (protection-by-sight claims, finding 1) and rows 13/15 ('processed once', finding 4). Files: docs/superpowers/specs/2026-07-02-reset-sync-safety-design.md verified against pre-fix Foqos/CloudKit/ProfileSyncManager.swift, Foqos/CloudKit/SyncCoordinator.swift, Foqos/CloudKit/SyncModels.swift (pull-before-push pass ordering, per-item swallowed push errors, push-optimistic profile syncVersion, pull-confirmed location syncVersion, and the isNewerSchemaVersion filters all confirmed in code and load-bearing for the timelines above).
+
+### temporal-1 [breaks-safety] Suppression is born expired for markers first sighted at local age >= 8d (rows 11/14/20 claim protection that does not exist)
+
+**Violated:**
+
+SAFETY property: local BlockedProfiles/SavedLocation deleted with no genuine remote deletion. Not covered by accepted residuals, whose stated preconditions are wrong: row 11 claims '7-21d: .skipExpired ... but sighted => suppressed — protected while others converge' (false: sight of a >=8d-old marker yields an already-expired window; 7-8d yields <1d); row 14 claims '<=14d fast: ... sight => suppression still protects its data' (false for small fast skews near day 7-8); row 20's own framing 'one sight suppresses for 8 days' is false — one sight suppresses until effectiveDate+8d, which can be zero time. Root cause: A1's basis for decodable markers is effectiveDate, so the window is anchored to the reset, not to the at-risk device's first contact — yet devices first contacting at age 7-21d are exactly the stragglers whose data nobody else re-pushed.
+
+**Interleaving:**
+
+All clocks accurate; no failures needed beyond an 8-day sync gap. Family {O: newly-added phone, D: primary phone}. T-30d..T-1d: D creates and pushes profiles P1..Pn (syncVersion>0 on D). T0-1h: user enables sync on O; O's initial pull is incomplete (user is resetting precisely because sync looks broken). T0: user runs resetSync on O: marker M saved (server creationDate=T0), O suppressed, zone wiped, O re-pushes only its own local set, which lacks some/all Pi. D is in a drawer from before T0 until T0+8d (vacation, kid's spare iPad — routine). T0+8d+1h: D syncs. pullResetRequests sights M and calls extendSuppression(effectiveDate=T0): suppressedUntil = max(nil, min(T0, now)+8d) = T0+8d, which is ALREADY IN THE PAST — zero protection. classify: age 8d1h > 7d => .skipExpired, so no dispatch and no reset re-push either. Same pass continues: pullProfiles returns O's non-empty set; now >= suppressedUntil; reconciliation deletes every local Pi with syncVersion>0 absent from remote — and this runs BEFORE didRequestLocalDataPush/pushLocalData at the end of the pass, so D's own every-pass push can never rescue them. Sole-held Pi (and their sessions/selections) are permanently destroyed; SavedLocations die identically. Variant needing only ~26h of unavailability: D syncs once at T0+7d-1h (age 7d => .process, suppression = T0+8d = 1h+... left), SIGKILLed before the queued pushTask executes, next syncs at T0+8d+1h => same self-wipe. Fast-clock variant: a receiver merely 2d fast sighting at real T0+6d computes local age 8d => .skipExpired AND suppressedUntil=T0+8d <= now_local => zero protection inside the nominal delivery window.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Extend suppression from NOW on FIRST sight of each marker requestId (persist a sighted-ids map alongside processedResetRequestIds, same 21d-class prune): suppressedUntil = max(cur, now + 8d), applied at most once per requestId per device. This preserves boundedness (a single marker extends each device at most once, ~8d; re-extension only possible after a 21d prune) and gives every device a full window from its own first contact, closing both the age>=8d zero-window and the age~7d thin-window cases. Then honestly document the remaining cross-device slack residual: a copy-holding device whose own window ends may delete its COPIES while a day-7 processor is still converging — bounded, non-permanent (originals re-pushed later, recreated with needsAppSelection=true).
+
+### temporal-2 [breaks-liveness] A single undecodable marker extends suppression unboundedly and is never GC'd — deletion propagation permanently dead, profiles become undeletable
+
+**Violated:**
+
+LIVENESS: 'suppression cannot be extended unboundedly by any single marker' (violated directly: basis=now on every sight), 'markers GC'd eventually' (no GC path exists for undecodable markers), 'deletion propagation resumes after windows close' (windows never close). Row 16's outcome column says only 'Protected. No processing, no GC' — it hides that 'no GC' + 'basis now on every sight' compounds into permanent family-wide suppression; not an honestly-stated residual.
+
+**Interleaving:**
+
+One SyncResetRequest record exists that fetches but never decodes (corrupt/missing guarded field, or a future app version that renamed requestId/requestedAt/clearRemoteAppSelections/originDeviceId — a case A1 explicitly embraces: 'a corrupt or future-schema marker still protects'). Every pass on every device: pullResetRequests sights the raw recordID => extendSuppression(basis=now) => suppressedUntil = now+8d. Any device syncing at least every 8 days (i.e., any normal device) keeps its own suppression alive FOREVER. GC cannot fire: B3/B4 GC is 'classify all decoded; age>21d => GC-delete' and age requires effectiveDate, which requires decode — an undecodable marker has no GC path on any device, ever. Consequence chain: user deletes a profile on device A (explicit CK delete succeeds); devices B/C never apply the absence-inference (suppressed forever) and re-push their local copies every pass; the zone record resurrects; A re-pulls it as an upsert. The user cannot delete any profile, family-wide, permanently.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+For fetched-but-undecodable records (.success with failed init), use CKRecord.creationDate — system metadata present on every server-fetched record regardless of custom-field decode — as the effectiveDate for BOTH the suppression basis and GC eligibility; such markers then suppress until creationDate+8d and are GC'd at age>21d like any other. For per-record .failure results (no record object at all), persist a first-sighted-at date per recordID locally; stop extending suppression and permit GC-by-recordID once first-sight + gcTTL passes.
+
+### temporal-3 [weakens] Forward clock roll during an active suppression window re-opens the #195 wipe (gate fails toward delete, violating the design's own fail-toward-keep constraint)
+
+**Violated:**
+
+Design constraint 'every clock-dependent rule must fail toward keep data' — the gate `now >= syncDeletionSuppressedUntil` fails toward delete under forward skew/jumps. Unstated residual: row 14 covers fast clocks only for GC (>14d), the intentional-behaviour-changes section describes the window as '~8 days' with no clock caveat. If 'skew up to days' in the safety property includes 8d, this is a property violation; at minimum it must be listed as a residual with honest preconditions (forward jump >= remaining window + a not-yet-re-pushed record).
+
+**Interleaving:**
+
+T0: reset; device R sighted the marker at T0 (suppressedUntil=T0+8d), processed it, but the re-push of R's sole-held profile Q item-failed (error swallowed by rePushLocalSyncedData's per-item catch). T0+1d: R's clock is set forward 8+ days — the design's stated threat model is children manipulating clocks, and the safety property requires tolerating 'clock skew up to days'. R syncs: A2's gate reads now_local >= T0+8d => passes; remote is non-empty (origin's data), Q absent => R deletes Q locally, before the end-of-pass push could restore it. Q is permanently lost. Also prunes are unaffected but the same jump would defeat ANY device's window mid-reset (deleting its local copies of not-yet-re-pushed profiles of other devices — recoverable but destroys selections/session history).
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Cannot be fully fixed with local clocks (inherent to time-boxed suppression); mitigate and document: persist a monotonic last-observed-now in SharedData and treat a forward jump larger than elapsed wall-time-plausible bounds as 'suppressed' for the gate (fail toward keep), and/or gate reconciliation additionally on 'this device has completed at least one successful push pass since its last marker sight'. At minimum add an honest residual row: a forward-rolled clock defeats suppression.
+
+### temporal-4 [weakens] processed-id prune (21d local) erases memory while a marker is still locally fresh for >14d-slow clocks — second selection-clear of an objectively ~3-week-old reset; rows 13/15's 'processed once' is overstated
+
+**Violated:**
+
+Safety exception (b) permits selection-clearing only of an 'unexpired (<=7d) reset' — server age here is ~21d. Rows 13/15 state 'processed once — id-idempotent, no loop possible by construction' unconditionally; the >14d-SLOW residual is unstated, asymmetric with the honestly-stated >14d-fast GC residual (row 14). Precondition is pathological (>14d slow clock AND marker surviving >21d real) but must be stated, exactly as the fast twin is.
+
+**Interleaving:**
+
+Receiver R is 15d slow (now_R = real - 15d). Marker M created at server time e; origin O goes offline right after (GC never runs; GC failures are also 'ignored, retried'). Real e+1h: R fetches M; effectiveDate=e > now_R => age clamps to 0 => .process => clears selections (flag set), processedResetRequestIds[M] = now_R = e-15d. Real e+21d+6h: R's pass prunes M's id (now_R - processedAt = 21d6h > 21d). M is still fetchable (nobody GC'd it; R's own GC needs LOCAL age > 21d but local age = now_R - e = 6d6h). classify: unprocessed (pruned), local age 6d6h <= 7d => .process => R re-dispatches didReceiveSyncReset and RE-CLEARS every profile's selectedActivity for a reset that is objectively 21+ days old — needsAppSelection set family-profile-wide on R, blocking silently stops until manually reconfigured. No infinite loop (next cycle: local age > 7d => .skipExpired, then local GC at 21d) — the id-map does kill the rev-3 loop — but 'once' becomes 'twice'. Boundary arithmetic: safe for slowness <= 14d exactly (processedAt >= e - s; need s <= pruneTTL - processTTL = 14d), broken beyond.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Prune processedResetRequestIds at pruneTTL = gcTTL + processTTL = 28d (or simply 'never prune an id while any live marker with that recordID is still being sighted'). With 28d: processedAt + 28d >= effectiveDate - s + 28d >= effectiveDate + 7d local-freshness horizon for all s <= 21d, restoring a margin at least as wide as the fast-clock one. Then add the symmetric residual row for >21d-slow clocks.
+
+### temporal-5 [nit] B5's 'superseded reset intent is dropped' only holds intra-pass; CKQuery staleness can apply an older reset after a newer one
+
+**Violated:**
+
+B5's stated guarantee ('last reset wins; older ones retired-without-applying') is not actually guaranteed under the spec's own query-staleness assumption; it holds only when both markers appear in the same pass.
+
+**Interleaving:**
+
+resetSync retried (row 7) => two live markers M1 (older) and M2 (newer), both <= 7d, both flag=true. Device pass 1: stale query returns only M2 => M2 processed (selections cleared, marked). Pass 2 hours later: differently-stale query returns only M1 (staleness in both directions is an explicit assumption) => M1 is unprocessed and the newest .process candidate IN THIS PASS => dispatched => the superseded reset's selection-clear is applied after the newer reset already ran, contradicting B5's 'selection-clearing intent of a superseded reset is intentionally dropped'. Both resets are genuine and unexpired, so this stays inside safety exception (b) — documentation/robustness nit only.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Persist latestProcessedResetEffectiveDate (monotonic max, SharedData); classify any candidate with effectiveDate <= that value as .skipAlreadyProcessed-equivalent (retire and mark its id). Or soften the B5 wording to 'dropped when observed together'.
+
+### temporal-6 [nit] B5 marks requestIds processed even when the dispatch no-ops (nil modelContext guard) — permanent delivery loss for that device
+
+**Violated:**
+
+LIVENESS: 'delivery to every device syncing within 7d' — broken for a device whose first post-reset pass precedes context wiring. B5 assumes the dispatch's synchronous part succeeded; the spec never conditions marking on application.
+
+**Interleaving:**
+
+A remote-notification- or setup-triggered performFullSync runs before SyncCoordinator.setModelContext has been called (app cold-start ordering). pullResetRequests classifies a fresh marker .process, dispatches didReceiveSyncReset — handleSyncReset hits `guard let context = modelContext else { return }` and does NOTHING (no selection clear, no re-push chain) — then step B5.3 unconditionally marks the requestId processed. Every later pass: .skipAlreadyProcessed. The reset is never applied on this device; delivery permanently lost (suppression was still extended on sight, so no data-safety impact). Whether this ordering is reachable depends on app wiring outside the three reviewed files — the current code sets the delegate in SyncCoordinator.init and setModelContext separately, so the spec should not assume dispatch always applies.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Have didReceiveSyncReset return whether it actually applied (context present, clear+chain executed); mark requestIds processed only for applied dispatches (re-dispatch next pass otherwise — idempotent, the safe direction B5 already relies on for the crash-before-mark case).
+
+## Lens: stateMachine — verdict: has-holes
+
+**Verifier reasoning:**
+
+> Human Meatbag — I read the rev-4 spec in full and re-traced the pre-fix code (ProfileSyncManager.swift resetSync:823 / pullResetRequests:373 / performFullSync:337; SyncCoordinator.swift handleSyncReset:529, pushTask chain :552-560/:620-648, reconciliation :179-201/:479-499; SyncModels.swift SyncResetRequest; SharedData withLock; FoqosApp.swift wiring :227/:341).
+> 
+> What HELD under attack (stating so per instructions): (1) the monotonic never-cleared suppression date genuinely kills every clear-race class from revs 2-3 — stale-presence, stale-absence-re-arm, concurrent-pass clear leaks, ack/wipe races (rows 5, 8, 9, 10 verified statement-by-statement, including SIGKILL between B5.2's context.save and B5.3's SharedData write: relaunch re-processes, idempotent direction). (2) Marker-before-wipe plus wipe-excludes-SyncResetRequest-entirely closes #195.3 and the dual-reset marker-annihilation; resetSync retries after step-1-success/step-3-failure leave multiple live markers and multiple bases safely (max of bounded bases; newest-wins retires older ids). (3) The id map truly kills the rev-3 infinite loop in every STATIC clock configuration including basis clamping: under any constant skew, by the time an entry can prune (21 local days), the marker's local age is ≥ 21d−s, so re-processing requires s ≥ 14d slow and is bounded at ~⌈(s−14d)/21d⌉+1 applications — finite, never infinite; only unbounded active clock oscillation (plus GC failure/marker survival) yields unbounded re-clears. (4) The pushTask chain cannot deadlock (the follow-up performFullSync spawns later chain links without awaiting them) and the 5-minute notification throttle cannot cause a device to miss all sightings beyond the accepted row-20 staleness class (markers persist ~21d; any unthrottled pass sights). (5) GC margin arithmetic now checks out (21d − 7d = 14d, fixing rev 3's error). (6) Locations differ from profiles only in pull-confirmed syncVersion and the missing schema clause — both make locations strictly safer; no location-specific hole. (7) Account-switching claims verified as stated.
+> 
+> What BROKE: the single load-bearing arithmetic flaw is anchoring suppression at the marker's effectiveDate rather than the device's first sighting. suppressedUntil = min(effectiveDate, now)+8d means the '8d window' exists only for devices that sight within moments of the reset; a day-7 processor gets 1d (so a single SIGKILL before its queued re-push + a 1-day gap wipes its sole-copy data — row 23's '≥8d of push failure' precondition is simply false for it); a first sight at 8-21d — an offline vacation device, or sync disabled/re-enabled — gets ZERO window despite the marker being live and sighted, and its first pass reconciles against the post-wipe zone before its first push, contradicting row 11 outright; a merely 8-14d-fast clock hits the same zero-window while row 14 claims that range is protected. That is a concrete violation of the core safety property with realistic preconditions, hence breaks-safety and verdict has-holes. Second, B5 marks ids processed even when handleSyncReset no-ops on nil modelContext — background content-available launches run full syncs before .onAppear ever sets the context, permanently consuming the reset undelivered (breaks-liveness against the 7d delivery guarantee). Third, id-map pruning by local clock breaks B1/row-13/row-15's 'processed once, no clock dependence' claims under ≥14d constant slow clocks — squarely inside the spec's own child-rolls-clock-back threat model, failing toward clear-selections/disable-blocking (weakens; bounded, extreme preconditions, honestly graded). Three nits: same-device double-dispatch via the GC await between classify and mark (idempotent but contradicts 'exactly once'); row 15's 'no extended suppression' is wrong for future-dated markers (rolling skew+8d window, bounded); row 3's unconditional 'Converges' hides the chunk-partial-wipe no-sight case that A2.1 does not cover.
+> 
+> I did not re-report the accepted residuals (rows 14>14d-fast, 20, 22, 23, intentional-behaviour-changes) except where their stated preconditions are demonstrably wrong (rows 14 and 23, folded into finding 1). All three substantive findings share cheap fixes that preserve the design's shape: per-requestId first-sight suppression anchor, mark-only-if-dispatched, and prune-only-when-marker-absent.
+
+### stateMachine-1 [breaks-safety] Suppression anchored to marker effectiveDate gives late-sighting and fast-clock devices ~zero protection — post-wipe reconciliation deletes their sole-copy data
+
+**Violated:**
+
+Core safety property (local BlockedProfiles/SavedLocation deleted, FamilyActivitySelection cleared, outside all three exceptions); row 11's stated outcome; row 14's stated ≤14d-fast precondition; row 23's stated '≥8 days of continuous push failure' precondition; row 9's '~8d' claim. Rows 11/9 are not in the accepted-residual list, and the accepted rows' preconditions are mis-stated, so this is reportable on both grounds.
+
+**Interleaving:**
+
+extendSuppression(basis=effectiveDate) yields suppressedUntil = effectiveDate+8d regardless of WHEN a device first sights the marker. (a) Day-7 processor: device D (2-device family; D pushed profile P at T-1h; origin O reset at T without pulling first — resetSync never pulls, so O never holds P) first syncs at T+7d. Boundary-inclusive .process: sight extends suppression only to T+8d; selections cleared; re-push queued on pushTask; SIGKILL after B5.3 (ids marked) but before the queued re-push executes — row 9's exact crash point. User reopens at T+8d+1h: pass sights marker (extension no-op, T+8d is past), classify .skipAlreadyProcessed, pullProfiles → gate passes (now ≥ suppressedUntil), P absent from wiped zone, syncVersion>0 ⇒ P deleted BEFORE pushLocalData runs at end of pass. Permanent loss, zero push failures needed — row 23's '≥8 days of continuous push failure' precondition is false here (the real requirement is effectiveDate+8d − firstSight, i.e. 1 day at day-7 sight, shrinking to 0). (b) First sight ≥8d: device X offline (or sync-disabled) since before the reset first syncs at T+10d. Marker live (age 10d ≤ 21d), sighted, classify .skipExpired — but min(T, now)+8d = T+8d < now, so the extension is a complete no-op and row 11's claim 'sighted ⇒ suppressed — protected while others converge' is false. Same pass: reconciliation runs on X's very first post-reset pull, before X's first push, deleting every syncVersion>0 profile/location no other device re-pushed (sole-copy = anything X pushed after O's last pull and before the wipe). Any copy that reappears later via another device's push is re-created with needsAppSelection=true / cleared selectedActivity — FamilyActivitySelection loss outside exceptions (a)/(b). (c) Clock 8–14d fast: at sight, now = T+k > T+8d ⇒ suppressedUntil already past ⇒ zero window, yet per B3 this device cannot GC the marker — row 14's stated boundary ('≤14d fast … sight ⇒ suppression still protects its data') is wrong; protection actually dies at >8d fast, not >14d. Note the perverse inversion: an UNDECODABLE marker (basis=now) grants a full 8d window while a decodable 8d-old one grants none.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Anchor the window at per-device first sight: persist firstSightedAt per requestId (insert-only map, same withLock/prune lifecycle as processedResetRequestIds) and extendSuppression(basis = min(firstSightedAt, now)) exactly once per marker per device, for any marker with age ≤ gcTTL. Boundedness is preserved (one extension per marker per device, ≤ firstSight+8d, firstSight ≤ GC horizon), the rev-3 loop stays dead (suppression never affects processing), and rows 9/11/14/23's stated preconditions become true: every device gets a genuine 8d convergence window from ITS first sighting.
+
+### stateMachine-2 [breaks-liveness] B5 marks the reset processed even when the dispatch no-ops on nil modelContext — reset consumed without ever being applied
+
+**Violated:**
+
+Liveness guarantee 'delivery to every device syncing within 7d (absent >14d-fast clocks)'; row 11's 'Marker age ≤ 7d: processes once — 3+ device delivery (#202.1)'; B5's implicit assumption that step 2's synchronous part actually clears selections.
+
+**Interleaving:**
+
+handleSyncReset (SyncCoordinator.swift:529) begins `guard let context = modelContext else { return }` — a silent no-op. setModelContext is called only from WindowGroup .onAppear (FoqosApp.swift:227), but didReceiveRemoteNotification (FoqosApp.swift:341ff) drives handleRemoteNotification → performFullSync on content-available pushes that cold-launch the app in the BACKGROUND, where .onAppear never fires. Interleaving: parent resets at T with clear-selections; child's device is background-launched by the zone-change push at T+1h with modelContext == nil; pullResetRequests sights the marker (suppression extended — data safe), classifies .process, B5.2 dispatches didReceiveSyncReset which returns immediately (nil context: no selection clear, no re-push queued), B5.3 then unconditionally marks the requestId processed and persists it. Every subsequent foreground pass: .skipAlreadyProcessed. The clear-selections command is never applied on that device, permanently — no crash, no network failure, no clock skew required. The same one-shot race exists at foreground cold start if the notification Task's performFullSync wins the MainActor race against .onAppear.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+In the B5 sequence, treat nil modelContext as 'not delivered': skip both the dispatch and the marking (and the retire-the-rest marking) for that pass, leaving the candidates .process-eligible for the next pass; equivalently have didReceiveSyncReset/handleSyncReset return a Bool 'applied' and only mark ids whose dispatch confirmed a context. Same guard applies to the pure marking helper's inputs so tests can pin it.
+
+### stateMachine-3 [weakens] Local-clock pruning of processedResetRequestIds breaks process-once idempotency under a constant ≥14d-slow clock — expired reset re-clears selections
+
+**Violated:**
+
+B1's stated guarantee ('a request whose requestId is in the map is never processed again — no clock dependence'); rows 13/15 stated outcomes; the letter of safety exception (b) (selection-clearing applied for a reset >7d old in real time); constraint 'every clock-dependent rule must fail toward keep data / keep marker'.
+
+**Interleaving:**
+
+Prune-by-own-clock reintroduces the clock dependence B1 claims to have eliminated. Device clock constant s ≥ 14d slow (spec constraint: 'assume children roll clocks back'; a child sets the clock back once, before the reset): marker M saved at server time T (effectiveDate = creationDate = T). Device sights it at real T+ε; local now = T−s ⇒ M appears future ⇒ age clamps to 0 ⇒ .process ⇒ processed (legitimate), entry recorded at local T−s. 21 LOCAL days later (real T+21d) the prune fires: entry removed. Same or next pass, M is still fetchable (origin retired/dormant after the reset — a realistic 'reset then replace phone' flow; or another device's GC delete failed and retries lag; or stale query presence): classify with empty map — age = local now − T = 21d − s ≤ 7d ⇒ .process AGAIN ⇒ selections cleared for a reset that is 21+ real days old (outside safety exception (b)'s ≤7d), re-push, follow-up sync, id re-marked. For s > 21d this repeats every 21 local days until age exceeds 7d — bounded at ≈⌈(s−14d)/21d⌉+1 total applications, so the rev-3 INFINITE loop is genuinely dead (under any constant skew the count is finite; only unbounded repeated clock oscillation yields unbounded re-clears), but B1's 'no date arithmetic, no clock dependence, never processed again' and row 15's 'processed once (id-idempotent)' / row 13's 'no loop possible by construction' are overstated: the id map's PRUNE is date arithmetic on an untrusted clock, and it fails toward 'clear selections / disable blocking' — the wrong direction for a screen-time app per the spec's own fail-toward-keep rule.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Prune an id only when its marker is confirmed gone: remove an entry iff its requestId was NOT among the recordIDs returned by the current pullResetRequests fetch AND the entry is older than gcTTL (belt: keep the age floor as a growth bound). A live/fetched marker can then never lose its idempotency record, killing reprocessing under every clock configuration while keeping the map bounded (markers are GC'd at 21d, after which entries age out).
+
+### stateMachine-4 [nit] GC-delete await sits between classification and mark in the data-flow diagram — concurrent passes can double-dispatch the same marker on one device
+
+**Violated:**
+
+B5's 'exactly once' wording / 'before any suspension point' as diagrammed (safe direction, so nit).
+
+**Interleaving:**
+
+The diagram orders 'classify all decoded; age>21d ⇒ GC-delete (failures ignored); newest .process ⇒ dispatch ⇒ mark'. GC-delete is a network await: pass 1 classifies M as .process (map read), suspends in a GC delete for some other expired marker; pass 2 (manual Sync Now) fetches, reads the still-unmarked map, classifies M .process, dispatches, marks; pass 1 resumes and dispatches M again. Double selection-clear + double re-push — idempotent and row-12-safe, but it contradicts B5's 'every device processes each reset exactly once' and the 'mark … before any suspension point' commitment is currently only stated relative to the dispatch, not relative to GC.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Pin in the spec and code-review checklist: read processed map → classify → dispatch → mark must be one synchronous MainActor slice immediately after the fetch resumes; perform GC deletes only after marking.
+
+### stateMachine-5 [nit] Row 15's 'no extended suppression' is inaccurate: a future-dated marker re-extends suppression from `now` on every sighting
+
+**Violated:**
+
+Row 15's stated outcome ('normal 8d window. No loop, no extended suppression').
+
+**Interleaving:**
+
+Receiver s days slow: marker effectiveDate T appears future for s days; every pass in that span extends suppression to min(T, now)+8d = now+8d, a rolling window. Total suppression ≈ s+8d in the receiver's frame (it stops growing once local now passes T, or once other devices GC the marker), not the 'normal 8d window' row 15 claims. Bounded by skew, so the liveness bullet 'cannot be extended unboundedly by any single marker' technically survives, but only with a 'bounded by skew' caveat the spec doesn't state; deletion propagation on a badly slow device is delayed by skew+8d.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Either state the skew+8d bound honestly in row 15, or extend from a future-dated marker at most once per requestId (falls out of the per-requestId first-sight fix for the breaks-safety finding).
+
+### stateMachine-6 [nit] Row 3's unconditional 'Converges' hides the chunk-partial-wipe + no-sight case (non-empty pull, A2.1 does not skip)
+
+**Violated:**
+
+Row 3's stated outcome (internal consistency with row 20; the accepted residual itself is not being re-reported).
+
+**Interleaving:**
+
+Origin crashes mid-type during the chunked wipe (e.g., 500 profiles, first 400-record chunk deleted). Row 3 claims non-sighting devices are safe because 'wiped types pull empty ⇒ A2.1 skips' — but a partially wiped type pulls NON-empty (the remaining 100), so on a device whose pullResetRequests was query-stale-absent for the (earlier-saved) marker, reconciliation runs against the partial set and deletes local copies of the wiped chunk. This is exactly row 20's accepted no-sight staleness class — not a new mechanism — but row 3 asserts convergence without the caveat, so the table overstates the wipe-partial guarantee.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Amend row 3: 'devices that don't sight it: fully-wiped types pull empty ⇒ A2.1 skips; a partially-wiped type is row 20's no-sight residual.'
+
+## Lens: specReview — verdict: has-holes
+
+**Verifier reasoning:**
+
+> Read docs/superpowers/specs/2026-07-02-reset-sync-safety-design.md (REVISION 4) in full, 371 lines. Findings for each requested check, human meatbag:
+> 
+> **(1) Placeholders** — none found. Grepped for TODO/TBD/FIXME/XXX/[fill/placeholder/<INSERT/???; the only hit was "read-only placeholders" in row 22, which is a domain term (stale husk records) not a spec placeholder marker. No unfilled sections, no dangling brackets.
+> 
+> **(2) Internal contradictions — TTL arithmetic, checked in every row**
+> `suppressionWindow = 8 days` ("processTTL + 1 day of slack", A1), `processTTL = 7 days` (B2), `gcTTL = 21 days` (B3), `margin = gcTTL − processTTL = 14 days` (B3). Every row that cites a duration uses these consistently: row 2 "≤ 8d", row 9/15 "~8d"/"8d window", row 11 "≤ 7d... 7–21d... >21d" (matches B4's exact ranges), row 14 "≤14d fast... >14d fast" plus the explicit correction note "arithmetic now consistent: margin = gcTTL − processTTL = 14d", row 23 "≥8 days of continuous push failure". The "Intentional behaviour changes" section ("~8 days", "up to ~21 days", "≤8 days across an account switch") and B4's boundary claims (7d ⇒ process-eligible, 21d ⇒ still `.skipExpired`, 21d+1s ⇒ `.expiredCollect`) all agree with the >, ≤ operator directions used consistently across B2/B3/B4/A2/test-plan item 1. No arithmetic contradiction found — this is the one area I expected to find slippage and didn't.
+> 
+> **(2) Other contradictions/gaps vs mechanisms, diagram, test plan** — see `breaks` list below (items 1, 2, 6).
+> 
+> **(3) Ambiguity**
+> - `extendSuppression` basis per caller: origin (`resetSync`, Part C step 2) uses `extendSuppression(now)` explicitly. `pullResetRequests` uses "marker's effective date, or `now` when unknown" — decoded records use `effectiveDate` (B2), undecodable/failed-fetch records use `now`. These two callers are consistent with each other and with the data-flow diagram's `extendSuppression(effectiveDate | now)`. No third caller exists (B5 step 1 reuses the same "on sight" A1 trigger, not a new call site).
+> - Shared suppression key: `SharedData.syncDeletionSuppressedUntil` is declared once (A1) and reused verbatim by both `handleSyncedProfiles` and `handleSyncedLocations` (A2, confirmed by the data-flow diagram's "same, minus the schema clause" for locations, and by the interleaving tables treating both under one combined section, rows 18–23). No row assumes a per-type or per-record-type suppression clock — this is confirmed consistent.
+> - Two real ambiguities found and reported below: (a) tie-breaking for "the newest" `.process` candidate when two markers share an `effectiveDate` (B5) is unspecified; (b) whether the classify→dispatch→mark sequence in B5 is safe under the doc's own "Concurrent passes exist... can overlap at await points" constraint is asserted (row 12: "No race") but not walked through for the same-device concurrent-pass case, only the cross-device case.
+> 
+> **(4) Test-plan completeness vs claimed fixes and code-inspection commitments**
+> Mapped every #195/#202 sub-item and every "Intentional behaviour changes" bullet to either a pure unit test (1–7) or a code-inspection commitment (4 bullets). Two gaps found and reported below: the ordering guarantee that actually closes #195.4 (intra-pass race) is never listed in the commitments (only the *failure*-abort path is), and the "Account switching" behavioral claims have no test or commitment at all. A smaller nit: A2's `now ≥ suppressedUntil` boundary isn't given the same exact-equality boundary test that B4's 7d/21d boundaries get.
+> 
+> Overall the core safety mechanism (monotonic max, TTL arithmetic, single shared suppression key, upserts-always/deletes-gated split) is internally consistent and the numbers check out everywhere I looked. The holes are all in verification-coverage/specification completeness (missing commitments, one unanalyzed interleaving, one unresolved tie-break), not in the core arithmetic or the profiles/locations shared-key design.
+
+### specReview-1 [weakens] The invariant that actually closes #195.4 (intra-pass re-push race) is never listed in the code-inspection commitments
+
+**Violated:**
+
+The 'Code-inspection commitments' list only has 4 bullets: resetSync step order (C.1-4); 'suppression extended on raw recordID sight before decode/classify (B/A1), and didReceiveSyncReset dispatched before ids are marked (B5 order)'; chunking/wipe-exclusion/GC-failure handling; and 'pass-abort: pullResetRequests failure prevents all reconciling pulls (Part C)' -- which only covers the *failure* case. None of the four bullets states the success-path sequencing fact ('pullResetRequests fully completes, including its suppression write, before pullProfiles runs, within one pass') even though that is the load-bearing mechanism the design credits with closing a *critical* bug's sub-case.
+
+**Interleaving:**
+
+Row 19 credits closing #195.4 to suppression being extended by pullResetRequests before the same pass's pullProfiles reconciles: 'remoteIds non-empty, suppressed | Skip. Closes #195.4 and every mid-window partial-zone case for devices that ever sighted the marker (or originated the reset).' That requires pullResetRequests's synchronous SharedData write to be committed and visible before pullProfiles runs later in the same performFullSync pass (success path, not just the abort-on-failure path).
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Add a fifth code-inspection commitment: 'pullResetRequests's suppression-extension writes are synchronously committed before performFullSync proceeds to pullProfiles/pullLocations within the same pass (success path) -- this is the mechanism that closes #195.4.'
+
+### specReview-2 [weakens] B5's classify-then-dispatch-then-mark sequence is a check-then-act pattern across an await point, but the doc only analyzes the cross-device case, not the same-device concurrent-pass case its own constraints section calls out
+
+**Violated:**
+
+No interleaving row models: 'same device, two concurrent performFullSync passes, both classify the same requestId as .process before either reaches step 3' -- despite the constraints section explicitly flagging that overlap as real ('can overlap at await points'). The Concurrency & storage discipline section only commits `withLock` around the *individual* extendSuppression and processed-id insert/prune operations, not around the classify->dispatch->mark sequence as a unit, so double-dispatch of didReceiveSyncReset (double selection-clear, double re-push) before either pass marks the id processed is not ruled out by anything stated.
+
+**Interleaving:**
+
+The constraints section states: 'Concurrent passes exist. performFullSync has no reentrancy guard; manual "Sync Now", remote notifications, setup, and the reset follow-up can overlap at await points. Any new state must be safe when read/written by interleaved passes.' B5's own ordering is: '1. suppression already extended... 2. dispatch didReceiveSyncReset(...)... it then chains re-push -> follow-up performFullSync on the pushTask chain; 3. mark requestIds processed (synchronously, same iteration, before any suspension point).' Between step 1 (classify sees the id as unprocessed) and step 3 (mark processed) there is an await (dispatch chains async work) on this device's own concurrent second pass. Row 12 only says: 'Two receivers process the same marker concurrently | Both apply (idempotent); ids marked on each; marker not deleted. No race' -- which reads as two *different devices*, each with its own independent processedResetRequestIds map, not two concurrent passes racing on the *same* device's single map before either writes 'processed'.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Add an explicit interleaving row for 'same-device concurrent passes both see requestId as unprocessed before either marks it' and state why double-dispatch of didReceiveSyncReset is safe (e.g., because clearing selections and re-pushing are themselves idempotent) -- or add a lock/guard and say so.
+
+### specReview-3 [nit] B5's tie-break rule for 'the newest' .process candidate is unspecified when two markers share the same effectiveDate
+
+**Violated:**
+
+'B5. Process the newest, once; retire the rest. Per pass: among .process candidates, dispatch only the newest (by effectiveDate)' presupposes a unique maximum but never states a tie-break. Test-plan item 2 ('several .process candidates => exactly the newest dispatched') also doesn't cover a tie.
+
+**Interleaving:**
+
+Row 6 ('Two devices reset near-simultaneously') is exactly the scenario where two SyncResetRequest records could have equal or sub-second-indistinguishable effectiveDate (CKRecord.creationDate) or, on the requestedAt fallback, an identical client timestamp.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+State an explicit deterministic tie-break (e.g., requestId lexicographic order) so two devices computing 'the newest' independently are guaranteed to agree, and add a boundary test for it.
+
+### specReview-4 [weakens] The 'Account switching' behavioral claims have no test-plan item or code-inspection commitment
+
+**Violated:**
+
+Intentional behaviour changes states: 'Account switching: processedResetRequestIds are UUIDs (cannot collide across accounts -- no cross-account suppression of delivery); syncDeletionSuppressedUntil may carry <=8 days across an account switch (blocks only deletions -- safe direction). Neither needs account-scoping.' Neither the 7-item pure test list nor the 4-item code-inspection commitments list mentions 'account' anywhere -- every other claimed behavior change in the doc maps to at least one of those two lists; this one maps to neither.
+
+**Interleaving:**
+
+An account switch on a device that has an active syncDeletionSuppressedUntil or processedResetRequestIds state from the prior account.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Add either a unit test (processedResetRequestIds UUID non-collision reasoning doesn't need CK, so is arguably pure-testable as 'no special-casing needed') or, at minimum, a fifth code-inspection commitment calling out that no account-scoping code was added and why that's safe, so a reviewer actually checks it.
+
+### specReview-5 [nit] A2's suppression boundary (now == suppressedUntil) lacks the exact-equality boundary test the doc gives every other TTL boundary
+
+**Violated:**
+
+A2 states the operator precisely: 'now >= syncDeletionSuppressedUntil (read fresh from SharedData inside the reconciliation branch; nil passes)' -- i.e. reconciliation is allowed to run exactly at the boundary. Test-plan item 4 only lists 'non-empty remote, suppression expired (or nil), one missing => deleted' without pinning now == suppressedUntil, unlike test-plan item 1's meticulous 7d/21d/21d+1s boundary pins for classify.
+
+**Interleaving:**
+
+A device's clock reads exactly syncDeletionSuppressedUntil at the moment handleSyncedProfiles runs.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Add a boundary case to test 4: now == suppressedUntil exactly => reconciliation runs (matches the >= operator).
+
+### specReview-6 [nit] The data-flow diagram places GC-delete between suppression-extend and dispatch/mark, but B5's prose 'single most correctness-critical sequence' only enumerates 3 steps and never places GC in it
+
+**Violated:**
+
+B5 says: 'Ordering inside the pass, single most correctness-critical sequence: 1. suppression already extended...; 2. dispatch didReceiveSyncReset...; 3. mark requestIds processed...' -- three steps, framed as *the* critical sequence. The data-flow diagram shows a fourth phase interposed: 'classify all decoded; age>21d => GC-delete (failures ignored)' sitting between the suppression-extend line and the 'newest .process => didReceiveSyncReset -> mark ALL .process ids processed' line. Functionally harmless here since .process (age<=7d) and .expiredCollect (age>21d) sets are disjoint, but the prose's claim to completeness ('single most correctness-critical sequence') is contradicted by the diagram depicting an unlisted step.
+
+**Interleaving:**
+
+A single performFullSync pass where pullResetRequests fetches both an expired (>21d) marker and a live (.process) marker in the same batch.
+
+**Verifier's suggested fix (historical; superseded by #267):**
+
+Either fold GC-delete explicitly into the B5 ordering list (even just to state 'GC-delete may happen before or after step 2/3, order is immaterial because .process and .expiredCollect are disjoint by age'), or note in the diagram that GC ordering is intentionally unconstrained.

--- a/docs/plans/2026-07-02-sync-engine-corpus-mapping.md
+++ b/docs/plans/2026-07-02-sync-engine-corpus-mapping.md
@@ -1,0 +1,99 @@
+# #267 corpus mapping — every A1 scenario under the CKSyncEngine design (v9)
+
+Normative companion to `2026-07-02-sync-engine-design.md` (v9; § references below).
+Verdicts (exactly one per row): **IBC** = impossible by construction (the state/mechanism
+producing the scenario does not exist); **SAFE** = attemptable, protected by a named
+mechanism; **RESIDUAL** = accepted, honest preconditions stated (pointer into §12 N-table).
+v9 tracks design v9 (round-8 fixes, SDK-verified: honest AB-4 bootstrap strip with containment nets; no fetch/send inside handleEvent; gate rationale via zone-CAS/N1; legacy identification routing arm; own-command lastApplied writes). v8 was round 7: total resume-gate case-split observed by direct record fetch; legacyCleanupIds persisted carrier; automaticallySync=false bootstrap strip — no send-timing assumption; provenance/scoping drift fixed). v7 was round 6: T1 strip covers restored database changes — resetIntent is the sole source of truth for zone changes; lastAppliedResetCommandId provenance; own-id resume; legacy flag on confirmation; refuse=remove; scoped rollback context; N12 widened to both sides). v6 was round 5: all restored pending deletes stripped + all recovered tombstones verified; failed-apply supersession + verify-before-replay; §5.2 dequeues the outbound delete; reset-resume command snapshot; abandoned intents dequeue zone changes; context rollback; echo guard cycle-start scoping; AB-3). v5 was round 4: verify-before-delete for recovered intents;
+tombstone rollback; §5.6 failed-apply retry; echo guard; T1 seed-intent recovery; N14
+added). v4 was round 3: the v3 §5.6 absence-sweep is deleted and replaced
+by I12 delete-intent tombstones; `systemFields` is apply-gated and type-scoped; seed
+intents clear only on observable signals; the own-origin apply skip is removed;
+pending-delete-wins on the fetch path). Residual pointers reference N1–N13 as amended
+(N5 corrected: local deletions survive toggle cycles via tombstones; N8 scoped to saves
+only).
+
+## Class A — deletion-by-absence vs. reset/wipe races
+
+| ID | Verdict | Why |
+|----|---------|-----|
+| A-1 | IBC | No absence inference exists (I1, I5); empty/partial fetches mutate nothing (S-2). The wipe signal is the zone-deletion event and/or the command record, neither of which deletes local data (T5, §8.3, S-3/S-8). |
+| A-2 | IBC | The "wiped but unsignalled" state cannot exist server-side: the wipe *is* the zone deletion. Delivery of the *signal* to a given device is not assumed (§1.1 assumption boundary): the command record is the guaranteed carrier (§8.3), and even a device that misses both signals loses nothing (I1) — its worst case is dormancy (N7), not deletion. A reset failing before the delete confirms is a no-op (§8.1). |
+| A-3 | IBC | No pass structure, no reconciliation; fetched deletions name records explicitly (§5.2). |
+| A-4 | IBC | Same — manual sync is `fetchChanges()`, which can only deliver explicit events. |
+| A-5 | IBC | Push acks update `systemFields` only (§5.3); no safety decision reads them. Records die with zones (database-level), not as inferable record absences. |
+| A-6 | IBC | Nothing compares "what I pushed" with "what a fetch returned"; token fetches are gap-free by the server contract. The one place server state meets local push state — `serverRecordChanged` (§5.3 branch C) — merges by version and re-enqueues; it cannot delete. |
+| A-7 | IBC | No decision consumes stale presence — no superset/verification check exists. |
+| A-8 | IBC | No decision consumes stale absence — the command is an instruction, not protection; missing it delays selection-clear/re-seed only until the fetch that delivers it (§8.3). |
+| A-9 | IBC | The vacuousness dilemma applied to evidence-gated absence deletion; deleted (§9). |
+| A-10 | SAFE | One serial main-actor event stream (§2, B-7); shared persisted state is add-only (`processedResetCommandIds`) or internally consistent per-account pairs (§7). No cross-pass flags exist. |
+| A-11 | IBC | Sole-copy data can only be deleted by an explicit deletion event for that record. Resets delete zones, not records; T5/§8.3 keep local data and re-seed it (I11). |
+| A-12 | SAFE | Newer-schema profiles: never enqueued for save (I2), provider removes any stray pending save (§5.4, S-14), and only an explicit deletion event can remove them locally (I1). |
+| A-13 | IBC | Locations ride the identical §5 event paths; no location-specific reconciliation exists. Their merge-rule divergence is N6 (RESIDUAL, non-destructive), stated per round-1 audit. |
+| A-14 | SAFE | Last-item deletion propagates as an explicit event (S-1). No empty-remote heuristic blocks it; seeding happens only on I11 transitions (S-19). Deliberate re-seeds can resurrect *lagging* deletions — stated honestly as N9 (any reset) and N5 (rejoin), both RESIDUAL pointers. |
+
+## Class B — reset-command lifecycle
+
+| ID | Verdict | Why |
+|----|---------|-----|
+| B-1 | IBC | Commands are never consumed by readers; the fixed-name record persists for its zone incarnation (§8.2), is never stored in `systemFields`, and no outbound-delete mechanism can touch it (I12 tombstones cover funnel deletes only — the v3 sweep that could destroy it is deleted); every device that fetches sees it. |
+| B-2 | SAFE | Lifecycle GC: the next reset's zone deletion removes the command; the origin pre-marks its own id (§8.1 step 1). A device syncing a year later applies the *current* incarnation's command — correct by definition; a *superseded* command cannot survive (CAS overwrite or zone death, §8.2). Clear-selections on a very late joiner is within reset semantics (corpus B-2/#202.3 acceptance carried over). |
+| B-3 | SAFE | Concurrent resets serialize at two CAS points: zone delete/recreate (server-side) and the fixed-name command record (§8.2). A superseded origin's queued command save fails `serverRecordChanged` and is dropped (§8.1 step 5, S-13) — the round-1 zombie-command interleaving is closed by construction of the fixed name. Churn bounded (N3). |
+| B-4 | IBC | No hand-rolled bulk delete; the only mass operation is `deleteZone` (one database change); the engine batches record sends internally; per-record failures follow §5.3 (S-17). |
+| B-5 | IBC (safety) | An undecodable command cannot suppress anything (commands are not protection) and dies with its zone; unknown types and undecodable payloads are logged and ignored (§5.1, stated explicitly in v5). Delivery of that reset's *selection-clear* is lost — equivalent to N1's last-reset-wins acceptance. |
+| B-6 | SAFE | I10: no engine exists before the context does — the nil-context state is unreachable, background cold launches included (S-7); applies are durable in-event (§5.0). |
+| B-7 | SAFE | One serial event stream; apply-then-mark is synchronous within the handler (I4); redelivery is idempotent anyway (S-5). |
+| B-8 | IBC | There is no multi-command ordering: one fixed-name record per incarnation; supersession is a server-serialized CAS overwrite (§8.2). No date ordering, no tie-break needed. |
+
+## Class C — clocks
+
+| ID | Verdict | Why |
+|----|---------|-----|
+| C-1 | SAFE | No date participates in any *safety or idempotency* decision (I3): command identity is UUID-keyed; supersession is CAS, not date-ordered. The one inherited client-clock comparison (location field merge) is N6 — non-destructive, named, with a fix vehicle. |
+| C-2 | IBC | No clock-based GC exists; command lifetime = zone lifetime. |
+| C-3 | IBC | No date-based idempotency exists to loop (I3, S-5). |
+| C-4 | IBC | No protection window exists to be born expired. |
+| C-5 | IBC | No local-time window exists for a forward roll to end. |
+| C-6 | IBC | `processedResetCommandIds` is never pruned (§2.1). |
+
+## Class D — process & state hygiene
+
+| ID | Verdict | Why |
+|----|---------|-----|
+| D-1 | SAFE | Ordering-sensitive persisted writes, each stated: apply-before-mark (I4, S-6); intent-before-consume for every seed entry point (I11, S-28); tombstone-with-delete (I12, S-29); funnel bump-inside-the-save (I2, S-15); AB-2 for fetch tokens only (S-26 — seed/tombstone intents never key off serialization capture). Kill windows fail toward idempotent re-apply or intent-driven recovery — never toward unprotected skips, orphaned seeds, or orphaned deletes. |
+| D-2 | IBC | No pass exists whose early step gates a later destructive step; events are self-contained; a failed fetch delivers no events and therefore no mutations. |
+| D-3 | SAFE | All *sync state* per-`userRecordID`, nothing purged on switch (T7, §7, S-12); UUID ids cross-account-collision-proof; the round-1 switch-back resurrection is closed by pair consistency. The *data store* is account-agnostic — cross-account data union is N11 (honest residual, pre-existing class), not claimed harmless. |
+| D-4 | SAFE | Toggle-off discards engine state; toggle-on is an explicit fresh bootstrap with rejoin semantics (T11/T1, N5 — stated, not hidden). Ordinary relaunch resumes the queue with zero re-derivation (S-19). |
+| D-5 | IBC | Throttle deleted; engine scheduler + tokens make a missed push pure latency (§1.1, N4). |
+| D-6 | SAFE | Zone deleted/recreated is first-class (T5/T6 + §5.5 confirmations + §5.3 `zoneNotFound` recovery); tokens engine-internal; bookkeeping resets via I6; re-seed crash-durable via `pendingSeedIntent` (I11, S-28) plus the §8.3 redundant carrier — modulo N7 (fully-quiet family) and N8 (save-enqueue kill window). |
+| D-7 | SAFE | §2.1 enumerates every persisted key with provenance; compound ops under `withLock`; the engine state file has a single writer. (v1's missing `pendingCommandApplication` key was deleted along with the buffering machinery, I10.) |
+
+## Class E — product semantics
+
+| ID | Verdict | Why |
+|----|---------|-----|
+| E-1 | SAFE | `needsAppSelection` semantics unchanged (§5.1); the husk mass-producers are IBC above. |
+| E-2 | SAFE | Deliberate decision §8.5: origin no longer clears its own selections; matches shipped copy. |
+| E-3 | SAFE | Keep-by-default is structural (I1); no ambiguity-resolving heuristics remain. |
+| E-4 | SAFE | Propagation is event-carried with app-managed re-adds on failure (§5.3, S-1, S-16, S-17, I8); version-bump ownership by I2/S-15/S-16; equal-version divergence by branch 0 + branch E + the §5.1 fetch-path rule (S-10, S-27); killed delete-enqueues by I12 tombstones (S-29 — recorded intent, never absence inference); own-origin echoes apply correctly (S-31, restore-from-backup heals); pending-delete-wins prevents self-resurrection (S-32). Deletion propagation to token-expired dormant devices is N10; session stops post-reset propagate via §6 stop-on-absent (S-24). |
+
+## Residual table (R1–R8, from the A1 rev-4 design)
+
+| ID | Verdict | Why |
+|----|---------|-----|
+| R1 | IBC | No suppression window exists (C-4). The vacation device fetches explicit events only; a reset in the interim reaches it via T5 *or* the §8.3 command (redundant carriers — the v1 claim that the zone event alone always arrives was retracted per round 1); its sole-copy data survives (I1) and re-uploads (I11). |
+| R2 | IBC | No suppression to extend; undecodable records inert (B-5). |
+| R3 | IBC | No local-time gate (C-5). |
+| R4 | SAFE | I10 context-gated engine (no nil-context processing exists) + §5.0 durable in-event applies (S-7). |
+| R5 | IBC | No prune (C-6). |
+| R6 | IBC | Required absence inference during marker invisibility; both halves gone (A-8). |
+| R7 | SAFE | Deletion propagation is never suspended (no windows), and seeding is restricted to I11 transitions (S-19) — the launch-time blanket re-push does not exist. Deliberate re-seeds can resurrect deletions not yet fetched by every device: N9 (reset), N5 (rejoin), N10 (token-expired dormancy) — honest residuals, not hidden. |
+| R8 | IBC | No clock GC of commands (C-2). |
+
+## Honest residuals of the new design
+
+N1–N14 as defined in design §12 (v9, editorial pass post-round-9; N14 split by stage). Round-3 corrections: N5's delete direction fixed —
+local deletions survive toggle cycles and re-propagate via I12 tombstones (the v3 claim
+that they "silently un-happen" was both dishonest and worse-behaved); N8 scoped to
+save-enqueues only (deletes recover via I12, recorded intent — the v3 §5.6 absence-sweep
+is deleted); N3 notes mixed-build payload-equality noise. N9–N13 unchanged from v3; N14 (restore-replayed reset intent, supersession-checked) added in v5; restored delete intents are guarded, not residual (I12 verify-before-delete, S-33).

--- a/docs/plans/2026-07-02-sync-engine-design.md
+++ b/docs/plans/2026-07-02-sync-engine-design.md
@@ -1,0 +1,777 @@
+# Design: CKSyncEngine sync transport (#267) — implementation contract
+
+- **Issue:** #267 (supersedes bundles A1/A2; absorbs #195, #202, #219, #200, #201)
+- **Date:** 2026-07-03 (v9 — incorporates adversarial round 8 (SDK-verified): the
+  bootstrap strip is honest — single engine, synchronous strip, named AB-4 with mocked
+  test and two containment nets (no 'by construction' claim; Configuration cannot be
+  mutated post-init); engine fetch/send never called from within handleEvent (documented
+  prohibition) — §5.5 retries are scheduled after the handler returns; gate arm-2
+  rationale corrected (zone-CAS + N1, zoneNotFound ⇒ resume); §5.1 legacy-identification
+  routing arm; own-command arms set lastAppliedResetCommandId; wording drift fixed.
+  v8 was round 7: the .deleting resume
+  gate observes the command by direct record fetch and its case-split is total
+  (own ⇒ confirmed; prior-or-none ⇒ resume; foreign ⇒ abandon+surface; undecodable ⇒
+  abandon+surface); legacyCleanupIds gives the legacy exemption an implementable,
+  persisted carrier; bootstrap inits with automatic sync disabled until the strip
+  completes (no send-timing assumption); lastAppliedResetCommandId write sites pinned;
+  I12 recovery scoped to controller start; table/text drift fixed. v7 was round 6: the T1 strip extends to
+  restored pending DATABASE changes (resetIntent is the sole source of truth for zone
+  changes, symmetric with tombstones); lastAppliedResetCommandId gives priorCommandId a
+  defined provenance; own-id resume case; legacy flag set on confirmed deletion; §5.4
+  refuse = remove; sync paths use a dedicated ModelContext so rollback is scoped;
+  in-flight async continuations invalidated on T7/T11. v6 was round 5: all restored pending
+  deletes stripped at start and every recovered tombstone verified (no fresh/restored
+  discretion); failed-apply entries superseded by later successful applies and .delete
+  replays verify-by-fetch; §5.2 tombstone-clear also dequeues the outbound delete;
+  reset-resume snapshots the known command id; abandoned reset intents dequeue their
+  zone changes; context rollback on failed writes; echo guard scoped by cycle start;
+  AB-3 fetch-cycle delimiters; T-row/branch cross-references pinned. v5 was round 4: verify-before-delete for
+  recovered delete intents (restore-from-backup replay class); tombstone rollback +
+  entity-present rule in the funnel delete path; persisted failed-apply retry set;
+  confirmed-delete echo guard; T1 recovers a stuck seed intent; legacy cleanup as an
+  enumerated exception. v4 was round 3: delete-intent tombstones
+  replace the v3 sweep's absence inference; apply-gated + type-scoped `systemFields`;
+  observable seed-intent clearing; own-origin apply skip removed; pending-delete-wins
+  fetch rule; branch naming disambiguated)
+- **Status:** **converged** — adversarial round 9 (2026-07-03) produced no breaking
+  interleaving (two independent attackers: sound-with-nits; remaining findings were
+  text drift, fixed editorially in this revision). Nine rounds total; full history in
+  the PR #268 description and the A1 corpus appendices.
+- **Acceptance suite:** `2026-07-02-reset-sync-a1-acceptance-corpus.md`; the mapping in
+  `2026-07-02-sync-engine-corpus-mapping.md` is a normative part of this design.
+- **Audience:** the implementing session. This is a contract: the state machine,
+  invariants, and named test scenarios are requirements. Where the contract is silent,
+  follow AGENTS.md and existing SyncCoordinator apply-side semantics.
+
+## 1. Scope and non-goals
+
+**Replace** the CKQuery-based private-database sync transport in
+`ProfileSyncManager`/`SyncCoordinator` — profiles (`SyncedProfile`), locations
+(`SyncedLocation`), sessions (`ProfileSession` transport only), emergency settings
+(`SyncedEmergencySettings`, a single fixed-name record), and the Reset Sync feature — with
+**`CKSyncEngine`** (iOS 17+; project targets 18.6).
+
+**Keep unchanged:** all CKRecord schemas (no new record types or fields — the reset
+command reuses the `SyncResetRequest` type); the apply-side merge semantics in
+`SyncCoordinator` — with two deliberate, named amendments (§5.1: the own-origin apply
+skip is removed; §5.1: fetched modifications shadowed by a pending delete are skipped);
+`SessionSyncService`'s CAS write path — with one deliberate amendment (§6:
+stop-on-absent); the shared-DB FamilyCommand/lock-code channel (out of scope, B2); all UI
+except §8.5.
+
+**Non-goals:** implementation (separate session); behavioural redesign of what syncs;
+performance tuning beyond what the engine provides.
+
+**V1→V2 migration independence (maintainer clarification, #267 2026-07-02):** the local
+migrator (`ProfileMigrationUtil` / `migrateToV2IfNeeded`) is a local schema transform with
+no ordering dependency in either direction on this rewrite. Explicit invariants:
+(a) **CKRecord payload shape is unchanged** — `SyncedProfile` records keep carrying both
+V1 fields (`blockingStrategyId`/`strategyData`) and the V2 trigger fields plus
+`profileSchemaVersion`; transport only, never record shape; (b) the **schema-version gate
+is I9** and must survive the swap intact. Migration-time mutations flow through the
+`MutationFunnel` (I2). #266 stays in bundle D4.
+
+### 1.1 Why CKSyncEngine (decision record)
+
+| Requirement (#267) | CKSyncEngine | Manual `CKFetchRecordZoneChangesOperation` |
+|---|---|---|
+| Deletions as explicit events | `fetchedRecordZoneChanges.deletions` (with `recordType`) | same, hand-rolled |
+| Token lifecycle incl. expiry | engine-internal | persisted tokens + `changeTokenExpired` by hand |
+| Push queue, scheduling, backoff | `state.pendingRecordZoneChanges`, persisted | hand-rolled queue (the #201 class, again) |
+| Push notifications | engine-owned database subscription | hand-rolled subscription + throttle (#200 class) |
+| Zone lifecycle events | `fetchedDatabaseChanges.deletions` with reasons | infer from `zoneNotFound` (the ambiguity that hid A-2) |
+| Account changes | `accountChange` event | `accountStatus` polling |
+
+The fallback would re-implement, by hand, the four subsystems whose hand-rolled versions
+produced this corpus. CKSyncEngine is chosen; the fallback is rejected unless
+implementation discovers a hard blocker (stop, document, return to design).
+
+**Assumption boundary (normative).** The engine is relied on for scheduling, tokens,
+subscriptions, event delivery shape, **and**:
+
+- **AB-1:** pending **database** changes are sent before pending **record** changes
+  (documented; §5.3 branch Z / §8.1 depend on it; mocked test S-25).
+- **AB-2:** a `stateUpdate` serialization reflects only fetch progress whose events have
+  already been delivered and handled (makes persist-on-`stateUpdate` safe for **fetch
+  tokens**; mocked test S-26).
+- **AB-3:** fetch cycles are delimited by `willFetchChanges`/`didFetchChanges`, and a
+  `didFetchChanges` implies that cycle's `fetchedRecordZoneChanges` events were all
+  delivered (T2 and the echo guard's cycle-start scoping depend on it; mocked test S-37).
+- **AB-4:** the engine initiates no send of restored pending changes between its init
+  and the end of the same synchronous main-actor region (the T1 strip window; mocked
+  test in S-38). This is the strip's one real timing assumption — `automaticallySync`
+  is an init-time `Configuration` value that cannot be flipped on a live engine, so the
+  window cannot be closed by construction. Two containment nets hold even if AB-4 is
+  violated: record deletes cannot materialize without §5.4's tombstone-membership
+  approval (a delegate chokepoint), and a zone-delete confirmation arriving with
+  `resetIntent == nil` is handled as T5 (purge + re-seed).
+- The delegate contract prohibits calling `fetchChanges()`/`sendChanges()` from within
+  `handleEvent` (documented; doing so deadlocks the serial event stream). All explicit
+  fetch/send requests are scheduled in a `Task` after the handler returns (§5.0).
+- Serial main-actor delegate delivery (B-7) additionally implies: a synchronous
+  main-actor region containing no suspension point cannot be interleaved by any engine
+  event — the T1 start-up strip (I12) relies on exactly this, nothing more.
+
+Explicitly **not** assumed: that a `stateUpdate` serialization captures `state.add` calls
+made before its *delivery* (its snapshot may predate them — which is why seed/delete
+intents clear only on *observable* signals, I11/I12); that failed changes remain queued
+(the app re-adds them, §5.3); that zone-deletion events reach every device across
+delete→recreate or token expiry (the command record is the redundant carrier, §8.3); that
+`handleEvent` returning implies durable consumption (applies are durable in-event, §5.0);
+that the engine redelivers self-originated changes (§5.3 branch U-save; residual N12);
+or any engine-side coalescing of same-id save+delete pairs (§5.4 removes shadowed saves
+itself).
+
+Consequences: manual "Sync Now" becomes `fetchChanges()`/`sendChanges()`; the old
+`CKRecordZoneSubscription("device-sync-zone-changes")` and the 5-minute throttle are
+deleted (D-5).
+
+## 2. Architecture
+
+```
+                    ┌───────────────────────────────────────────────┐
+                    │ SyncEngineController (@MainActor, owns engine) │
+ CKSyncEngine ─────►│  handleEvent(_:)  nextRecordZoneChangeBatch    │
+   (private DB,     │  persists: engine state, system-fields cache,  │
+    DeviceSync zone)│  processed ids, reset/seed/delete intents      │
+                    └───────┬───────────────────────────┬───────────┘
+                            │ apply (upserts/deletes)    │ record materialization
+                            ▼                            ▼
+                    SyncCoordinator (apply-side,   RecordProvider
+                    amended merge semantics)       (SwiftData / EmergencyUnblockManager
+                            │                       → CKRecord, system-fields cache)
+                            ▼
+                    SwiftData (ModelContext)
+   Locally-originated mutations ──► MutationFunnel ──► bump / tombstone ──► state.add [I2]
+```
+
+- **`SyncEngineController`** — new type; sole owner of `CKSyncEngine`; conforms to
+  `CKSyncEngineDelegate`; main-actor; events applied serially (B-7). **Construction is
+  gated on the `ModelContext` (I10):** created with the context in its initializer, from
+  the app entry point where the `ModelContainer` already exists (`FoqosApp` init /
+  `didFinishLaunching`; `fatalError`-on-failure, so it exists for background launches
+  too). No event can be observed without a context; no buffering machinery exists.
+- **`MutationFunnel`** — the one API for every **locally-originated** create/update/delete
+  of a synced entity (user action, migration, auto-heal; absorbs #210/#233). Per call:
+  - **save path:** (1) bump the entity's version *inside the same persisted write*
+    (profiles `syncVersion += 1`, replacing `SyncCoordinator.pushProfile`'s increment;
+    locations advance `updatedAt`; emergency settings `emergencySettingsVersion += 1`);
+    (2) require the write to succeed; (3) `state.add(.saveRecord(id))`. Saves of
+    `isNewerSchemaVersion` profiles are never enqueued.
+  - **delete path:** (1) persist a **delete-intent tombstone** (`deleteTombstones[user]`,
+    §2.1: id → last-known server change tag from `systemFields`, nil if never synced) *in
+    the same `withLock` scope as* — and before returning from — the operation that
+    deletes the entity; (2) require the entity delete to succeed — **if it fails, remove
+    the tombstone in the same `withLock` scope AND `context.rollback()` the pending
+    entity deletion before returning** (round-4/5: a lingering tombstone would later kill
+    the live record family-wide; a poisoned context would commit the un-bookkept
+    deletion on the next unrelated save). The same rollback rule applies to any thrown
+    apply (§5.1/S-30) — a failed write never leaves dirty state to piggyback on a later
+    save. **Funnel and apply writes run on the sync paths' own `ModelContext`** (not a shared UI
+    context; the funnel receives the already-saved user mutation via its id and re-reads
+    it on the sync context — the version bump is part of the funnel's own persisted
+    write), so a rollback can never discard unrelated uncommitted user edits (round-6); (3) `state.add(.deleteRecord(id))`. The tombstone carries the user's
+    intent; cleared only per I12.
+- **`RecordProvider`** — materializes `CKRecord`s for `nextRecordZoneChangeBatch`:
+  profiles/locations from SwiftData, emergency settings from `EmergencyUnblockManager`,
+  on cached system fields (fresh if none); reuses `toCKRecord`/`updateCKRecord`.
+- **Payload equality (§5.1/§5.3):** two synced representations are *payload-equal* iff
+  all synced fields match **excluding sync metadata** (`lastModified`, `originDeviceId`,
+  system fields). Encoded-`Data` fields (`strategyData`, trigger/schedule blobs) compare
+  by **decoded semantic value** where a decoder exists, else by bytes — byte-comparison
+  across mixed app builds can demote branch-0 no-ops to branch-E conflict noise (bounded,
+  non-destructive; noted). Metadata never participates in conflict decisions
+  (materialization stamps `lastModified = Date()`, `originDeviceId = self` —
+  `SyncModels.swift:276-277`).
+- **Deleted:** `pullProfiles`, `pullLocations`, `pullResetRequests`,
+  `pullProfileSessionRecords`, `pullEmergencySettings`, `performFullSync`,
+  `deleteAllSyncedData`, `handleRemoteNotification` + throttle, `pushLocalData`,
+  `didRequestLocalDataPush`, deletion reconciliation (both handlers), the
+  `SyncResetRequest` consume/GC logic, `resetSync`'s wipe, `handleSessionSync`'s
+  `.notFound → stopRemoteSession` branch (§6), and the **own-origin apply skip**
+  (`if syncedProfile.originDeviceId == deviceId { continue }`,
+  `SyncCoordinator.swift:117`) — under version-ruled applies an own echo is an
+  equal-version payload-equal no-op, while keeping the skip silently breaks
+  restore-from-backup healing (round-3 finding; test S-31). The session-side
+  `lastModifiedBy` filter in `applySessionState` stays (it prevents acting on own session
+  writes — different mechanism, not absence-based). **No CKQuery remains in the
+  private-DB sync path** (I5).
+
+### 2.1 Persisted state
+
+All keys per-`userRecordID` (§7), new unless marked, compound updates under
+`SharedData.withLock`:
+
+| Key | Type | Provenance | Written by | Purpose |
+|---|---|---|---|---|
+| `engineState[user]` | `Data` (`State.Serialization`) | new | `stateUpdate` (§5.0) | engine tokens + pending queues |
+| `systemFields[user]` | `[recordName: Data]`, **`SyncedProfile`/`SyncedLocation`/`SyncedEmergencySettings` records only, written only on successful apply/sent-save** (§5.1/§5.3) | new | sent saves; fetched modifications *after* durable apply | change-tag-correct saves. Never stores `ProfileSession` (SessionSyncService owns its CAS cache) or `SyncResetRequest` (never re-sent after supersession) — round-3 finding |
+| `processedResetCommandIds[user]` | `Set<UUID>` | new | §8.3 / §8.1 step 1 | identity idempotency; never pruned |
+| `resetIntent[user]` | `{id, clear, stage ∈ .deleting/.recreating/.seeding, priorCommandId?}` | new | origin reset machine (§8.1); cleared by completion, T6, T11 (abandonment also dequeues its zone changes) | crash-resumable origin reset |
+| `lastAppliedResetCommandId[user]` | `UUID?` | new | §8.3 step 3 (every applied or self-marked command); §8.1 step 1 (own id) | defined provenance for `priorCommandId` snapshots |
+| `pendingSeedIntent[user]` | `Bool` | new | every I11 entry point | crash-durable seeding; cleared only per I11's observable rule |
+| `deleteTombstones[user]` | `[recordName: changeTag?]` | new | funnel delete path (§2) | crash-durable local deletion intent + verify tag; cleared per I12; **survives T11** |
+| `failedApplies[user]` | `Set<{recordName, recordType, op}>` | new | §5.1/§5.2 apply-failure catch | retry carrier for thrown applies (the engine never redelivers); replayed at launch and after each fetch (§5.6) |
+| `legacyCleanupDone[user]` | `Bool` | new (pattern: `legacyCleanupKey(for:)`) | §11 one-shot, set when `legacyCleanupIds` empties | idempotency flag for the legacy-cleanup exception |
+| `legacyCleanupIds[user]` | `Set<recordName>` | new | §11 one-shot: written durably in the handler that identifies legacy records from the first-bootstrap fetch (§5.0); per-id cleared on §5.3 confirmation (deletedRecordIDs / U-delete / branch F) | implementable carrier for the strip/§5.4 exemptions (pending changes carry no recordType) and for re-enqueueing after a kill |
+| `syncEnabled` | `Bool` | existing | UI toggle | engine start/stop |
+
+## 3. Invariants (normative)
+
+- **I1 — No inferred destruction.** Local synced entities are deleted, selections
+  cleared, or sessions stopped only by (a) explicit fetched events naming them, (b) a
+  current-incarnation command with the flag (§8.3), or (c) direct user action. Zone
+  deletions, empty fetches, account changes, token resets, and record absence never
+  destroy anything. **Corollary (round-3): no *outbound* delete is ever enqueued from
+  inferred state either — only the funnel (user intent), I12 tombstone recovery, and the
+  §11 legacy-cleanup one-shot (scoped to `recordType == LegacySyncedSession`) produce
+  `.deleteRecord` changes. (§5.6's `.delete` path is a *local* apply of an explicit
+  fetched event; it never enqueues an outbound delete.)**
+- **I2 — Single funnel for locally-originated mutations.** Every locally-originated
+  mutation flows through `MutationFunnel` (bump/tombstone + enqueue in one operation).
+  Remote applies write versions verbatim and never bump/enqueue, **except** the
+  enumerated conflict sites: the I9 auto-heal re-push, the §5.1 equal-version
+  payload-differing rule, and the §5.3 branch-E re-add. Exclusivity: CI/grep — for data
+  entities, `state.add(pendingRecordZoneChanges:` appears only in `MutationFunnel`, the
+  §5.3 re-add sites, the §5.1 conflict-bump site, I11/I12 recovery, §8.1 step 4 (command
+  record), and the §11 legacy-cleanup one-shot (§5.6 never enqueues — its `.delete` path
+  is a local apply). Tests S-15, S-27.
+- **I3 — Command idempotency by identity** (no date arithmetic in idempotency/safety).
+- **I4 — Apply-before-mark** for command application (§8.3); origin pre-mark carve-out
+  (§8.1 step 1) is safe via §8.3's independent `originDeviceId == self` check.
+- **I5 — No queries** in the private-DB sync path; CI/grep + review.
+- **I6 — Zone events reset bookkeeping, not data:** purge `systemFields[user]`, flush
+  `SessionSyncService`'s cache. Local entities, tombstones, processed ids untouched.
+  Account changes purge nothing (§7).
+- **I7 — Engine state is authoritative for the queue.** Seeding only on I11 transitions;
+  ordinary relaunch enqueues nothing except I11/I12 *recovery* of persisted intents
+  (S-19 scoped accordingly).
+- **I8 — Conflicts merge, never drop silently.** Every failed save-or-delete outcome
+  lands in exactly one §5.3 branch: adopt (branch 0, or branch C's server-wins merge) /
+  re-enqueue (local-wins, Z, U-save, R) / re-enqueue-with-bump-and-surface (branch E) /
+  skip-for-pending-delete (branch C, tombstoned id) / remove (F: surfaced; U-delete:
+  silent, already satisfied). Payload-equal collisions are silent by design. Tests S-10,
+  S-17, S-23.
+- **I9 — Schema-version gate preserved** (fetch-apply and `serverRecordChanged`): newer
+  schema ⇒ mark-read-only, never clobber; older ⇒ reject + auto-heal via I2. Test S-18.
+- **I10 — Context-gated engine.**
+- **I11 — (Re)creating the zone implies re-seeding, crash-durably.** Entry points: T1
+  first bootstrap; T5; §8.1 step 4; §8.3; §5.3 branch Z. Each **first persists
+  `pendingSeedIntent`** (same `withLock` scope as whatever consumes its trigger), then
+  enqueues `saveZone` + save-all-restorable (profiles excluding `isNewerSchemaVersion`;
+  locations; the emergency-settings record; not sessions — §6/N13). **Clearing is an
+  optimization and uses only observable signals:** clear after (a) every seed-batch
+  change has been observed sent (§5.3/§5.5 saved) or terminally resolved (§5.3 branches
+  F/U, §5.4 removal) **and** (b) at least one `stateUpdate` has been persisted after (a).
+  A kill at any point leaves the intent set; launch with it set re-runs purge + seed
+  (idempotent — the engine deduplicates pending changes; collisions no-op via §5.3
+  branch 0). Never cleared on an assumption about serialization capture (round-3: that
+  property is not granted — see §1.1). Tests S-8, S-19, S-28.
+- **I12 — Delete tombstones carry deletion intent to completion.** Written (with the
+  record's last-known server change tag) by the funnel delete path (§2). **Recovery** at
+  controller start (mid-session I6 events need none: a live process's pending deletes
+  survive the purge — I6 touches `systemFields`/session cache only), for each tombstoned
+  id with no pending `.deleteRecord`:
+  - entity still present locally ⇒ the local delete never completed — **abort**: clear
+    the tombstone, enqueue nothing, log (fail-toward-keep, E-3; the UI reported the
+    delete failed and the entity is still the user's);
+  - entity absent, **fresh intent** (tombstone written by the current process instance)
+    ⇒ enqueue the delete;
+  - entity absent, **recovered intent** (any tombstone found at controller start) ⇒
+    **verify-before-delete**: fetch the record by `CKRecord.ID` (a record fetch, not a
+    query — I5-compatible): absent ⇒ intent already complete, clear; present with
+    matching stored change tag ⇒ enqueue the delete; present with a different tag or no
+    stored tag ⇒ re-adopted since this device's state was snapshotted (e.g. an N9/N5
+    re-seed) — clear the tombstone, surface a conflict entry, **do not delete**;
+    `zoneNotFound` or transient fetch error ⇒ keep the tombstone; the retry re-runs on the
+    §5.6 cadence within the session (recovery is *initiated* at controller start; its
+    retries are not start-only) — never silently drop a genuine intent. Change tags are
+    server-assigned — clock-immune. The verify is advisory (CloudKit deletes are
+    unconditional by recordID): its residual window equals the ordinary fresh-intent
+    delete-vs-edit race, because a *true re-adoption* requires the prior deletion to
+    have completed, which forces absent-or-different-tag at verify time.
+  **Cleared when:** confirmed (§5.3 `deletedRecordIDs`); terminally resolved (U-delete);
+  a fetched deletion for the id arrives first (§5.2 — intent satisfied); permanently
+  abandoned (branch F, surfaced); or recovery aborts it (entity-present / re-adopted).
+  **At controller start, in the same synchronous main-actor region as engine init
+  (AB-4; containment nets per §1.1 if it ever fails), the strip removes ALL pending
+  `.deleteRecord`s (except `legacyCleanupIds` members) AND all pending database changes
+  (`deleteZone`/`saveZone`) from the restored engine state** — a
+  restored serialization may be a backup-consistent stale pair, and database changes
+  have no delegate chokepoint gating their send (round-6: an orphaned restored
+  `deleteZone` would replay a zone reset with no command ever published). Record deletes
+  are then re-enqueued only via the recovery case-split above; zone changes only via
+  `resetIntent` stage resume (§8.1) after its gate passes or via I11 seeding's
+  `saveZone` (a zone *save* is idempotent and harmless to replay; only `deleteZone` is
+  intent-gated) — `resetIntent` is the sole source of truth for **zone** changes, tombstones for record
+  **deletes**, and `pendingSeedIntent`/funnel state for record **saves** (each intent
+  class re-derives exactly its own stripped changes). Tombstones are the sole source of truth for deletes; §5.4
+  additionally refuses to materialize any `.deleteRecord` without a live tombstone
+  (exempting §11 legacy cleanup). Tombstones survive
+  T11 and account switches (per-user). The v3 §5.6 absence-sweep is **deleted** — it was
+  inference. Tests S-29, S-32, S-33.
+
+## 4. State machine
+
+States: `Disabled` → `Bootstrapping` → `Steady`; `OriginReset(stage)`; `Purged`.
+
+| # | From | Event | To | Actions |
+|---|------|-------|----|---------|
+| T1 | Disabled | sync enabled (toggle or launch with `syncEnabled`) | Bootstrapping | create controller (I10); **init engine with `engineState[user]`, then in the same synchronous main-actor region strip all restored pending `.deleteRecord`s (except `legacyCleanupIds`) AND all pending database changes (I12, AB-4)**; then: I12 verify-and-re-enqueue recovery; §5.6 retry; re-enqueue remaining `legacyCleanupIds` if flag unset (§11); **at most one of**: `engineState[user] == nil` ⇒ set `pendingSeedIntent` then I11 seed, else `pendingSeedIntent[user]` set ⇒ re-run I6 purge + I11 seed (crash recovery), else no seed (ordinary relaunch, S-19); iff `resetIntent[user]` set ⇒ resume per §8.1 from `stage` (`.deleting` runs the gate first); `fetchChanges()` (scheduled outside any handler) |
+| T2 | Bootstrapping | `didFetchChanges` | Steady | none |
+| T3 | any enabled | `fetchedRecordZoneChanges` | same | §5.1/§5.2 |
+| T4 | any enabled | `sentRecordZoneChanges` | same | §5.3 |
+| T4b | any enabled | `sentDatabaseChanges` | same | §5.5 |
+| T5 | any enabled | **DeviceSync**-zone deletion `.deleted`/`.encryptedDataReset` | same | I6 purge; I11 seed (intent-first). No dedicated resume state; `pendingSeedIntent` + §8.3 cover kills |
+| T6 | any enabled | **DeviceSync**-zone deletion `.purged` | Purged | I6 purge; discard `engineState[user]`; clear `resetIntent` + `pendingSeedIntent` (tombstones survive — deletion intent is not consent-scoped); `syncEnabled = false`; one-time notice. Explicit re-enable = fresh consent → T1 |
+| T7 | any | `accountChange` | Disabled → T1 for new user if enabled | stop engine; **invalidate in-flight async continuations** (I12 verifies, §5.6 refetches — each re-checks the active namespace + enabled flag before acting); purge nothing; switch namespace (N11) |
+| T8 | Steady | user taps Reset Sync | OriginReset(.deleting) | §8.1 |
+| T9 | OriginReset(*) | per-stage confirmation | next stage / Steady | §8.1; resume from `stage` at relaunch |
+| T10 | any | `stateUpdate` | same | persist serialization (safe for fetch tokens per AB-2; seed/tombstone intents do **not** key off this — I11/I12) |
+| T11 | any enabled | sync disabled | Disabled | clear `resetIntent` + dequeue its zone changes **first**, and clear `pendingSeedIntent`; then best-effort final `sendChanges()` (an N5 mitigation for pending record saves, never for mid-reset zone ops); stop engine; invalidate in-flight async continuations (as T7); discard `engineState[user]` (pending unsent **saves** lost — N5); **`deleteTombstones` survive** — local deletions re-propagate at re-enable via I12 |
+
+Notes: `didFetchChanges` after T2 recurs on every fetch cycle — it drives the §5.6
+retry sweep and the echo-guard drain check (no dedicated T-row; handled in §5.1/§5.6
+prose). T3/T4/T4b's "same" refers to the top-level state only — `resetIntent.stage`
+progression (T9/§8.1) is an orthogonal dimension evaluated inside the same handlers.
+T5 *may* fire on the origin too (its own zone deletion echoing back — engine behaviour
+not in the AB list and deliberately not relied on either way): if it does, it is a safe
+duplicate of the in-flight §8.1 sequence — purge is idempotent, seed collisions no-op
+via branch 0; if it does not, §8.1's own steps perform the same actions.
+`syncEnabled` is deliberately **global** (pre-existing single key, not per-account): T7's
+"if enabled" reads it; a user who enabled sync keeps it enabled across account switches.
+
+## 5. Event handling contract
+
+### 5.0 Durability ordering
+
+Within `handleEvent`, applies (SwiftData saves, `systemFields` writes conditional on
+those saves, processed-id marks, intent writes) complete before the handler returns.
+`stateUpdate` serializations are persisted in their handler (safe for fetch progress per
+AB-2). Seed/tombstone intents never rely on serialization capture (I11/I12).
+
+### 5.1 Fetched modifications
+
+Route by `recordType`: `SyncedProfile` → profile upsert (incl. `needsAppSelection =
+true` on create — E-1 semantics preserved verbatim); `SyncedLocation` → location
+upsert (client-clock merge kept verbatim; N6); `ProfileSession` → `applySessionState`;
+`SyncedEmergencySettings` → versioned apply; `SyncResetRequest` → §8.3;
+`LegacySyncedSession` (while `legacyCleanupDone` unset — state-independent, any fetch
+cycle) → record its id into `legacyCleanupIds` + enqueue its delete (§11) — never
+applied locally.
+Other unknown types **or undecodable payloads**: log, ignore (a known-type record whose payload cannot decode
+— including a command with no readable `requestId` — is inert; it dies with its zone).
+
+Per-type meaning of "version" and "bump" throughout §5.1/§5.3: profiles —
+`syncVersion` / `+= 1`; locations — `updatedAt` ordering / advance-to-now (client clock;
+N6); emergency settings — `emergencySettingsVersion` / `+= 1`. Branch 0/E apply to all
+three.
+
+Amendments and rules (each deliberate, each tested):
+
+- **Own-origin records are applied**, not skipped (§2 deletion list; S-31). Version rules
+  make own echoes no-ops and let a restored-from-backup device heal forward.
+- **Pending-delete-wins:** a modification whose id has a pending `.deleteRecord`, a live
+  tombstone, **or an entry in the in-memory confirmed-delete echo guard** is skipped.
+  The echo guard (`recentlyConfirmedDeletes`, in-memory only) is populated when §5.3
+  `deletedRecordIDs` confirms a delete; a guarded id is skipped **only when the
+  delivering fetch cycle started before the confirmation** (AB-3 delimiters), and the
+  guard drains at the *start* of the first cycle beginning after the confirmation — such
+  a cycle reads post-delete server state, so a modification it delivers is a genuine
+  branch U-save recreation and must apply (round-5: draining at cycle *completion*
+  swallowed exactly those recreations). In-memory suffices: across a relaunch, any fetch
+  re-runs against post-delete state. (S-32, S-34.)
+- **Equal-version divergence:** incoming version == local, not payload-equal ⇒ conflict
+  now: bump (`syncVersion += 1`), enqueue, surface a conflict entry (I2 exception).
+  Payload-equal ⇒ no-op.
+- **`systemFields` are stored only after the entity's durable local apply succeeds**, and
+  only for `SyncedProfile`/`SyncedLocation`/`SyncedEmergencySettings` (§2.1; round-3:
+  unconditional storage armed the deleted sweep's false positives). Test S-30.
+- **Apply failures roll back their context** (no dirty state survives a thrown apply;
+  §2) **and are persisted for retry (§5.6):** if an apply throws, record
+  `{recordName, recordType, .upsert}` into `failedApplies[user]` in the same handler —
+  the engine never redelivers, so "heals via a later fetch" is false for a record that
+  never changes again (round-4). Same rule in §5.2 for thrown deletion applies
+  (`.delete`).
+
+### 5.2 Fetched deletions
+
+The only remote-driven local deletion path (I1). By `recordType`: profile → delete
+local; location → delete local; `ProfileSession` → stop matching remote-started session
+(#203); command/legacy/unknown → no-op. Absent locally → no-op. Drop the `systemFields`
+entry; clear a matching tombstone **and `state.remove` any pending `.deleteRecord(id)`**
+(the deletion happened — intent satisfied; an orphaned outbound delete would later kill
+a branch U-save recreation; round-5); if a pending save exists with no local entity,
+`state.remove` it (§5.4).
+
+### 5.3 Sent record changes
+
+`savedRecords` → update `systemFields` (scoped types only). `deletedRecordIDs` → drop
+`systemFields` entries **and clear matching tombstones** (I12).
+
+The engine does not retain failed changes; the app re-adds them. Branches (named to
+avoid ordinal collisions — round-3 nit):
+
+- **Branch C (`.serverRecordChanged`):** `SyncResetRequest` conflicts are handled
+  entirely by §8.1 step 5, never here (commands have no version field). For data
+  records: unless the tombstoned sub-branch applies (then store nothing), store
+  `error.serverRecord`'s system fields first (scoped types); merge via §5.1 rules
+  (no-op on local fields when local is strictly newer; I9 applies); then exactly one of:
+  - **branch 0** — equal version, payload-equal: adopt server tag; no re-add; silent;
+  - server strictly newer: merged; no re-add;
+  - local strictly newer: re-add `.saveRecord(id)`;
+  - **branch E** — equal version, payload-differing: bump (per-type, §5.1), re-add,
+    surface a conflict entry. One loser per server round; converges;
+  - **tombstoned / pending-delete id:** skip the merge (§5.1 pending-delete-wins), store
+    nothing, re-add nothing — the pending `.deleteRecord` carries the intent.
+- **Branch Z (`.zoneNotFound`):** enqueue `saveZone`; I11 seed (intent-first); re-add
+  the failed change — saves and deletes alike (a re-added delete resolves via branch
+  U-delete after recreation, clearing its tombstone). (`zoneNotFound` is authoritative;
+  transient errors surface as branch R codes.)
+- **Branch U-save (`.unknownItem` on save):** drop the `systemFields` entry; re-add as
+  create. A fetched deletion arriving first wins (§5.2/§5.4). Reverse ordering: N12.
+- **Branch U-delete (`.unknownItem` on delete):** done; drop the `systemFields` entry
+  **and clear the tombstone** (round-3: otherwise the id re-enqueues every launch).
+- **Branch R (retriable):** re-add once per failure event (honour `retryAfterSeconds`).
+- **Branch F (non-retriable):** remove permanently; log; surface a conflict entry (I8).
+  For a tombstoned delete, also clear the tombstone (surfaced, not looping).
+
+### 5.4 `nextRecordZoneChangeBatch`
+
+Materialize on cached system fields (fresh if none), filtered by
+`context.options.scope`. Pending save with entity absent locally: **remove it** (a
+pending or tombstoned delete carries the intent; an unmaterializable save must never be
+skip-and-retained). Same removal for pending saves of `isNewerSchemaVersion` profiles.
+**Any `.deleteRecord` without a live tombstone is removed from the pending queue, not
+materialized** (defence in depth for I12's source-of-truth rule; refuse = remove, never
+skip-and-retain; §11 legacy-cleanup deletes exempt).
+
+### 5.5 Sent database changes
+
+`savedZones` → confirmed. `failedZoneSaves`: zone-already-exists class → counts as
+confirmed; retriable → re-add and rely on the engine's own scheduling/backoff for the re-send
+(no explicit `sendChanges()` — it would need `retryAfterSeconds` handling and is a
+latency optimization at best; any explicit request elsewhere is always scheduled in a
+`Task` after the handler returns, never from within `handleEvent` — §1.1 prohibition);
+non-retriable → surface, keep `resetIntent`. `deletedZoneIDs` → confirmed; `failedZoneDeletes` `.zoneNotFound` →
+confirmed; retriable → re-add.
+
+### 5.6 Failed-apply retry
+
+At controller start and after each completed fetch cycle, for each `failedApplies[user]`
+entry, **verify then re-apply** (a persisted failed event is stale evidence and gets the
+same treatment as every other replayed intent):
+- `.delete` ⇒ fetch by `CKRecord.ID`: absent/`.unknownItem` ⇒ apply the local deletion,
+  clear; **present ⇒ the record was re-created since (branch U-save) — drop the entry,
+  do not delete** (round-5);
+- `.upsert` ⇒ fetch by `CKRecord.ID` and re-run the §5.1 apply; clear on success or
+  `.unknownItem`; a retry skipped by pending-delete-wins or the echo guard retains its
+  entry and drains on a later cycle (bounded: the delete confirms → `.unknownItem`, or
+  the guard drains → the apply runs).
+**Supersession rule:** any *successful* §5.1 apply (modification or deletion) for a
+recordName clears that record's `failedApplies` entry — a later explicit event always
+supersedes an older failed one. Entries per-user, `withLock`-updated, bounded by
+distinct failing records. Tests S-35.
+
+## 6. Sessions (CAS coexistence)
+
+Session writes stay on `SessionSyncService`, with one amendment: `stopSession`'s
+`.notFound` branch, when this device believes a session for that profile is (or was)
+active, **writes a stopped record** (create-if-absent, `isActive = false`, fresh
+sequence). **On `serverRecordChanged` during that create** (a concurrent fresh start won
+the race): do not blind-overwrite — refetch; a newer active session supersedes the stale
+stop (treat as `.alreadyStopped`); test S-24 covers both orderings. Session propagation
+is §5.1/§5.2 events only; the `.notFound → stopRemoteSession` polling branch is deleted
+(I1). `SessionSyncService` must (a) flush its cache on I6 (S-20) and (b) treat its first
+CAS save after zone recreation as create-if-absent (S-21). Session records are not in
+the I11 seed set and **never enter `systemFields`** (§2.1); the post-reset
+session-discovery gap is N13.
+
+## 7. Account scoping (D-3)
+
+All §2.1 keys namespaced by `userRecordID.recordName`. `accountChange` stops the engine
+and switches namespace, purging nothing. Tombstones are per-user: a deletion applied
+under account B's namespace clears only B's state, and account A's I12 tombstone
+recovery can only re-enqueue deletes A's *own funnel* recorded — the round-3
+cross-account manufactured delete is impossible (no tombstone, no delete). UUID command ids are
+cross-account-collision-proof. The local data store is account-agnostic — union residual
+N11.
+
+## 8. Reset Sync, re-designed
+
+Reset means: *this device's data becomes the new seed; other devices keep local data,
+optionally clear app selections, and re-upload.* Two redundant carriers: the
+zone-deletion event (T5, fast path) and the command record (§8.3, guaranteed path,
+crash-durable via `pendingSeedIntent`).
+
+### 8.1 Origin sequence (crash-resumable via `resetIntent.stage`)
+
+1. Persist `resetIntent = {id: UUID(), clear: flag, stage: .deleting,
+   priorCommandId: lastAppliedResetCommandId[user]}` (§2.1 — written by §8.3 whenever a
+   command is applied or marked, and by this step for the own id; nil on a family with
+   no reset history known to this device); mark `id` into
+   `processedResetCommandIds` and set `lastAppliedResetCommandId = id` (I4 carve-out).
+2. Enqueue `deleteZone(DeviceSync)`; `sendChanges()`.
+3. On delete confirmed (§5.5; `.zoneNotFound` counts): I6 purge; `stage = .recreating`;
+   enqueue `saveZone`.
+4. On zone-save confirmed (§5.5): `stage = .seeding`; enqueue the command record + I11
+   seed (intent-first).
+5. On the command save confirmed (§5.3 `savedRecords` — the command's tag is **not**
+   stored, §2.1): clear `resetIntent`. On `.serverRecordChanged` for the command save,
+   read `error.serverRecord`: foreign `requestId` ⇒ superseded — drop the pending save,
+   clear `resetIntent`, **surface a conflict entry** (the user's reset did not run —
+   same surfacing as the resume gate's abandon arm); own `requestId` ⇒ the earlier save
+   succeeded — confirmed, clear `resetIntent`; undecodable ⇒ treat as foreign (incl.
+   the surfacing).
+
+Crash at any stage resumes from `stage` (resume re-enqueues; the engine deduplicates) —
+**except**: a resume of stage `.deleting` found at controller start first **fetches the
+command record directly by `CKRecord.ID("sync-reset-command")`** (a record fetch, not a
+query — I5-compatible, and independent of §8.3's processed-guard, so every outcome is
+observable). Total case-split:
+- `requestId == resetIntent.id` ⇒ our command already published — treat as step-5
+  confirmed, clear the intent;
+- `requestId == priorCommandId`, **or no command exists (any snapshot), or the gate
+  fetch returns `zoneNotFound`** ⇒ prior incarnation's state, or a zone that
+  died/was T5-reseeded without a command — ⇒ resume normally (a genuinely newer reset
+  either published a command, hitting the next arm, or is itself mid-`.deleting`, in
+  which case the racing resets serialize at the zone delete/recreate CAS and the command
+  CAS — whichever command publishes last wins, N1/N3);
+- foreign and different from both ⇒ superseded (or a concurrent reset won) ⇒ abandon
+  **and surface to the user** (the requested reset did not run);
+- undecodable ⇒ abandon + surface (mirrors step 5; conservative, and the undecodable
+  command is inert everywhere per B-5);
+- transient fetch error ⇒ keep the intent, retry at next start/§5.6 cadence.
+Zone changes for a resumed stage are re-enqueued only after this gate passes (the T1
+strip removed the restored ones).
+**Abandoning `resetIntent` without completion — here, at step 5 supersession, or at
+T6/T11 — also `state.remove`s any `deleteZone`/`saveZone` database changes it enqueued**
+(round-5: an orphaned restored `deleteZone` otherwise fires with no command ever
+published). A zone-delete confirmation arriving with `resetIntent == nil` is handled as
+T5 (purge + intent-first seed). The residual backup replay when the current command
+matches the snapshot (or none exists) is N14. Failure before step 3 confirms is a no-op.
+
+### 8.2 The command record (fixed name)
+
+One per zone incarnation: `recordType = SyncResetRequest`,
+`recordName = "sync-reset-command"`, fields as today. Supersession is a
+server-serialized CAS; no multi-command ordering exists; never stored in `systemFields`.
+
+### 8.3 Command application (any device)
+
+On a fetched modification of the command record: **always set
+`lastAppliedResetCommandId = requestId` first** (the fetched fixed-name record is by
+definition the current incarnation's command; stale redelivery is unreachable under the
+engine's token model). Then: `requestId ∈ processed` → ignore; `originDeviceId == self`
+→ mark, ignore; else, in order:
+1. persist `pendingSeedIntent`;
+2. if `clearRemoteAppSelections`, clear selections on all local profiles and save;
+   regardless of the flag, I6 purge + I11 seed (the redundant re-seed carrier);
+3. mark `requestId` processed and set `lastAppliedResetCommandId[user] = requestId`
+   (I4; §2.1 provenance).
+A kill anywhere is recovered: before step 3, the command redelivers and re-applies
+idempotently; after step 3, `pendingSeedIntent` re-runs purge + seed at launch.
+Re-seeding after T5 already ran is idempotent (branch 0).
+
+### 8.4 Non-origin zone-deletion handling (T5)
+
+Keep all local data (I1); I6 purge; I11 seed (intent-first). No dedicated resume state.
+If the origin died at `.deleting` and no command exists: the first T5 observer's seed
+recreates the zone; devices that saw neither signal self-heal via §5.3 branch Z on their
+next local edit — residual N7.
+
+### 8.5 Product decisions (deliberate, no live users)
+
+- The origin no longer clears its own selections (resolves E-2 per shipped alert copy).
+- `.purged` disables sync instead of re-seeding (T6).
+
+## 9. What replaces the old guards
+
+| Old mechanism | Fate |
+|---|---|
+| Deletion reconciliation (profiles + locations) | deleted; §5.2 explicit events |
+| `remoteIds.isEmpty` guard | deleted |
+| `syncVersion > 0` deletion eligibility | deleted; `syncVersion` = merge ordering only, funnel-bumped |
+| `pushProfile` version increment | moved into `MutationFunnel` (I2) |
+| Own-origin apply skip (`SyncCoordinator.swift:117`) | deleted (§2, S-31); version rules subsume it |
+| 5-min notification throttle | deleted (#200) |
+| `SyncResetRequest` consume/skip/GC | fixed-name command + identity application (§8.2/8.3) |
+| Blanket every-pass `pushLocalData` | deleted; I11 transitions only (S-19) |
+| `handleSessionSync` `.notFound→stop` | deleted (§6); `stopSession` `.notFound` writes a stopped record |
+| v3 §5.6 absence sweep | deleted; replaced by I12 delete-intent tombstones |
+| Legacy subscription + `LegacySyncedSession` cleanup | one-shot at first bootstrap |
+
+## 10. Named test scenarios (implementation must ship these)
+
+Mocked engine protocol + `TestModelContainer`; pinned `now` where dates appear.
+
+- **S-1** fetched deletion deletes exactly that local profile; clears tombstone if one
+  matches (E-4, I12).
+- **S-2** empty fetch ⇒ zero local mutations.
+- **S-3** zone deletion `.deleted` ⇒ data intact; purge; intent-first seed (T5).
+- **S-4** `.purged` ⇒ data intact; sync disabled; engine state discarded;
+  `resetIntent == nil ∧ pendingSeedIntent == nil`; tombstones intact; nothing enqueued.
+- **S-5** command applied once; same-id redelivery no-op (I3).
+- **S-6** kill between apply and mark ⇒ idempotent re-apply (I4).
+- **S-7** controller cannot exist without a context (I10); applies durable in-event.
+- **S-8** command application: purge + seed regardless of clear flag; order
+  intent → apply → mark (§8.3).
+- **S-9** own-origin command ⇒ marked, never applied; origin pre-mark (§8.1 step 1).
+- **S-10** branch C (I8): tag stored first (scoped types); branch 0 adopt-silent;
+  server-wins; local-wins re-add; branch E bump + re-add + conflict entry; re-sent save
+  carries the fresh tag; I9 through this path (with S-18).
+- **S-11** branch Z ⇒ saveZone + intent-first seed + change re-added.
+- **S-12** account switch ⇒ neither namespace purged; switch-back resumes (T7/§7).
+- **S-13** origin resume from each stage; command-save `serverRecordChanged` with
+  foreign / own / undecodable `serverRecord` (§8.1 step 5).
+- **S-14** newer-schema profile: never enqueued; stray pending save removed; fetched
+  deletion still applies.
+- **S-15** funnel save path bumps version in the same write, enqueues exactly once;
+  failed write ⇒ no bump, no enqueue. Funnel delete path writes the tombstone (with
+  change tag) in the same `withLock` scope, enqueues exactly once; **failed entity
+  delete ⇒ tombstone removed before returning, nothing enqueued** (I2, I12).
+- **S-16** edit round-trip: funnel-bumped edit on A applies on B; an edit bypassing the
+  funnel (no bump) must not propagate — the locked-in regression.
+- **S-17** branch R re-added exactly once per failure event; branch F removed + conflict
+  entry (+ tombstone cleared for deletes); no loop (I8).
+- **S-18** schema-version gate (I9): fetch-apply and branch C.
+- **S-19** relaunch with existing `engineState`, `resetIntent == nil`,
+  `pendingSeedIntent == nil`, no tombstones ⇒ zero enqueues (I7/I11/I12).
+- **S-20** I6 flushes session cache. **S-21** first CAS save post-recreation is
+  create-if-absent.
+- **S-22** session stop propagates via fetched modification; session-record absence
+  never stops anything (I1).
+- **S-23** branch U-save ⇒ tag dropped, re-added as create; interleaved fetched deletion
+  wins.
+- **S-24** stop-on-absent creates a stopped record and the mirror stops; on
+  `serverRecordChanged` vs a concurrent fresh start, the stop yields (§6).
+- **S-25** AB-1: `saveZone` sends before seeded record saves.
+- **S-26** AB-2: kill after a `stateUpdate` interleaved between two fetch events ⇒ the
+  second event's changes re-delivered on relaunch.
+- **S-27** fetched modification applied ⇒ zero pending changes, version verbatim (I2);
+  §5.1 equal-version payload-differing ⇒ bump + enqueue + conflict entry; payload-equal
+  ⇒ pure no-op.
+- **S-28** kill after `pendingSeedIntent` persisted, before the observable clear
+  condition ⇒ launch re-runs purge + seed; the intent clears only after every seed change
+  is observed sent/resolved plus one subsequent persisted `stateUpdate` (I11).
+- **S-29** tombstone lifecycle (I12): funnel delete ⇒ tombstone + enqueue; kill before
+  enqueue capture ⇒ launch re-enqueues (fresh-intent path); confirmed delete / U-delete /
+  §5.2 fetched deletion / branch F ⇒ tombstone cleared (no every-launch loop);
+  **negative cases:** session records, the command record, and failed-apply records
+  never produce outbound deletes; tombstone-present + entity-present ⇒ recovery aborts;
+  restored pending deletes stripped at start; §5.4 refuses tombstone-less
+  `.deleteRecord`s (legacy cleanup exempt); recovered-verify transient error ⇒ tombstone
+  kept and retried.
+- **S-30** fetched create whose `context.save()` throws ⇒ no `systemFields` entry, no
+  tombstone, no outbound effect (§5.1).
+- **S-31** own-origin fetched record: newer version applies (restore-from-backup heals);
+  equal-version payload-equal echo is a no-op; branch C with own-origin `serverRecord`
+  merges normally (§2).
+- **S-32** fetched modification for a tombstoned/pending-delete id is skipped
+  (pending-delete-wins, §5.1); the delete then propagates.
+- **S-33** verify-before-delete (I12 recovered intents): recovered tombstone, record
+  absent ⇒ cleared; matching tag ⇒ delete enqueued; different/missing tag ⇒ cleared +
+  conflict entry, no delete (restored-backup replay guard).
+- **S-34** confirmed-delete echo guard: a modification delivered by a cycle that
+  *started before* the confirmation is skipped; one delivered by a cycle started *after*
+  it applies (genuine recreation); the guard drains at that cycle's start (§5.1, AB-3).
+- **S-35** failed-apply retry (§5.6): thrown upsert ⇒ entry ⇒ refetch + re-apply;
+  thrown deletion ⇒ verify-by-fetch — absent ⇒ applied + cleared, **present ⇒ dropped,
+  never deleted**; a later successful apply for the id clears the entry (supersession).
+- **S-36** `.deleting`-stage resume gate (direct record fetch), all five arms: own id ⇒
+  confirmed; == `priorCommandId`, **no command (any snapshot)**, or `zoneNotFound` ⇒
+  resume; foreign ⇒
+  abandoned + surfaced + zone changes dequeued; undecodable ⇒ abandoned + surfaced;
+  transient error ⇒ intent kept, retried. Zone-delete confirmation with
+  `resetIntent == nil` handled as T5 (§8.1).
+- **S-37** AB-3: cycle delimiters observable; `didFetchChanges` implies that cycle's
+  record events were delivered (mocked).
+- **S-38** T1 strip + AB-4 (mocked): no send of restored pending changes occurs between
+  engine init and the end of the strip's synchronous main-actor region; a restored
+  `deleteZone` with `resetIntent == nil` is removed and never sent; zone changes
+  re-enqueue only after the stage gate; `legacyCleanupIds` members survive the strip and
+  re-enqueue while the flag is unset; kill mid-legacy-cleanup ⇒ ids persist and complete
+  on relaunch (§11).
+- **Manual two-device checklist** (in the PR): reset with/without clear-selections;
+  concurrent edit; delete-vs-edit race both orderings; device offline across a reset;
+  token-expired device across a reset; active session across a reset incl.
+  stop-on-absent both orderings; purge; account switch and back; toggle off → local
+  delete → on (delete propagates via tombstone, N5); toggle off → remote delete → on
+  (resurrects, N5); restore-from-backup then edit (S-31 path).
+
+## 11. Migration & rollout
+
+No live users: no compatibility shims. First launch: T1 first bootstrap seeds and
+full-fetches; a legacy random-name `SyncResetRequest` record applies at most once by id
+(§8.3). The **legacy-cleanup one-shot** (gated by `legacyCleanupDone[user]`, §2.1, **set only
+when `legacyCleanupIds` empties** (per-id removal on §5.3 `deletedRecordIDs`/U-delete
+confirmation or a surfaced branch-F abandonment — resolved, not necessarily deleted) —
+so a kill
+before the sends cannot strand the cleanup behind the flag; its pending deletes are
+exempt from the T1 strip and §5.4 **by membership in `legacyCleanupIds`** — pending
+changes carry no recordType, so the persisted id set is the only implementable carrier;
+T1 re-enqueues any remaining ids after the strip while the flag is unset) removes the old
+`device-sync-zone-changes` subscription and deletes `LegacySyncedSession` records — an
+**explicitly enumerated exception** to I1's corollary and I2's grep whitelist, scoped to
+`recordType == LegacySyncedSession`; it identifies the records from the first
+bootstrap's full fetch (no CKQuery — I5 holds). Mixed old/new
+builds unsupported (noted in the PR).
+
+## 12. Honest residuals
+
+- **N1** — a device offline across two back-to-back resets applies only the surviving
+  command (last reset wins).
+- **N2** — `.purged` is observed device-by-device.
+- **N3** — concurrent resets: bounded re-seed churn until the CAS-surviving command
+  settles; branch-0 no-ops; converges. Mixed-build byte-unequal blobs can demote some
+  branch-0 no-ops to branch-E noise (§2 payload equality) — bounded, non-destructive.
+- **N4** — engine scheduler latency is unbounded; nothing lost, immediacy not promised.
+- **N5** — toggle-off/on is union-merge rejoin **for saves**: T11 discards pending
+  unsent *saves* (recovered by the T1 rejoin seed at re-enable), and records deleted
+  *remotely* during the disabled window are re-uploaded by the rejoin seed. Local
+  *deletions* are **not** lost: tombstones survive T11 and re-propagate via I12 at
+  re-enable — as recovered intents they are verify-before-delete'd, so they propagate
+  iff the record was not remotely modified during the disabled window (else: cleared +
+  surfaced, keep-biased). Deliberate keep-biased change from the old rejoin
+  (which pull-reconciled deletions before pushing).
+- **N6** — location merge is client-clock-ordered (inherited; non-destructive; #218/#221).
+- **N7** — origin dead at `.deleting` + nobody observes the deletion + nobody edits ⇒
+  dormant, data intact, until any of those occurs.
+- **N8** — a kill between a funnel **save**-enqueue and its send orphans that enqueue;
+  recovered by the next edit of that entity. **Deletes are exempt** (I12 tombstones).
+- **N9** — any reset resurrects deletions not yet fetched by every device at zone-death
+  (husk family-wide). Precondition: any device lagging a deletion when a reset lands.
+- **N10** — record deletions are unrecoverable across change-token expiry (nil-token
+  refetch cannot express deletions; I1 keeps stale local copies; later seeds can
+  resurrect them as husks). Tombstones do not help — they cover *this device's own*
+  deletions, not un-received foreign ones. Practical bound: token lifetime vs. dormancy.
+- **N11** — the local store is account-agnostic: switching accounts unions data across
+  private DBs over time (pre-existing class; product follow-up if isolation is wanted).
+- **N12** — delete-vs-edit recreation races, both sides: (a) a branch U-save re-created
+  record landing before the deletion event is fetched leaves transient divergence on the
+  re-creating device; (b) on the *deleting* device, a recreation landing between the
+  server-side delete and its confirmation can be delivered by a cycle the echo
+  guard/tombstone still covers and be skipped. Both transient, keep-biased server-side,
+  healed by any later edit/seed of the record (engine self-change redelivery not
+  assumed).
+- **N13** — ongoing sessions' records die with the zone at a reset; mirrors keep running
+  (I1); stops propagate via §6; a device coming online mid-window cannot discover a
+  still-active session until the owner's next CAS write.
+- **N14** — a device restored from a backup taken while an origin `resetIntent` was
+  live can replay that reset: `.deleting` replays iff the gate's fetched command matches
+  `priorCommandId` or none exists (an own-id match is treated as already-completed — no
+  replay); `.recreating`/`.seeding` replay their remaining steps unconditionally,
+  bounded by the command CAS. I.e. replay requires that no newer reset intervened
+  (§8.1 resume rule). Effects are within reset semantics (data survives, N9/N13 apply;
+  selection-clear per the restored flag) but unrequested by any current user.
+  Precondition: backup captured in the intent-live window ∧ restore ∧ no intervening
+  reset. Delete-intent replay from restored backups is, by contrast, **guarded**
+  (verify-before-delete, I12/S-33).
+
+## 13. Out of scope / follow-ups
+
+- Shared-DB FamilyCommand/lock-code channel (B2).
+- #218/#221 merge-policy refinements (incl. N6).
+- `cloudkit-schema.ckdb` drift (pre-existing).
+- Settings sync-section UI beyond §8.5.
+- Account-scoped local data (N11).


### PR DESCRIPTION
## What

Two deliverables for the #267 sync-engine replacement, per the maintainer decision recorded on that issue:

### 1. A1 acceptance corpus (first commit)
- `2026-07-02-reset-sync-a1-acceptance-corpus.md` — canonical catalogue: **47 scenarios** across 5 classes, the vacuous-reconciliation proof, the A1 rev-4 residual table with real preconditions.
- `…-design-rev{1..4}.md` — the four A1 design revisions, each annotated with why adversarial verification broke it.
- `…-interleavings-round{1,2,3}.md` — all **65 A1 verifier findings, verbatim**.

### 2. #267 design (second commit) — **converged**
- `2026-07-02-sync-engine-design.md` — implementation contract: CKSyncEngine transport (decision record + explicit assumption boundary AB-1..AB-4); deletions **only** as explicit fetched events; Reset Sync = zone-delete + fixed-name command record (CAS supersession, identity-keyed idempotency, dual delivery carriers); delete-intent tombstones with verify-before-delete; crash-durable seed intents with observable clearing; 12 invariants; 11-transition state machine; **38 named test scenarios** the implementation must ship; honest residuals N1–N14.
- `2026-07-02-sync-engine-corpus-mapping.md` — normative mapping: every corpus scenario → impossible-by-construction / safe (mechanism named) / residual (honest preconditions). No 'narrow window' verdicts.

## Verification

Nine adversarial rounds, three independent verifier lenses each (interleaving attackers + spec-consistency), fresh agents every round:

| Round | Target | Outcome |
|---|---|---|
| 1–2 | v1–v2 | broke syncVersion ownership, zone-event delivery assumption, background-launch buffering, launch-time seed-all, engine retry retention, zombie commands |
| 3 | v3 | broke the §5.6 absence-sweep (re-imported the corpus root disease via bookkeeping) — replaced with recorded-intent tombstones |
| 4–5 | v4–v5 | broke replay-without-verification (restored backups, failed-apply replays, echo races) — everything replayed is now verified first |
| 6–7 | v6–v7 | liveness/spec gaps (restored database changes, priorCommandId provenance) — closed with symmetric source-of-truth rules |
| 8 | v8 | two SDK-verified API-text defects (init-only `automaticallySync`, fetch/send-in-handler prohibition) — fixed honestly (AB-4 named + mock-tested, containment nets stated) |
| **9** | **v9** | **no breaking interleaving** (both attackers: sound-with-nits); nits fixed editorially |

## Review notes

- Docs only; no code; no build/simulator impact.
- `docs/plans/` is in `.gitignore` — these files were committed via the API like the rest of the repo's plan docs; flag if that ignore entry should change.
- Implementation is a separate session working from this contract (#267 requirement 4: mocked-engine unit tests S-1..S-38 + the manual two-device checklist in §10).

Refs #267 #195 #202 #219 #200 #201 #263