### PR TITLE
Fix app-group migration ordering

### DIFF
--- a/Foqos/Utils/UserDefaultsMigration.swift
+++ b/Foqos/Utils/UserDefaultsMigration.swift
@@ -55,10 +55,14 @@ enum UserDefaultsMigration {
     guard !defaults.bool(forKey: appGroupMigrationFlag) else { return }
 
     for (old, new) in appGroupKeyMapping {
-      if let value = defaults.object(forKey: old) {
+      // Copy the legacy value only when the new key is absent. An extension (DeviceActivity
+      // monitor / widget) may have written the new key through SharedData before the main app
+      // first launched and migrated; that value is fresher and must win over the legacy shadow
+      // (#217). Always drop the legacy key so it can never resurrect stale state on a later run.
+      if defaults.object(forKey: new) == nil, let value = defaults.object(forKey: old) {
         defaults.set(value, forKey: new)
-        defaults.removeObject(forKey: old)
       }
+      defaults.removeObject(forKey: old)
     }
 
     defaults.set(true, forKey: appGroupMigrationFlag)

--- a/FoqosTests/SharedDataLegacyKeyClearingTests.swift
+++ b/FoqosTests/SharedDataLegacyKeyClearingTests.swift
@@ -1,3 +1,4 @@
+import FamilyControls
 @preconcurrency import FoqosShared
 import XCTest
 
@@ -27,6 +28,35 @@ final class SharedDataLegacyKeyClearingTests: XCTestCase {
     return SharedData.SessionSnapshot(
       id: id, tag: "t", blockedProfileId: UUID(), startTime: now,
       endTime: ended ? now : nil, forceStarted: true)
+  }
+
+  func testGivenLegacyProfileSnapshotsKey_WhenSnapshotWritten_ThenLegacyKeyCleared() {
+    suite.set(Data([1, 2, 3]), forKey: "profileSnapshots")  // pre-migration legacy shadow
+    let profileId = UUID().uuidString
+    let now = Date()  // pin time: one Date() per test path (AGENTS.md)
+    let snapshot = SharedData.ProfileSnapshot(
+      id: UUID(),
+      name: "Focus",
+      selectedActivity: FamilyActivitySelection(),
+      createdAt: now,
+      updatedAt: now,
+      blockingStrategyId: nil,
+      strategyData: nil,
+      order: 0,
+      enableLiveActivity: false,
+      enableBreaks: false,
+      enableStrictMode: false,
+      enableAllowMode: false,
+      enableAllowModeDomains: false,
+      enableSafariBlocking: false
+    )
+
+    SharedData.setSnapshot(snapshot, for: profileId)
+
+    XCTAssertNil(
+      suite.object(forKey: "profileSnapshots"),
+      "legacy profileSnapshots key must be cleared on write (#217)")
+    XCTAssertEqual(SharedData.profileSnapshots[profileId], snapshot)
   }
 
   func testGivenLegacyActiveKey_WhenActiveSharedSessionWritten_ThenLegacyKeyCleared() {

--- a/FoqosTests/SharedDataLegacyKeyClearingTests.swift
+++ b/FoqosTests/SharedDataLegacyKeyClearingTests.swift
@@ -1,0 +1,79 @@
+@preconcurrency import FoqosShared
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class SharedDataLegacyKeyClearingTests: XCTestCase {
+  private var suite: UserDefaults!
+  private var suiteName: String!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "SharedDataLegacyKeyClearingTests-\(UUID().uuidString)"
+    suite = UserDefaults(suiteName: suiteName)!
+    SharedData.configure(suite: suite)
+  }
+
+  override func tearDown() async throws {
+    UserDefaults().removePersistentDomain(forName: suiteName)
+    suite = nil
+    suiteName = nil
+    try await super.tearDown()
+  }
+
+  private func makeSnapshot(id: String, ended: Bool = false) -> SharedData.SessionSnapshot {
+    let now = Date()  // pin time: one Date() per test path (AGENTS.md)
+    return SharedData.SessionSnapshot(
+      id: id, tag: "t", blockedProfileId: UUID(), startTime: now,
+      endTime: ended ? now : nil, forceStarted: true)
+  }
+
+  func testGivenLegacyActiveKey_WhenActiveSharedSessionWritten_ThenLegacyKeyCleared() {
+    suite.set(Data([1, 2, 3]), forKey: "activeScheduleSession")  // pre-migration legacy shadow
+
+    SharedData.createActiveSharedSession(for: makeSnapshot(id: "s1"))
+
+    XCTAssertNil(
+      suite.object(forKey: "activeScheduleSession"),
+      "legacy active key must be cleared on write (#217)")
+    XCTAssertEqual(SharedData.getActiveSharedSession()?.id, "s1")
+  }
+
+  func testGivenLegacyActiveKey_WhenActiveSessionEnded_ThenNoResurrectionPossible() {
+    SharedData.createActiveSharedSession(for: makeSnapshot(id: "s1"))
+    // Simulate the stale legacy shadow lingering alongside the extension's new-key write.
+    suite.set(Data([9, 9, 9]), forKey: "activeScheduleSession")
+
+    SharedData.endActiveSharedSession()
+
+    XCTAssertNil(SharedData.getActiveSharedSession(), "no active session after end")
+    XCTAssertNil(
+      suite.object(forKey: "activeScheduleSession"),
+      "legacy active key must not survive end() — else migration resurrects it (#217)")
+  }
+
+  func testGivenLegacyCompletedKey_WhenCompletedSessionAppended_ThenLegacyKeyCleared() {
+    suite.set(Data([1, 2, 3]), forKey: "completedScheduleSessions")  // legacy shadow
+    SharedData.createActiveSharedSession(for: makeSnapshot(id: "s1"))
+
+    // endActiveSharedSession appends to completedSessionsInScheduler (a setter write).
+    SharedData.endActiveSharedSession()
+
+    XCTAssertNil(
+      suite.object(forKey: "completedScheduleSessions"),
+      "legacy completed key must be cleared on write (#217)")
+  }
+
+  func testGivenLegacyDeviceSyncKeys_WhenWritten_ThenLegacyKeysCleared() {
+    suite.set("old-id", forKey: "deviceSyncId")
+    suite.set(false, forKey: "deviceSyncEnabled")
+
+    SharedData.deviceSyncId = UUID()
+    SharedData.deviceSyncEnabled = true
+
+    XCTAssertNil(suite.object(forKey: "deviceSyncId"), "legacy deviceSyncId key cleared on write")
+    XCTAssertNil(
+      suite.object(forKey: "deviceSyncEnabled"), "legacy deviceSyncEnabled key cleared on write")
+  }
+}

--- a/FoqosTests/UserDefaultsMigrationTests.swift
+++ b/FoqosTests/UserDefaultsMigrationTests.swift
@@ -144,6 +144,45 @@ final class UserDefaultsMigrationTests: XCTestCase {
     // Should not crash or set any flags — just returns early
   }
 
+  func testGivenNewAppGroupKeyAlreadyWritten_WhenMigrate_ThenNewValueKeptAndOldRemoved() {
+    // An extension wrote the new key before the first app launch; the legacy shadow lingers.
+    defaults.set(Data([4, 5, 6]), forKey: "family_foqos_active_schedule_session")
+    defaults.set(Data([9, 9, 9]), forKey: "activeScheduleSession")
+
+    UserDefaultsMigration.migrateAppGroupIfNeeded(defaults: defaults)
+
+    XCTAssertEqual(
+      defaults.data(forKey: "family_foqos_active_schedule_session"), Data([4, 5, 6]),
+      "fresh extension-written value must survive migration (#217)")
+    XCTAssertNil(
+      defaults.object(forKey: "activeScheduleSession"), "stale legacy key must be removed")
+  }
+
+  func testGivenNewCompletedListWithFreshSession_WhenMigrate_ThenNotClobberedByLegacyList() {
+    // Legacy completed list from before the update...
+    defaults.set(Data([1, 1]), forKey: "completedScheduleSessions")
+    // ...and the extension's appended (superset) list under the new key.
+    defaults.set(Data([1, 1, 2, 2]), forKey: "family_foqos_completed_schedule_sessions")
+
+    UserDefaultsMigration.migrateAppGroupIfNeeded(defaults: defaults)
+
+    XCTAssertEqual(
+      defaults.data(forKey: "family_foqos_completed_schedule_sessions"), Data([1, 1, 2, 2]),
+      "the just-completed session must not be lost to the stale legacy list (#217)")
+    XCTAssertNil(defaults.object(forKey: "completedScheduleSessions"))
+  }
+
+  func testGivenLegacyOnlyAppGroupKey_WhenMigrate_ThenStillCopiedToNewKey() {
+    // Normal migration path (no extension pre-write) must be unchanged.
+    defaults.set(Data([7, 8, 9]), forKey: "completedScheduleSessions")
+
+    UserDefaultsMigration.migrateAppGroupIfNeeded(defaults: defaults)
+
+    XCTAssertEqual(
+      defaults.data(forKey: "family_foqos_completed_schedule_sessions"), Data([7, 8, 9]))
+    XCTAssertNil(defaults.object(forKey: "completedScheduleSessions"))
+  }
+
   // MARK: - Synchronous contract tests
 
   func testGivenOldShowIntroScreen_WhenMigrate_ThenNewKeyPopulatedSynchronously() {

--- a/Packages/FoqosShared/Sources/FoqosShared/SharedData.swift
+++ b/Packages/FoqosShared/Sources/FoqosShared/SharedData.swift
@@ -138,8 +138,8 @@ public enum SharedData {
   /// Removes the pre-migration (legacy) key on every write, so a stale legacy value can never
   /// shadow or resurrect state after the main-app app-group migration runs (#217). Pairs with
   /// `UserDefaultsMigration`'s copy-only-when-new-absent guard.
-  /// MUST NOT take `withLock` — it is called from setters already inside a caller's `withLock`,
-  /// which is non-reentrant.
+  /// MUST NOT take `withLock` because the lock is non-reentrant. Callers that need cross-process
+  /// synchronization must hold the relevant outer `withLock` around their whole write.
   private static func clearLegacy(_ legacyKey: LegacyKey) {
     suite.removeObject(forKey: legacyKey.rawValue)
   }
@@ -583,11 +583,15 @@ public enum SharedData {
   /// Whether device sync is enabled for this device.
   public static var deviceSyncEnabled: Bool {
     get {
-      return bool(forKey: .deviceSyncEnabled, legacyKey: .deviceSyncEnabled)
+      withLock {
+        return bool(forKey: .deviceSyncEnabled, legacyKey: .deviceSyncEnabled)
+      }
     }
     set {
-      suite.set(newValue, forKey: Key.deviceSyncEnabled.rawValue)
-      clearLegacy(.deviceSyncEnabled)
+      withLock {
+        suite.set(newValue, forKey: Key.deviceSyncEnabled.rawValue)
+        clearLegacy(.deviceSyncEnabled)
+      }
     }
   }
 }

--- a/Packages/FoqosShared/Sources/FoqosShared/SharedData.swift
+++ b/Packages/FoqosShared/Sources/FoqosShared/SharedData.swift
@@ -135,6 +135,15 @@ public enum SharedData {
     return suite.bool(forKey: legacyKey.rawValue)
   }
 
+  /// Removes the pre-migration (legacy) key on every write, so a stale legacy value can never
+  /// shadow or resurrect state after the main-app app-group migration runs (#217). Pairs with
+  /// `UserDefaultsMigration`'s copy-only-when-new-absent guard.
+  /// MUST NOT take `withLock` — it is called from setters already inside a caller's `withLock`,
+  /// which is non-reentrant.
+  private static func clearLegacy(_ legacyKey: LegacyKey) {
+    suite.removeObject(forKey: legacyKey.rawValue)
+  }
+
   // MARK: – Serializable snapshot of a profile (no sessions)
 
   public struct ProfileSnapshot: Codable, Equatable {
@@ -315,6 +324,7 @@ public enum SharedData {
       } else {
         suite.removeObject(forKey: Key.profileSnapshots.rawValue)
       }
+      clearLegacy(.profileSnapshots)
     }
   }
 
@@ -351,6 +361,7 @@ public enum SharedData {
       } else {
         suite.removeObject(forKey: Key.completedScheduleSessions.rawValue)
       }
+      clearLegacy(.completedScheduleSessions)
     }
   }
 
@@ -367,6 +378,7 @@ public enum SharedData {
       } else {
         suite.removeObject(forKey: Key.activeScheduleSession.rawValue)
       }
+      clearLegacy(.activeScheduleSession)
     }
   }
 
@@ -556,12 +568,14 @@ public enum SharedData {
         // Generate new ID if none exists
         let newId = UUID()
         suite.set(newId.uuidString, forKey: Key.deviceSyncId.rawValue)
+        clearLegacy(.deviceSyncId)
         return newId
       }
     }
     set {
       withLock {
         suite.set(newValue.uuidString, forKey: Key.deviceSyncId.rawValue)
+        clearLegacy(.deviceSyncId)
       }
     }
   }
@@ -573,6 +587,7 @@ public enum SharedData {
     }
     set {
       suite.set(newValue, forKey: Key.deviceSyncEnabled.rawValue)
+      clearLegacy(.deviceSyncEnabled)
     }
   }
 }

--- a/docs/plans/2026-07-06-pr-281-review-r1.md
+++ b/docs/plans/2026-07-06-pr-281-review-r1.md
@@ -1,0 +1,67 @@
+# Address PR #281 Review Comments (Round 1)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Address accepted review comments from PR #281.
+
+**Architecture:** Keep `clearLegacy(_:)` lock-free because `SharedData.withLock` is non-reentrant, but make `deviceSyncEnabled` own its getter/setter critical sections. Add missing regression coverage for the `profileSnapshots` setter path.
+
+**Tech Stack:** Swift 6, Foundation `UserDefaults`, FoqosShared, XCTest.
+
+---
+
+### Task 1: Lock `deviceSyncEnabled` and clarify `clearLegacy` docs (comments #1, #2, #3)
+
+**Review comments addressed:**
+- #1: `deviceSyncEnabled` getter should use `withLock`.
+- #2: `deviceSyncEnabled` setter should use `withLock`.
+- #3: `clearLegacy` doc comment should not imply the helper itself enforces locking.
+
+**Evidence:**
+- `deviceSyncEnabled` getter currently returns `bool(forKey: .deviceSyncEnabled, legacyKey: .deviceSyncEnabled)` directly at `Packages/FoqosShared/Sources/FoqosShared/SharedData.swift:585-587`.
+- `deviceSyncEnabled` setter currently calls `suite.set` and `clearLegacy(.deviceSyncEnabled)` directly at `SharedData.swift:588-591`.
+- `clearLegacy` comment at `SharedData.swift:138-142` says it is called from setters already inside a caller's `withLock`, which is not universally true before this task.
+
+**Fix approach:**
+- Reword `clearLegacy` comment to state it intentionally does not lock and callers that are part of compound shared writes must hold/own the appropriate outer `withLock`.
+- Wrap the `deviceSyncEnabled` getter in `withLock`.
+- Wrap the `deviceSyncEnabled` setter body in `withLock`, keeping `suite.set` and `clearLegacy(.deviceSyncEnabled)` in the same critical section.
+- Do not add locking inside `clearLegacy`.
+
+**Verification:**
+- Run `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -parallel-testing-enabled NO -skip-testing:FoqosUITests -only-testing:FoqosTests/SharedDataLegacyKeyClearingTests -only-testing:FoqosTests/SharedDataLockTests | xcpretty`
+
+---
+
+### Task 2: Add `profileSnapshots` legacy-clearing regression test (comment #4)
+
+**Review comment addressed:**
+- #4: `SharedDataLegacyKeyClearingTests` does not cover the `profileSnapshots` setter path.
+
+**Evidence:**
+- `SharedData.profileSnapshots` clears legacy at `SharedData.swift:321-327`.
+- `SharedData.setSnapshot(_:for:)` writes through that setter at `SharedData.swift:335-340`.
+- Existing `SharedDataLegacyKeyClearingTests` covers active session, completed sessions, `deviceSyncId`, and `deviceSyncEnabled`, but no `profileSnapshots` assertion.
+
+**Fix approach:**
+- Add one XCTest to `FoqosTests/SharedDataLegacyKeyClearingTests.swift`.
+- Pre-seed `suite["profileSnapshots"]` with legacy data.
+- Call `SharedData.setSnapshot(_:for:)`.
+- Assert `suite.object(forKey: "profileSnapshots") == nil`.
+- Assert `SharedData.profileSnapshots` contains the written snapshot.
+
+**TDD red/green:**
+- Add the test first.
+- Run the selected test before production changes if needed; it should already pass once Task 1 does not affect the profile snapshot path, because production code already clears `.profileSnapshots`. The purpose is closing a coverage gap found in review, not driving new production behavior.
+
+**Verification:**
+- Run `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -parallel-testing-enabled NO -skip-testing:FoqosUITests -only-testing:FoqosTests/SharedDataLegacyKeyClearingTests | xcpretty`
+
+---
+
+### Final Verification
+
+- Run `swift-format lint --recursive .`.
+- Run `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -parallel-testing-enabled NO -only-testing:FoqosTests | xcpretty`.
+- Commit the review fixes.
+- Reply to and resolve all four PR review threads.

--- a/docs/superpowers/plans/2026-07-06-i-app-group-migration-ordering.md
+++ b/docs/superpowers/plans/2026-07-06-i-app-group-migration-ordering.md
@@ -10,6 +10,8 @@
 
 **Source commit (current `main` at authoring):** `6ffb8c22b52c4b47da610b978783ccc69774f712`
 
+**Citations refreshed before implementation:** `66ba422241c2c75115451929866516e02cdf90f7`
+
 **Epic:** #263 (defect-audit follow-ups). Bundle I. Issue: #217 (high).
 
 ## Implementation Sequencing (read first)
@@ -37,15 +39,18 @@ Bundle **F** (zombie-model safety, #213/#235) and Bundle **I** are implemented a
 
 ---
 
-## The defect (re-verified against the source commit)
+## The defect (re-verified against refreshed `main`)
 
-Confirmed intact on current `main` — PR #277 (D2) added session-**identity** gating to the `SharedData` mutators but did **not** touch the migration, the legacy-key fallback readers, the write-only-new-key setters, or `endActiveSharedSession`.
+Confirmed intact on current `main` — PR #277 (D2) added session-**identity** gating to the
+`SharedData` mutators, and PR #279 (D1) routed schedule-stop through
+`endActiveSharedSession(expectedSessionId:)`; neither touched the migration, the legacy-key
+fallback readers, or the write-only-new-key setters.
 
 1. `migrateAppGroupIfNeeded` (`Foqos/Utils/UserDefaultsMigration.swift:57-62`) unconditionally copies each legacy app-group key over the new prefixed key, guarded only by a one-time flag that is unset until the first launch after update. It runs **only** in the main app (`FoqosApp.swift:109`).
-2. `SharedData` setters write **only** the new prefixed keys and never remove the legacy keys (`SharedData.swift`: `profileSnapshots` set → 311/313; `completedSessionsInScheduler` set → 347/349; `activeSharedSession` set → 363/365; `deviceSyncId`/`deviceSyncEnabled` → 509/515/526). Its getters fall back to the legacy key (`data/string/bool(forKey:legacyKey:)`, 122-136).
+2. `SharedData` setters write **only** the new prefixed keys and never remove the legacy keys (`SharedData.swift`: `profileSnapshots` set → 312-318; `completedSessionsInScheduler` set → 348-354; `activeSharedSession` set → 364-370; `deviceSyncId`/`deviceSyncEnabled` → 556-565/574-576). Its getters fall back to the legacy key (`data/string/bool(forKey:legacyKey:)`, 122-136).
 3. `SharedData.swift:111-113` explicitly documents that extensions may run before the app migrates — but only the **read** path was handled, not the **write** path.
 
-**Failure chain:** pre-rename app has an active schedule session under legacy `"activeScheduleSession"`. App updates via the App Store overnight. The DeviceActivity interval ends **before** first app launch: `DeviceActivityMonitorExtension.intervalDidEnd → ScheduleTimerActivity.stop` (`ScheduleTimerActivity.swift:88-109`) deactivates restrictions and calls `SharedData.endActiveSharedSession()`, which appends the completed session under the **new** key and clears only the **new** active key — the legacy `"activeScheduleSession"` still holds the session. On first app launch, `migrateAppGroupIfNeeded` copies that stale legacy session over the new active key (resurrecting an ended session as "active" while ManagedSettings restrictions are off) and copies the stale legacy completed list over the new list (losing the just-completed session from stats/insights/sync).
+**Failure chain:** pre-rename app has an active schedule session under legacy `"activeScheduleSession"`. App updates via the App Store overnight. The DeviceActivity interval ends **before** first app launch: `DeviceActivityMonitorExtension.intervalDidEnd` (`FoqosDeviceMonitor/DeviceActivityMonitorExtension.swift:37-41`) routes through `TimerActivityUtil.stopTimerActivity` (`Packages/FoqosShared/Sources/FoqosShared/Timers/TimerActivityUtil.swift:16-25`) to `ScheduleTimerActivity.stop` (`Packages/FoqosShared/Sources/FoqosShared/Timers/ScheduleTimerActivity.swift:130-156`), which deactivates restrictions after calling `SharedData.endActiveSharedSession(expectedSessionId:)`. That appends the completed session under the **new** key and clears only the **new** active key — the legacy `"activeScheduleSession"` still holds the session. On first app launch, `migrateAppGroupIfNeeded` copies that stale legacy session over the new active key (resurrecting an ended session as "active" while ManagedSettings restrictions are off) and copies the stale legacy completed list over the new list (losing the just-completed session from stats/insights/sync).
 
 ---
 


### PR DESCRIPTION
## Summary
- Refresh Bundle I plan citations against post-D1/post-F `main`.
- Make app-group migration copy legacy values only when the new prefixed key is absent, while always removing legacy keys.
- Clear legacy app-group keys from every `SharedData` setter/write path so extension writes cannot leave stale shadows.

Fixes #217

## Deviations / notes
- No semantic deviations from the approved plan. The plan's new-key-wins merge semantics were implemented as written.
- Environmental handling: used simulator UUID `B9E4A679-BDF3-4541-A59F-DA4BE21F80ED`; booted it explicitly and waited for `bootstatus`.
- Environmental handling: sandboxed `xcodebuild`/`simctl` could not access CoreSimulator, DerivedData, or SwiftPM caches, so required Xcode commands were rerun outside the sandbox.
- Environmental handling: Xcode test launch hung until `-parallel-testing-enabled NO` was added. Full verification ran the complete `FoqosTests` unit target via `-only-testing:FoqosTests`; UI tests were not part of this bundle plan.

## Test plan
- RED: `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -parallel-testing-enabled NO -skip-testing:FoqosUITests -only-testing:FoqosTests/UserDefaultsMigrationTests | xcpretty` failed the two new migration clobbering tests as expected.
- GREEN: same `UserDefaultsMigrationTests` command passed 13 tests, 0 failures.
- RED: `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -parallel-testing-enabled NO -skip-testing:FoqosUITests -only-testing:FoqosTests/SharedDataLegacyKeyClearingTests | xcpretty` failed the four new legacy-clearing tests as expected.
- GREEN: same `SharedDataLegacyKeyClearingTests` command passed 4 tests, 0 failures.
- Regression: `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -parallel-testing-enabled NO -skip-testing:FoqosUITests -only-testing:FoqosTests/SharedDataSessionIdentityTests -only-testing:FoqosTests/SharedDataLockTests | xcpretty` passed 10 tests, 0 failures.
- Full unit target: `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -parallel-testing-enabled NO -only-testing:FoqosTests | xcpretty` passed 732 tests, 0 failures.
- `swift-format lint --recursive .` passed.

## Review
Review requested before merge per AGENTS.md.

## Summary by Sourcery

Adjust app-group migration and shared data handling to prevent stale legacy keys from clobbering or resurrecting newer extension-written state (#217).

Bug Fixes:
- Ensure app-group migration copies legacy values to new keys only when the new key is absent while always removing legacy keys.
- Clear legacy app-group keys from all SharedData write paths so legacy shadows cannot override or resurrect migrated state.

Documentation:
- Refresh the Bundle I app-group migration plan document with updated citations and a more detailed description of the verified defect chain.

Tests:
- Add migration tests covering new-key-wins semantics and legacy-only migration behavior for app-group keys.
- Add SharedData tests verifying that writes and session-ending logic clear legacy app-group keys, including device sync settings.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a migration ordering bug (#217) where stale legacy `UserDefaults` values could overwrite or resurrect state that an extension (DeviceActivity monitor/widget) had already written under the new prefixed keys before the main app's first post-update launch.

- **Migration fix** (`UserDefaultsMigration.swift`): `migrateAppGroupIfNeeded` now skips the copy when the new key is already present (new-key-wins), while always removing the legacy key unconditionally.
- **Setter defence** (`SharedData.swift`): a new `clearLegacy(_:)` helper is called from every write path (`profileSnapshots`, `completedSessionsInScheduler`, `activeSharedSession`, `deviceSyncId`, `deviceSyncEnabled`) so extensions can never leave a stale legacy shadow.
- **Tests**: three new `UserDefaultsMigrationTests` cases cover the new-key-wins semantics; four new `SharedDataLegacyKeyClearingTests` cases verify the setter-side clearing.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The fix is minimal and targeted — two lines changed in the migration loop, plus a one-line clearLegacy helper wired into each write path. All the scenarios described in the failure chain are covered by new unit tests.

The migration logic change is correct and the new-key-wins semantics are directly tested. The clearLegacy additions in SharedData follow a consistent pattern across four of the five affected keys; profileSnapshots has the code wired in but no dedicated legacy-clearing test to verify it. This is a minor gap rather than a logic flaw, but it is worth noting before merge.

Packages/FoqosShared/Sources/FoqosShared/SharedData.swift — clearLegacy(.profileSnapshots) is present in the setter but the corresponding test in SharedDataLegacyKeyClearingTests is missing.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Foqos/Utils/UserDefaultsMigration.swift | Core migration fix: copy-on-absent guard added to migrateAppGroupIfNeeded; old key is always removed regardless of whether a copy occurred. Logic is correct and regression-tested. |
| Packages/FoqosShared/Sources/FoqosShared/SharedData.swift | New clearLegacy(_:) helper added and wired into five write paths. All call sites respect the non-reentrant contract. Test coverage for the profileSnapshots setter path is absent among the new legacy-clearing tests. |
| FoqosTests/SharedDataLegacyKeyClearingTests.swift | New test class; uses unique UUID-based suite names for isolation. Covers active-session write, session-end, completed-sessions append, and deviceSync setters. profileSnapshots write path not covered. |
| FoqosTests/UserDefaultsMigrationTests.swift | Three new tests added for new-key-wins migration semantics (extension pre-write survives, legacy-only path still migrates, clobbering test for completed list). All look correct. |
| docs/superpowers/plans/2026-07-06-i-app-group-migration-ordering.md | Plan document refreshed with updated citations and failure-chain call-stack detail after D1/D2 merges. Documentation only. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([App launches post-update]) --> B{appGroupMigrationFlag set?}
    B -- yes --> Z([Return — already migrated])
    B -- no --> C[For each legacy → new key pair]
    C --> D{new key present in UserDefaults?}
    D -- yes\nextension already wrote it --> E[Skip copy — new value wins]
    D -- no\nlegacy-only path --> F{legacy key present?}
    F -- yes --> G[Copy legacy → new key]
    F -- no --> H[Nothing to copy]
    E --> I[Remove legacy key unconditionally]
    G --> I
    H --> I
    I --> C
    C --> J[Set appGroupMigrationFlag = true]

    subgraph Extension write path
        K([Extension setter called]) --> L[Write new prefixed key via suite.set]
        L --> M[clearLegacy — suite.removeObject on legacy key]
    end

    style E fill:#d4edda
    style I fill:#f8d7da
    style M fill:#f8d7da
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([App launches post-update]) --> B{appGroupMigrationFlag set?}
    B -- yes --> Z([Return — already migrated])
    B -- no --> C[For each legacy → new key pair]
    C --> D{new key present in UserDefaults?}
    D -- yes\nextension already wrote it --> E[Skip copy — new value wins]
    D -- no\nlegacy-only path --> F{legacy key present?}
    F -- yes --> G[Copy legacy → new key]
    F -- no --> H[Nothing to copy]
    E --> I[Remove legacy key unconditionally]
    G --> I
    H --> I
    I --> C
    C --> J[Set appGroupMigrationFlag = true]

    subgraph Extension write path
        K([Extension setter called]) --> L[Write new prefixed key via suite.set]
        L --> M[clearLegacy — suite.removeObject on legacy key]
    end

    style E fill:#d4edda
    style I fill:#f8d7da
    style M fill:#f8d7da
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(#217): clear legacy app-group keys o..."](https://github.com/mnbf9rca/family-foqos/commit/1673ad1ea27da65e89e9985d11f20b8576097610) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42204530)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->