### PR TITLE
C1: DeviceActivity interval validation

### DIFF
--- a/Foqos/Components/Strategy/TimerDurationView.swift
+++ b/Foqos/Components/Strategy/TimerDurationView.swift
@@ -18,7 +18,7 @@ struct TimerDurationView: View {
   private let largeIncrement: Double = 15
 
   // Common snap points (in minutes)
-  private let snapPoints: [Double] = [15, 30, 45, 60, 90, 120, 180, 240, 360, 480, 720, 1440]
+  private let snapPoints: [Double] = [15, 30, 45, 60, 90, 120, 180, 240, 360, 480, 720]
   private let snapThreshold: Double = 10  // How close to snap (in minutes)
 
   var body: some View {
@@ -171,15 +171,32 @@ struct TimerDurationView: View {
     }
   }
 
+  /// Returns the snap target for a slider value: the nearest snap point if one is
+  /// within `threshold`, otherwise the value itself — always clamped to
+  /// `maxMinutes` so the result can never exceed the slider's honorable range (#212).
+  static func snappedDuration(
+    for value: Double,
+    snapPoints: [Double],
+    threshold: Double,
+    maxMinutes: Double
+  ) -> Double {
+    guard let closest = snapPoints.min(by: { abs($0 - value) < abs($1 - value) }) else {
+      return min(value, maxMinutes)
+    }
+    let snapped = abs(closest - value) <= threshold ? closest : value
+    return min(snapped, maxMinutes)
+  }
+
   private func snapToNearestPreset() {
-    // Find the closest snap point
-    if let closest = snapPoints.min(by: { abs($0 - durationMinutes) < abs($1 - durationMinutes) }) {
-      let distance = abs(closest - durationMinutes)
-      if distance <= snapThreshold {
-        withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
-          durationMinutes = closest
-        }
-      }
+    let target = Self.snappedDuration(
+      for: durationMinutes,
+      snapPoints: snapPoints,
+      threshold: snapThreshold,
+      maxMinutes: maxMinutes
+    )
+    guard target != durationMinutes else { return }
+    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+      durationMinutes = target
     }
   }
 

--- a/Foqos/Components/Strategy/TimerDurationView.swift
+++ b/Foqos/Components/Strategy/TimerDurationView.swift
@@ -12,8 +12,8 @@ struct TimerDurationView: View {
   @State private var isSliding = false
 
   // Constants
-  private let minMinutes: Double = 15
-  private let maxMinutes: Double = 1439  // 23h 59m
+  private let minMinutes = Double(DeviceActivityLimits.minimumIntervalMinutes)
+  private let maxMinutes = Double(DeviceActivityLimits.maximumTimerMinutes)
   private let smallIncrement: Double = 5
   private let largeIncrement: Double = 15
 

--- a/Foqos/Intents/IntentError.swift
+++ b/Foqos/Intents/IntentError.swift
@@ -16,7 +16,7 @@ enum IntentError: Error, CustomLocalizedStringResourceConvertible {
     case .sessionAlreadyActive:
       "A session is already active."
     case .durationOutOfRange:
-      "Duration must be between 15 and 1440 minutes."
+      "Duration must be between 15 minutes and 23 hours 59 minutes."
     case .noActiveSession(let name):
       "\(name) is not currently active."
     case .backgroundStopsDisabled(let name):

--- a/Foqos/Intents/StartProfileIntent.swift
+++ b/Foqos/Intents/StartProfileIntent.swift
@@ -17,7 +17,7 @@ struct StartProfileIntent: AppIntent {
   nonisolated(unsafe) static var title: LocalizedStringResource = "Start Family Foqos Profile"  // SAFETY: AppIntents requires static var; immutable after init
 
   nonisolated(unsafe) static var description = IntentDescription(  // SAFETY: AppIntents requires static var; immutable after init
-    "Start a Family Foqos blocking profile. Optionally specify a timer duration in minutes (15-1440)."
+    "Start a Family Foqos blocking profile. Optionally specify a timer duration between 15 minutes and 23 hours 59 minutes."
   )
 
   @MainActor

--- a/Foqos/Models/TriggerConfigurationModel.swift
+++ b/Foqos/Models/TriggerConfigurationModel.swift
@@ -63,6 +63,22 @@ final class TriggerConfigurationModel: ObservableObject {
     {
       errors.append("Start and stop times can't be the same")
     }
+    if startTriggers.schedule && stopConditions.schedule,
+      let start = startSchedule, let stop = stopSchedule,
+      start.isActive, stop.isActive
+    {
+      let window = TriggerValidator.scheduleWindowMinutes(
+        startHour: start.hour, startMinute: start.minute,
+        stopHour: stop.hour, stopMinute: stop.minute
+      )
+      // window == 0 is already reported by the same-time rule above.
+      if window > 0 && window < DeviceActivityLimits.minimumIntervalMinutes {
+        errors.append(
+          "A scheduled window must be at least "
+            + "\(DeviceActivityLimits.minimumIntervalMinutes) minutes long"
+        )
+      }
+    }
 
     validationErrors = errors
     if !validationErrors.isEmpty {

--- a/Foqos/Models/TriggerConfigurationModel.swift
+++ b/Foqos/Models/TriggerConfigurationModel.swift
@@ -59,6 +59,7 @@ final class TriggerConfigurationModel: ObservableObject {
     }
     if startTriggers.schedule && stopConditions.schedule,
       let start = startSchedule, let stop = stopSchedule,
+      start.isActive, stop.isActive,
       start.hour == stop.hour && start.minute == stop.minute
     {
       errors.append("Start and stop times can't be the same")

--- a/Foqos/Models/TriggerValidator.swift
+++ b/Foqos/Models/TriggerValidator.swift
@@ -107,3 +107,17 @@ final class TriggerValidator {
       .map { $0.message }
   }
 }
+
+extension TriggerValidator {
+  /// Length, in minutes, of the repeating DeviceActivity window a start/stop
+  /// time pair produces. Computed modulo a 24h day so it is correct for both
+  /// same-day windows (stop after start) and cross-midnight windows (stop before
+  /// start). Returns 0 when the two times are identical.
+  static func scheduleWindowMinutes(
+    startHour: Int, startMinute: Int, stopHour: Int, stopMinute: Int
+  ) -> Int {
+    let startMin = startHour * 60 + startMinute
+    let stopMin = stopHour * 60 + stopMinute
+    return ((stopMin - startMin) % 1440 + 1440) % 1440
+  }
+}

--- a/Foqos/Utils/DeviceActivityCenterUtil.swift
+++ b/Foqos/Utils/DeviceActivityCenterUtil.swift
@@ -414,11 +414,26 @@ class DeviceActivityCenterUtil {
   static func getTimeIntervalStartAndEnd(from minutes: Int, now: Date = Date()) -> (
     intervalStart: DateComponents, intervalEnd: DateComponents
   ) {
+    // Clamp the upper bound so the computed interval can never collapse to a
+    // zero-length window: exactly 1440 minutes (24h), or any larger multiple,
+    // lands intervalEnd on the same wall-clock minute as intervalStart, which
+    // DeviceActivity silently refuses to monitor and defers ~24h (#212).
+    // NOTE: the lower bound is intentionally NOT clamped here — that would
+    // silently rewrite user-chosen break durations (see MAINTAINER DECISION 3).
+    let clampedMinutes = min(minutes, DeviceActivityLimits.maximumTimerMinutes)
+    if clampedMinutes != minutes {
+      Log.warning(
+        "Timer duration \(minutes)m exceeds DeviceActivity's honorable maximum; "
+          + "clamped to \(clampedMinutes)m",
+        category: .timer
+      )
+    }
+
     let calendar = Calendar.current
     let startComponents = calendar.dateComponents([.hour, .minute], from: now)
     let intervalStart = DateComponents(hour: startComponents.hour, minute: startComponents.minute)
 
-    let endDate = now.addingTimeInterval(Double(minutes) * 60)
+    let endDate = now.addingTimeInterval(Double(clampedMinutes) * 60)
     let endComponents = calendar.dateComponents([.hour, .minute], from: endDate)
     let intervalEnd = DateComponents(hour: endComponents.hour, minute: endComponents.minute)
 

--- a/Foqos/Utils/DeviceActivityCenterUtil.swift
+++ b/Foqos/Utils/DeviceActivityCenterUtil.swift
@@ -120,8 +120,9 @@ class DeviceActivityCenterUtil {
     }
 
     let stopSchedule = profile.stopSchedule!
-    let intervalStart = DateComponents(hour: 0, minute: 0)
-    let intervalEnd = DateComponents(hour: stopSchedule.hour, minute: stopSchedule.minute)
+    let (intervalStart, intervalEnd) = stopScheduleInterval(
+      stopHour: stopSchedule.hour, stopMinute: stopSchedule.minute
+    )
 
     let deviceActivitySchedule = DeviceActivitySchedule(
       intervalStart: intervalStart,
@@ -437,6 +438,33 @@ class DeviceActivityCenterUtil {
     let endComponents = calendar.dateComponents([.hour, .minute], from: endDate)
     let intervalEnd = DateComponents(hour: endComponents.hour, minute: endComponents.minute)
 
+    return (intervalStart: intervalStart, intervalEnd: intervalEnd)
+  }
+
+  /// Computes the DeviceActivity interval for a stop-only schedule.
+  ///
+  /// The stop-only activity only cares about `intervalDidEnd` firing at the stop
+  /// time (`StopScheduleTimerActivity.start(for:)` is a no-op), so `intervalStart`
+  /// is a free internal artifact. Anchoring it at 00:00 (the historical default)
+  /// yields a window of `stopHour*60 + stopMinute` minutes — under DeviceActivity's
+  /// 15-minute minimum, or zero-length when stop == 00:00, whenever the stop time
+  /// is before 00:15. In that case we anchor `intervalStart` one minute AFTER the
+  /// stop so the repeating window wraps ~24h and still delivers `intervalDidEnd`
+  /// at the stop time (#228). For stop times at or after 00:15 the historical
+  /// 00:00 anchor is preserved (no behavior change).
+  static func stopScheduleInterval(stopHour: Int, stopMinute: Int) -> (
+    intervalStart: DateComponents, intervalEnd: DateComponents
+  ) {
+    let intervalEnd = DateComponents(hour: stopHour, minute: stopMinute)
+    let stopMinuteOfDay = stopHour * 60 + stopMinute
+
+    let intervalStart: DateComponents
+    if stopMinuteOfDay < DeviceActivityLimits.minimumIntervalMinutes {
+      let anchor = (stopMinuteOfDay + 1) % 1440
+      intervalStart = DateComponents(hour: anchor / 60, minute: anchor % 60)
+    } else {
+      intervalStart = DateComponents(hour: 0, minute: 0)
+    }
     return (intervalStart: intervalStart, intervalEnd: intervalEnd)
   }
 }

--- a/Foqos/Utils/DeviceActivityLimits.swift
+++ b/Foqos/Utils/DeviceActivityLimits.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Hard limits imposed by Apple's DeviceActivity framework on the repeating
+/// intervals we register via `DeviceActivityCenter.startMonitoring`.
+///
+/// DeviceActivity silently rejects (throws from `startMonitoring`, which this
+/// codebase currently only logs) any monitored interval shorter than 15
+/// minutes, and a 24-hour (1440-minute) now-relative timer collapses to a
+/// zero-length interval because its end wraps to the same wall-clock minute as
+/// its start. These constants are the single source of truth for the C1
+/// interval-validation guards (#212, #228).
+enum DeviceActivityLimits {
+  /// DeviceActivity's minimum honorable monitored interval length, in minutes.
+  static let minimumIntervalMinutes = 15
+
+  /// Maximum now-relative timer duration, in minutes (23h59m). Exactly 1440
+  /// (24h), or any larger multiple, makes `intervalStart == intervalEnd`.
+  static let maximumTimerMinutes = 1439
+
+  /// Human-readable form of `maximumTimerMinutes` for user-facing copy, derived
+  /// from the constant so it can never drift out of sync (e.g. "23 hours 59
+  /// minutes").
+  static var maximumTimerDescription: String {
+    let hours = maximumTimerMinutes / 60
+    let minutes = maximumTimerMinutes % 60
+    return "\(hours) hours \(minutes) minutes"
+  }
+}

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -356,8 +356,14 @@ class StrategyManager: ObservableObject {
       }
 
       if let duration = durationInMinutes {
-        if duration < 15 || duration > 1440 {
-          self.errorMessage = "Duration must be between 15 and 1440 minutes."
+        if duration < DeviceActivityLimits.minimumIntervalMinutes
+          || duration > DeviceActivityLimits.maximumTimerMinutes
+        {
+          // Plain String → interpolate the min constant and the derived
+          // human-readable max (single-sourced; no bare literals).
+          self.errorMessage =
+            "Duration must be between \(DeviceActivityLimits.minimumIntervalMinutes) minutes "
+            + "and \(DeviceActivityLimits.maximumTimerDescription)."
           throw IntentError.durationOutOfRange
         }
 

--- a/FoqosTests/ScheduleWindowValidationTests.swift
+++ b/FoqosTests/ScheduleWindowValidationTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class ScheduleWindowValidationTests: XCTestCase {
+
+  // MARK: - Pure modular window math
+
+  func testGivenSameDayTenMinuteWindow_WhenComputingWindow_ThenReturnsTen() {
+    XCTAssertEqual(
+      TriggerValidator.scheduleWindowMinutes(
+        startHour: 9, startMinute: 0, stopHour: 9, stopMinute: 10), 10)
+  }
+
+  func testGivenSameDayFifteenMinuteWindow_WhenComputingWindow_ThenReturnsFifteen() {
+    XCTAssertEqual(
+      TriggerValidator.scheduleWindowMinutes(
+        startHour: 9, startMinute: 0, stopHour: 9, stopMinute: 15), 15)
+  }
+
+  func testGivenCrossMidnightNearBoundary_WhenComputingWindow_ThenReturnsSubFifteen() {
+    // 23:59 -> 00:00 is a 1-minute window, NOT ~24h.
+    XCTAssertEqual(
+      TriggerValidator.scheduleWindowMinutes(
+        startHour: 23, startMinute: 59, stopHour: 0, stopMinute: 0), 1)
+  }
+
+  func testGivenLegitimateOvernightWindow_WhenComputingWindow_ThenReturns480() {
+    XCTAssertEqual(
+      TriggerValidator.scheduleWindowMinutes(
+        startHour: 22, startMinute: 0, stopHour: 6, stopMinute: 0), 480)
+  }
+
+  func testGivenIdenticalTimes_WhenComputingWindow_ThenReturnsZero() {
+    XCTAssertEqual(
+      TriggerValidator.scheduleWindowMinutes(
+        startHour: 9, startMinute: 0, stopHour: 9, stopMinute: 0), 0)
+  }
+}
+
+@MainActor
+final class ScheduleWindowValidationIntegrationTests: XCTestCase {
+
+  private func makeModel(
+    startHour: Int, startMinute: Int, stopHour: Int, stopMinute: Int
+  ) -> TriggerConfigurationModel {
+    let model = TriggerConfigurationModel()
+    model.startTriggers.schedule = true
+    model.stopConditions.schedule = true
+    model.startSchedule = ProfileScheduleTime(
+      days: [.monday], hour: startHour, minute: startMinute, updatedAt: .distantPast)
+    model.stopSchedule = ProfileScheduleTime(
+      days: [.monday], hour: stopHour, minute: stopMinute, updatedAt: .distantPast)
+    return model
+  }
+
+  func testGivenSubFifteenSameDayWindow_WhenValidating_ThenAppendsWindowError() {
+    let model = makeModel(startHour: 9, startMinute: 0, stopHour: 9, stopMinute: 10)
+    model.validate()
+    XCTAssertTrue(model.validationErrors.contains { $0.contains("at least 15 minutes") })
+  }
+
+  func testGivenCrossMidnightSubFifteenWindow_WhenValidating_ThenAppendsWindowError() {
+    let model = makeModel(startHour: 23, startMinute: 55, stopHour: 0, stopMinute: 5)
+    model.validate()
+    XCTAssertTrue(model.validationErrors.contains { $0.contains("at least 15 minutes") })
+  }
+
+  func testGivenFifteenMinuteWindow_WhenValidating_ThenNoWindowError() {
+    let model = makeModel(startHour: 9, startMinute: 0, stopHour: 9, stopMinute: 15)
+    model.validate()
+    XCTAssertFalse(model.validationErrors.contains { $0.contains("at least 15 minutes") })
+  }
+
+  func testGivenLegitimateOvernightWindow_WhenValidating_ThenNoWindowError() {
+    let model = makeModel(startHour: 22, startMinute: 0, stopHour: 6, stopMinute: 0)
+    model.validate()
+    XCTAssertFalse(model.validationErrors.contains { $0.contains("at least 15 minutes") })
+  }
+}

--- a/FoqosTests/ScheduleWindowValidationTests.swift
+++ b/FoqosTests/ScheduleWindowValidationTests.swift
@@ -40,6 +40,8 @@ final class ScheduleWindowValidationTests: XCTestCase {
 
 @MainActor
 final class ScheduleWindowValidationIntegrationTests: XCTestCase {
+  private let minimumWindowErrorFragment =
+    "at least \(DeviceActivityLimits.minimumIntervalMinutes) minutes"
 
   private func makeModel(
     startHour: Int,
@@ -61,25 +63,25 @@ final class ScheduleWindowValidationIntegrationTests: XCTestCase {
   func testGivenSubFifteenSameDayWindow_WhenValidating_ThenAppendsWindowError() {
     let model = makeModel(startHour: 9, startMinute: 0, stopHour: 9, stopMinute: 10)
     model.validate()
-    XCTAssertTrue(model.validationErrors.contains { $0.contains("at least 15 minutes") })
+    XCTAssertTrue(model.validationErrors.contains { $0.contains(minimumWindowErrorFragment) })
   }
 
   func testGivenCrossMidnightSubFifteenWindow_WhenValidating_ThenAppendsWindowError() {
     let model = makeModel(startHour: 23, startMinute: 55, stopHour: 0, stopMinute: 5)
     model.validate()
-    XCTAssertTrue(model.validationErrors.contains { $0.contains("at least 15 minutes") })
+    XCTAssertTrue(model.validationErrors.contains { $0.contains(minimumWindowErrorFragment) })
   }
 
   func testGivenFifteenMinuteWindow_WhenValidating_ThenNoWindowError() {
     let model = makeModel(startHour: 9, startMinute: 0, stopHour: 9, stopMinute: 15)
     model.validate()
-    XCTAssertFalse(model.validationErrors.contains { $0.contains("at least 15 minutes") })
+    XCTAssertFalse(model.validationErrors.contains { $0.contains(minimumWindowErrorFragment) })
   }
 
   func testGivenLegitimateOvernightWindow_WhenValidating_ThenNoWindowError() {
     let model = makeModel(startHour: 22, startMinute: 0, stopHour: 6, stopMinute: 0)
     model.validate()
-    XCTAssertFalse(model.validationErrors.contains { $0.contains("at least 15 minutes") })
+    XCTAssertFalse(model.validationErrors.contains { $0.contains(minimumWindowErrorFragment) })
   }
 
   func testGivenInactiveMatchingSchedules_WhenValidating_ThenNoSameTimeError() {

--- a/FoqosTests/ScheduleWindowValidationTests.swift
+++ b/FoqosTests/ScheduleWindowValidationTests.swift
@@ -42,15 +42,19 @@ final class ScheduleWindowValidationTests: XCTestCase {
 final class ScheduleWindowValidationIntegrationTests: XCTestCase {
 
   private func makeModel(
-    startHour: Int, startMinute: Int, stopHour: Int, stopMinute: Int
+    startHour: Int,
+    startMinute: Int,
+    stopHour: Int,
+    stopMinute: Int,
+    days: [Weekday] = [.monday]
   ) -> TriggerConfigurationModel {
     let model = TriggerConfigurationModel()
     model.startTriggers.schedule = true
     model.stopConditions.schedule = true
     model.startSchedule = ProfileScheduleTime(
-      days: [.monday], hour: startHour, minute: startMinute, updatedAt: .distantPast)
+      days: days, hour: startHour, minute: startMinute, updatedAt: .distantPast)
     model.stopSchedule = ProfileScheduleTime(
-      days: [.monday], hour: stopHour, minute: stopMinute, updatedAt: .distantPast)
+      days: days, hour: stopHour, minute: stopMinute, updatedAt: .distantPast)
     return model
   }
 
@@ -76,5 +80,11 @@ final class ScheduleWindowValidationIntegrationTests: XCTestCase {
     let model = makeModel(startHour: 22, startMinute: 0, stopHour: 6, stopMinute: 0)
     model.validate()
     XCTAssertFalse(model.validationErrors.contains { $0.contains("at least 15 minutes") })
+  }
+
+  func testGivenInactiveMatchingSchedules_WhenValidating_ThenNoSameTimeError() {
+    let model = makeModel(startHour: 9, startMinute: 0, stopHour: 9, stopMinute: 0, days: [])
+    model.validate()
+    XCTAssertFalse(model.validationErrors.contains { $0.contains("can't be the same") })
   }
 }

--- a/FoqosTests/StopScheduleIntervalTests.swift
+++ b/FoqosTests/StopScheduleIntervalTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class StopScheduleIntervalTests: XCTestCase {
+
+  func testGivenStopBeforeMidnightPlus15_WhenComputingInterval_ThenWindowIsHonorable() {
+    let (start, end) = DeviceActivityCenterUtil.stopScheduleInterval(stopHour: 0, stopMinute: 10)
+    // Anchor moves to 00:11 so the wrap window is ~1439 min, still ending at 00:10.
+    XCTAssertEqual(end.hour, 0)
+    XCTAssertEqual(end.minute, 10)
+    XCTAssertEqual(start.hour, 0)
+    XCTAssertEqual(start.minute, 11)
+    XCTAssertFalse(start.hour == end.hour && start.minute == end.minute)
+  }
+
+  func testGivenStopAtExactlyMidnight_WhenComputingInterval_ThenNotZeroLength() {
+    let (start, end) = DeviceActivityCenterUtil.stopScheduleInterval(stopHour: 0, stopMinute: 0)
+    XCTAssertEqual(end.hour, 0)
+    XCTAssertEqual(end.minute, 0)
+    XCTAssertEqual(start.hour, 0)
+    XCTAssertEqual(start.minute, 1)
+    XCTAssertFalse(start.hour == end.hour && start.minute == end.minute)
+  }
+
+  func testGivenStopAt0015_WhenComputingInterval_ThenKeepsMidnightAnchor() {
+    let (start, end) = DeviceActivityCenterUtil.stopScheduleInterval(stopHour: 0, stopMinute: 15)
+    XCTAssertEqual(start.hour, 0)
+    XCTAssertEqual(start.minute, 0)
+    XCTAssertEqual(end.hour, 0)
+    XCTAssertEqual(end.minute, 15)
+  }
+
+  func testGivenStopMidMorning_WhenComputingInterval_ThenKeepsMidnightAnchor() {
+    let (start, end) = DeviceActivityCenterUtil.stopScheduleInterval(stopHour: 9, stopMinute: 0)
+    XCTAssertEqual(start.hour, 0)
+    XCTAssertEqual(start.minute, 0)
+    XCTAssertEqual(end.hour, 9)
+    XCTAssertEqual(end.minute, 0)
+  }
+}

--- a/FoqosTests/StrategyManagerBackgroundTests.swift
+++ b/FoqosTests/StrategyManagerBackgroundTests.swift
@@ -93,6 +93,23 @@ final class StrategyManagerBackgroundTests: XCTestCase {
     }
   }
 
+  func testGivenDurationExactly1440_WhenStartingFromBackground_ThenThrowsDurationOutOfRange() throws {
+    let profile = BlockedProfiles(name: "Test")
+    context.insert(profile)
+    try context.save()
+
+    XCTAssertThrowsError(
+      try manager.startSessionFromBackground(
+        profile.id, context: context, durationInMinutes: 1440
+      )
+    ) { error in
+      if case IntentError.durationOutOfRange = error {
+      } else {
+        XCTFail("Expected durationOutOfRange, got \(error)")
+      }
+    }
+  }
+
   // MARK: - stopSessionFromBackground
 
   func testGivenNoProfile_WhenStoppingFromBackground_ThenThrowsProfileNotFound() async {

--- a/FoqosTests/TimerDurationSnapTests.swift
+++ b/FoqosTests/TimerDurationSnapTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class TimerDurationSnapTests: XCTestCase {
+
+  // Mirrors the production snapPoints after the 1440 entry is removed.
+  private let snapPoints: [Double] = [15, 30, 45, 60, 90, 120, 180, 240, 360, 480, 720]
+  private let maxMinutes: Double = 1439
+  private let threshold: Double = 10
+
+  func testGivenValueNearSnapPoint_WhenSnapping_ThenSnapsToIt() {
+    let result = TimerDurationView.snappedDuration(
+      for: 62, snapPoints: snapPoints, threshold: threshold, maxMinutes: maxMinutes)
+    XCTAssertEqual(result, 60)
+  }
+
+  func testGivenValueFarFromAnySnapPoint_WhenSnapping_ThenReturnsValue() {
+    let result = TimerDurationView.snappedDuration(
+      for: 1000, snapPoints: snapPoints, threshold: threshold, maxMinutes: maxMinutes)
+    XCTAssertEqual(result, 1000)
+  }
+
+  func testGivenValueAtMax_WhenSnapping_ThenNeverExceedsMax() {
+    let result = TimerDurationView.snappedDuration(
+      for: 1439, snapPoints: snapPoints, threshold: threshold, maxMinutes: maxMinutes)
+    XCTAssertEqual(result, 1439)
+  }
+
+  func testGivenStraySnapPointAboveMax_WhenSnapping_ThenClampedToMax() {
+    // Defense in depth: even with a bad snap point present, the result is capped.
+    let result = TimerDurationView.snappedDuration(
+      for: 1435, snapPoints: [720, 1440], threshold: threshold, maxMinutes: maxMinutes)
+    XCTAssertEqual(result, 1439)
+  }
+}

--- a/FoqosTests/TimerIntervalTests.swift
+++ b/FoqosTests/TimerIntervalTests.swift
@@ -76,4 +76,37 @@ final class TimerIntervalTests: XCTestCase {
     XCTAssertEqual(end.hour, 9)
     XCTAssertEqual(end.minute, 30)
   }
+
+  // MARK: - #212 upper-bound clamp (24h zero-length collapse guard)
+
+  func testGiven1440Minutes_WhenComputingInterval_ThenClampedToNonZeroWindow() {
+    let now = referenceDateAt(hour: 8, minute: 0)
+    let (start, end) = DeviceActivityCenterUtil.getTimeIntervalStartAndEnd(from: 1440, now: now)
+    // 24h would collapse to 08:00–08:00; clamp to 1439 → ends 07:59.
+    XCTAssertEqual(start.hour, 8)
+    XCTAssertEqual(start.minute, 0)
+    XCTAssertEqual(end.hour, 7)
+    XCTAssertEqual(end.minute, 59)
+    XCTAssertFalse(
+      start.hour == end.hour && start.minute == end.minute,
+      "Interval must never be zero-length"
+    )
+  }
+
+  func testGiven1439Minutes_WhenComputingInterval_ThenEndIsOneMinuteBeforeStart() {
+    let now = referenceDateAt(hour: 8, minute: 0)
+    let (start, end) = DeviceActivityCenterUtil.getTimeIntervalStartAndEnd(from: 1439, now: now)
+    XCTAssertEqual(start.hour, 8)
+    XCTAssertEqual(start.minute, 0)
+    XCTAssertEqual(end.hour, 7)
+    XCTAssertEqual(end.minute, 59)
+  }
+
+  func testGivenMultipleOfDay_WhenComputingInterval_ThenClampedNonZero() {
+    let now = referenceDateAt(hour: 8, minute: 0)
+    let (start, end) = DeviceActivityCenterUtil.getTimeIntervalStartAndEnd(from: 2880, now: now)
+    XCTAssertFalse(start.hour == end.hour && start.minute == end.minute)
+    XCTAssertEqual(end.hour, 7)
+    XCTAssertEqual(end.minute, 59)
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes #212 by clamping 24h timer intervals at the shared DeviceActivity chokepoint, removing the 1440 slider snap point, and rejecting 1440-minute Shortcuts starts with corrected copy.
- Fixes #228 by rejecting sub-15-minute combined schedule windows at validation time and reshaping stop-only schedule anchors before 00:15.
- Implements epic #263 bundle C1 only; no sub-15-minute enforcement/fallback mechanism was added.

## Maintainer Decisions
- #228A: reject at save via TriggerConfigurationModel.validate().
- #228B: reshape the internal stop-only interval anchor.
- Break-timer sub-15 behavior deferred to #214.

## Test Plan
- [x] xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' | xcpretty
- [x] swift-format lint --recursive .

Fixes #212
Fixes #228
Refs #263

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements bundle C1 of the DeviceActivity interval-validation epic: it fixes a 24-hour timer collapse bug (#212) by clamping `getTimeIntervalStartAndEnd` to 1439 minutes, fixes sub-15-minute stop-only schedule windows (#228) by reshaping the anchor and adding save-time validation, and removes the 1440 snap point from the duration slider.

- **`DeviceActivityLimits`** centralises the two framework-imposed constants (`minimumIntervalMinutes = 15`, `maximumTimerMinutes = 1439`) so all enforcement points share a single source of truth.
- **`stopScheduleInterval`** detects stop times before 00:15 and shifts the internal anchor one minute past the stop time, creating a ~1439-minute cross-midnight window that DeviceActivity will honour.
- **`TriggerConfigurationModel.validate()`** adds a save-time gate for schedule windows < 15 minutes using the new `TriggerValidator.scheduleWindowMinutes` modular-arithmetic helper, with a correct `window > 0` guard to avoid duplicate errors alongside the existing same-time check.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core interval-clamping and window-validation logic is correct and well-tested across all meaningful edge cases.

The three hardcoded duration strings in IntentError, StartProfileIntent, and the test assertions are the only rough edges — they can silently drift if DeviceActivityLimits constants change. All runtime logic (clamp, modular window math, stop-only anchor reshaping) is correct, and the test suite is thorough.

Foqos/Intents/IntentError.swift and Foqos/Intents/StartProfileIntent.swift carry hardcoded limit strings; FoqosTests/ScheduleWindowValidationTests.swift uses a hardcoded substring in its assertions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Foqos/Utils/DeviceActivityLimits.swift | New file — single source of truth for DeviceActivity interval limits (min 15 min, max 1439 min). Clean and well-documented. |
| Foqos/Utils/DeviceActivityCenterUtil.swift | Adds upper-bound clamp in getTimeIntervalStartAndEnd (fixes #212) and new stopScheduleInterval function for stop-only schedule anchoring (fixes #228). Logic and edge cases are correct. |
| Foqos/Models/TriggerConfigurationModel.swift | Adds sub-15-minute schedule window validation using scheduleWindowMinutes; correctly guards window > 0 to avoid duplicating the existing same-time error. |
| Foqos/Models/TriggerValidator.swift | Adds scheduleWindowMinutes static method using modular arithmetic; correctly handles both same-day and cross-midnight windows. |
| Foqos/Intents/IntentError.swift | Updated durationOutOfRange copy to '23 hours 59 minutes' but the string is hardcoded rather than derived from DeviceActivityLimits constants, creating a drift risk. |
| Foqos/Intents/StartProfileIntent.swift | Updated intent description copy to '23 hours 59 minutes' but similarly hardcoded rather than derived from DeviceActivityLimits. |
| FoqosTests/ScheduleWindowValidationTests.swift | Good coverage of scheduleWindowMinutes math and TriggerConfigurationModel integration, but assertions use hardcoded 'at least 15 minutes' strings rather than the DeviceActivityLimits constant. |
| FoqosTests/StopScheduleIntervalTests.swift | Covers stopScheduleInterval edge cases (midnight, 00:10, 00:15, 09:00) thoroughly; all assertions match the expected wrapping behavior. |
| FoqosTests/TimerIntervalTests.swift | Adds tests for 1440m clamp and multiples-of-day clamp; correctly verifies the non-zero-length invariant post-clamp. |
| FoqosTests/TimerDurationSnapTests.swift | New unit tests for snappedDuration static function, including a defense-in-depth case with a bad snap point above max. |
| FoqosTests/StrategyManagerBackgroundTests.swift | Adds test verifying that exactly 1440 minutes is now rejected with durationOutOfRange from startSessionFromBackground. |
| Foqos/Components/Strategy/TimerDurationView.swift | Removes 1440 snap point, extracts snappedDuration as a testable static method with max clamping. Logic is correct and now unit-tested. |
| Foqos/Utils/StrategyManager.swift | Updates duration bounds check to use DeviceActivityLimits constants; now correctly rejects exactly 1440 minutes. Error message matches the updated copy in IntentError. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User / Shortcut sets duration] --> B{duration < 15 or > 1439?}
    B -- yes --> C[Throw durationOutOfRange\nError shown to user]
    B -- no --> D[Save profile]

    D --> E[scheduleTimerActivity]
    E --> F{hasV2StartSchedule?}
    F -- yes + stop schedule --> G[intervalStart = startTime\nintervalEnd = stopTime]
    F -- yes, no stop --> H[intervalEnd = startTime - 1 min\n~1439 min window]
    F -- no --> I[Legacy path]

    D --> J[scheduleStopActivity]
    J --> K{hasScheduledStop and NOT hasScheduledStart?}
    K -- no --> L[Remove stop-only activity]
    K -- yes --> M[stopScheduleInterval\nstopHour:stopMinute]
    M --> N{stopMinuteOfDay < 15?}
    N -- yes --> O[anchor = stopMinute + 1\n~1439 min cross-midnight window]
    N -- no --> P[anchor = 00:00\nwindow = stopMinuteOfDay minutes]
    O --> Q[startMonitoring]
    P --> Q

    D --> R[TriggerConfigurationModel.validate]
    R --> S[scheduleWindowMinutes\nmodular arithmetic]
    S --> T{window > 0 and window < 15?}
    T -- yes --> U[Error: window must be >= 15 min\nBlocks save]
    T -- no --> V[Valid config]

    style C fill:#f99,stroke:#c00
    style U fill:#f99,stroke:#c00
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User / Shortcut sets duration] --> B{duration < 15 or > 1439?}
    B -- yes --> C[Throw durationOutOfRange\nError shown to user]
    B -- no --> D[Save profile]

    D --> E[scheduleTimerActivity]
    E --> F{hasV2StartSchedule?}
    F -- yes + stop schedule --> G[intervalStart = startTime\nintervalEnd = stopTime]
    F -- yes, no stop --> H[intervalEnd = startTime - 1 min\n~1439 min window]
    F -- no --> I[Legacy path]

    D --> J[scheduleStopActivity]
    J --> K{hasScheduledStop and NOT hasScheduledStart?}
    K -- no --> L[Remove stop-only activity]
    K -- yes --> M[stopScheduleInterval\nstopHour:stopMinute]
    M --> N{stopMinuteOfDay < 15?}
    N -- yes --> O[anchor = stopMinute + 1\n~1439 min cross-midnight window]
    N -- no --> P[anchor = 00:00\nwindow = stopMinuteOfDay minutes]
    O --> Q[startMonitoring]
    P --> Q

    D --> R[TriggerConfigurationModel.validate]
    R --> S[scheduleWindowMinutes\nmodular arithmetic]
    S --> T{window > 0 and window < 15?}
    T -- yes --> U[Error: window must be >= 15 min\nBlocks save]
    T -- no --> V[Valid config]

    style C fill:#f99,stroke:#c00
    style U fill:#f99,stroke:#c00
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(#228): reshape stop-only interval an..."](https://github.com/mnbf9rca/family-foqos/commit/19f38d464e1e3d24b3cf6d6d777338abea081fb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41954886)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->