### PR TITLE
docs(#263/F,I): zombie-model safety + app-group migration ordering plans (#213, #235, #217)

### DIFF
--- a/docs/superpowers/plans/2026-07-06-f-zombie-model-safety.md
+++ b/docs/superpowers/plans/2026-07-06-f-zombie-model-safety.md
@@ -1,0 +1,717 @@
+# Bundle F — Zombie-Model Safety in Secondary Views Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop two `EXC_BREAKPOINT` zombie-model crashes: `ProfileInsightsUtil`/`ProfileInsightsView` dereferencing a `BlockedProfiles` that was deleted (e.g. via CloudKit sync) while the Insights sheet is open (#213), and `BlockedSessionsHabitTracker` dereferencing `BlockedProfileSession` objects it cached in `@State` after they were cascade-deleted (#235).
+
+**Architecture:** Reuse the codebase's existing three-layer zombie defense — the `.valid` array filter (`Foqos/Utils/Extensions.swift`) and `SafeModelView` render guard (`Foqos/Utils/SafeModelView.swift`). #213: harden the data path in `ProfileInsightsUtil` with a profile-aliveness guard (unit-testable) and wrap the view body in `SafeModelView` for the render path. #235: stop caching model objects in `@State`; derive the day's sessions fresh from the parent's `@SafeQuery`-backed array through a pure, `.valid`-filtering, `now`-injectable static function (unit-testable). No new machinery is invented.
+
+**Tech Stack:** Swift 6, SwiftUI, SwiftData, XCTest. iOS app target module name is `FamilyFoqos`.
+
+**Source commit (current `main` at authoring):** `6ffb8c22b52c4b47da610b978783ccc69774f712`
+
+**Epic:** #263 (defect-audit follow-ups). Bundle F. Issues: #213 (high), #235 (medium).
+
+## Implementation Sequencing (read first)
+
+Bundle **F** and Bundle **I** (app-group UserDefaults migration ordering, #217) are implemented as **two separate, sequential PRs**. **F ships first.** Branch F from `main`; open its PR; after F merges, branch I from the new `main`. Do not develop them in parallel — this repo forbids concurrent build/test streams on one machine (see AGENTS.md "NO parallel development").
+
+## Global Constraints
+
+- Read `AGENTS.md` at the repo root before writing any code. It overrides everything else.
+- Work on a feature branch off `main`. **NEVER** amend or force-push; new commits only. Request code review before merging.
+- Views must use `@SafeQuery` (never raw `@Query`); non-query model arrays must be filtered with `.valid`.
+- Use `Log.<level>(_, category:)` instead of `print()`. Never log lock codes or personal identifiers.
+- swift-format is enforced by a pre-commit hook (2-space indent, ~100–120 col). Run `swift-format --in-place --recursive .` before committing if not relying on the hook.
+- Tests: name `testGivenX_WhenY_ThenZ()`; pin time — capture **one** `let now = Date()` per test and derive all other dates from it; inject via `now:` parameters.
+- Tests import the app module with `@testable import FamilyFoqos`. Use the existing `TestModelContainer.create()` (in-memory `ModelContainer` for `BlockedProfiles`, `BlockedProfileSession`, `SavedLocation`).
+- Run tests against an **already-booted** simulator by **UUID** (never device name), reusing one boot:
+  ```bash
+  xcrun simctl list devices available | grep "iPhone 17"   # pick the UUID once
+  xcrun simctl boot <UUID>                                  # once per session (~3-4 min)
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+    -destination 'platform=iOS Simulator,id=<UUID>' | xcpretty
+  # Single class:
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+    -destination 'platform=iOS Simulator,id=<UUID>' -only-testing:FoqosTests/ClassName | xcpretty
+  ```
+
+## Background: why `.valid` alone does not fix #213
+
+`.valid` filters *zombie elements out of an array*. For #235 that is the whole fix (the deleted objects are the `BlockedProfileSession` elements). For #213 the deleted object is the **`BlockedProfiles` itself** — the very expression `profile.sessions` dereferences the deleted model and crashes **before** any `.valid` filter can run. So #213 needs a guard on the *profile's* liveness (`profile.modelContext != nil && !profile.isDeleted`) **before** touching `profile.sessions`, plus `.valid` on the resulting sessions for cascade-deleted children. This is exactly what `SafeModelView` checks at render time; Task F1 mirrors it in the data path so the crash is fixed *and* unit-testable.
+
+## Existing infrastructure (verified on the source commit — do not re-create)
+
+`Foqos/Utils/Extensions.swift:13`:
+```swift
+extension Array where Element: PersistentModel {
+  var valid: [Element] {
+    filter { $0.modelContext != nil && !$0.isDeleted }
+  }
+}
+```
+
+`Foqos/Utils/SafeModelView.swift`:
+```swift
+struct SafeModelView<Model: PersistentModel, Content: View>: View {
+  let model: Model
+  let content: (Model) -> Content
+  init(_ model: Model, @ViewBuilder content: @escaping (Model) -> Content) {
+    self.model = model
+    self.content = content
+  }
+  var body: some View {
+    if model.modelContext != nil && !model.isDeleted {
+      content(model)
+    }
+  }
+}
+```
+
+`BlockedProfileSession` (`Foqos/Models/BlockedProfileSessions.swift`) relevant surface:
+```swift
+init(tag: String, blockedProfile: BlockedProfiles, forceStarted: Bool = false, startTime: Date = Date())
+func duration(now: Date = Date()) -> TimeInterval   // endTime ?? now, minus startTime
+var startTime: Date; var endTime: Date?; var blockedProfile: BlockedProfiles
+```
+`BlockedProfiles` convenience init used in tests: `BlockedProfiles(name: "…")` and
+`BlockedProfiles(id: UUID(), name: "…", selectedActivity: .init(), blockingStrategyId: "manual")`.
+
+---
+
+## File Structure
+
+- **Modify** `Foqos/Utils/ProfileInsightsUtil.swift` — add profile-aliveness + `.valid` guard; route all 8 `profile.sessions` reads through it (Task F1).
+- **Modify** `Foqos/Views/ProfileInsightsView.swift` — wrap the sheet body in `SafeModelView` (Task F2).
+- **Modify** `Foqos/Components/Dashboard/BlockedSessionsHabitTracker.swift` — remove the `@State` session cache; add a pure static `sessionsForDate(_:in:now:)` and a `validSessions` computed (Task F3).
+- **Create** `FoqosTests/ProfileInsightsUtilTests.swift` — unit tests for F1.
+- **Create** `FoqosTests/BlockedSessionsHabitTrackerTests.swift` — unit tests for F3.
+
+---
+
+## Task F1: Harden `ProfileInsightsUtil` against a deleted profile (#213)
+
+**Files:**
+- Modify: `Foqos/Utils/ProfileInsightsUtil.swift`
+- Test: `FoqosTests/ProfileInsightsUtilTests.swift` (create)
+
+**Interfaces:**
+- Consumes: `Array.valid` (`Foqos/Utils/Extensions.swift`), `BlockedProfiles`, `BlockedProfileSession`.
+- Produces: unchanged public surface of `ProfileInsightsUtil` — `init(profile:)`, `metrics`, `refresh()`, `setDateRange(start:end:)`, `dailyAggregates(days:endingOn:)`, `hourlyAggregates(days:endingOn:)`, `breakDailyAggregates`, `breakHourlyAggregates`, `sessionEndHourlyAggregates`, `breakStartHourlyAggregates`, `breakEndHourlyAggregates`. Behavior change: every aggregation now returns empty/zero when the profile is a zombie, instead of crashing.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `FoqosTests/ProfileInsightsUtilTests.swift`:
+
+```swift
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class ProfileInsightsUtilTests: XCTestCase {
+  private var container: ModelContainer!
+  private var context: ModelContext!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    container = try TestModelContainer.create()
+    context = container.mainContext
+  }
+
+  override func tearDown() async throws {
+    container = nil
+    context = nil
+    try await super.tearDown()
+  }
+
+  private func makeProfileWithCompletedSession(now: Date) throws -> BlockedProfiles {
+    let profile = BlockedProfiles(
+      id: UUID(), name: "Insights", selectedActivity: .init(), blockingStrategyId: "manual")
+    context.insert(profile)
+    let session = BlockedProfileSession(
+      tag: "s", blockedProfile: profile, startTime: now.addingTimeInterval(-3600))
+    session.endTime = now.addingTimeInterval(-1800)
+    context.insert(session)
+    try context.save()
+    return profile
+  }
+
+  func testGivenLiveProfileWithSession_WhenInit_ThenCountsCompletedSession() throws {
+    let now = Date()
+    let profile = try makeProfileWithCompletedSession(now: now)
+
+    let util = ProfileInsightsUtil(profile: profile)
+
+    XCTAssertEqual(util.metrics.totalCompletedSessions, 1)
+  }
+
+  func testGivenProfileDeletedAfterInit_WhenRefreshAndAggregate_ThenReturnsEmptyWithoutCrashing()
+    throws
+  {
+    let now = Date()
+    let profile = try makeProfileWithCompletedSession(now: now)
+    let util = ProfileInsightsUtil(profile: profile)
+    XCTAssertEqual(util.metrics.totalCompletedSessions, 1, "precondition: alive")
+
+    // Profile is deleted (e.g. a remote CloudKit deletion) while the sheet retains `util`.
+    context.delete(profile)
+
+    // None of these may crash; all must return empty/zero.
+    util.refresh()
+    XCTAssertEqual(util.metrics.totalCompletedSessions, 0)
+    XCTAssertEqual(util.metrics.totalFocusTime, 0)
+    XCTAssertTrue(util.dailyAggregates(days: 14, endingOn: now).allSatisfy { $0.sessionsCount == 0 })
+    XCTAssertTrue(
+      util.hourlyAggregates(days: 14, endingOn: now).allSatisfy { $0.sessionsStarted == 0 })
+    XCTAssertTrue(
+      util.breakDailyAggregates(days: 14, endingOn: now).allSatisfy { $0.breaksCount == 0 })
+    XCTAssertTrue(
+      util.sessionEndHourlyAggregates(days: 14, endingOn: now).allSatisfy { $0.sessionsEnded == 0 })
+  }
+
+  func testGivenOneCascadeDeletedSession_WhenInit_ThenExcludesZombieSession() throws {
+    let now = Date()
+    let profile = BlockedProfiles(
+      id: UUID(), name: "Insights", selectedActivity: .init(), blockingStrategyId: "manual")
+    context.insert(profile)
+    let live = BlockedProfileSession(
+      tag: "live", blockedProfile: profile, startTime: now.addingTimeInterval(-3600))
+    live.endTime = now.addingTimeInterval(-1800)
+    let zombie = BlockedProfileSession(
+      tag: "zombie", blockedProfile: profile, startTime: now.addingTimeInterval(-3600))
+    zombie.endTime = now.addingTimeInterval(-1800)
+    context.insert(live)
+    context.insert(zombie)
+    try context.save()
+
+    context.delete(zombie)
+
+    let util = ProfileInsightsUtil(profile: profile)
+    XCTAssertEqual(util.metrics.totalCompletedSessions, 1)
+  }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=<UUID>' \
+  -only-testing:FoqosTests/ProfileInsightsUtilTests | xcpretty
+```
+Expected: `testGivenProfileDeletedAfterInit_…` **crashes / fails** (an `EXC_BREAKPOINT` or a non-zero count) because `refresh()` → `computeMetrics` dereferences `profile.sessions` on the deleted model. `testGivenOneCascadeDeletedSession_…` fails with count `2` (zombie not filtered). The live-profile test passes.
+
+- [ ] **Step 3: Add the aliveness + `.valid` guard**
+
+In `Foqos/Utils/ProfileInsightsUtil.swift`, insert these two members immediately after the `refresh()` method (after the closing brace of `refresh()`, before `private static func computeMetrics`):
+
+```swift
+  /// Zombie-safe access to the profile's sessions. Returns `[]` when the profile has been
+  /// deleted (e.g. via CloudKit sync) while this util is retained by an open sheet — accessing
+  /// `profile.sessions` on a deleted model raises EXC_BREAKPOINT (#213). Also `.valid`-filters
+  /// any individually cascade-deleted sessions. Mirrors the SafeModelView render guard in the
+  /// data path so the fix is unit-testable. See AGENTS.md (@SafeQuery / `.valid`).
+  private static func validSessions(of profile: BlockedProfiles) -> [BlockedProfileSession] {
+    guard profile.modelContext != nil && !profile.isDeleted else { return [] }
+    return profile.sessions.valid
+  }
+
+  private var validSessions: [BlockedProfileSession] {
+    Self.validSessions(of: profile)
+  }
+```
+
+- [ ] **Step 4: Route all 8 `profile.sessions` reads through the guard**
+
+Make these exact replacements in `Foqos/Utils/ProfileInsightsUtil.swift`. Each currently reads `profile.sessions.filter { … }`; there are 8 occurrences.
+
+In `computeMetrics` (a `static` method — call the static helper):
+```swift
+    let completed = validSessions(of: profile).filter { session in
+```
+
+In each of the seven **instance** methods, replace `profile.sessions.filter` with `validSessions.filter`. The binding names are unchanged:
+
+- `dailyAggregates` → `let completed = validSessions.filter { session in`
+- `hourlyAggregates` → `let completed = validSessions.filter { session in`
+- `breakDailyAggregates` → `let sessionsWithBreaks = validSessions.filter { session in`
+- `breakHourlyAggregates` → `let sessionsWithBreaks = validSessions.filter { session in`
+- `sessionEndHourlyAggregates` → `let completedSessions = validSessions.filter { session in`
+- `breakStartHourlyAggregates` → `let sessionsWithBreaks = validSessions.filter { session in`
+- `breakEndHourlyAggregates` → `let sessionsWithCompletedBreaks = validSessions.filter { session in`
+
+After this step there must be **zero** remaining `profile.sessions` occurrences in this file. Verify:
+```bash
+grep -n "profile.sessions" Foqos/Utils/ProfileInsightsUtil.swift   # expect: no output
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=<UUID>' \
+  -only-testing:FoqosTests/ProfileInsightsUtilTests | xcpretty
+```
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Foqos/Utils/ProfileInsightsUtil.swift FoqosTests/ProfileInsightsUtilTests.swift
+git commit -m "fix(#213): guard ProfileInsightsUtil against deleted profile"
+```
+
+---
+
+## Task F2: Guard `ProfileInsightsView` render path with `SafeModelView` (#213)
+
+**Files:**
+- Modify: `Foqos/Views/ProfileInsightsView.swift`
+
+**Interfaces:**
+- Consumes: `SafeModelView` (`Foqos/Utils/SafeModelView.swift`), `viewModel.profile`.
+- Produces: no API change. When the profile is deleted while the sheet is open, the body renders nothing (the close button stays available) instead of crashing.
+
+**Why (not covered by F1):** `ProfileInsightsView.nerdStatsItems` reads `viewModel.profile` properties **directly** (`profile.createdAt`, `profile.updatedAt`, `profile.id`, `profile.selectedActivity`, `profile.sessions.count`, `profile.activeScheduleTimerActivity`) — these bypass `ProfileInsightsUtil`, so F1 does not cover them. Wrapping the body in `SafeModelView` is the codebase's documented render-time guard (layer 3). This view is presented as a `.sheet` from `HomeView.swift:319` and `BlockedProfileView.swift:703` with no `SafeModelView`, unlike sibling session views.
+
+> **No unit test for this task.** A SwiftUI sheet body is not unit-testable here; `SafeModelView`'s guard is already covered by `FoqosTests/SafeModelViewTests.swift` (`testSafeModelViewWithDeletedModel`). F1's tests cover the data-path regression. F2 is a mechanical, inspection-verified application of the existing guard. Verification is a clean build (Step 3).
+
+- [ ] **Step 1: Wrap the body content in `SafeModelView`**
+
+In `Foqos/Views/ProfileInsightsView.swift`, the `body` currently is `NavigationStack { ScrollView { … } .background(…) .navigationTitle("Stats for Nerds") .toolbar { … } }`.
+
+Change **only** the opening: replace
+```swift
+  var body: some View {
+    NavigationStack {
+      ScrollView {
+```
+with
+```swift
+  var body: some View {
+    NavigationStack {
+      SafeModelView(viewModel.profile) { _ in
+        ScrollView {
+```
+
+Then close the new `SafeModelView` closure by moving the brace: the block currently ends as
+```swift
+      }
+      .background(Color(.systemGroupedBackground).ignoresSafeArea())
+      .navigationTitle("Stats for Nerds")
+      .toolbar {
+```
+Replace that with
+```swift
+        }
+        .background(Color(.systemGroupedBackground).ignoresSafeArea())
+      }
+      .navigationTitle("Stats for Nerds")
+      .toolbar {
+```
+
+Net effect: `SafeModelView(viewModel.profile) { _ in ScrollView { … }.background(…) }` becomes the `NavigationStack`'s content, and `.navigationTitle`/`.toolbar` (with the Close button) stay on the `SafeModelView` so the user can always dismiss even when the profile is gone. Leave the entire inner `VStack` (all chart cards, lines ~15–452 of the original body) **exactly as-is** — only the two brace/indent boundaries above change. Re-run swift-format to normalize the added indentation level:
+```bash
+swift-format --in-place Foqos/Views/ProfileInsightsView.swift
+```
+
+- [ ] **Step 2: Verify it builds**
+
+Run:
+```bash
+xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -configuration Debug build 2>&1 | xcpretty
+```
+Expected: BUILD SUCCEEDED. (Optionally re-run the F1 test class to confirm nothing regressed.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Foqos/Views/ProfileInsightsView.swift
+git commit -m "fix(#213): guard ProfileInsightsView render with SafeModelView"
+```
+
+---
+
+## Task F3: Stop `BlockedSessionsHabitTracker` caching sessions in `@State` (#235)
+
+**Files:**
+- Modify: `Foqos/Components/Dashboard/BlockedSessionsHabitTracker.swift`
+- Test: `FoqosTests/BlockedSessionsHabitTrackerTests.swift` (create)
+
+**Interfaces:**
+- Consumes: `Array.valid`, `BlockedProfileSession.duration(now:)`, the `sessions: [BlockedProfileSession]` input (passed by `HomeView.swift:164` from a `@SafeQuery`-backed `recentCompletedSessions`).
+- Produces: new **internal static** `BlockedSessionsHabitTracker.sessionsForDate(_ date: Date, in sessions: [BlockedProfileSession], now: Date) -> [BlockedProfileSession]` (pure, `.valid`-filtering, `now`-injectable — the unit-testable seam). Removes the `@State selectedSessions` cache; `selectedDate` + `showingSessionDetails` remain.
+
+**Root cause:** `handleDateTap` stored `selectedSessions = sessionsForDate(date)` in `@State`. Because `@State` persists across re-renders (stable view identity), that snapshot outlives deletion of the underlying `BlockedProfileSession` objects (profile deletion cascades to its sessions — `BlockedProfiles.deleteProfile` deletes every session). The next render then reads `session.blockedProfile.name` on a zombie → `EXC_BREAKPOINT`. Fix: never cache; derive the day's sessions fresh from the always-current `sessions` input each render, `.valid`-filtered.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `FoqosTests/BlockedSessionsHabitTrackerTests.swift`:
+
+```swift
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class BlockedSessionsHabitTrackerTests: XCTestCase {
+  private var container: ModelContainer!
+  private var context: ModelContext!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    container = try TestModelContainer.create()
+    context = container.mainContext
+  }
+
+  override func tearDown() async throws {
+    container = nil
+    context = nil
+    try await super.tearDown()
+  }
+
+  func testGivenDeletedSession_WhenSessionsForDate_ThenExcludesZombieWithoutCrashing() throws {
+    let now = Date()
+    let calendar = Calendar.current
+    let dayStart = calendar.startOfDay(for: now)
+    let profile = BlockedProfiles(
+      id: UUID(), name: "P", selectedActivity: .init(), blockingStrategyId: "manual")
+    context.insert(profile)
+    // Anchor to startOfDay(now) with a fixed endTime so overlap is time-of-day-independent
+    // (a `now - 3600` completed session would not overlap today between 00:00 and 01:00).
+    let live = BlockedProfileSession(
+      tag: "live", blockedProfile: profile, startTime: dayStart.addingTimeInterval(3600))
+    live.endTime = dayStart.addingTimeInterval(3600 + 1800)
+    let zombie = BlockedProfileSession(
+      tag: "zombie", blockedProfile: profile, startTime: dayStart.addingTimeInterval(3600))
+    zombie.endTime = dayStart.addingTimeInterval(3600 + 1800)
+    context.insert(live)
+    context.insert(zombie)
+    try context.save()
+
+    context.delete(zombie)
+
+    // Derived from the (now partly-zombie) array — must filter the zombie and not crash on it.
+    let result = BlockedSessionsHabitTracker.sessionsForDate(now, in: [live, zombie], now: now)
+
+    XCTAssertEqual(result.count, 1)
+    XCTAssertEqual(result.first?.tag, "live")
+  }
+
+  func testGivenSessionsOverlappingDate_WhenSessionsForDate_ThenReturnsSortedByDurationDescending()
+    throws
+  {
+    let now = Date()
+    let calendar = Calendar.current
+    let dayStart = calendar.startOfDay(for: now)
+    let profile = BlockedProfiles(
+      id: UUID(), name: "P", selectedActivity: .init(), blockingStrategyId: "manual")
+    context.insert(profile)
+
+    // Short session: 30 min, inside the day.
+    let short = BlockedProfileSession(
+      tag: "short", blockedProfile: profile, startTime: dayStart.addingTimeInterval(3600))
+    short.endTime = dayStart.addingTimeInterval(3600 + 1800)
+    // Long session: 2 h, inside the day.
+    let long = BlockedProfileSession(
+      tag: "long", blockedProfile: profile, startTime: dayStart.addingTimeInterval(7200))
+    long.endTime = dayStart.addingTimeInterval(7200 + 7200)
+    // Other-day session: excluded.
+    let other = BlockedProfileSession(
+      tag: "other", blockedProfile: profile,
+      startTime: dayStart.addingTimeInterval(-2 * 86400))
+    other.endTime = dayStart.addingTimeInterval(-2 * 86400 + 1800)
+    context.insert(short)
+    context.insert(long)
+    context.insert(other)
+    try context.save()
+
+    let result = BlockedSessionsHabitTracker.sessionsForDate(
+      now, in: [short, long, other], now: now)
+
+    XCTAssertEqual(result.map { $0.tag }, ["long", "short"])
+  }
+
+  func testGivenActiveSessionStartedToday_WhenSessionsForDate_ThenIncludedUsingInjectedNow() throws {
+    let now = Date()
+    let profile = BlockedProfiles(
+      id: UUID(), name: "P", selectedActivity: .init(), blockingStrategyId: "manual")
+    context.insert(profile)
+    // Active session (endTime nil) started one hour ago — overlaps today only via injected `now`.
+    let active = BlockedProfileSession(
+      tag: "active", blockedProfile: profile, startTime: now.addingTimeInterval(-3600))
+    context.insert(active)
+    try context.save()
+
+    let result = BlockedSessionsHabitTracker.sessionsForDate(now, in: [active], now: now)
+
+    XCTAssertEqual(result.map { $0.tag }, ["active"])
+  }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=<UUID>' \
+  -only-testing:FoqosTests/BlockedSessionsHabitTrackerTests | xcpretty
+```
+Expected: **compile failure** — `BlockedSessionsHabitTracker.sessionsForDate(_:in:now:)` does not exist yet (the current method is a `private` instance method with a different signature).
+
+- [ ] **Step 3: Remove the `@State` cache**
+
+In `Foqos/Components/Dashboard/BlockedSessionsHabitTracker.swift`, replace:
+```swift
+  @State private var selectedDate: Date?
+  @State private var selectedSessions: [BlockedProfileSession] = []
+  @State private var showingSessionDetails = false
+```
+with:
+```swift
+  @State private var selectedDate: Date?
+  @State private var showingSessionDetails = false
+```
+
+- [ ] **Step 4: Replace the instance `sessionsForDate` with a pure static + add `validSessions`**
+
+Replace the whole method (the `/// Gets sessions that have any overlap with the specified date` block):
+```swift
+  /// Gets sessions that have any overlap with the specified date
+  private func sessionsForDate(_ date: Date) -> [BlockedProfileSession] {
+    let calendar = Calendar.current
+    let dayStart = calendar.startOfDay(for: date)
+    guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) else { return [] }
+
+    let now = Date()
+    return sessions.filter { session in
+      let sessionStart = session.startTime
+      let sessionEnd = session.endTime ?? now
+
+      // Check if session overlaps with this day
+      return sessionStart < dayEnd && sessionEnd > dayStart
+    }.sorted { $0.duration(now: now) > $1.duration(now: now) }
+  }
+```
+with:
+```swift
+  /// The input sessions, defensively `.valid`-filtered to drop any SwiftData zombie models
+  /// per AGENTS.md (components receiving model arrays must filter with `.valid`). #235.
+  private var validSessions: [BlockedProfileSession] {
+    sessions.valid
+  }
+
+  /// Sessions that have any overlap with the specified date.
+  /// Pure and `now`-injectable so it is unit-testable, and `.valid`-filters zombies *before*
+  /// any property access. Derived fresh from `sessions` on every render — never cached in
+  /// `@State`, which is the #235 crash (a cached array outlives the models' deletion).
+  static func sessionsForDate(
+    _ date: Date,
+    in sessions: [BlockedProfileSession],
+    now: Date
+  ) -> [BlockedProfileSession] {
+    let calendar = Calendar.current
+    let dayStart = calendar.startOfDay(for: date)
+    guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) else { return [] }
+
+    return sessions.valid.filter { session in
+      let sessionStart = session.startTime
+      let sessionEnd = session.endTime ?? now
+
+      // Check if session overlaps with this day
+      return sessionStart < dayEnd && sessionEnd > dayStart
+    }.sorted { $0.duration(now: now) > $1.duration(now: now) }
+  }
+```
+
+- [ ] **Step 5: Use `validSessions` in the day-square hours calc**
+
+In `sessionHoursForDate(_:)`, replace:
+```swift
+    let totalSeconds = sessions.reduce(0.0) { total, session in
+```
+with:
+```swift
+    let totalSeconds = validSessions.reduce(0.0) { total, session in
+```
+
+- [ ] **Step 6: Drop the cache write in `handleDateTap`**
+
+Replace:
+```swift
+  private func handleDateTap(_ date: Date) {
+    let isCurrentlySelected = selectedDate == date
+
+    if isCurrentlySelected {
+      // Deselect if already selected
+      selectedDate = nil
+      selectedSessions = []
+      showingSessionDetails = false
+    } else {
+      // Select a new date
+      selectedDate = date
+      selectedSessions = sessionsForDate(date)
+      showingSessionDetails = true
+    }
+  }
+```
+with:
+```swift
+  private func handleDateTap(_ date: Date) {
+    let isCurrentlySelected = selectedDate == date
+
+    if isCurrentlySelected {
+      // Deselect if already selected
+      selectedDate = nil
+      showingSessionDetails = false
+    } else {
+      // Select a new date — the day's sessions are derived fresh from `sessions` at render
+      // time (see sessionDetailsView), never cached in @State (#235).
+      selectedDate = date
+      showingSessionDetails = true
+    }
+  }
+```
+
+- [ ] **Step 7: Derive the day's sessions at render time**
+
+Replace `sessionDetailsView(for:)`:
+```swift
+  private func sessionDetailsView(for date: Date) -> some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text(formatDate(date))
+        .font(.subheadline)
+        .fontWeight(.medium)
+
+      if selectedSessions.isEmpty {
+        Text("No sessions on this day")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      } else {
+        sessionListView(for: date)
+      }
+    }
+    .padding(.top, 8)
+    .transition(.move(edge: .bottom).combined(with: .opacity))
+    .animation(.easeInOut, value: showingSessionDetails)
+  }
+```
+with:
+```swift
+  private func sessionDetailsView(for date: Date) -> some View {
+    let daySessions = Self.sessionsForDate(date, in: sessions, now: Date())
+    return VStack(alignment: .leading, spacing: 10) {
+      Text(formatDate(date))
+        .font(.subheadline)
+        .fontWeight(.medium)
+
+      if daySessions.isEmpty {
+        Text("No sessions on this day")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      } else {
+        sessionListView(daySessions, for: date)
+      }
+    }
+    .padding(.top, 8)
+    .transition(.move(edge: .bottom).combined(with: .opacity))
+    .animation(.easeInOut, value: showingSessionDetails)
+  }
+```
+
+And replace `sessionListView(for:)` so it takes the derived array:
+```swift
+  private func sessionListView(for date: Date) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      let displayedSessions = Array(selectedSessions.prefix(3))
+
+      ForEach(displayedSessions, id: \.id) { session in
+        sessionRowView(for: session, on: date)
+
+        if session != displayedSessions.last {
+          Divider()
+        }
+      }
+
+      if selectedSessions.count > 3 {
+        Text("+ \(selectedSessions.count - 3) more sessions")
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .padding(.top, 4)
+      }
+    }
+  }
+```
+with:
+```swift
+  private func sessionListView(_ daySessions: [BlockedProfileSession], for date: Date) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      let displayedSessions = Array(daySessions.prefix(3))
+
+      ForEach(displayedSessions, id: \.id) { session in
+        sessionRowView(for: session, on: date)
+
+        if session != displayedSessions.last {
+          Divider()
+        }
+      }
+
+      if daySessions.count > 3 {
+        Text("+ \(daySessions.count - 3) more sessions")
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .padding(.top, 4)
+      }
+    }
+  }
+```
+
+`sessionRowView(for:on:)` is unchanged: it accesses `session.blockedProfile.name`, but `daySessions` is `.valid`-filtered, so every element is a live model (a deleted profile cascade-deletes its sessions, which `.valid` then drops). After this step there must be **no** remaining `selectedSessions` reference. Verify:
+```bash
+grep -n "selectedSessions" Foqos/Components/Dashboard/BlockedSessionsHabitTracker.swift   # expect: no output
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run:
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=<UUID>' \
+  -only-testing:FoqosTests/BlockedSessionsHabitTrackerTests | xcpretty
+```
+Expected: PASS (3 tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Foqos/Components/Dashboard/BlockedSessionsHabitTracker.swift \
+        FoqosTests/BlockedSessionsHabitTrackerTests.swift
+git commit -m "fix(#235): derive habit-tracker sessions fresh instead of caching in @State"
+```
+
+---
+
+## Final verification (before requesting review)
+
+- [ ] **Full suite green.** Run the whole `FoqosTests` target once (reusing the booted simulator):
+  ```bash
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+    -destination 'platform=iOS Simulator,id=<UUID>' | xcpretty
+  ```
+  Expected: all existing tests plus the 6 new tests pass; no behavior change outside the two defect sites.
+- [ ] **swift-format clean:** `swift-format lint --recursive .` reports no violations for the four changed files.
+- [ ] **No stragglers:** `grep -rn "profile.sessions" Foqos/Utils/ProfileInsightsUtil.swift` and `grep -rn "selectedSessions" Foqos/Components/Dashboard/BlockedSessionsHabitTracker.swift` both return nothing.
+- [ ] **Request code review** before merging (AGENTS.md requirement). Reference #213 and #235.
+
+## Acceptance criteria (from the handovers)
+
+- #213: The Insights sheet no longer crashes when its profile is deleted (via sync or locally) while open — covered by `ProfileInsightsUtilTests` (data path) + `SafeModelView` wrap (render path).
+- #235: The 4-Week Activity day-details panel no longer crashes when the shown sessions/profile are deleted while expanded — covered by `BlockedSessionsHabitTrackerTests` and the removal of `@State` caching.
+- Regression tests exist in `FoqosTests` (naming `testGivenX_WhenY_ThenZ`, injected `now:`).
+- No behavior change outside the defects' scope; all existing tests pass; swift-format clean; review requested.

--- a/docs/superpowers/plans/2026-07-06-i-app-group-migration-ordering.md
+++ b/docs/superpowers/plans/2026-07-06-i-app-group-migration-ordering.md
@@ -1,0 +1,481 @@
+# Bundle I — App-Group UserDefaults Migration Ordering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the main-app app-group key migration from clobbering fresher values that an extension (DeviceActivity monitor / widget) wrote through `SharedData` before the app's first post-update launch — which today resurrects an already-ended schedule session as "active" and permanently loses a just-completed session record (#217).
+
+**Architecture:** Two composed fixes. **Fix B (migration ordering):** `UserDefaultsMigration.migrateAppGroupIfNeeded` copies a legacy value to the new prefixed key **only when the new key is absent**, and always drops the legacy key. **Fix A (write hygiene):** every `SharedData` setter clears its pre-migration (legacy) key on write, so a stale legacy value can never shadow or resurrect state after migration. Together they make "the new prefixed key always wins" hold in every ordering. No behavior change to normal migration (legacy-only → still copied).
+
+**Tech Stack:** Swift 6, Foundation (`UserDefaults`), the `FoqosShared` Swift package, XCTest. iOS app target module name is `FamilyFoqos`; the shared code is module `FoqosShared`.
+
+**Source commit (current `main` at authoring):** `6ffb8c22b52c4b47da610b978783ccc69774f712`
+
+**Epic:** #263 (defect-audit follow-ups). Bundle I. Issue: #217 (high).
+
+## Implementation Sequencing (read first)
+
+Bundle **F** (zombie-model safety, #213/#235) and Bundle **I** are implemented as **two separate, sequential PRs**. **F ships first; I second.** Branch I from `main` **after F has merged**; open I's PR from there. Do not develop them in parallel — this repo forbids concurrent build/test streams on one machine (AGENTS.md "NO parallel development").
+
+## Global Constraints
+
+- Read `AGENTS.md` at the repo root before writing any code. It overrides everything else.
+- Work on a feature branch off `main`. **NEVER** amend or force-push; new commits only. Request code review before merging.
+- Use `Log.<level>(_, category:)` instead of `print()`. Never log lock codes or personal identifiers.
+- swift-format is enforced by a pre-commit hook (2-space indent, ~100–120 col). Run `swift-format --in-place --recursive .` before committing if not relying on the hook.
+- Tests: name `testGivenX_WhenY_ThenZ()`; pin time — capture **one** `let now = Date()` per test if dates are needed.
+- Tests import the app module with `@testable import FamilyFoqos`; shared code with `@preconcurrency import FoqosShared`.
+- Run tests against an **already-booted** simulator by **UUID** (never device name), reusing one boot:
+  ```bash
+  xcrun simctl list devices available | grep "iPhone 17"   # pick the UUID once
+  xcrun simctl boot <UUID>                                  # once per session (~3-4 min)
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+    -destination 'platform=iOS Simulator,id=<UUID>' | xcpretty
+  # Single class:
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+    -destination 'platform=iOS Simulator,id=<UUID>' -only-testing:FoqosTests/ClassName | xcpretty
+  ```
+
+---
+
+## The defect (re-verified against the source commit)
+
+Confirmed intact on current `main` — PR #277 (D2) added session-**identity** gating to the `SharedData` mutators but did **not** touch the migration, the legacy-key fallback readers, the write-only-new-key setters, or `endActiveSharedSession`.
+
+1. `migrateAppGroupIfNeeded` (`Foqos/Utils/UserDefaultsMigration.swift:57-62`) unconditionally copies each legacy app-group key over the new prefixed key, guarded only by a one-time flag that is unset until the first launch after update. It runs **only** in the main app (`FoqosApp.swift:109`).
+2. `SharedData` setters write **only** the new prefixed keys and never remove the legacy keys (`SharedData.swift`: `profileSnapshots` set → 311/313; `completedSessionsInScheduler` set → 347/349; `activeSharedSession` set → 363/365; `deviceSyncId`/`deviceSyncEnabled` → 509/515/526). Its getters fall back to the legacy key (`data/string/bool(forKey:legacyKey:)`, 122-136).
+3. `SharedData.swift:111-113` explicitly documents that extensions may run before the app migrates — but only the **read** path was handled, not the **write** path.
+
+**Failure chain:** pre-rename app has an active schedule session under legacy `"activeScheduleSession"`. App updates via the App Store overnight. The DeviceActivity interval ends **before** first app launch: `DeviceActivityMonitorExtension.intervalDidEnd → ScheduleTimerActivity.stop` (`ScheduleTimerActivity.swift:88-109`) deactivates restrictions and calls `SharedData.endActiveSharedSession()`, which appends the completed session under the **new** key and clears only the **new** active key — the legacy `"activeScheduleSession"` still holds the session. On first app launch, `migrateAppGroupIfNeeded` copies that stale legacy session over the new active key (resurrecting an ended session as "active" while ManagedSettings restrictions are off) and copies the stale legacy completed list over the new list (losing the just-completed session from stats/insights/sync).
+
+---
+
+## Merge Semantics Analysis — why "new key wins" is correct (NOT a maintainer decision)
+
+The instruction for this bundle was to flag a **MAINTAINER DECISION REQUIRED** if the correct merge, when *both* the app and an extension have written a key, is ambiguous. **It is not ambiguous. No maintainer decision is required.** Reasoning, grounded in the current `SharedData` API:
+
+- Every `SharedData` **getter** reads the new key with a fallback to the legacy key: `suite.data(forKey: new) ?? suite.data(forKey: legacy)` (and the `string`/`bool` equivalents).
+- Every `SharedData` **setter** writes the *whole* structure it just read back to the **new** key (dictionaries for `profileSnapshots`, arrays for `completedSessionsInScheduler`, the single object for `activeSharedSession`).
+- Therefore any write an extension performs after update **seeds from the legacy value via the getter fallback and re-persists a fresher, superset/replacement value to the new key.** The new key is never an *independent* datum that could lose information relative to legacy — it is always the more-recent merge.
+
+Consequences:
+- **"Prefer the new key when present" (Fix B) never loses data.** Example — completed sessions: legacy `[A,B]`; the extension's `endActiveSharedSession` reads `new(absent) ?? legacy [A,B]`, appends `C`, and writes new `[A,B,C]`. Keeping new `[A,B,C]` and discarding legacy `[A,B]` is strictly correct.
+- **The one key that can end up "new-absent, legacy-present" after an extension write is `activeSharedSession`** (its setter is driven to `nil` by `endActiveSharedSession`). Fix B alone does **not** cover that case — the new key is absent, so a naive "copy when new absent" would still resurrect the legacy session. **Fix A closes it** by clearing the legacy key on that write. This is why both fixes are required, not just the migration guard.
+- `familyFoqosThemeColorName` is **not** managed by `SharedData` — `ThemeManager` reads/writes the *new* key `family_foqos_theme_color_name` directly via `@AppStorage` with no legacy fallback (`ThemeManager.swift:32`). It is cosmetic and covered by Fix B only (if some process wrote the new theme key first, keep it; otherwise migrate legacy). No session-state risk.
+
+If a reviewer disputes the invariant above (i.e. believes some app-group key can hold genuinely independent legacy-vs-new values that must be *merged* rather than new-wins), escalate — but no such key exists in the current `SharedData` surface.
+
+### A note on `activeSharedSession = nil` and `JSONEncoder`
+
+`activeSharedSession`'s setter runs `try? JSONEncoder().encode(newValue)` where `newValue` is `SessionSnapshot?`. Whether encoding a top-level `nil` Optional throws (→ `removeObject`, new key **absent**) or succeeds as a `null` blob (→ new key present-but-undecodable, getter still returns `nil`) is an OS/toolchain detail we deliberately do **not** rely on. Fix A removes the **legacy** key unconditionally on that write, so the resurrection is prevented in either case. (The getter returns `nil` after `end()` regardless, because a `null`/garbage blob fails to decode.)
+
+---
+
+## File Structure
+
+- **Modify** `Foqos/Utils/UserDefaultsMigration.swift` — Fix B: copy legacy→new only when new is absent; always drop legacy (Task I1).
+- **Modify** `Packages/FoqosShared/Sources/FoqosShared/SharedData.swift` — Fix A: add a `clearLegacy(_:)` helper and call it from every setter (Task I2).
+- **Modify** `FoqosTests/UserDefaultsMigrationTests.swift` — add Fix B regression tests (Task I1).
+- **Create** `FoqosTests/SharedDataLegacyKeyClearingTests.swift` — Fix A regression tests (Task I2).
+
+---
+
+## Task I1: Migration copies legacy→new only when new is absent (#217, Fix B)
+
+**Files:**
+- Modify: `Foqos/Utils/UserDefaultsMigration.swift` (the `migrateAppGroupIfNeeded` loop, lines 57-62)
+- Test: `FoqosTests/UserDefaultsMigrationTests.swift` (add cases)
+
+**Interfaces:**
+- Consumes: `appGroupKeyMapping` (`[(old, new)]`) and the `appGroupMigrationFlag`, both already present.
+- Produces: no signature change to `migrateAppGroupIfNeeded(defaults:)`. Behavior change: a present new key is no longer overwritten; the legacy key is always removed.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these methods to `FoqosTests/UserDefaultsMigrationTests.swift` (inside the `final class UserDefaultsMigrationTests`, in the `// MARK: - App group suite tests` section). They reuse the existing `defaults` fixture (suite `"UserDefaultsMigrationTests"`, cleared each test in `setUp`/`tearDown`):
+
+```swift
+  func testGivenNewAppGroupKeyAlreadyWritten_WhenMigrate_ThenNewValueKeptAndOldRemoved() {
+    // An extension wrote the new key before the first app launch; the legacy shadow lingers.
+    defaults.set(Data([4, 5, 6]), forKey: "family_foqos_active_schedule_session")
+    defaults.set(Data([9, 9, 9]), forKey: "activeScheduleSession")
+
+    UserDefaultsMigration.migrateAppGroupIfNeeded(defaults: defaults)
+
+    XCTAssertEqual(
+      defaults.data(forKey: "family_foqos_active_schedule_session"), Data([4, 5, 6]),
+      "fresh extension-written value must survive migration (#217)")
+    XCTAssertNil(
+      defaults.object(forKey: "activeScheduleSession"), "stale legacy key must be removed")
+  }
+
+  func testGivenNewCompletedListWithFreshSession_WhenMigrate_ThenNotClobberedByLegacyList() {
+    // Legacy completed list from before the update...
+    defaults.set(Data([1, 1]), forKey: "completedScheduleSessions")
+    // ...and the extension's appended (superset) list under the new key.
+    defaults.set(Data([1, 1, 2, 2]), forKey: "family_foqos_completed_schedule_sessions")
+
+    UserDefaultsMigration.migrateAppGroupIfNeeded(defaults: defaults)
+
+    XCTAssertEqual(
+      defaults.data(forKey: "family_foqos_completed_schedule_sessions"), Data([1, 1, 2, 2]),
+      "the just-completed session must not be lost to the stale legacy list (#217)")
+    XCTAssertNil(defaults.object(forKey: "completedScheduleSessions"))
+  }
+
+  func testGivenLegacyOnlyAppGroupKey_WhenMigrate_ThenStillCopiedToNewKey() {
+    // Normal migration path (no extension pre-write) must be unchanged.
+    defaults.set(Data([7, 8, 9]), forKey: "completedScheduleSessions")
+
+    UserDefaultsMigration.migrateAppGroupIfNeeded(defaults: defaults)
+
+    XCTAssertEqual(
+      defaults.data(forKey: "family_foqos_completed_schedule_sessions"), Data([7, 8, 9]))
+    XCTAssertNil(defaults.object(forKey: "completedScheduleSessions"))
+  }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=<UUID>' \
+  -only-testing:FoqosTests/UserDefaultsMigrationTests | xcpretty
+```
+Expected: `testGivenNewAppGroupKeyAlreadyWritten_…` fails (new key becomes `Data([9,9,9])` — clobbered) and `testGivenNewCompletedListWithFreshSession_…` fails (new key becomes `Data([1,1])` — lost session). `testGivenLegacyOnlyAppGroupKey_…` passes (documents unchanged path). Existing app-group tests still pass.
+
+- [ ] **Step 3: Apply Fix B**
+
+In `Foqos/Utils/UserDefaultsMigration.swift`, replace the `migrateAppGroupIfNeeded` copy loop:
+```swift
+    for (old, new) in appGroupKeyMapping {
+      if let value = defaults.object(forKey: old) {
+        defaults.set(value, forKey: new)
+        defaults.removeObject(forKey: old)
+      }
+    }
+```
+with:
+```swift
+    for (old, new) in appGroupKeyMapping {
+      // Copy the legacy value only when the new key is absent. An extension (DeviceActivity
+      // monitor / widget) may have written the new key through SharedData before the main app
+      // first launched and migrated; that value is fresher and must win over the legacy shadow
+      // (#217). Always drop the legacy key so it can never resurrect stale state on a later run.
+      if defaults.object(forKey: new) == nil, let value = defaults.object(forKey: old) {
+        defaults.set(value, forKey: new)
+      }
+      defaults.removeObject(forKey: old)
+    }
+```
+
+Leave the `standardKeyMapping` loop in `migrateIfNeeded` unchanged — those are standard-suite, in-app-only keys with no cross-process extension writer, so the ordering hazard does not apply.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=<UUID>' \
+  -only-testing:FoqosTests/UserDefaultsMigrationTests | xcpretty
+```
+Expected: PASS (all existing + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Foqos/Utils/UserDefaultsMigration.swift FoqosTests/UserDefaultsMigrationTests.swift
+git commit -m "fix(#217): migrate app-group keys only when new key absent"
+```
+
+---
+
+## Task I2: `SharedData` setters clear the legacy key on write (#217, Fix A)
+
+**Files:**
+- Modify: `Packages/FoqosShared/Sources/FoqosShared/SharedData.swift`
+- Test: `FoqosTests/SharedDataLegacyKeyClearingTests.swift` (create)
+
+**Interfaces:**
+- Consumes: the existing private `Key` and `LegacyKey` enums; the `suite` accessor.
+- Produces: new `private static func clearLegacy(_ legacyKey: LegacyKey)`. No public API change. Behavior change: after any write through a `SharedData` setter, that setter's legacy key is guaranteed absent.
+
+**Critical:** `clearLegacy` must be a plain `suite.removeObject` with **no** `withLock` — `withLock` is non-reentrant and several setters already run inside a caller's `withLock` (`createActiveSharedSession`, `endActiveSharedSession`, `deviceSyncId`). A nested `withLock` would release the process lock early (see the contract comment at `SharedData.swift:70-77`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `FoqosTests/SharedDataLegacyKeyClearingTests.swift`:
+
+```swift
+@preconcurrency import FoqosShared
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class SharedDataLegacyKeyClearingTests: XCTestCase {
+  private var suite: UserDefaults!
+  private var suiteName: String!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "SharedDataLegacyKeyClearingTests-\(UUID().uuidString)"
+    suite = UserDefaults(suiteName: suiteName)!
+    SharedData.configure(suite: suite)
+  }
+
+  override func tearDown() async throws {
+    UserDefaults().removePersistentDomain(forName: suiteName)
+    suite = nil
+    suiteName = nil
+    try await super.tearDown()
+  }
+
+  private func makeSnapshot(id: String, ended: Bool = false) -> SharedData.SessionSnapshot {
+    let now = Date()  // pin time: one Date() per test path (AGENTS.md)
+    return SharedData.SessionSnapshot(
+      id: id, tag: "t", blockedProfileId: UUID(), startTime: now,
+      endTime: ended ? now : nil, forceStarted: true)
+  }
+
+  func testGivenLegacyActiveKey_WhenActiveSharedSessionWritten_ThenLegacyKeyCleared() {
+    suite.set(Data([1, 2, 3]), forKey: "activeScheduleSession")  // pre-migration legacy shadow
+
+    SharedData.createActiveSharedSession(for: makeSnapshot(id: "s1"))
+
+    XCTAssertNil(
+      suite.object(forKey: "activeScheduleSession"),
+      "legacy active key must be cleared on write (#217)")
+    XCTAssertEqual(SharedData.getActiveSharedSession()?.id, "s1")
+  }
+
+  func testGivenLegacyActiveKey_WhenActiveSessionEnded_ThenNoResurrectionPossible() {
+    SharedData.createActiveSharedSession(for: makeSnapshot(id: "s1"))
+    // Simulate the stale legacy shadow lingering alongside the extension's new-key write.
+    suite.set(Data([9, 9, 9]), forKey: "activeScheduleSession")
+
+    SharedData.endActiveSharedSession()
+
+    XCTAssertNil(SharedData.getActiveSharedSession(), "no active session after end")
+    XCTAssertNil(
+      suite.object(forKey: "activeScheduleSession"),
+      "legacy active key must not survive end() — else migration resurrects it (#217)")
+  }
+
+  func testGivenLegacyCompletedKey_WhenCompletedSessionAppended_ThenLegacyKeyCleared() {
+    suite.set(Data([1, 2, 3]), forKey: "completedScheduleSessions")  // legacy shadow
+    SharedData.createActiveSharedSession(for: makeSnapshot(id: "s1"))
+
+    // endActiveSharedSession appends to completedSessionsInScheduler (a setter write).
+    SharedData.endActiveSharedSession()
+
+    XCTAssertNil(
+      suite.object(forKey: "completedScheduleSessions"),
+      "legacy completed key must be cleared on write (#217)")
+  }
+
+  func testGivenLegacyDeviceSyncKeys_WhenWritten_ThenLegacyKeysCleared() {
+    suite.set("old-id", forKey: "deviceSyncId")
+    suite.set(false, forKey: "deviceSyncEnabled")
+
+    SharedData.deviceSyncId = UUID()
+    SharedData.deviceSyncEnabled = true
+
+    XCTAssertNil(suite.object(forKey: "deviceSyncId"), "legacy deviceSyncId key cleared on write")
+    XCTAssertNil(
+      suite.object(forKey: "deviceSyncEnabled"), "legacy deviceSyncEnabled key cleared on write")
+  }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=<UUID>' \
+  -only-testing:FoqosTests/SharedDataLegacyKeyClearingTests | xcpretty
+```
+Expected: all four fail — the legacy keys are still present because setters do not clear them yet.
+
+- [ ] **Step 3: Add the `clearLegacy` helper**
+
+In `Packages/FoqosShared/Sources/FoqosShared/SharedData.swift`, immediately after the `bool(forKey:legacyKey:)` reader helper (the method ending at line 136, just before `// MARK: – Serializable snapshot of a profile`), add:
+
+```swift
+  /// Removes the pre-migration (legacy) key on every write, so a stale legacy value can never
+  /// shadow or resurrect state after the main-app app-group migration runs (#217). Pairs with
+  /// `UserDefaultsMigration`'s copy-only-when-new-absent guard.
+  /// MUST NOT take `withLock` — it is called from setters already inside a caller's `withLock`,
+  /// which is non-reentrant.
+  private static func clearLegacy(_ legacyKey: LegacyKey) {
+    suite.removeObject(forKey: legacyKey.rawValue)
+  }
+```
+
+- [ ] **Step 4: Call `clearLegacy` from every setter**
+
+Make these edits in `SharedData.swift`.
+
+`profileSnapshots` setter — replace:
+```swift
+    set {
+      if let data = try? JSONEncoder().encode(newValue) {
+        suite.set(data, forKey: Key.profileSnapshots.rawValue)
+      } else {
+        suite.removeObject(forKey: Key.profileSnapshots.rawValue)
+      }
+    }
+```
+with:
+```swift
+    set {
+      if let data = try? JSONEncoder().encode(newValue) {
+        suite.set(data, forKey: Key.profileSnapshots.rawValue)
+      } else {
+        suite.removeObject(forKey: Key.profileSnapshots.rawValue)
+      }
+      clearLegacy(.profileSnapshots)
+    }
+```
+
+`completedSessionsInScheduler` setter — replace:
+```swift
+    set {
+      if let data = try? JSONEncoder().encode(newValue) {
+        suite.set(data, forKey: Key.completedScheduleSessions.rawValue)
+      } else {
+        suite.removeObject(forKey: Key.completedScheduleSessions.rawValue)
+      }
+    }
+```
+with:
+```swift
+    set {
+      if let data = try? JSONEncoder().encode(newValue) {
+        suite.set(data, forKey: Key.completedScheduleSessions.rawValue)
+      } else {
+        suite.removeObject(forKey: Key.completedScheduleSessions.rawValue)
+      }
+      clearLegacy(.completedScheduleSessions)
+    }
+```
+
+`activeSharedSession` setter — replace:
+```swift
+    set {
+      if let data = try? JSONEncoder().encode(newValue) {
+        suite.set(data, forKey: Key.activeScheduleSession.rawValue)
+      } else {
+        suite.removeObject(forKey: Key.activeScheduleSession.rawValue)
+      }
+    }
+```
+with:
+```swift
+    set {
+      if let data = try? JSONEncoder().encode(newValue) {
+        suite.set(data, forKey: Key.activeScheduleSession.rawValue)
+      } else {
+        suite.removeObject(forKey: Key.activeScheduleSession.rawValue)
+      }
+      clearLegacy(.activeScheduleSession)
+    }
+```
+
+`deviceSyncId` — clear legacy in **both** the getter's generate-branch and the setter. Replace the getter branch:
+```swift
+        // Generate new ID if none exists
+        let newId = UUID()
+        suite.set(newId.uuidString, forKey: Key.deviceSyncId.rawValue)
+        return newId
+```
+with:
+```swift
+        // Generate new ID if none exists
+        let newId = UUID()
+        suite.set(newId.uuidString, forKey: Key.deviceSyncId.rawValue)
+        clearLegacy(.deviceSyncId)
+        return newId
+```
+and replace the setter:
+```swift
+    set {
+      withLock {
+        suite.set(newValue.uuidString, forKey: Key.deviceSyncId.rawValue)
+      }
+    }
+```
+with:
+```swift
+    set {
+      withLock {
+        suite.set(newValue.uuidString, forKey: Key.deviceSyncId.rawValue)
+        clearLegacy(.deviceSyncId)
+      }
+    }
+```
+
+`deviceSyncEnabled` setter — replace:
+```swift
+    set {
+      suite.set(newValue, forKey: Key.deviceSyncEnabled.rawValue)
+    }
+```
+with:
+```swift
+    set {
+      suite.set(newValue, forKey: Key.deviceSyncEnabled.rawValue)
+      clearLegacy(.deviceSyncEnabled)
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=<UUID>' \
+  -only-testing:FoqosTests/SharedDataLegacyKeyClearingTests | xcpretty
+```
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Guard against regressions in the shared session identity/lock suites**
+
+Run the two existing `SharedData` suites to confirm Fix A didn't disturb identity gating or locking:
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=<UUID>' \
+  -only-testing:FoqosTests/SharedDataSessionIdentityTests \
+  -only-testing:FoqosTests/SharedDataLockTests | xcpretty
+```
+Expected: PASS (unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Packages/FoqosShared/Sources/FoqosShared/SharedData.swift \
+        FoqosTests/SharedDataLegacyKeyClearingTests.swift
+git commit -m "fix(#217): clear legacy app-group keys on every SharedData write"
+```
+
+---
+
+## Final verification (before requesting review)
+
+- [ ] **Full suite green.** Run the whole `FoqosTests` target once (reusing the booted simulator):
+  ```bash
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+    -destination 'platform=iOS Simulator,id=<UUID>' | xcpretty
+  ```
+  Expected: all existing tests plus the 7 new tests pass.
+- [ ] **swift-format clean:** `swift-format lint --recursive .` reports no violations for the changed files.
+- [ ] **Reconfirm the end-to-end scenario by inspection:** with both fixes, the extension's `endActiveSharedSession` clears the legacy active key (Fix A) so migration finds nothing to resurrect, and the migration keeps the extension's fresher new-key completed list (Fix B) so no completed session is lost.
+- [ ] **Request code review** before merging (AGENTS.md requirement). Reference #217.
+
+## Acceptance criteria (from the handover)
+
+- The #217 failure chain can no longer be reproduced: no resurrected "active" session after an interval ends pre-launch, and no lost completed-session record on the upgrade path.
+- Regression tests exist in `FoqosTests` (naming `testGivenX_WhenY_ThenZ`): Fix B in `UserDefaultsMigrationTests`, Fix A in `SharedDataLegacyKeyClearingTests`.
+- Normal migration (legacy-only keys) is unchanged; all existing tests pass; swift-format clean; review requested.
+- Merge semantics are documented (new-key-wins) with the reasoning above; no maintainer decision was required.


### PR DESCRIPTION
Plan-only PR. Two bundles from epic #263, authored with the superpowers writing-plans skill, to be implemented as **two separate sequential PRs (F first)** — each branches from `main` after the prior merges (no parallel build/test streams, per AGENTS.md).

Base commit re-verified: `6ffb8c22`. Both drafts were re-checked against current `main` (post #264/#269/#271/#275/#277) and each passed a one-skeptic adversarial pass; findings folded in.

## F — Zombie-model safety in secondary views
`docs/superpowers/plans/2026-07-06-f-zombie-model-safety.md`

- **#213** (high): `ProfileInsightsUtil`/`ProfileInsightsView` dereference a `BlockedProfiles` deleted via CloudKit sync while the Insights sheet is open. Fix routes the 8 `profile.sessions` reads through a profile-aliveness + `.valid` guard (unit-testable) and wraps the view body in the existing `SafeModelView` (render path — covers `nerdStatsItems`' direct profile reads).
- **#235** (medium): `BlockedSessionsHabitTracker` caches `[BlockedProfileSession]` in `@State` and later dereferences cascade-deleted models. Fix stops caching — derives the day's sessions fresh from the `@SafeQuery`-backed input through a pure, `.valid`-filtering, `now:`-injectable static function.
- Reuses existing `.valid` / `SafeModelView` idioms — no new machinery. Per-task TDD; 6 named `testGivenX_WhenY_ThenZ` tests with pinned/injected `now:`.

## I — App-group UserDefaults migration ordering
`docs/superpowers/plans/2026-07-06-i-app-group-migration-ordering.md`

- **#217** (high): the main-app app-group migration clobbers fresher values an extension wrote through `SharedData` before first launch — resurrecting an ended schedule session as "active" and losing a just-completed session record.
- **Fix B**: migrate legacy→new only when the new key is absent; always drop legacy. **Fix A**: every `SharedData` setter clears its legacy key on write (closes the `activeSharedSession = nil` case Fix B alone can't).
- **#277 impact checked**: the D2 identity work only added `expectedSessionId` gating to the mutators; it does **not** touch the legacy-key fallback, the write-only-new-key setters, or `endActiveSharedSession` — #217 holds line-for-line.
- **Merge semantics**: documented as new-key-wins with a proof (getters fall back to legacy; setters rewrite the full merged structure to new ⇒ new is always the fresher superset). **No MAINTAINER DECISION required** — the invariant makes new-wins unambiguously correct; the reasoning is in the plan so the choice isn't silent.
- Per-task TDD; 7 named tests (Fix B in `UserDefaultsMigrationTests`, Fix A in a new `SharedDataLegacyKeyClearingTests`).

## Not in this PR
Implementation. These are prescriptive, self-contained plans for a no-context executor; each fix ships as its own reviewed PR.