### PR TITLE
D2 remote session handling

### DIFF
--- a/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
@@ -108,6 +108,11 @@ final class SyncApplyService {
         clearDeletionBookkeeping(recordName: recordName)  // intent already satisfied
         return .notPresent
       }
+      // §5.2 / #203: if the deleted profile owns the active session, stop it first so
+      // restrictions are deactivated and the manager does not retain a deleted model.
+      if sessionController.activeSession?.blockedProfile.id == id {
+        sessionController.stopRemoteSession(context: modelContext, profileId: id)
+      }
       try BlockedProfiles.deleteProfile(profile, in: modelContext)  // defers save
       try commit()
       clearDeletionBookkeeping(recordName: recordName)

--- a/Foqos/Models/BlockedProfileSessions.swift
+++ b/Foqos/Models/BlockedProfileSessions.swift
@@ -65,7 +65,7 @@ class BlockedProfileSession: BreakDurationCalculable {
   }
 
   func startBreak(now: Date = Date()) {
-    SharedData.setBreakStartTime(date: now)
+    SharedData.setBreakStartTime(date: now, expectedSessionId: id)
     self.breakStartTime = now
   }
 
@@ -74,12 +74,12 @@ class BlockedProfileSession: BreakDurationCalculable {
     oneMoreMinuteStartTime = now
 
     // Sync to SharedData for background/foreground transitions
-    SharedData.setOneMoreMinuteStartTime(date: now)
+    SharedData.setOneMoreMinuteStartTime(date: now, expectedSessionId: id)
   }
 
   func endSession(now: Date = Date()) {
     // Set the end time in shared data in case its being saved
-    SharedData.setEndTime(date: now)
+    SharedData.setEndTime(date: now, expectedSessionId: id)
     self.endTime = now
 
     // If this was a schedule-started session, record when it stopped.
@@ -91,7 +91,7 @@ class BlockedProfileSession: BreakDurationCalculable {
       BlockedProfiles.updateSnapshot(for: blockedProfile)
     }
 
-    SharedData.flushActiveSession()
+    SharedData.flushActiveSession(expectedSessionId: id)
   }
 
   func toSnapshot() -> SharedData.SessionSnapshot {

--- a/Foqos/Utils/LockCodeManager.swift
+++ b/Foqos/Utils/LockCodeManager.swift
@@ -358,6 +358,24 @@ class LockCodeManager: ObservableObject {
     return unlockedProfileId == profileId
   }
 
+  /// Pure gate for user-initiated edit/delete of a profile. Uses `== .child` so Individual
+  /// mode is not gated (AGENTS.md). Sync-applied deletes must not consult this gate.
+  nonisolated static func isEditLocked(
+    isManaged: Bool,
+    mode: AppMode,
+    isUnlocked: Bool
+  ) -> Bool {
+    isManaged && mode == .child && !isUnlocked
+  }
+
+  /// Gate `profile` against this device's current mode and temporary unlock state.
+  func isEditLocked(_ profile: BlockedProfiles) -> Bool {
+    LockCodeManager.isEditLocked(
+      isManaged: profile.isManaged,
+      mode: appModeManager.currentMode,
+      isUnlocked: isUnlocked(profile.id))
+  }
+
   /// Revoke temporary unlock (called when profile view is dismissed)
   func revokeUnlock() {
     unlockedProfileId = nil

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -118,7 +118,8 @@ class StrategyManager: ObservableObject {
       // #237 / MD3: reconcile against cross-process state before ending a possibly stale
       // on-screen session. The next Stop acts on the refreshed state.
       if let displayed = activeSession,
-        SharedData.getActiveSharedSession()?.id != displayed.id
+        let sharedSession = SharedData.getActiveSharedSession(),
+        sharedSession.id != displayed.id
       {
         try? loadActiveSession(context: context)
         errorMessage =

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -1183,8 +1183,10 @@ class StrategyManager: ObservableObject {
         startTime: startTime
       )
 
-      // Set as active session
-      self.activeSession = activeSession
+      // Converge on the single activation path so remote-started sessions get the same
+      // side effects as local starts. syncSessionStart is suppressed while processingRemoteChange
+      // is true, so this does not echo a session record back to CloudKit (#204).
+      activateSession(activeSession, context: context)
 
       Log.info(
         "Started remote session for profile '\(profile.name)' with synced startTime",

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -115,6 +115,18 @@ class StrategyManager: ObservableObject {
 
   func toggleBlocking(context: ModelContext, activeProfile: BlockedProfiles?) {
     if isBlocking {
+      // #237 / MD3: reconcile against cross-process state before ending a possibly stale
+      // on-screen session. The next Stop acts on the refreshed state.
+      if let displayed = activeSession,
+        SharedData.getActiveSharedSession()?.id != displayed.id
+      {
+        try? loadActiveSession(context: context)
+        errorMessage =
+          "This session was changed by a scheduled timer. The view has been refreshed. "
+          + "Tap Stop again if a session is still active."
+        return
+      }
+
       // Check geofence rule if one exists
       if let session = activeSession,
         let geofenceRule = session.blockedProfile.geofenceRule,

--- a/Foqos/Views/BlockedProfileListView.swift
+++ b/Foqos/Views/BlockedProfileListView.swift
@@ -6,6 +6,8 @@ struct BlockedProfileListView: View {
   @Environment(\.modelContext) private var context
   @Environment(\.dismiss) private var dismiss
   @EnvironmentObject private var profileSyncManager: ProfileSyncManager
+  @ObservedObject private var appModeManager = AppModeManager.shared
+  @ObservedObject private var lockCodeManager = LockCodeManager.shared
 
   @SafeQuery(sort: [
     SortDescriptor(\BlockedProfiles.order, order: .forward),
@@ -21,12 +23,14 @@ struct BlockedProfileListView: View {
 
   private enum DeleteError {
     case activeProfile
+    case lockedProfile
     case fetchFailed
     case syncFailed(String)
 
     var title: String {
       switch self {
       case .activeProfile: "Cannot Delete Active Profile"
+      case .lockedProfile: "Profile Locked"
       case .fetchFailed: "Unable to Delete"
       case .syncFailed: "Sync Error"
       }
@@ -36,6 +40,8 @@ struct BlockedProfileListView: View {
       switch self {
       case .activeProfile:
         "You cannot delete a profile that is currently active. Please switch to a different profile first."
+      case .lockedProfile:
+        "This profile is locked. Open it and enter the lock code to delete it."
       case .fetchFailed:
         "Something went wrong while checking profile status. Please try again."
       case .syncFailed(let message):
@@ -149,11 +155,15 @@ struct BlockedProfileListView: View {
     }
     let profilesToDelete = profiles
 
-    // Check if any of the profiles to delete are active
+    // Check if any of the profiles to delete are active or locked
     for index in offsets {
       let profile = profilesToDelete[index]
       if profile.id == activeSession?.blockedProfile.id {
         deleteError = .activeProfile
+        return
+      }
+      if lockCodeManager.isEditLocked(profile) {
+        deleteError = .lockedProfile
         return
       }
     }

--- a/Foqos/Views/BlockedProfileListView.swift
+++ b/Foqos/Views/BlockedProfileListView.swift
@@ -41,7 +41,8 @@ struct BlockedProfileListView: View {
       case .activeProfile:
         "You cannot delete a profile that is currently active. Please switch to a different profile first."
       case .lockedProfile:
-        "This profile is locked. Open it and enter the lock code to delete it."
+        "This profile is locked. Open the profile, enter the lock code, "
+          + "then delete it from the profile screen."
       case .fetchFailed:
         "Something went wrong while checking profile status. Please try again."
       case .syncFailed(let message):

--- a/FoqosTests/LockCodeEditGateTests.swift
+++ b/FoqosTests/LockCodeEditGateTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class LockCodeEditGateTests: XCTestCase {
+  // Only a managed profile, on a child device, not temporarily unlocked, is edit-locked.
+  func testGivenManagedProfileOnChildDeviceLocked_WhenGating_ThenEditLocked() {
+    XCTAssertTrue(
+      LockCodeManager.isEditLocked(isManaged: true, mode: .child, isUnlocked: false))
+  }
+
+  func testGivenManagedProfileOnChildDeviceUnlocked_WhenGating_ThenNotLocked() {
+    XCTAssertFalse(
+      LockCodeManager.isEditLocked(isManaged: true, mode: .child, isUnlocked: true))
+  }
+
+  func testGivenManagedProfileOnParentDevice_WhenGating_ThenNotLocked() {
+    XCTAssertFalse(
+      LockCodeManager.isEditLocked(isManaged: true, mode: .parent, isUnlocked: false))
+  }
+
+  // AGENTS.md invariant: Individual mode must NOT be gated (`== .child`, not `!= .parent`).
+  func testGivenManagedProfileOnIndividualDevice_WhenGating_ThenNotLocked() {
+    XCTAssertFalse(
+      LockCodeManager.isEditLocked(isManaged: true, mode: .individual, isUnlocked: false))
+  }
+
+  func testGivenUnmanagedProfileOnChildDevice_WhenGating_ThenNotLocked() {
+    XCTAssertFalse(
+      LockCodeManager.isEditLocked(isManaged: false, mode: .child, isUnlocked: false))
+  }
+}

--- a/FoqosTests/OneMoreMinuteTests.swift
+++ b/FoqosTests/OneMoreMinuteTests.swift
@@ -282,7 +282,8 @@ final class OneMoreMinuteTests: XCTestCase {
 
     // Act: Call the real API
     let oneMoreMinuteStart = Date()
-    SharedData.setOneMoreMinuteStartTime(date: oneMoreMinuteStart)
+    SharedData.setOneMoreMinuteStartTime(
+      date: oneMoreMinuteStart, expectedSessionId: "test-session")
 
     // Assert: SharedData is updated
     let afterSession = SharedData.getActiveSharedSession()
@@ -293,9 +294,30 @@ final class OneMoreMinuteTests: XCTestCase {
 
   func testGivenNoActiveSession_WhenSettingOneMoreMinuteStartTime_ThenNoOp() {
     // Act: Call the API with no active session (should not crash)
-    SharedData.setOneMoreMinuteStartTime(date: Date())
+    SharedData.setOneMoreMinuteStartTime(date: Date(), expectedSessionId: "any-id")
 
     // Assert: Still no session
     XCTAssertNil(SharedData.getActiveSharedSession())
+  }
+
+  func testGivenDifferentActiveSession_WhenSettingOneMoreMinute_ThenNoOp() {
+    let now = Date()
+    let profileId = UUID()
+    let stored = SharedData.SessionSnapshot(
+      id: "stored-session",
+      tag: "tag",
+      blockedProfileId: profileId,
+      startTime: now,
+      forceStarted: false
+    )
+    SharedData.createActiveSharedSession(for: stored)
+
+    // A different session tries to stamp one-more-minute.
+    SharedData.setOneMoreMinuteStartTime(date: now, expectedSessionId: "other-session")
+
+    let after = SharedData.getActiveSharedSession()
+    XCTAssertEqual(after?.id, "stored-session", "stored session untouched")
+    XCTAssertFalse(after?.oneMoreMinuteUsed ?? true, "mismatch is a no-op (#237)")
+    XCTAssertNil(after?.oneMoreMinuteStartTime)
   }
 }

--- a/FoqosTests/SharedDataSessionIdentityTests.swift
+++ b/FoqosTests/SharedDataSessionIdentityTests.swift
@@ -1,0 +1,75 @@
+@preconcurrency import FoqosShared
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class SharedDataSessionIdentityTests: XCTestCase {
+  private var container: ModelContainer!
+  private var context: ModelContext!
+  private var suiteName: String!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "SharedDataSessionIdentityTests-\(UUID().uuidString)"
+    SharedData.configure(suite: UserDefaults(suiteName: suiteName)!)
+    container = try TestModelContainer.create()
+    context = container.mainContext
+  }
+
+  override func tearDown() async throws {
+    UserDefaults().removePersistentDomain(forName: suiteName)
+    try await super.tearDown()
+  }
+
+  // #237: an in-app stop of session A must NOT clobber an extension-created session B.
+  func testGivenExtensionSessionForOtherProfile_WhenInAppSessionEnds_ThenExtensionSessionUntouched()
+    throws
+  {
+    let now = Date()
+    let profileA = BlockedProfiles(name: "A")
+    let profileB = BlockedProfiles(name: "B")
+    context.insert(profileA)
+    context.insert(profileB)
+    // App session for A (its snapshot is NOT the shared active session -- the extension replaced it).
+    let sessionA = BlockedProfileSession(tag: "A", blockedProfile: profileA)
+    context.insert(sessionA)
+    try context.save()
+
+    // Extension replaced the shared active session with B's scheduled session (fresh id).
+    SharedData.createSessionForScheduler(for: profileB.id)
+    let sharedBefore = SharedData.getActiveSharedSession()
+    XCTAssertEqual(sharedBefore?.blockedProfileId, profileB.id)
+    XCTAssertNotEqual(sharedBefore?.id, sessionA.id, "precondition: shared session is B, not A")
+
+    // Act: user taps Stop on the still-displayed A.
+    sessionA.endSession(now: now)
+
+    // Assert: B's shared session is intact -- not end-stamped, not flushed.
+    let sharedAfter = SharedData.getActiveSharedSession()
+    XCTAssertEqual(sharedAfter?.blockedProfileId, profileB.id, "B must survive the A stop (#237)")
+    XCTAssertNil(sharedAfter?.endTime, "B must not be end-stamped by A's stop")
+    // A's own SwiftData row still receives its endTime (the local mutation is unconditional).
+    XCTAssertEqual(sessionA.endTime, now)
+  }
+
+  // The matching case still works: ending the session that owns the shared snapshot clears it.
+  func testGivenOwnSharedSession_WhenInAppSessionEnds_ThenSharedSessionFlushed() throws {
+    let now = Date()
+    let profile = BlockedProfiles(name: "Own")
+    context.insert(profile)
+    let session = BlockedProfileSession(tag: "own", blockedProfile: profile)
+    context.insert(session)
+    try context.save()
+
+    // App start wrote the shared snapshot with session.id.
+    SharedData.createActiveSharedSession(for: session.toSnapshot())
+    XCTAssertEqual(SharedData.getActiveSharedSession()?.id, session.id)
+
+    session.endSession(now: now)
+
+    XCTAssertNil(SharedData.getActiveSharedSession(), "own shared session is flushed on stop")
+    XCTAssertEqual(session.endTime, now)
+  }
+}

--- a/FoqosTests/StrategyManagerReconcileTests.swift
+++ b/FoqosTests/StrategyManagerReconcileTests.swift
@@ -1,0 +1,62 @@
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class StrategyManagerReconcileTests: XCTestCase {
+  private var container: ModelContainer!
+  private var context: ModelContext!
+  private var manager: StrategyManager!
+  private var suiteName: String!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "StrategyManagerReconcileTests-\(UUID().uuidString)"
+    SharedData.configure(suite: UserDefaults(suiteName: suiteName)!)
+    container = try TestModelContainer.create()
+    context = container.mainContext
+    manager = StrategyManager()
+  }
+
+  override func tearDown() async throws {
+    manager.stopTimer()
+    UserDefaults().removePersistentDomain(forName: suiteName)
+    try await super.tearDown()
+  }
+
+  // #237 / Design Q1: tapping Stop while the shared active session was swapped by the extension
+  // must NOT end the stale on-screen session -- it reloads and surfaces instead.
+  func testGivenSharedSessionSwapped_WhenToggleStop_ThenStaleSessionNotEndedAndSurfaced() throws {
+    let profileA = BlockedProfiles(name: "A")
+    context.insert(profileA)
+    let sessionA = BlockedProfileSession(tag: "A", blockedProfile: profileA)
+    context.insert(sessionA)
+    try context.save()
+    manager.activeSession = sessionA  // stale on-screen session
+    // Extension swapped the shared active session to a different one (fresh id != sessionA.id).
+    SharedData.createSessionForScheduler(for: UUID())
+    XCTAssertNotEqual(
+      SharedData.getActiveSharedSession()?.id, sessionA.id, "precondition: shared session swapped")
+
+    manager.toggleBlocking(context: context, activeProfile: profileA)
+
+    XCTAssertNil(sessionA.endTime, "the stale session must NOT be ended (#237 / Q1)")
+    XCTAssertNotNil(manager.errorMessage, "the state change is surfaced to the user")
+  }
+
+  // Control: when the shared session matches the on-screen session, Stop proceeds normally.
+  func testGivenMatchingSharedSession_WhenToggleStop_ThenSessionEnds() throws {
+    let profile = BlockedProfiles(name: "Focus")
+    context.insert(profile)
+    let session = BlockedProfileSession(tag: "manual", blockedProfile: profile)
+    context.insert(session)
+    try context.save()
+    manager.activeSession = session
+    SharedData.createActiveSharedSession(for: session.toSnapshot())  // shared id == session.id
+
+    manager.toggleBlocking(context: context, activeProfile: profile)
+
+    XCTAssertNotNil(session.endTime, "a matching-identity Stop ends the session")
+  }
+}

--- a/FoqosTests/StrategyManagerReconcileTests.swift
+++ b/FoqosTests/StrategyManagerReconcileTests.swift
@@ -59,4 +59,20 @@ final class StrategyManagerReconcileTests: XCTestCase {
 
     XCTAssertNotNil(session.endTime, "a matching-identity Stop ends the session")
   }
+
+  // Control: a missing shared session means the displayed session is still safe to stop normally.
+  func testGivenNoSharedSession_WhenToggleStop_ThenSessionEndsWithoutScheduledTimerError() throws {
+    let profile = BlockedProfiles(name: "Focus")
+    context.insert(profile)
+    let session = BlockedProfileSession(tag: "manual", blockedProfile: profile)
+    context.insert(session)
+    try context.save()
+    manager.activeSession = session
+    XCTAssertNil(SharedData.getActiveSharedSession(), "precondition: no shared session exists")
+
+    manager.toggleBlocking(context: context, activeProfile: profile)
+
+    XCTAssertNotNil(session.endTime, "nil SharedData falls through to normal Stop")
+    XCTAssertNil(manager.errorMessage, "nil SharedData should not surface the scheduled-timer error")
+  }
 }

--- a/FoqosTests/StrategyManagerRemoteSessionTests.swift
+++ b/FoqosTests/StrategyManagerRemoteSessionTests.swift
@@ -59,4 +59,25 @@ final class StrategyManagerRemoteSessionTests: XCTestCase {
     XCTAssertNil(manager.activeSession, "cannot start remotely without local app selection")
     XCTAssertNil(manager.timerTask)
   }
+
+  // #203 payload: the real stopRemoteSession must clear the manager's active session and stop
+  // the timer. The SyncApplyService mock only proves the deletion path calls this seam.
+  func testGivenRealActiveSession_WhenStopRemoteSession_ThenActiveSessionClearedAndTimerStopped()
+    throws
+  {
+    let profile = BlockedProfiles(name: "Focus")
+    context.insert(profile)
+    let session = BlockedProfileSession(tag: "local", blockedProfile: profile)
+    context.insert(session)
+    try context.save()
+    manager.activeSession = session
+    manager.startTimer()
+    XCTAssertNotNil(manager.timerTask, "precondition: timer running")
+
+    manager.stopRemoteSession(context: context, profileId: profile.id)
+
+    XCTAssertNil(manager.activeSession, "real stopRemoteSession clears the active session (#203)")
+    XCTAssertNil(manager.timerTask, "real stopRemoteSession stops the timer (#203)")
+    XCTAssertNotNil(session.endTime, "the session is ended")
+  }
 }

--- a/FoqosTests/StrategyManagerRemoteSessionTests.swift
+++ b/FoqosTests/StrategyManagerRemoteSessionTests.swift
@@ -1,0 +1,62 @@
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class StrategyManagerRemoteSessionTests: XCTestCase {
+  private var container: ModelContainer!
+  private var context: ModelContext!
+  private var manager: StrategyManager!
+  private var suiteName: String!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "StrategyManagerRemoteSessionTests-\(UUID().uuidString)"
+    SharedData.configure(suite: UserDefaults(suiteName: suiteName)!)
+    container = try TestModelContainer.create()
+    context = container.mainContext
+    manager = StrategyManager()
+  }
+
+  override func tearDown() async throws {
+    manager.stopTimer()
+    UserDefaults().removePersistentDomain(forName: suiteName)
+    try await super.tearDown()
+  }
+
+  // #204: a remote start must converge on activateSession, not hand-roll a subset.
+  // timerTask is the synchronous discriminator for activateSession's startTimer().
+  func testGivenRemoteStart_WhenStartRemoteSession_ThenActiveSessionAndTimerStarted() throws {
+    let now = Date()
+    let profile = BlockedProfiles(name: "Focus")
+    context.insert(profile)
+    try context.save()
+
+    manager.startRemoteSession(
+      context: context, profileId: profile.id, sessionId: UUID(), startTime: now)
+
+    XCTAssertEqual(
+      manager.activeSession?.blockedProfile.id, profile.id,
+      "remote session becomes the active session")
+    XCTAssertEqual(manager.activeSession?.startTime, now, "synced startTime preserved")
+    XCTAssertNotNil(
+      manager.timerTask,
+      "activateSession's startTimer() must run on the remote-start path (#204)")
+  }
+
+  // Guard: a remote start for a profile needing app selection must NOT activate.
+  func testGivenProfileNeedsAppSelection_WhenStartRemoteSession_ThenNoActivation() throws {
+    let now = Date()
+    let profile = BlockedProfiles(name: "NoApps")
+    profile.needsAppSelection = true
+    context.insert(profile)
+    try context.save()
+
+    manager.startRemoteSession(
+      context: context, profileId: profile.id, sessionId: UUID(), startTime: now)
+
+    XCTAssertNil(manager.activeSession, "cannot start remotely without local app selection")
+    XCTAssertNil(manager.timerTask)
+  }
+}

--- a/FoqosTests/SyncApplyServiceTests.swift
+++ b/FoqosTests/SyncApplyServiceTests.swift
@@ -459,6 +459,56 @@ final class SyncApplyServiceTests: XCTestCase {
     XCTAssertEqual(sessionController.stopRemoteSessionProfileId, id)
   }
 
+  // #203: a remote profile deletion for the active profile must stop the session
+  // before deleting the profile.
+  func testGivenActiveSessionProfile_WhenProfileDeletionApplied_ThenSessionStoppedThenDeleted()
+    throws
+  {
+    let id = UUID()
+    let profile = BlockedProfiles(id: id, name: "Focus", syncVersion: 1)
+    context.insert(profile)
+    let session = BlockedProfileSession(tag: "local", blockedProfile: profile)
+    context.insert(session)
+    try context.save()
+    sessionController.activeSession = session
+
+    let outcome = makeService().applyFetchedDeletion(
+      recordID: CKRecord.ID(recordName: id.uuidString, zoneID: zoneID),
+      recordType: SyncedProfile.recordType)
+
+    XCTAssertEqual(outcome, .deleted)
+    XCTAssertTrue(
+      sessionController.stopRemoteSessionCalled,
+      "the owned session must be stopped before the profile is deleted (#203)")
+    XCTAssertEqual(sessionController.stopRemoteSessionProfileId, id)
+    XCTAssertNil(
+      try BlockedProfiles.findProfile(byID: id, in: context), "profile is still deleted")
+  }
+
+  // Negative: a remote profile deletion for a non-active profile must not touch the session.
+  func testGivenDeletionForNonActiveProfile_WhenApplied_ThenNoSessionStop() throws {
+    let activeId = UUID()
+    let deleteId = UUID()
+    let activeProfile = BlockedProfiles(id: activeId, name: "Active", syncVersion: 1)
+    let deleteProfile = BlockedProfiles(id: deleteId, name: "Delete", syncVersion: 1)
+    context.insert(activeProfile)
+    context.insert(deleteProfile)
+    let activeSession = BlockedProfileSession(tag: "local", blockedProfile: activeProfile)
+    context.insert(activeSession)
+    try context.save()
+    sessionController.activeSession = activeSession
+
+    XCTAssertEqual(
+      makeService().applyFetchedDeletion(
+        recordID: CKRecord.ID(recordName: deleteId.uuidString, zoneID: zoneID),
+        recordType: SyncedProfile.recordType),
+      .deleted)
+    XCTAssertFalse(
+      sessionController.stopRemoteSessionCalled, "unrelated profile deletion never stops the session")
+    XCTAssertNil(try BlockedProfiles.findProfile(byID: deleteId, in: context))
+    XCTAssertNotNil(try BlockedProfiles.findProfile(byID: activeId, in: context))
+  }
+
   // MARK: - S-2
 
   func testGivenEmptyFetch_WhenApplied_ThenZeroLocalMutations() throws {

--- a/Packages/FoqosShared/Sources/FoqosShared/SharedData.swift
+++ b/Packages/FoqosShared/Sources/FoqosShared/SharedData.swift
@@ -412,8 +412,9 @@ public enum SharedData {
     }
   }
 
-  public static func flushActiveSession() {
+  public static func flushActiveSession(expectedSessionId: String) {
     withLock {
+      guard activeSharedSession?.id == expectedSessionId else { return }
       activeSharedSession = nil
     }
   }
@@ -429,36 +430,39 @@ public enum SharedData {
     }
   }
 
-  public static func setBreakStartTime(date: Date) {
+  public static func setBreakStartTime(date: Date, expectedSessionId: String) {
     withLock {
+      guard activeSharedSession?.id == expectedSessionId else { return }
       activeSharedSession?.breakStartTime = date
     }
   }
 
-  public static func setBreakEndTime(date: Date) {
+  public static func setBreakEndTime(date: Date, expectedSessionId: String) {
     withLock {
+      guard activeSharedSession?.id == expectedSessionId else { return }
       activeSharedSession?.breakEndTime = date
     }
   }
 
-  public static func setEndTime(date: Date) {
+  public static func setEndTime(date: Date, expectedSessionId: String) {
     withLock {
+      guard activeSharedSession?.id == expectedSessionId else { return }
       activeSharedSession?.endTime = date
     }
   }
 
-  public static func setOneMoreMinuteStartTime(date: Date) {
+  public static func setOneMoreMinuteStartTime(date: Date, expectedSessionId: String) {
     withLock {
-      guard var session = activeSharedSession else { return }
+      guard var session = activeSharedSession, session.id == expectedSessionId else { return }
       session.oneMoreMinuteStartTime = date
       session.oneMoreMinuteUsed = true
       activeSharedSession = session
     }
   }
 
-  public static func clearOneMoreMinuteStartTime() {
+  public static func clearOneMoreMinuteStartTime(expectedSessionId: String) {
     withLock {
-      guard var session = activeSharedSession else { return }
+      guard var session = activeSharedSession, session.id == expectedSessionId else { return }
       session.oneMoreMinuteStartTime = nil
       activeSharedSession = session
     }

--- a/Packages/FoqosShared/Sources/FoqosShared/SharedData.swift
+++ b/Packages/FoqosShared/Sources/FoqosShared/SharedData.swift
@@ -412,9 +412,26 @@ public enum SharedData {
     }
   }
 
+  private static func activeSharedSessionMatchesExpected(
+    _ expectedSessionId: String, operation: String
+  ) -> Bool {
+    guard activeSharedSession?.id == expectedSessionId else {
+      let activeSessionId = activeSharedSession?.id ?? "nil"
+      Log.debug(
+        "SharedData \(operation) skipped: expected session \(expectedSessionId), "
+          + "active session \(activeSessionId)",
+        category: .session
+      )
+      return false
+    }
+
+    return true
+  }
+
   public static func flushActiveSession(expectedSessionId: String) {
     withLock {
-      guard activeSharedSession?.id == expectedSessionId else { return }
+      guard activeSharedSessionMatchesExpected(expectedSessionId, operation: "flushActiveSession")
+      else { return }
       activeSharedSession = nil
     }
   }
@@ -432,28 +449,33 @@ public enum SharedData {
 
   public static func setBreakStartTime(date: Date, expectedSessionId: String) {
     withLock {
-      guard activeSharedSession?.id == expectedSessionId else { return }
+      guard activeSharedSessionMatchesExpected(expectedSessionId, operation: "setBreakStartTime")
+      else { return }
       activeSharedSession?.breakStartTime = date
     }
   }
 
   public static func setBreakEndTime(date: Date, expectedSessionId: String) {
     withLock {
-      guard activeSharedSession?.id == expectedSessionId else { return }
+      guard activeSharedSessionMatchesExpected(expectedSessionId, operation: "setBreakEndTime")
+      else { return }
       activeSharedSession?.breakEndTime = date
     }
   }
 
   public static func setEndTime(date: Date, expectedSessionId: String) {
     withLock {
-      guard activeSharedSession?.id == expectedSessionId else { return }
+      guard activeSharedSessionMatchesExpected(expectedSessionId, operation: "setEndTime")
+      else { return }
       activeSharedSession?.endTime = date
     }
   }
 
   public static func setOneMoreMinuteStartTime(date: Date, expectedSessionId: String) {
     withLock {
-      guard var session = activeSharedSession, session.id == expectedSessionId else { return }
+      guard activeSharedSessionMatchesExpected(expectedSessionId, operation: "setOneMoreMinuteStartTime"),
+        var session = activeSharedSession
+      else { return }
       session.oneMoreMinuteStartTime = date
       session.oneMoreMinuteUsed = true
       activeSharedSession = session
@@ -462,7 +484,9 @@ public enum SharedData {
 
   public static func clearOneMoreMinuteStartTime(expectedSessionId: String) {
     withLock {
-      guard var session = activeSharedSession, session.id == expectedSessionId else { return }
+      guard activeSharedSessionMatchesExpected(expectedSessionId, operation: "clearOneMoreMinuteStartTime"),
+        var session = activeSharedSession
+      else { return }
       session.oneMoreMinuteStartTime = nil
       activeSharedSession = session
     }

--- a/Packages/FoqosShared/Sources/FoqosShared/Timers/BreakTimerActivity.swift
+++ b/Packages/FoqosShared/Sources/FoqosShared/Timers/BreakTimerActivity.swift
@@ -40,7 +40,7 @@ public class BreakTimerActivity: TimerActivity {
 
     // End the active scheduled session
     let now = Date()
-    SharedData.setBreakStartTime(date: now)
+    SharedData.setBreakStartTime(date: now, expectedSessionId: activeSession.id)
   }
 
   public func stop(for profile: SharedData.ProfileSnapshot) {
@@ -69,7 +69,8 @@ public class BreakTimerActivity: TimerActivity {
 
       // Set the break end time
       let now = Date()
-      SharedData.setBreakEndTime(date: now)
+      // If the shared session changed since the read above, this no-ops for the foreign session.
+      SharedData.setBreakEndTime(date: now, expectedSessionId: activeSession.id)
     }
   }
 }

--- a/Packages/FoqosShared/Sources/FoqosShared/Timers/OneMoreMinuteTimerActivity.swift
+++ b/Packages/FoqosShared/Sources/FoqosShared/Timers/OneMoreMinuteTimerActivity.swift
@@ -52,7 +52,7 @@ public class OneMoreMinuteTimerActivity: TimerActivity {
       appBlocker.activateRestrictions(for: profile)
 
       // Clear the one more minute start time so the session knows it's no longer active
-      SharedData.clearOneMoreMinuteStartTime()
+      SharedData.clearOneMoreMinuteStartTime(expectedSessionId: activeSession.id)
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #237 by identity-gating SharedData session mutators and reconciling/surfacing stale manual Stop attempts.
- Fixes #194 by adding the child-only local edit/delete lock gate used by the profile list delete handler.
- Fixes #204 by routing remote session starts through activateSession so local side effects are restored.
- Fixes #203 by stopping the owned active session before applying a remote profile deletion.

Fixes #203
Fixes #204
Fixes #237
Fixes #194

## Maintainer decisions
- MD1 (#203): implemented stop-immediately-before-delete.
- MD2 (#203): remote deletes are honored uniformly; no mode/lock logic was added to SyncApplyService. The local #194 delete gate is included in this PR.
- MD3 (#237): identity mismatch no-ops at the mutator floor and the manual Stop path reloads and surfaces the refreshed state.

## Plan notes
- Executed the mandatory citation refresh first against current main, including the post-#275 StrategyManager and DeviceActivityCenterUtil state.
- No semantic deviations from the approved plan. Task 4 was implemented before Task 3 to satisfy the plan prerequisite.
- Setup friction resolved locally: core.hooksPath was changed from an absolute path to .githooks as required by the build script.

## Verification
- Baseline before edits: xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED | xcpretty -> passed.
- Red/green targeted tests were run for each task per TDD.
- Final full suite: xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED | xcpretty -> passed.
- swift-format lint --recursive . -> exit 0; reports two pre-existing naming warnings in WelcomeIntroScreen.swift and FoqosApp.swift.

## Review
Please review before merge per AGENTS.md.

## Summary by Sourcery

Align remote and local session handling with shared session identity and locking rules, ensuring safe remote deletions, timer-driven changes, and child-only profile edit/delete gating.

New Features:
- Add a child-only lock gate for profile edit/delete actions and surface locked-profile errors in the profile list.
- Route remote session starts through the unified activation path so they become the active session with the same side effects as local starts.
- Gate SharedData session mutations by expected session identity to prevent one process from clobbering another session.

Bug Fixes:
- Ensure remote deletion of an active profile stops the owned session first so restrictions are cleaned up and the manager does not retain a deleted model.
- Prevent in-app stops and timer activities from mutating or flushing a shared session when its identity no longer matches the on-screen session, instead reloading and surfacing the updated state.

Enhancements:
- Add reconciliation logic to StrategyManager stop handling to detect and reload when the shared active session was swapped by an extension and show a user-facing message.
- Refine LockCodeManager with a reusable edit-lock predicate that matches the child-only gating rules while keeping Individual mode ungated.

Tests:
- Add dedicated tests for SyncApplyService, StrategyManager remote sessions and reconciliation, SharedData session identity behavior, lock-code edit gating, and one-more-minute identity checks to cover the new session and locking rules.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes four related remote/shared-session bugs: identity-gates all `SharedData` session mutators with an `expectedSessionId` parameter so a stale in-app session can never clobber an extension-created session; reconciles cross-process state before a manual Stop; routes remote-started sessions through `activateSession` so timer, Live Activity, and DeviceActivity side-effects are properly initialised; and stops an owned active session before applying a remote profile deletion.

- **#237 / SharedData identity gate**: All `SharedData` mutators (`setBreakStartTime`, `setBreakEndTime`, `setEndTime`, `setOneMoreMinuteStartTime`, `clearOneMoreMinuteStartTime`, `flushActiveSession`) now carry an `expectedSessionId` guard. `toggleBlocking` reconciles against `SharedData.getActiveSharedSession()` before stopping and surfaces a refresh error when the IDs diverge.
- **#204 / Remote session activation**: `startRemoteSession` now delegates to `activateSession` instead of hand-rolling `self.activeSession =`; `syncSessionStart` is suppressed while `processingRemoteChange` is true, preventing a CloudKit echo.
- **#203 / Delete-before-stop**: `SyncApplyService.deleteLocalProfile` calls `stopRemoteSession` before `deleteProfile`, deactivating restrictions and clearing the manager reference before the profile row is removed.
- **#194 / Child edit-lock gate**: `LockCodeManager.isEditLocked` is extracted as a pure `nonisolated static` function and wired into `BlockedProfileListView`'s delete handler, blocking managed-profile deletion on a child device.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The four targeted bugs are correctly addressed and every changed behaviour is covered by new tests that were verified to go red/green.

The SharedData identity-gate, activateSession routing, stop-before-delete, and child edit-lock changes are each clean and well-tested. Two minor concerns were found: if commit() throws after stopRemoteSession in deleteLocalProfile, the in-memory side-effects cannot be rolled back by modelContext.rollback(), leaving a small recovery gap on an uncommon error path; and the reconcile guard in toggleBlocking also fires when SharedData holds no session, which could surface a misleading 'changed by scheduled timer' message in an abnormal system state. Both are edge-case, non-blocking concerns.

SyncApplyService.swift (stop-before-delete error path) and StrategyManager.swift (reconcile nil guard) are worth a second look; all other files are straightforward.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Packages/FoqosShared/Sources/FoqosShared/SharedData.swift | All session-mutating methods now require an expectedSessionId guard; identity mismatch is a silent no-op. Public API change is additive only. |
| Foqos/Utils/StrategyManager.swift | Reconcile guard in toggleBlocking is correct for the swap case; nil SharedData triggers the same guard path and could produce a spurious error message in an edge case. startRemoteSession now routes through activateSession correctly. |
| Foqos/CloudKit/SyncEngine/SyncApplyService.swift | stopRemoteSession is called before deleteProfile as required; if commit() throws, modelContext.rollback() restores SwiftData but in-memory side effects are not reversible — minor inconsistency on an uncommon error path. |
| Foqos/Models/BlockedProfileSessions.swift | All SharedData mutator calls updated with expectedSessionId: id. Correct and complete. |
| Foqos/Utils/LockCodeManager.swift | New isEditLocked static gate uses == .child (not != .parent) per AGENTS.md invariant; nonisolated and pure, making it unit-testable without a real LockCodeManager instance. |
| Foqos/Views/BlockedProfileListView.swift | Adds lockCodeManager.isEditLocked(profile) check before deletion, consistent with the pattern used in other views. Both new @ObservedObject singletons follow the established codebase pattern. |
| Packages/FoqosShared/Sources/FoqosShared/Timers/BreakTimerActivity.swift | Both setBreakStartTime and setBreakEndTime calls updated with expectedSessionId. Correct. |
| Packages/FoqosShared/Sources/FoqosShared/Timers/OneMoreMinuteTimerActivity.swift | clearOneMoreMinuteStartTime updated with expectedSessionId. Correct. |
| FoqosTests/SharedDataSessionIdentityTests.swift | New test file covers the cross-process session clobber scenario and the happy-path own-session flush. |
| FoqosTests/StrategyManagerRemoteSessionTests.swift | Tests confirm timer starts on remote session activation and stopRemoteSession clears state correctly. |
| FoqosTests/StrategyManagerReconcileTests.swift | Tests the swap-detection reconcile path and the matching-identity fast path. Both cases covered. |
| FoqosTests/LockCodeEditGateTests.swift | Five parameterised cases cover the isEditLocked matrix including the AGENTS.md individual-mode invariant. |
| FoqosTests/SyncApplyServiceTests.swift | Two new tests cover the stop-before-delete path (positive) and the non-active profile deletion path (negative). |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Ext as Extension
    participant SD as SharedData
    participant SM as StrategyManager
    participant SAS as SyncApplyService
    participant SwiftData

    note over Ext,SwiftData: #237 — Cross-process session swap
    Ext->>SD: createSessionForScheduler(profileB.id)
    SM->>SD: "getActiveSharedSession()?.id != displayed.id"
    SM->>SM: loadActiveSession(context)
    SM-->>SM: "errorMessage = session changed"

    note over SM,SwiftData: #204 — Remote session start via activateSession
    SAS->>SM: startRemoteSession(context, profileId, startTime)
    SM->>SM: "processingRemoteChange = true"
    SM->>SwiftData: createSession(in:, tag:remote-sync)
    SwiftData->>SD: createActiveSharedSession(for: snapshot)
    SM->>SM: activateSession — startTimer, scheduleStopActivity
    SM->>SM: syncSessionStart skipped (processingRemoteChange)
    SM->>SM: "processingRemoteChange = false"

    note over SAS,SwiftData: #203 — Remote profile deletion stops owned session first
    SAS->>SM: stopRemoteSession(context, profileId)
    SM->>SM: "processingRemoteChange = true"
    SM->>SD: flushActiveSession(expectedSessionId: id)
    SM->>SM: "activeSession = nil, no sync echo"
    SM->>SM: "processingRemoteChange = false"
    SAS->>SwiftData: deleteProfile(profile)
    SAS->>SwiftData: commit()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Ext as Extension
    participant SD as SharedData
    participant SM as StrategyManager
    participant SAS as SyncApplyService
    participant SwiftData

    note over Ext,SwiftData: #237 — Cross-process session swap
    Ext->>SD: createSessionForScheduler(profileB.id)
    SM->>SD: "getActiveSharedSession()?.id != displayed.id"
    SM->>SM: loadActiveSession(context)
    SM-->>SM: "errorMessage = session changed"

    note over SM,SwiftData: #204 — Remote session start via activateSession
    SAS->>SM: startRemoteSession(context, profileId, startTime)
    SM->>SM: "processingRemoteChange = true"
    SM->>SwiftData: createSession(in:, tag:remote-sync)
    SwiftData->>SD: createActiveSharedSession(for: snapshot)
    SM->>SM: activateSession — startTimer, scheduleStopActivity
    SM->>SM: syncSessionStart skipped (processingRemoteChange)
    SM->>SM: "processingRemoteChange = false"

    note over SAS,SwiftData: #203 — Remote profile deletion stops owned session first
    SAS->>SM: stopRemoteSession(context, profileId)
    SM->>SM: "processingRemoteChange = true"
    SM->>SD: flushActiveSession(expectedSessionId: id)
    SM->>SM: "activeSession = nil, no sync echo"
    SM->>SM: "processingRemoteChange = false"
    SAS->>SwiftData: deleteProfile(profile)
    SAS->>SwiftData: commit()
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Foqos/CloudKit/SyncEngine/SyncApplyService.swift`, line 111-120 ([link](https://github.com/mnbf9rca/family-foqos/blob/e153de5472886917cfe667a7c206ad3424318e96/Foqos/CloudKit/SyncEngine/SyncApplyService.swift#L111-L120)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Partial in-memory rollback on `commit()` failure**

   `stopRemoteSession` runs to completion before `deleteProfile` is attempted: it sets `StrategyManager.activeSession = nil`, calls `SharedData.flushActiveSession`, deactivates restrictions, and ends the Live Activity. If `commit()` subsequently throws, `modelContext.rollback()` restores the SwiftData session's `endTime` and the profile row, but none of those in-memory side-effects are reversed. The app then has an active SwiftData session with no `endTime`, a `nil` manager reference, and a cleared `SharedData` slot — requiring a fresh `loadActiveSession` (e.g. via app re-foreground) to recover.

   `commit()` failing here is uncommon and the restrictions are already off, so the user isn't blocked. Worth noting as a recovery gap in the error path if `SyncApplyService` ever gains retry logic.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(#203): stop owned session before rem..."](https://github.com/mnbf9rca/family-foqos/commit/e153de5472886917cfe667a7c206ad3424318e96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42019097)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->