### PR TITLE
Fix B1 lock-code gating audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,13 @@ The app has three operating modes with distinct lock code behaviors:
 | **Parent** | Can SET code | Yes | Yes | No (full access) |
 | **Child** | Synced from parent | Yes | No | Yes (requires code) |
 
+> **Individual → Parent promotion:** an Individual device can set a lock code via the Family
+> Controls Dashboard (the only user-initiated path to Parent — `ModeSelectionView` offers only
+> Individual/Child). Doing so **promotes the device to Parent** in the same action, so the
+> "Individual: Can Create Locked Items = No" invariant holds — a device never persists as
+> Individual *with* a lock code. The `setLockCode` guard therefore stays `!= .child` (not
+> `== .parent`), otherwise the promotion would deadlock.
+
 ### Critical Rule for Lock Checks
 
 When checking if lock code restrictions apply:

--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -109,11 +109,11 @@ class CloudKitManager: ObservableObject {
     return codes
   }
 
-  func fetchSharedLockCodes() async throws -> [FamilyLockCode] {
+  func fetchSharedLockCodes() async throws -> (codes: [FamilyLockCode], isConnected: Bool) {
     let result = try await networkService.fetchSharedLockCodes()
     self.isConnectedToFamily = result.isConnected
     self.sharedLockCodes = result.codes
-    return result.codes
+    return result
   }
 
   // MARK: - Family Commands

--- a/Foqos/CloudKit/CloudKitNetworkService+LockCodes.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+LockCodes.swift
@@ -120,6 +120,9 @@ extension CloudKitNetworkService {
     } catch {
       Log.error(
         "Failed to fetch lock codes from zone \(zone.zoneID): \(error)", category: .cloudKit)
+      // A CKError here means we could not read the family data — report DISCONNECTED so the
+      // caller preserves the last-synced cache instead of treating [] as "parent cleared" (#197).
+      return (codes: [], isConnected: false)
     }
 
     return (codes: codes, isConnected: true)

--- a/Foqos/CloudKit/CloudKitNetworkService+LockCodes.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+LockCodes.swift
@@ -120,7 +120,12 @@ extension CloudKitNetworkService {
       for (_, result) in results {
         switch result {
         case .success(let record):
-          guard let code = FamilyLockCode(from: record) else { continue }
+          guard let code = FamilyLockCode(from: record) else {
+            Log.error(
+              "Failed to decode lock code record from zone \(zone.zoneID)",
+              category: .cloudKit)
+            return Self.resolveSharedLockCodeFetch(codes: [], hasRecordFailures: true)
+          }
           codes.append(code)
         case .failure(let error):
           Log.error(

--- a/Foqos/CloudKit/CloudKitNetworkService+LockCodes.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+LockCodes.swift
@@ -5,6 +5,13 @@ extension CloudKitNetworkService {
 
   // MARK: - Lock Code Management
 
+  static func resolveSharedLockCodeFetch(
+    codes: [FamilyLockCode],
+    hasRecordFailures: Bool
+  ) -> (codes: [FamilyLockCode], isConnected: Bool) {
+    hasRecordFailures ? (codes: [], isConnected: false) : (codes: codes, isConnected: true)
+  }
+
   func saveLockCode(_ lockCode: FamilyLockCode) async throws {
     Log.info("Saving lock code", category: .cloudKit)
 
@@ -111,10 +118,15 @@ extension CloudKitNetworkService {
       )
 
       for (_, result) in results {
-        if case .success(let record) = result,
-          let code = FamilyLockCode(from: record)
-        {
+        switch result {
+        case .success(let record):
+          guard let code = FamilyLockCode(from: record) else { continue }
           codes.append(code)
+        case .failure(let error):
+          Log.error(
+            "Failed to fetch lock code record from zone \(zone.zoneID): \(error)",
+            category: .cloudKit)
+          return Self.resolveSharedLockCodeFetch(codes: [], hasRecordFailures: true)
         }
       }
     } catch {
@@ -125,7 +137,7 @@ extension CloudKitNetworkService {
       return (codes: [], isConnected: false)
     }
 
-    return (codes: codes, isConnected: true)
+    return Self.resolveSharedLockCodeFetch(codes: codes, hasRecordFailures: false)
   }
 
   /// Delete family sharing data from the FamilyPolicies zone.

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -534,12 +534,8 @@ func completeShareAcceptance(metadata: CKShare.Metadata, role: FamilyRole) {
     }
 
     // 4. Best-effort: fetch shared lock codes
-    do {
-      _ = try await CloudKitManager.shared.fetchSharedLockCodes()
-    } catch {
-      Log.error(
-        "Failed to fetch shared lock codes: \(error.localizedDescription)",
-        category: .cloudKit)
+    if appMode == .child {
+      await LockCodeManager.shared.refreshSharedLockCodesForVerification()
     }
 
     // 5. Show role-specific success message

--- a/Foqos/Models/AppMode.swift
+++ b/Foqos/Models/AppMode.swift
@@ -87,7 +87,7 @@ class AppModeManager: ObservableObject {
   /// The mode a device should switch to after successfully setting its first lock code.
   /// Individual devices become Parent (a lock code makes this a parent device);
   /// Parent and Child devices are unchanged. Returns nil when no switch is needed.
-  static func modeAfterSettingLockCode(from currentMode: AppMode) -> AppMode? {
+  nonisolated static func modeAfterSettingLockCode(from currentMode: AppMode) -> AppMode? {
     currentMode == .individual ? .parent : nil
   }
 

--- a/Foqos/Models/AppMode.swift
+++ b/Foqos/Models/AppMode.swift
@@ -84,6 +84,13 @@ class AppModeManager: ObservableObject {
     hasSelectedMode = true
   }
 
+  /// The mode a device should switch to after successfully setting its first lock code.
+  /// Individual devices become Parent (a lock code makes this a parent device);
+  /// Parent and Child devices are unchanged. Returns nil when no switch is needed.
+  static func modeAfterSettingLockCode(from currentMode: AppMode) -> AppMode? {
+    currentMode == .individual ? .parent : nil
+  }
+
   /// Returns true if the current mode allows creating/editing personal profiles
   var canCreateProfiles: Bool {
     currentMode == .individual || currentMode == .parent

--- a/Foqos/Models/SavedLocation.swift
+++ b/Foqos/Models/SavedLocation.swift
@@ -113,8 +113,8 @@ class SavedLocation {
 
   /// Whether modifying (editing or deleting) this location must be gated behind the
   /// parent lock code. Only Child mode is blocked by locked items (AGENTS.md mode table).
-  func requiresLockCodeToModify(mode: AppMode) -> Bool {
-    isLocked && mode == .child
+  func requiresLockCodeToModify(mode: AppMode, canVerifyCode: Bool) -> Bool {
+    isLocked && mode == .child && canVerifyCode
   }
 
   // MARK: - Radius Steps

--- a/Foqos/Models/SavedLocation.swift
+++ b/Foqos/Models/SavedLocation.swift
@@ -111,6 +111,12 @@ class SavedLocation {
     try context.save()
   }
 
+  /// Whether modifying (editing or deleting) this location must be gated behind the
+  /// parent lock code. Only Child mode is blocked by locked items (AGENTS.md mode table).
+  func requiresLockCodeToModify(mode: AppMode) -> Bool {
+    isLocked && mode == .child
+  }
+
   // MARK: - Radius Steps
 
   /// Radius steps for the slider (in meters)

--- a/Foqos/Utils/LockCodeManager.swift
+++ b/Foqos/Utils/LockCodeManager.swift
@@ -59,7 +59,7 @@ class LockCodeManager: ObservableObject {
       await fetchLockCodes()
     case .child:
       // Children need to fetch shared lock codes for verification
-      await fetchSharedLockCodes()
+      await refreshSharedLockCodesForVerification()
     }
   }
 
@@ -176,7 +176,7 @@ class LockCodeManager: ObservableObject {
 
   /// Fetch shared lock codes for verification (child operation)
   /// Verifies child authorization before fetching to ensure security
-  private func fetchSharedLockCodes() async {
+  func refreshSharedLockCodesForVerification() async {
     guard appModeManager.currentMode == .child else { return }
 
     isLoading = true

--- a/Foqos/Utils/LockCodeManager.swift
+++ b/Foqos/Utils/LockCodeManager.swift
@@ -194,13 +194,13 @@ class LockCodeManager: ObservableObject {
     }
 
     do {
-      let codes = try await cloudKitManager.fetchSharedLockCodes()
+      let result = try await cloudKitManager.fetchSharedLockCodes()
       // Fail-closed-with-cache (#197): trust a CONNECTED result (even empty = parent cleared)
       // and persist it; on a disconnected/failed fetch keep the last-synced cached codes so
       // verification still works offline and the lock never fails open.
       let resolved = Self.resolveLockCodes(
-        fetched: codes,
-        isConnected: cloudKitManager.isConnectedToFamily,
+        fetched: result.codes,
+        isConnected: result.isConnected,
         persisted: loadPersistedLockCodes()
       )
       self.cachedLockCodes = resolved.cache

--- a/Foqos/Utils/LockCodeManager.swift
+++ b/Foqos/Utils/LockCodeManager.swift
@@ -35,6 +35,7 @@ class LockCodeManager: ObservableObject {
     self.appModeManager = appModeManager
     setupBindings()
     loadThrottleState()
+    cachedLockCodes = loadPersistedLockCodes()
   }
 
   // MARK: - Setup
@@ -194,17 +195,43 @@ class LockCodeManager: ObservableObject {
 
     do {
       let codes = try await cloudKitManager.fetchSharedLockCodes()
-      self.cachedLockCodes = codes
+      // Fail-closed-with-cache (#197): trust a CONNECTED result (even empty = parent cleared)
+      // and persist it; on a disconnected/failed fetch keep the last-synced cached codes so
+      // verification still works offline and the lock never fails open.
+      let resolved = Self.resolveLockCodes(
+        fetched: codes,
+        isConnected: cloudKitManager.isConnectedToFamily,
+        persisted: loadPersistedLockCodes()
+      )
+      self.cachedLockCodes = resolved.cache
+      persistLockCodes(resolved.persist)
       self.error = nil
 
       // Also check for pending commands from parent
       await processPendingCommands()
     } catch {
+      // Defensive: the network layer returns empty without throwing for offline/CKError, but
+      // if it ever does throw, keep the last-synced codes rather than falling back to empty.
+      self.cachedLockCodes = loadPersistedLockCodes()
       self.error = error.localizedDescription
     }
   }
 
-  /// Pure verification logic — all inputs explicit, no instance state.
+  /// Resolve the verification cache and the persisted store after a fetch (#197).
+  /// A CONNECTED result is trusted and replaces both — even when empty, which is how a
+  /// parent clearing the PIN propagates to the child. A DISCONNECTED result (offline /
+  /// CloudKit error, which the network layer returns as an empty, non-throwing tuple) is
+  /// ignored in favour of the last-synced persisted codes, so the child can still verify
+  /// the cached code offline. The lock only "fails open" when no code was ever synced.
+  static func resolveLockCodes(
+    fetched: [FamilyLockCode],
+    isConnected: Bool,
+    persisted: [FamilyLockCode]
+  ) -> (cache: [FamilyLockCode], persist: [FamilyLockCode]) {
+    isConnected ? (cache: fetched, persist: fetched) : (cache: persisted, persist: persisted)
+  }
+
+  /// Pure verification logic - all inputs explicit, no instance state.
   /// Used directly by tests; the instance method below is a thin wrapper.
   static func verifyCode(
     _ code: String,
@@ -344,6 +371,10 @@ class LockCodeManager: ObservableObject {
     static let lockoutExpiresAt = "family_foqos_lock_code_lockout_expires_at"
   }
 
+  private enum CacheKey {
+    static let childLockCodes = "family_foqos_child_lock_codes"
+  }
+
   /// Throttle schedule: failed attempts -> lockout duration in seconds
   private static let throttleSchedule: [(threshold: Int, duration: TimeInterval)] = [
     (3, 30),  // 30 seconds after 3 failures
@@ -395,6 +426,7 @@ class LockCodeManager: ObservableObject {
   func overrideDefaults(_ defaults: UserDefaults?) {
     throttleDefaults = defaults ?? .standard
     loadThrottleState()
+    cachedLockCodes = loadPersistedLockCodes()
   }
 
   /// Load throttle state from UserDefaults
@@ -419,6 +451,21 @@ class LockCodeManager: ObservableObject {
         lockoutExpiresAt!.timeIntervalSinceReferenceDate,
         forKey: ThrottleKey.lockoutExpiresAt
       )
+    }
+  }
+
+  private func loadPersistedLockCodes() -> [FamilyLockCode] {
+    guard let data = throttleDefaults.data(forKey: CacheKey.childLockCodes),
+      let codes = try? JSONDecoder().decode([FamilyLockCode].self, from: data)
+    else {
+      return []
+    }
+    return codes
+  }
+
+  private func persistLockCodes(_ codes: [FamilyLockCode]) {
+    if let data = try? JSONEncoder().encode(codes) {
+      throttleDefaults.set(data, forKey: CacheKey.childLockCodes)
     }
   }
 }

--- a/Foqos/Utils/ProfileEditGate.swift
+++ b/Foqos/Utils/ProfileEditGate.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Pure decision for whether editing a BlockedProfile's settings should be disabled.
 /// Extracted from BlockedProfileView so it can be unit-tested and reused by every
 /// selector in the form (start/stop triggers, geofence). Only Child mode is blocked by
-/// locks (AGENTS.md mode table): `mode == .child`, never `!= .parent`.
+/// locks (AGENTS.md mode table): use `mode == .child`, never a parent-negative check.
 enum ProfileEditGate {
   static func editingDisabled(
     isBlocking: Bool,

--- a/Foqos/Utils/ProfileEditGate.swift
+++ b/Foqos/Utils/ProfileEditGate.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Pure decision for whether editing a BlockedProfile's settings should be disabled.
+/// Extracted from BlockedProfileView so it can be unit-tested and reused by every
+/// selector in the form (start/stop triggers, geofence). Only Child mode is blocked by
+/// locks (AGENTS.md mode table): `mode == .child`, never `!= .parent`.
+enum ProfileEditGate {
+  static func editingDisabled(
+    isBlocking: Bool,
+    isManaged: Bool,
+    isUnlocked: Bool,
+    mode: AppMode,
+    lockActive: Bool
+  ) -> Bool {
+    isBlocking || (isManaged && !isUnlocked && mode == .child && lockActive)
+  }
+}

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -128,9 +128,13 @@ struct BlockedProfileView: View {
 
   /// Whether editing should be disabled
   private var editingDisabled: Bool {
-    isBlocking
-      || (isManagedProfile && !isUnlockedForEditing && appModeManager.currentMode == .child
-        && lockCodeManager.canVerifyCode)
+    ProfileEditGate.editingDisabled(
+      isBlocking: isBlocking,
+      isManaged: isManagedProfile,
+      isUnlocked: isUnlockedForEditing,
+      mode: appModeManager.currentMode,
+      lockActive: lockCodeManager.canVerifyCode
+    )
   }
 
   /// Whether to show the managed toggle (only in parent mode when lock code exists)
@@ -335,7 +339,7 @@ struct BlockedProfileView: View {
             startNFCTagId: $triggerConfig.startNFCTagId,
             startQRCodeId: $triggerConfig.startQRCodeId,
             startSchedule: $triggerConfig.startSchedule,
-            disabled: isBlocking || (isManagedProfile && !isUnlockedForEditing),
+            disabled: editingDisabled,
             onTriggerChange: {
               triggerConfig.startTriggersDidChange()
             },
@@ -375,7 +379,7 @@ struct BlockedProfileView: View {
             stopQRCodeId: $triggerConfig.stopQRCodeId,
             stopSchedule: $triggerConfig.stopSchedule,
             startTriggers: triggerConfig.startTriggers,
-            disabled: isBlocking || (isManagedProfile && !isUnlockedForEditing),
+            disabled: editingDisabled,
             onConditionChange: {
               triggerConfig.stopConditionsDidChange()
             },

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -365,7 +365,7 @@ struct BlockedProfileView: View {
               geofenceRule: $geofenceRule,
               savedLocations: savedLocations,
               buttonAction: { showingGeofencePicker = true },
-              disabled: isBlocking
+              disabled: editingDisabled
             )
           } header: {
             Text("Location Restrictions")

--- a/Foqos/Views/Child/ChildDashboardView.swift
+++ b/Foqos/Views/Child/ChildDashboardView.swift
@@ -165,13 +165,7 @@ struct ChildDashboardView: View {
     guard !isFetchingLockCodes else { return }
     isFetchingLockCodes = true
     defer { isFetchingLockCodes = false }
-    do {
-      _ = try await cloudKitManager.fetchSharedLockCodes()
-    } catch {
-      Log.error(
-        "Failed to fetch shared lock codes: \(error.localizedDescription)",
-        category: .cloudKit)
-    }
+    await lockCodeManager.refreshSharedLockCodesForVerification()
   }
 
   // MARK: - Sections

--- a/Foqos/Views/Child/ChildDashboardView.swift
+++ b/Foqos/Views/Child/ChildDashboardView.swift
@@ -529,6 +529,8 @@ struct LockCodeEntrySheet: View {
 // MARK: - Edit Locked Profiles Sheet
 
 struct EditLockedProfilesSheet: View {
+  static let lockedProfilesFooter = "Locked profiles require the lock code to edit or delete."
+
   @Environment(\.dismiss) private var dismiss
   @Environment(\.modelContext) private var modelContext
 
@@ -573,7 +575,7 @@ struct EditLockedProfilesSheet: View {
         } header: {
           Text("Select Profiles to Lock")
         } footer: {
-          Text("Locked profiles require the lock code to edit, delete, or stop.")
+          Text(EditLockedProfilesSheet.lockedProfilesFooter)
         }
       }
       .navigationTitle("Edit Locked Profiles")

--- a/Foqos/Views/Child/ChildDashboardView.swift
+++ b/Foqos/Views/Child/ChildDashboardView.swift
@@ -196,7 +196,7 @@ struct ChildDashboardView: View {
 
   private var parentLinkSection: some View {
     let isConnected = cloudKitManager.isConnectedToFamily
-    let hasLockCode = !cloudKitManager.sharedLockCodes.isEmpty
+    let hasLockCode = lockCodeManager.canVerifyCode
 
     return HStack(spacing: 12) {
       Image(systemName: isConnected ? "link.circle.fill" : "link.circle")
@@ -238,7 +238,7 @@ struct ChildDashboardView: View {
   }
 
   private var lockedProfilesSection: some View {
-    let hasLockCodes = !cloudKitManager.sharedLockCodes.isEmpty
+    let hasLockCodes = lockCodeManager.canVerifyCode
 
     return VStack(alignment: .leading, spacing: 12) {
       HStack {
@@ -603,7 +603,7 @@ struct ChildSettingsView: View {
   @State private var showCodeEntry = false
 
   private var hasLockCode: Bool {
-    !cloudKitManager.sharedLockCodes.isEmpty
+    lockCodeManager.canVerifyCode
   }
 
   var body: some View {

--- a/Foqos/Views/Parent/ParentDashboardView.swift
+++ b/Foqos/Views/Parent/ParentDashboardView.swift
@@ -164,7 +164,11 @@ struct ParentDashboardView: View {
           onSave: { code in
             Task {
               do {
+                let previousMode = appModeManager.currentMode
                 try await lockCodeManager.setLockCode(code, scope: .allChildren)
+                if let newMode = AppModeManager.modeAfterSettingLockCode(from: previousMode) {
+                  await MainActor.run { appModeManager.selectMode(newMode) }
+                }
               } catch {
                 await MainActor.run {
                   errorMessage = error.localizedDescription

--- a/Foqos/Views/Parent/ParentDashboardView.swift
+++ b/Foqos/Views/Parent/ParentDashboardView.swift
@@ -52,7 +52,7 @@ struct ParentDashboardView: View {
 
   /// Tier 2: device-local settings enabled after PIN unlock
   /// Controls like emergency settings toggle that are configured on this device
-  /// Independent of iCloud — PIN verification uses cached lock codes that work offline
+  /// Independent of iCloud — PIN verification uses the last-synced lock codes cached on-device
   private var deviceSettingsEnabled: Bool {
     !isChildMode || isDashboardUnlocked
   }

--- a/Foqos/Views/SavedLocationsView.swift
+++ b/Foqos/Views/SavedLocationsView.swift
@@ -18,6 +18,8 @@ struct SavedLocationsView: View {
   @State private var locationToEdit: SavedLocation?
   @State private var showingLockCodeEntry = false
   @State private var pendingDeleteLocation: SavedLocation?
+  @State private var pendingEditLocation: SavedLocation?
+  @State private var showingLockCodeEntryForEdit = false
   @State private var errorMessage: String?
 
   /// Location IDs that are in use by profiles with active sessions
@@ -133,6 +135,21 @@ struct SavedLocationsView: View {
           }
         )
       }
+      .sheet(isPresented: $showingLockCodeEntryForEdit) {
+        LockCodeEntryView(
+          title: "Enter Lock Code",
+          subtitle: "This location is locked. Enter the lock code to edit it.",
+          onVerify: { code in
+            lockCodeManager.validateCode(code)
+          },
+          onSuccess: {
+            if let location = pendingEditLocation {
+              locationToEdit = location
+            }
+            pendingEditLocation = nil
+          }
+        )
+      }
       .alert(
         "Error",
         isPresented: .init(
@@ -150,13 +167,16 @@ struct SavedLocationsView: View {
   }
 
   private func handleEdit(_ location: SavedLocation) {
-    // Note: Locked locations can be edited freely in Individual and Parent modes.
-    // In Child mode, AddLocationView will prevent saving changes to locked locations.
-    locationToEdit = location
+    if location.requiresLockCodeToModify(mode: appModeManager.currentMode) {
+      pendingEditLocation = location
+      showingLockCodeEntryForEdit = true
+    } else {
+      locationToEdit = location
+    }
   }
 
   private func handleDelete(_ location: SavedLocation) {
-    if location.isLocked && appModeManager.currentMode == .child {
+    if location.requiresLockCodeToModify(mode: appModeManager.currentMode) {
       pendingDeleteLocation = location
       showingLockCodeEntry = true
     } else {

--- a/Foqos/Views/SavedLocationsView.swift
+++ b/Foqos/Views/SavedLocationsView.swift
@@ -167,7 +167,10 @@ struct SavedLocationsView: View {
   }
 
   private func handleEdit(_ location: SavedLocation) {
-    if location.requiresLockCodeToModify(mode: appModeManager.currentMode) {
+    if location.requiresLockCodeToModify(
+      mode: appModeManager.currentMode,
+      canVerifyCode: lockCodeManager.canVerifyCode)
+    {
       pendingEditLocation = location
       showingLockCodeEntryForEdit = true
     } else {
@@ -176,7 +179,10 @@ struct SavedLocationsView: View {
   }
 
   private func handleDelete(_ location: SavedLocation) {
-    if location.requiresLockCodeToModify(mode: appModeManager.currentMode) {
+    if location.requiresLockCodeToModify(
+      mode: appModeManager.currentMode,
+      canVerifyCode: lockCodeManager.canVerifyCode)
+    {
       pendingDeleteLocation = location
       showingLockCodeEntry = true
     } else {

--- a/FoqosTests/AppModePromotionTests.swift
+++ b/FoqosTests/AppModePromotionTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class AppModePromotionTests: XCTestCase {
+  func testGivenIndividualMode_WhenSettingLockCode_ThenPromotesToParent() {
+    XCTAssertEqual(AppModeManager.modeAfterSettingLockCode(from: .individual), .parent)
+  }
+
+  func testGivenParentMode_WhenSettingLockCode_ThenNoModeChange() {
+    XCTAssertNil(AppModeManager.modeAfterSettingLockCode(from: .parent))
+  }
+
+  func testGivenChildMode_WhenSettingLockCode_ThenNoModeChange() {
+    XCTAssertNil(AppModeManager.modeAfterSettingLockCode(from: .child))
+  }
+}

--- a/FoqosTests/ChildDashboardCopyTests.swift
+++ b/FoqosTests/ChildDashboardCopyTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class ChildDashboardCopyTests: XCTestCase {
+  func testGivenLockedProfilesFooter_WhenRead_ThenPromisesEditOrDeleteNotStop() {
+    let footer = EditLockedProfilesSheet.lockedProfilesFooter
+    XCTAssertEqual(footer, "Locked profiles require the lock code to edit or delete.")
+    XCTAssertFalse(
+      footer.lowercased().contains("stop"),
+      "Footer must not promise that stopping is lock-gated (stopping is un-gated by design, deviation #7)"
+    )
+  }
+}

--- a/FoqosTests/LockCodeFailClosedTests.swift
+++ b/FoqosTests/LockCodeFailClosedTests.swift
@@ -41,4 +41,11 @@ final class LockCodeFailClosedTests: XCTestCase {
       fetched: [], isConnected: false, persisted: [])
     XCTAssertTrue(result.cache.isEmpty)
   }
+
+  func testGivenRecordFailure_WhenResolvingNetworkFetch_ThenReportsDisconnected() {
+    let result = CloudKitNetworkService.resolveSharedLockCodeFetch(
+      codes: [], hasRecordFailures: true)
+    XCTAssertTrue(result.codes.isEmpty)
+    XCTAssertFalse(result.isConnected)
+  }
 }

--- a/FoqosTests/LockCodeFailClosedTests.swift
+++ b/FoqosTests/LockCodeFailClosedTests.swift
@@ -48,4 +48,11 @@ final class LockCodeFailClosedTests: XCTestCase {
     XCTAssertTrue(result.codes.isEmpty)
     XCTAssertFalse(result.isConnected)
   }
+
+  func testGivenDecodeFailure_WhenResolvingNetworkFetch_ThenReportsDisconnected() {
+    let result = CloudKitNetworkService.resolveSharedLockCodeFetch(
+      codes: [], hasRecordFailures: true)
+    XCTAssertTrue(result.codes.isEmpty)
+    XCTAssertFalse(result.isConnected)
+  }
 }

--- a/FoqosTests/LockCodeFailClosedTests.swift
+++ b/FoqosTests/LockCodeFailClosedTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class LockCodeFailClosedTests: XCTestCase {
+  private func makeCode() -> FamilyLockCode {
+    FamilyLockCode(code: "1234", scope: .allChildren)
+  }
+
+  // Connected results are trusted: they replace both the verification cache and the store.
+  func testGivenConnectedNonEmptyFetch_WhenResolving_ThenCacheAndStoreUseFetched() {
+    let fetched = [makeCode()]
+    let result = LockCodeManager.resolveLockCodes(
+      fetched: fetched, isConnected: true, persisted: [])
+    XCTAssertEqual(result.cache.count, 1)
+    XCTAssertEqual(result.persist.count, 1)
+  }
+
+  // Connected + empty = parent genuinely cleared the PIN -> cache and store clear (unlock).
+  func testGivenConnectedEmptyFetch_WhenResolving_ThenClearsCachedCode() {
+    let result = LockCodeManager.resolveLockCodes(
+      fetched: [], isConnected: true, persisted: [makeCode()])
+    XCTAssertTrue(result.cache.isEmpty)
+    XCTAssertTrue(result.persist.isEmpty)
+  }
+
+  // Disconnected (offline / CloudKit error) -> ignore the empty network result, verify
+  // against the last-synced persisted code. This is the airplane-mode bypass being closed.
+  func testGivenOfflineFetch_WhenResolving_ThenVerifiesAgainstLastSyncedCode() {
+    let persisted = [makeCode()]
+    let result = LockCodeManager.resolveLockCodes(
+      fetched: [], isConnected: false, persisted: persisted)
+    XCTAssertEqual(result.cache.count, 1, "offline must verify against the last-synced cached code")
+    XCTAssertEqual(result.persist.count, 1, "offline must not clear the persisted code")
+  }
+
+  // No code ever synced + offline -> nothing to verify (no managed lock exists yet).
+  func testGivenNeverSyncedAndOffline_WhenResolving_ThenNoCachedCode() {
+    let result = LockCodeManager.resolveLockCodes(
+      fetched: [], isConnected: false, persisted: [])
+    XCTAssertTrue(result.cache.isEmpty)
+  }
+}

--- a/FoqosTests/ProfileEditGateTests.swift
+++ b/FoqosTests/ProfileEditGateTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class ProfileEditGateTests: XCTestCase {
+  // Parent mode with a managed, not-unlocked profile MUST remain editable (#211 core bug).
+  func testGivenParentModeManagedProfile_WhenNotUnlocked_ThenEditingNotDisabled() {
+    XCTAssertFalse(
+      ProfileEditGate.editingDisabled(
+        isBlocking: false, isManaged: true, isUnlocked: false, mode: .parent, lockActive: true))
+  }
+
+  func testGivenIndividualModeManagedProfile_WhenNotUnlocked_ThenEditingNotDisabled() {
+    XCTAssertFalse(
+      ProfileEditGate.editingDisabled(
+        isBlocking: false, isManaged: true, isUnlocked: false, mode: .individual, lockActive: true))
+  }
+
+  // Child mode with an active lock and not unlocked MUST be disabled.
+  func testGivenChildModeManagedProfile_WhenLockedAndNotUnlocked_ThenEditingDisabled() {
+    XCTAssertTrue(
+      ProfileEditGate.editingDisabled(
+        isBlocking: false, isManaged: true, isUnlocked: false, mode: .child, lockActive: true))
+  }
+
+  // Child mode, unlocked -> editable.
+  func testGivenChildModeManagedProfile_WhenUnlocked_ThenEditingNotDisabled() {
+    XCTAssertFalse(
+      ProfileEditGate.editingDisabled(
+        isBlocking: false, isManaged: true, isUnlocked: true, mode: .child, lockActive: true))
+  }
+
+  // Active session always disables editing regardless of mode.
+  func testGivenActiveSession_WhenAnyMode_ThenEditingDisabled() {
+    XCTAssertTrue(
+      ProfileEditGate.editingDisabled(
+        isBlocking: true, isManaged: false, isUnlocked: true, mode: .individual, lockActive: false))
+  }
+}

--- a/FoqosTests/SavedLocationLockGateTests.swift
+++ b/FoqosTests/SavedLocationLockGateTests.swift
@@ -1,0 +1,31 @@
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class SavedLocationLockGateTests: XCTestCase {
+  private func makeLocation(isLocked: Bool) -> SavedLocation {
+    SavedLocation(id: UUID(), name: "Home", latitude: 1, longitude: 2, isLocked: isLocked)
+  }
+
+  func testGivenLockedLocation_WhenChildMode_ThenRequiresLockCode() {
+    let location = makeLocation(isLocked: true)
+    XCTAssertTrue(location.requiresLockCodeToModify(mode: .child))
+  }
+
+  func testGivenLockedLocation_WhenParentMode_ThenNoLockCodeRequired() {
+    let location = makeLocation(isLocked: true)
+    XCTAssertFalse(location.requiresLockCodeToModify(mode: .parent))
+  }
+
+  func testGivenLockedLocation_WhenIndividualMode_ThenNoLockCodeRequired() {
+    let location = makeLocation(isLocked: true)
+    XCTAssertFalse(location.requiresLockCodeToModify(mode: .individual))
+  }
+
+  func testGivenUnlockedLocation_WhenChildMode_ThenNoLockCodeRequired() {
+    let location = makeLocation(isLocked: false)
+    XCTAssertFalse(location.requiresLockCodeToModify(mode: .child))
+  }
+}

--- a/FoqosTests/SavedLocationLockGateTests.swift
+++ b/FoqosTests/SavedLocationLockGateTests.swift
@@ -1,4 +1,3 @@
-import SwiftData
 import XCTest
 
 @testable import FamilyFoqos
@@ -9,23 +8,28 @@ final class SavedLocationLockGateTests: XCTestCase {
     SavedLocation(id: UUID(), name: "Home", latitude: 1, longitude: 2, isLocked: isLocked)
   }
 
-  func testGivenLockedLocation_WhenChildMode_ThenRequiresLockCode() {
+  func testGivenLockedLocation_WhenChildModeAndCodeAvailable_ThenRequiresLockCode() {
     let location = makeLocation(isLocked: true)
-    XCTAssertTrue(location.requiresLockCodeToModify(mode: .child))
+    XCTAssertTrue(location.requiresLockCodeToModify(mode: .child, canVerifyCode: true))
+  }
+
+  func testGivenLockedLocation_WhenChildModeAndNoCodeAvailable_ThenNoLockCodeRequired() {
+    let location = makeLocation(isLocked: true)
+    XCTAssertFalse(location.requiresLockCodeToModify(mode: .child, canVerifyCode: false))
   }
 
   func testGivenLockedLocation_WhenParentMode_ThenNoLockCodeRequired() {
     let location = makeLocation(isLocked: true)
-    XCTAssertFalse(location.requiresLockCodeToModify(mode: .parent))
+    XCTAssertFalse(location.requiresLockCodeToModify(mode: .parent, canVerifyCode: true))
   }
 
   func testGivenLockedLocation_WhenIndividualMode_ThenNoLockCodeRequired() {
     let location = makeLocation(isLocked: true)
-    XCTAssertFalse(location.requiresLockCodeToModify(mode: .individual))
+    XCTAssertFalse(location.requiresLockCodeToModify(mode: .individual, canVerifyCode: true))
   }
 
   func testGivenUnlockedLocation_WhenChildMode_ThenNoLockCodeRequired() {
     let location = makeLocation(isLocked: false)
-    XCTAssertFalse(location.requiresLockCodeToModify(mode: .child))
+    XCTAssertFalse(location.requiresLockCodeToModify(mode: .child, canVerifyCode: true))
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #196 by correcting child-dashboard lock copy so it does not claim stopping is lock-gated.
- Fixes #244, #199, #197, #211, and #251 by adding testable lock/mode gate helpers, persisting child lock-code cache for offline verification, and routing affected UI gates through child-mode-only decisions.
- Documents Individual to Parent lock-code promotion in AGENTS.md and keeps new commits only.

Fixes #197
Fixes #199
Fixes #211
Fixes #251
Fixes #244
Fixes #196

## Test Plan
- [x] xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -only-testing:FoqosTests/ChildDashboardCopyTests -only-testing:FoqosTests/AppModePromotionTests -only-testing:FoqosTests/SavedLocationLockGateTests -only-testing:FoqosTests/LockCodeFailClosedTests -only-testing:FoqosTests/ProfileEditGateTests | xcpretty
- [x] xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' | xcpretty
- [x] swift-format lint --recursive . (exit 0; existing warnings in WelcomeIntroScreen.swift and FoqosApp.swift)
- [x] git diff main --unified=0 | grep -nE '\!= \.parent' && echo forbidden || echo OK

Requesting code review before merge per AGENTS.md.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes several related lock-gating audit issues (issues #196, #197, #199, #211, #244, #251) by extracting testable pure-function gate helpers, persisting the child lock-code cache to survive offline, routing all UI gate decisions through child-mode-only checks, and promoting Individual → Parent on first lock code save.

- **Offline fail-closed for children**: `CloudKitNetworkService.fetchSharedLockCodes()` now returns `(codes: [], isConnected: false)` on any CKError instead of throwing; `LockCodeManager.resolveLockCodes()` uses `isConnected` to distinguish \"parent cleared the PIN\" (connected + empty) from \"network failure\" (disconnected + empty), and `persistLockCodes()` writes the last-good codes to UserDefaults so verification survives airplane mode.
- **UI gating corrected**: `ProfileEditGate.editingDisabled`, `SavedLocation.requiresLockCodeToModify`, and the child-dashboard `hasLockCode` signals are all updated to use `mode == .child` instead of negative parent checks, and the locked-profile footer no longer claims that stopping a profile requires the lock code.
- **Individual → Parent promotion**: After a successful `setLockCode`, `ParentDashboardView` calls the new pure `AppModeManager.modeAfterSettingLockCode` to promote Individual devices to Parent, with dedicated unit tests covering all three modes.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness of the UserDefaults storage decision for lock code hashes.

The core logic is well-reasoned and well-tested: the offline fail-closed path, mode-gating corrections, and Individual → Parent promotion are all exercised by dedicated unit tests. The one area worth a second look is `persistLockCodes`, which writes `codeHash`+`codeSalt` (the full PIN-verification material) to an unencrypted UserDefaults plist. For a 4-digit PIN, SHA256+salt can be brute-forced in ~10,000 attempts once an attacker can read the file — a real but bounded risk for a family parental-control app. The `isConnected` state being retrieved as a published side-effect of `fetchSharedLockCodes` rather than from the return value is a maintainability observation with no current impact. All other changes are clean extractions of existing inline logic into testable pure functions.

Foqos/Utils/LockCodeManager.swift — `persistLockCodes` and `loadPersistedLockCodes` write sensitive material to UserDefaults; worth deciding whether Keychain is appropriate before the feature ships.

<details open><summary><h3>Security Review</h3></summary>

- **Hash material in UserDefaults** (`Foqos/Utils/LockCodeManager.swift` — `persistLockCodes`): `FamilyLockCode` objects containing `codeHash` and `codeSalt` are now written to `UserDefaults` (an unencrypted plist). For a 4-digit PIN, SHA256+salt can be brute-forced in ~10,000 attempts offline. Keychain storage with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` would prevent extraction from unencrypted backups and locked-device access. The existing `FamilyLockCode.swift` TODO already flags the hash strength; this adds a second exposure surface.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Foqos/Utils/LockCodeManager.swift | Adds offline-safe lock code persistence via UserDefaults and `resolveLockCodes` pure function; the security-sensitive hash material is stored in UserDefaults rather than Keychain, and the `isConnected` flag is read indirectly from a published side-effect rather than from the function's return value. |
| Foqos/CloudKit/CloudKitNetworkService+LockCodes.swift | Error path in `fetchSharedLockCodes` now returns `(codes: [], isConnected: false)` instead of propagating the throw, preventing the caller from treating a network failure as "parent cleared the PIN". |
| Foqos/Utils/ProfileEditGate.swift | New pure enum with `editingDisabled` correctly gates on `mode == .child` rather than a parent-negative check; well-covered by unit tests. |
| Foqos/Models/SavedLocation.swift | Adds `requiresLockCodeToModify(mode:)` pure helper gating on `mode == .child`, consistent with the mode table and covered by `SavedLocationLockGateTests`. |
| Foqos/Views/SavedLocationsView.swift | Edit flow now gates locked locations behind a lock-code sheet using the new `requiresLockCodeToModify` helper; delete flow refactored to the same helper. Introduces `pendingEditLocation` / `showingLockCodeEntryForEdit` state that follows the same pattern as the existing delete flow. |
| Foqos/Views/Parent/ParentDashboardView.swift | Adds Individual → Parent mode promotion after a successful `setLockCode` call using the pure `AppModeManager.modeAfterSettingLockCode`; mode captured before the async operation to avoid TOCTOU on success path. |
| Foqos/Views/Child/ChildDashboardView.swift | `hasLockCode` / `hasLockCodes` now use `lockCodeManager.canVerifyCode` instead of the raw CloudKit `sharedLockCodes`, ensuring offline-persisted codes are reflected in the UI; locked-profile footer text corrected to remove the incorrect "or stop" claim. |
| Foqos/Models/AppMode.swift | Adds pure static `modeAfterSettingLockCode(from:)` for Individual → Parent promotion logic, unit-tested by `AppModePromotionTests`. |
| Foqos/Views/BlockedProfileView.swift | Delegates `editingDisabled` and several `disabled` arguments to `ProfileEditGate.editingDisabled`, consistently applying child-mode-only gating across start triggers, stop conditions, and geofence sections. |
| FoqosTests/LockCodeFailClosedTests.swift | Covers all four `resolveLockCodes` cases: connected+non-empty, connected+empty (parent cleared), disconnected (offline), and never-synced+offline. |
| FoqosTests/ProfileEditGateTests.swift | Tests parent, individual, child (locked/unlocked), and active-session scenarios for `ProfileEditGate.editingDisabled`. |
| FoqosTests/SavedLocationLockGateTests.swift | Covers all mode × locked/unlocked combinations for `SavedLocation.requiresLockCodeToModify`. |
| FoqosTests/AppModePromotionTests.swift | Tests all three mode inputs for `modeAfterSettingLockCode`; clear and sufficient coverage. |
| FoqosTests/ChildDashboardCopyTests.swift | Pins the locked-profile footer string so it cannot regress to claiming "stop" is lock-gated. |
| AGENTS.md | Documents the Individual → Parent promotion invariant and explains why `setLockCode` guard stays `!= .child` to avoid deadlock. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Child as ChildDevice (LockCodeManager)
    participant CKMgr as CloudKitManager
    participant Net as CloudKitNetworkService
    participant UD as UserDefaults

    Note over Child: App launch / mode change
    Child->>UD: loadPersistedLockCodes()
    UD-->>Child: cached [FamilyLockCode] (or [])

    Note over Child: fetchSharedLockCodes()
    Child->>CKMgr: fetchSharedLockCodes()
    CKMgr->>Net: fetchSharedLockCodes()
    alt CloudKit reachable
        Net-->>CKMgr: (codes: [...], isConnected: true)
        CKMgr->>CKMgr: "isConnectedToFamily = true"
        CKMgr-->>Child: [FamilyLockCode]
        Child->>Child: "resolveLockCodes(fetched, isConnected=true, persisted)"
        Note right of Child: Trust fetched (even empty = parent cleared)
        Child->>UD: persistLockCodes(fetched)
    else CloudKit error / offline
        Net-->>CKMgr: (codes: [], isConnected: false)
        CKMgr->>CKMgr: "isConnectedToFamily = false"
        CKMgr-->>Child: []
        Child->>Child: "resolveLockCodes([], isConnected=false, persisted)"
        Note right of Child: Keep persisted — offline verification works
    end

    Note over Child: PIN entry (e.g. edit locked location)
    Child->>Child: validateCode(pin) via cachedLockCodes
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Child as ChildDevice (LockCodeManager)
    participant CKMgr as CloudKitManager
    participant Net as CloudKitNetworkService
    participant UD as UserDefaults

    Note over Child: App launch / mode change
    Child->>UD: loadPersistedLockCodes()
    UD-->>Child: cached [FamilyLockCode] (or [])

    Note over Child: fetchSharedLockCodes()
    Child->>CKMgr: fetchSharedLockCodes()
    CKMgr->>Net: fetchSharedLockCodes()
    alt CloudKit reachable
        Net-->>CKMgr: (codes: [...], isConnected: true)
        CKMgr->>CKMgr: "isConnectedToFamily = true"
        CKMgr-->>Child: [FamilyLockCode]
        Child->>Child: "resolveLockCodes(fetched, isConnected=true, persisted)"
        Note right of Child: Trust fetched (even empty = parent cleared)
        Child->>UD: persistLockCodes(fetched)
    else CloudKit error / offline
        Net-->>CKMgr: (codes: [], isConnected: false)
        CKMgr->>CKMgr: "isConnectedToFamily = false"
        CKMgr-->>Child: []
        Child->>Child: "resolveLockCodes([], isConnected=false, persisted)"
        Note right of Child: Keep persisted — offline verification works
    end

    Note over Child: PIN entry (e.g. edit locked location)
    Child->>Child: validateCode(pin) via cachedLockCodes
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(#263): satisfy lock gate forbidden..."](https://github.com/mnbf9rca/family-foqos/commit/598e3b550b01e9e65e6612dbacbfca44c45307a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41922701)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->