### PR TITLE
plans the fix for #294

### DIFF
--- a/docs/superpowers/plans/2026-07-08-294-tap-to-stop-validation-probe.md
+++ b/docs/superpowers/plans/2026-07-08-294-tap-to-stop-validation-probe.md
@@ -1,0 +1,672 @@
+# #294 — "Tap to stop" Validation Regression: Empirical Probe + Gated Fix Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove — on a clean, known-commit device build — whether creating a new profile with "Tap to stop" actually fails validation, and if so capture the exact write that sets `stopConditions.manual = false`; only then apply a minimal fix targeted at the proven mechanism. Do **not** ship a "seed defaults" band-aid.
+
+**Architecture:** This plan is empirical-probe-first, in the style of `docs/superpowers/plans/2026-07-07-285-rev2-empirical-two-phase-delete.md`. A pre-flight code investigation (below, and independently verified by a 3-lens adversarial panel) found that **the mechanism #294 describes cannot exist in the current committed codebase**: the symbols it cites do not exist, no new-profile manual-seeding has ever existed, and no code path clears `stopConditions.manual` true→false on the create flow. The device log therefore does not prove what the issue claims. Phase 0 instruments every write to `stopConditions.manual` (UI-state logging, not sync-chain) and reproduces on a physical device from a named commit. A decision gate with four outcomes then routes to either a targeted fix (Phase 1, TDD) or a maintainer decision (likely: #294 is a stale artifact of a lost WIP build → close/downgrade and unblock #286).
+
+**Tech Stack:** Swift 6, SwiftUI (`Form`/`Section`, `@Published`, custom `Binding`), SwiftData, XCTest, physical-device verification (iOS 27 device that produced the report), custom durable `Log` (category `.ui`).
+
+---
+
+## Binding Context
+
+### The report and its artifact
+
+- Symptom (issue #294): clean install → enable sync → create profile → choose "Tap to stop" → validation fails ("At least one stop condition is required"); no profile is created, nothing syncs.
+- Device log (present only in the original checkout, `docs/plans/` is gitignored):
+  - `docs/plans/FamilyFoqos-Logs-2026-07-08-230111.log:38`
+  - ```
+    [22:00:50] [DEBUG] [UI] TriggerConfigurationModel.swift:86 validate() - Trigger validation errors:
+    At least one stop condition is required. Start: manual=true, NFC=false, QR=false, schedule=false,
+    deepLink=false. Stop: manual=false, timer=false, NFC=false, QR=false, schedule=false, deepLink=false
+    ```
+  - Sibling log `docs/plans/FamilyFoqos-Logs-2026-07-08-230144.log` (36 lines) shows the same launch/enable-sync sequence with no validate() line (no create attempt).
+
+### Pre-flight investigation findings (all independently verified — treat as established, but re-confirm citations in Task 0.0)
+
+1. **The issue's cited code does not exist.** `applyNewProfileDefaults()` and `didLoadTriggerConfig` appear in **no commit** (`git log --all -S` for each = 0 results), **no stash**, **no reflog**, **no working tree**, and **no untracked file**. `BlockedProfileView.swift:596` (per the issue) is a toolbar dismiss `Button`, not an `.onAppear`.
+2. **New-profile manual seeding never existed.** `TriggerConfigurationModel` has an empty `init() {}` and bare defaults: `@Published var startTriggers = ProfileStartTriggers()` and `@Published var stopConditions = ProfileStopConditions()` (`Foqos/Models/TriggerConfigurationModel.swift:10-11,24`). `ProfileStartTriggers.manual` defaults `false` (`Foqos/Models/ProfileStartTriggers.swift:7`); `ProfileStopConditions.init` defaults `manual: false` (`Packages/FoqosShared/Sources/FoqosShared/ProfileStopConditions.swift:20`). `.onAppear` seeds **only when editing** an existing profile (`Foqos/Views/BlockedProfileView.swift:588-592`, guarded by `if let existingProfile = profile`). The introduction commit `41ff702` already had bare defaults. The **only** source line that sets `stop.manual = true` is `Foqos/Utils/TriggerMigration.swift:52` (V1→V2 migration), which is never invoked on the interactive create flow.
+3. **No code path clears `stopConditions.manual` true→false on the new-profile flow.** Traced and verified: the `binding(\.manual)` set writes only the `manual` keyPath (`StopConditionSelector.swift:148-156`); `NFCStopOption`/`QRStopOption.apply(to:)` touch only NFC/QR fields, never `manual` (`TriggerPickerOptions.swift:59-63,128-132`); `.onChange(of: nfcOption/qrOption)` and `.onChange(of: startTriggers.hasNFC/hasQR)` only re-apply NFC/QR options (`StopConditionSelector.swift:37-47,63-73`); `.onChange(of: conditions)` reassigns only the local `@State nfcOption/qrOption`, not `conditions` (`StopConditionSelector.swift:125-128`); `startTriggersDidChange()` → `validator.autoFix` only clears `sameNFC`/`sameQR` (`TriggerConfigurationModel.swift:27-30`, `TriggerValidator.swift:32-34,41-43,98-102`); `validate()` is read-only. There is **no wholesale reassignment** of `stopConditions` on the create path (only `init` and `loadFromProfile`, the latter editing-only).
+4. **The "Tap to stop" toggle is functional for new profiles.** `disabled: editingDisabled` (`BlockedProfileView.swift:382`); for `profile == nil`: `isManagedProfile = false`, `isUnlockedForEditing = true`, so `ProfileEditGate.editingDisabled(isBlocking:false, isManaged:false, …) = false` (`Foqos/Utils/ProfileEditGate.swift:15`).
+5. **`validate()` reads live state, not a stale copy** (`TriggerConfigurationModel.swift:38-39,88-89`). The log line is emitted only when `validationErrors` is non-empty, and mirrors current state. `Start: manual=true` therefore means only that the user toggled "Tap to start"; it does **not** prove seeding ran or that a stop condition was cleared.
+
+### Where the defect lives (answers to two maintainer questions)
+
+- **Does the defect live on `fix/286-reset-sync-poison`?** Not in its committed code. `fix/286`'s versions of `BlockedProfileView.swift`, `TriggerConfigurationModel.swift`, `StopConditionSelector.swift`, `TriggerPickerOptions.swift`, and `TriggerValidator.swift` are **byte-identical to `origin/main`** (empty diff). The device build was `fix/286` **plus then-present uncommitted working-tree edits** to `BlockedProfileView.swift` and `TriggerConfigurationModel.swift` (both showed `M` at the start of the investigation session). Those edits were **since reverted**, were **never committed or stashed** (the two stashes touch only CloudKit sync files), and are **unrecoverable** (no dangling git blob holds them). If the defect was ever real, it lived transiently in those lost WIP edits — not in any branch's committed code.
+- **Is `main == origin/main`?** No. Local `main` (`4307654`, #289) is a strict ancestor of `origin/main` (`dff1333`, #292); they differ by three **plan-only** PRs (#290, #291, #292) that touch no code. For the trigger code they are identical. This plan's known-good build commit is `origin/main` HEAD.
+
+### Working conclusion this plan must test
+
+The most probable outcome is that **#294 does not reproduce on a clean current-`main` build**, because the described mechanism is absent from committed code and the reporting build's exact source is lost. Phase 0 exists to confirm or overturn that on device before any code is written. If it *does* reproduce, the probe will name the exact write, and Phase 1 applies a minimal fix to that write.
+
+---
+
+## Global Constraints
+
+- **Phase 0 is required. No fix before device evidence.** The stated mechanism is falsified by code reading; do not re-implement it.
+- **No "seed defaults" band-aid.** Seeding `manual: true` for new profiles duplicates behavior that never existed and targets a non-existent cause. It is explicitly prohibited as a fix. (A regression **test** encoding the correct contract is allowed — see Phase 1 baseline.)
+- **Physical-device verification is authoritative.** The report is device-only; in-memory unit tests cannot reproduce SwiftUI `Form` render/commit timing. The device that produced `FamilyFoqos-Logs-2026-07-08-230111.log` (iOS 27) is the reference.
+- **Build from a named commit.** Base every build on `origin/main` HEAD (currently `dff1333`); record the exact SHA in the evidence note. Do **not** build from `fix/286` or any working tree with uncommitted edits — the whole point is a clean, reconstructable source.
+- **UI-state logging only.** Probe logs use category `.ui` and cover the trigger UI state machine. Do **not** add sync-chain (`.sync`/`.cloudKit`) logging in this plan.
+- **Temporary probe code must not ship.** Commit probes normally, then remove them with a normal revert/commit before any production fix. Never amend, never force-push (AGENTS.md).
+- **TDD for any Phase 1 code.** Write the failing test first; test names follow `testGivenX_WhenY_ThenZ`.
+- **Single build/test stream.** Simulator UUID `B9E4A679-BDF3-4541-A59F-DA4BE21F80ED` (iPhone 17, already booted). Never use a device **name** in `-destination` (clones a 16 GB sim each run — AGENTS.md). Use `-parallel-testing-enabled NO` if test launch hangs.
+- **Branching.** The implementing session branches `fix/294-tap-to-stop-validation` off `origin/main`. `#294` must **not** be folded into `#286`.
+- **PR wording.** The plan PR (this document) is titled **"plans the fix for #294"** — never "fixes #294". The eventual fix PR wording is a separate decision at that time.
+- **#294 blocks #286** and is top of the queue: `#286`'s exit criterion is the two-device sync checklist, which cannot run until profiles can be created. `#286`'s code is complete/reviewed and paused at its verification gate.
+
+---
+
+## File Structure
+
+### Phase 0 — temporary probe files (all reverted before Phase 1)
+
+- Modify temporarily: `Foqos/Models/TriggerConfigurationModel.swift`
+  - Add `didSet` observers on `startTriggers` and `stopConditions` that log every change to `.manual` with a call-stack marker. Add a state log to `loadFromProfile`.
+- Modify temporarily: `Foqos/Components/BlockedProfileView/StopConditionSelector.swift`
+  - Log the "Tap to stop" binding set; log `.manual` before/after each `apply(to:)` in the NFC/QR `onChange` handlers (to prove they never touch `manual`).
+- Modify temporarily: `Foqos/Views/BlockedProfileView.swift`
+  - Log `.onAppear` (proves no seeding for new profiles) and `saveProfile()` entry state (the value `validate()` will read).
+
+### Phase 1 — candidate production files (only if the decision gate routes to a code fix)
+
+- Modify: `Foqos/Models/TriggerConfigurationModel.swift` **and/or** `Foqos/Components/BlockedProfileView/StopConditionSelector.swift` — exact file depends on the proven mechanism (see Decision Gate).
+- Test (always shipped): `FoqosTests/TriggerConfigurationModelTests.swift` — regression tests encoding the create-flow invariants.
+- Test (conditional): `FoqosTests/StopConditionSelectorBindingTests.swift` — only if the device proves a binding/`onChange` mechanism reproducible at the model layer.
+
+---
+
+## Phase 0: Empirical Device Probe
+
+### Task 0.0: Refresh citations against the build commit
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Record the build commit and confirm the cited code still matches**
+
+Run from the repo root:
+
+```bash
+git rev-parse HEAD
+git grep -n "applyNewProfileDefaults\|didLoadTriggerConfig" -- '*.swift' ; echo "grep-exit=$?"
+grep -n "Log.debug" Foqos/Models/TriggerConfigurationModel.swift | head -1
+sed -n '10,11p;24p' Foqos/Models/TriggerConfigurationModel.swift
+sed -n '588,592p' Foqos/Views/BlockedProfileView.swift
+sed -n '148,156p' Foqos/Components/BlockedProfileView/StopConditionSelector.swift
+sed -n '15p' Foqos/Utils/ProfileEditGate.swift
+```
+
+Expected:
+- `grep-exit=1` (no matches — the issue's symbols do not exist). **If this prints matches, STOP** — the code has diverged from this plan's premise; re-investigate before probing.
+- `TriggerConfigurationModel.swift` `Log.debug` inside `validate()` is at **line 86** (matches the device log `TriggerConfigurationModel.swift:86`).
+- Lines 10–11 are the bare `@Published var startTriggers = ProfileStartTriggers()` / `= ProfileStopConditions()`; line 24 is `init() {}`.
+- `BlockedProfileView.swift:588-592` is the `.onAppear` whose body is only `if let existingProfile = profile { triggerConfig.loadFromProfile(existingProfile) }`.
+- `ProfileEditGate.swift:15` is `isBlocking || (isManaged && !isUnlocked && mode == .child && lockActive)`.
+
+If any line number drifted (edits landed since this plan), update the Task 0.1–0.3 anchors accordingly before editing. The probe content does not change — only the insertion points.
+
+### Task 0.1: Instrument every write to `stopConditions.manual`
+
+**Files:**
+- Modify temporarily: `Foqos/Models/TriggerConfigurationModel.swift`
+
+- [ ] **Step 1: Add `didSet` manual-change logging to both published trigger structs**
+
+Replace lines 10–11:
+
+```swift
+  @Published var startTriggers = ProfileStartTriggers()
+  @Published var stopConditions = ProfileStopConditions()
+```
+
+with:
+
+```swift
+  @Published var startTriggers = ProfileStartTriggers() {
+    didSet {
+      guard oldValue.manual != startTriggers.manual else { return }
+      Log.debug(
+        "[#294 PROBE] startTriggers.manual \(oldValue.manual)->\(startTriggers.manual)\n"
+          + Thread.callStackSymbols.dropFirst().prefix(10).joined(separator: "\n"),
+        category: .ui
+      )
+    }
+  }
+  @Published var stopConditions = ProfileStopConditions() {
+    didSet {
+      guard oldValue.manual != stopConditions.manual else { return }
+      Log.debug(
+        "[#294 PROBE] stopConditions.manual \(oldValue.manual)->\(stopConditions.manual)\n"
+          + Thread.callStackSymbols.dropFirst().prefix(10).joined(separator: "\n"),
+        category: .ui
+      )
+    }
+  }
+```
+
+`stopConditions` is a value-type struct; any field mutation through the `$triggerConfig.stopConditions` binding reassigns the whole struct and fires `didSet`. The `guard` filters to `.manual` transitions only, so this logs **exactly** the writes we care about, with the call stack that caused each one. `startTriggers` is instrumented symmetrically as a control (the log shows `start.manual=true` surviving — we want to confirm the start toggle persists identically to the stop toggle).
+
+- [ ] **Step 2: Log the load path (must NOT run for a new profile)**
+
+In `loadFromProfile(_:)`, immediately after the opening brace (before `startTriggers = profile.startTriggers`), add:
+
+```swift
+    Log.debug(
+      "[#294 PROBE] loadFromProfile called (EDITING existing profile) id=\(profile.id)",
+      category: .ui)
+```
+
+For the #294 create flow this line must **never** appear. If it does, the view is being handed a non-nil `profile` when the user thinks they are creating one — a different bug.
+
+- [ ] **Step 3: Verify the probe compiles**
+
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
+  -parallel-testing-enabled NO \
+  -only-testing:FoqosTests/TriggerConfigurationModelTests | xcpretty
+```
+
+Expected: `TriggerConfigurationModelTests` pass (existing suite, unchanged behavior — the `didSet` only logs). If it fails to compile because `@Published` + `didSet` is rejected by the toolchain, fall back to a manual observer: rename the stored properties to `startTriggers`/`stopConditions` computed wrappers over `_startTriggersStorage` is over-engineering — instead move the log into the two call sites in Task 0.2 and skip the `didSet`. Note which path you took in the evidence note.
+
+### Task 0.2: Instrument the selector's write sites
+
+**Files:**
+- Modify temporarily: `Foqos/Components/BlockedProfileView/StopConditionSelector.swift`
+
+- [ ] **Step 1: Log the "Tap to stop" binding set**
+
+In `binding(_:)` (lines 148–156), replace the `set:` closure:
+
+```swift
+      set: { newValue in
+        conditions[keyPath: keyPath] = newValue
+        onConditionChange()
+      }
+```
+
+with:
+
+```swift
+      set: { newValue in
+        if keyPath == \ProfileStopConditions.manual {
+          Log.debug(
+            "[#294 PROBE] StopConditionSelector Tap-to-stop toggle set newValue=\(newValue)",
+            category: .ui)
+        }
+        conditions[keyPath: keyPath] = newValue
+        onConditionChange()
+      }
+```
+
+This proves whether the user's tap on "Tap to stop" reaches the binding at all.
+
+- [ ] **Step 2: Prove the NFC/QR `apply` paths never touch `manual`**
+
+Replace the NFC picker `onChange` (lines 37–40):
+
+```swift
+      .onChange(of: nfcOption) { _, newValue in
+        newValue.apply(to: &conditions)
+        onConditionChange()
+      }
+```
+
+with:
+
+```swift
+      .onChange(of: nfcOption) { _, newValue in
+        let before = conditions.manual
+        newValue.apply(to: &conditions)
+        Log.debug(
+          "[#294 PROBE] nfcOption.apply(\(newValue.rawValue)) manual \(before)->\(conditions.manual)",
+          category: .ui)
+        onConditionChange()
+      }
+```
+
+Replace the QR picker `onChange` (lines 63–66) with the analogous block, substituting `qrOption` for `nfcOption`:
+
+```swift
+      .onChange(of: qrOption) { _, newValue in
+        let before = conditions.manual
+        newValue.apply(to: &conditions)
+        Log.debug(
+          "[#294 PROBE] qrOption.apply(\(newValue.rawValue)) manual \(before)->\(conditions.manual)",
+          category: .ui)
+        onConditionChange()
+      }
+```
+
+Expected on device: every such line shows `manual X->X` (unchanged). If any shows `true->false`, that `apply` is the culprit (would contradict the code reading — capture it).
+
+- [ ] **Step 3: Verify compile**
+
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
+  -parallel-testing-enabled NO \
+  -only-testing:FoqosTests/TriggerConfigurationModelTests | xcpretty
+```
+
+Expected: pass.
+
+### Task 0.3: Instrument the create-flow boundaries
+
+**Files:**
+- Modify temporarily: `Foqos/Views/BlockedProfileView.swift`
+
+- [ ] **Step 1: Log `.onAppear` state (proves no seeding)**
+
+Replace the `.onAppear` block (lines 588–592):
+
+```swift
+        .onAppear {
+          if let existingProfile = profile {
+            triggerConfig.loadFromProfile(existingProfile)
+          }
+        }
+```
+
+with:
+
+```swift
+        .onAppear {
+          Log.debug(
+            "[#294 PROBE] BlockedProfileView.onAppear isNewProfile=\(profile == nil) "
+              + "start.manual=\(triggerConfig.startTriggers.manual) "
+              + "stop.manual=\(triggerConfig.stopConditions.manual)",
+            category: .ui)
+          if let existingProfile = profile {
+            triggerConfig.loadFromProfile(existingProfile)
+          }
+        }
+```
+
+Expected for the create flow: `isNewProfile=true start.manual=false stop.manual=false` — i.e. no seeding, both start all-false. (This directly falsifies the issue's "seeding ran" premise, or overturns the code reading if it prints `true`.)
+
+- [ ] **Step 2: Log `saveProfile()` entry state (what `validate()` will read)**
+
+In `saveProfile()`, immediately before `triggerConfig.validate()` (line 941), add:
+
+```swift
+    Log.debug(
+      "[#294 PROBE] saveProfile begin isEditing=\(isEditing) "
+        + "start.manual=\(triggerConfig.startTriggers.manual) "
+        + "stop.manual=\(triggerConfig.stopConditions.manual)",
+      category: .ui)
+```
+
+- [ ] **Step 3: Verify compile**
+
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
+  -parallel-testing-enabled NO \
+  -only-testing:FoqosTests/TriggerConfigurationModelTests | xcpretty
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit the probe**
+
+```bash
+git add Foqos/Models/TriggerConfigurationModel.swift \
+  Foqos/Components/BlockedProfileView/StopConditionSelector.swift \
+  Foqos/Views/BlockedProfileView.swift
+git commit -m "refs #294: add temporary Tap-to-stop UI-state probe"
+```
+
+### Task 0.4: Physical-device reproduction
+
+**Files:** none.
+
+- [ ] **Step 1: Build, install, launch on the reference device**
+
+Discover the paired device UUID:
+
+```bash
+xcrun devicectl list devices
+```
+
+Build and install (substitute the discovered device id for `<DEVICE_ID>`):
+
+```bash
+xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS,id=<DEVICE_ID>' -configuration Debug build | xcpretty
+
+xcrun devicectl device install app --device <DEVICE_ID> \
+  "$(xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+      -destination 'platform=iOS,id=<DEVICE_ID>' -configuration Debug -showBuildSettings \
+      | awk -F' = ' '/ BUILT_PRODUCTS_DIR =/{d=$2} / FULL_PRODUCT_NAME =/{n=$2} END{print d"/"n}')"
+
+xcrun devicectl device process launch --device <DEVICE_ID> com.cynexia.family-foqos
+```
+
+- [ ] **Step 2: Run the exact repro and watch the log**
+
+Reproduce the issue's steps precisely, observing the live device console (Xcode → Window → Devices and Simulators → Open Console, or `Log` export via Settings → Diagnostics → Debug Mode → Export Logs afterward):
+
+1. Delete the app (clean install).
+2. Launch; complete onboarding as **Individual**; grant Family Controls.
+3. Enable Profile Sync (wait for `Profile Sync toggle changed: enabled=true engineAttached=true`).
+4. Tap **+** to create a new profile. → capture the `BlockedProfileView.onAppear` probe line.
+5. Enter a name.
+6. Toggle **"Tap to start"** ON. → capture `startTriggers.manual false->true`.
+7. Toggle **"Tap to stop"** ON. → **capture whether `StopConditionSelector Tap-to-stop toggle set newValue=true` AND `stopConditions.manual false->true` appear.**
+8. Do **not** touch any other trigger control.
+9. Tap the **checkmark** (Create). → capture `saveProfile begin … stop.manual=?` and, if it fails, the `validate()` line.
+10. Repeat steps 4–9 a second time, this time toggling "Tap to stop" **before** "Tap to start", to test ordering.
+
+- [ ] **Step 3: Export and save the device log next to the original evidence**
+
+Save the exported log to `docs/plans/FamilyFoqos-Logs-294-probe-<HHMMSS>.log` (gitignored; lives only in the original checkout). Keep it for the evidence note.
+
+### Task 0.5: Decision gate
+
+**Files:** none (write the evidence note into the plan thread, not a repo doc).
+
+- [ ] **Step 1: Fill in the evidence note**
+
+```markdown
+## #294 Phase 0 Evidence
+- Build commit (git rev-parse HEAD):
+- onAppear line (isNewProfile / start.manual / stop.manual):
+- After "Tap to start": startTriggers.manual line seen? (yes/no, values)
+- After "Tap to stop": "toggle set newValue=true" seen? (yes/no)
+- After "Tap to stop": "stopConditions.manual false->true" seen? (yes/no)
+- Any "stopConditions.manual true->false" line? (yes/no) — if yes, paste its call stack
+- Any "*.apply(...) manual true->false" line? (yes/no)
+- saveProfile begin stop.manual value:
+- validate() outcome (pass / which errors):
+- loadFromProfile called on create? (must be no):
+- Reproduced? (yes/no)
+- Conclusion:
+```
+
+- [ ] **Step 2: Route by outcome**
+
+**Gate A — Reproduced, and a `stopConditions.manual true->false` line was logged.** The call stack on that line names the exact mutation site (the analysis says this cannot happen from committed code, so this site is the real, previously-unseen cause). → Proceed to **Phase 1**, Task 1.2, using the logged site as the fix target. Also keep Task 1.1 (regression tests).
+
+**Gate B — Reproduced, but no `manual false->true` line ever appeared after tapping "Tap to stop"** (the toggle set line is absent or `stopConditions.manual` never went true). The user's tap is not reaching/persisting through the binding — a SwiftUI `Form`/`Binding` commit-timing bug. → Proceed to **Phase 1**, Task 1.3, plus Task 1.1.
+
+**Gate C — Not reproduced** (`stop.manual` goes `false->true` on the toggle, stays true through `saveProfile begin`, and `validate()` passes / the profile is created). This is the outcome the code reading predicts. → **STOP for maintainer decision.** #294 is a stale artifact of the lost WIP device build. Ship **only** Task 1.1 (regression tests locking in the correct contract), then recommend closing #294 and unblocking #286. See "Maintainer Decision" below.
+
+**Gate D — Reproduced, `stop.manual` is true at `saveProfile begin`, but `validate()` still reports "At least one stop condition is required."** `validate()`/`isValid` is misreading state. → Proceed to **Phase 1**, Task 1.4, plus Task 1.1.
+
+---
+
+## Phase 1: Gated Fix
+
+Task 1.1 ships in **every** non-STOP outcome (and is the sole code change under Gate C). Tasks 1.2–1.4 are mutually exclusive and selected by the gate.
+
+### Task 1.1: Regression tests for the create-flow invariants (always)
+
+**Files:**
+- Test: `FoqosTests/TriggerConfigurationModelTests.swift`
+
+These encode the behavior the code reading proved and that any fix must preserve. They pass on current `main` (they are guardrails), and would fail if a future change reintroduces new-profile all-false-then-cleared behavior. They are **not** a "seed defaults" change — they assert the model contract only.
+
+- [ ] **Step 1: Write the failing/guard tests**
+
+Add to `TriggerConfigurationModelTests` (match the file's existing `@MainActor` / setup conventions; `TriggerConfigurationModel` is `@MainActor`):
+
+```swift
+func testGivenNewModel_WhenInitialized_ThenStartAndStopAreAllFalse() {
+  let model = TriggerConfigurationModel()
+  XCTAssertFalse(model.startTriggers.manual)
+  XCTAssertFalse(model.stopConditions.manual)
+  XCTAssertFalse(model.stopConditions.isValid)
+}
+
+func testGivenTapToStopSelected_WhenStartTriggersChange_ThenStopManualIsPreserved() {
+  let model = TriggerConfigurationModel()
+  // User picks "Tap to stop".
+  model.stopConditions.manual = true
+  model.stopConditionsDidChange()
+  XCTAssertTrue(model.stopConditions.manual)
+
+  // User then picks "Tap to start"; start-change auto-fix must not clear manual stop.
+  model.startTriggers.manual = true
+  model.startTriggersDidChange()
+
+  XCTAssertTrue(
+    model.stopConditions.manual,
+    "changing start triggers must not clear an already-selected manual stop condition")
+  XCTAssertTrue(model.validationErrors.isEmpty, "manual start + manual stop is a valid config")
+}
+
+func testGivenManualStartAndStop_WhenValidated_ThenNoErrors() {
+  let model = TriggerConfigurationModel()
+  model.startTriggers.manual = true
+  model.stopConditions.manual = true
+  model.validate()
+  XCTAssertTrue(model.validationErrors.isEmpty)
+}
+
+func testGivenManualStartOnly_WhenValidated_ThenRequiresStopCondition() {
+  let model = TriggerConfigurationModel()
+  model.startTriggers.manual = true
+  model.validate()
+  XCTAssertTrue(
+    model.validationErrors.contains("At least one stop condition is required"),
+    "this is the exact device-log error; it is correct when no stop condition is set")
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
+  -parallel-testing-enabled NO \
+  -only-testing:FoqosTests/TriggerConfigurationModelTests | xcpretty
+```
+
+Expected: **all pass on current `main`** (they are regression guards, not red-first). If `testGivenTapToStopSelected_WhenStartTriggersChange_ThenStopManualIsPreserved` fails, the device mechanism reproduces at the model layer — record it and re-route to Task 1.2.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add FoqosTests/TriggerConfigurationModelTests.swift
+git commit -m "test(#294): lock in new-profile trigger invariants (manual stop preserved)"
+```
+
+### Task 1.2: Fix a proven mutation site (Gate A only)
+
+**Files:**
+- Modify: the file/line named by the `true->false` call stack from Task 0.5.
+- Test: `FoqosTests/TriggerConfigurationModelTests.swift` (or `StopConditionSelectorBindingTests.swift` if the site is view-layer).
+
+- [ ] **Step 1: Write a red test reproducing the proven site**
+
+Translate the logged call stack into the smallest failing assertion. Example shape (fill the actual trigger action from the stack — e.g. if toggling "Timer" cleared `manual`):
+
+```swift
+func testGivenTapToStop_When<ProvenAction>_ThenStopManualIsPreserved() {
+  let model = TriggerConfigurationModel()
+  model.stopConditions.manual = true
+  // <invoke exactly the mutation the call stack showed, e.g.:>
+  // model.stopConditions.timer = true ; model.stopConditionsDidChange()
+  XCTAssertTrue(model.stopConditions.manual)
+}
+```
+
+- [ ] **Step 2: Run it red**
+
+Run the focused command from Task 1.1 Step 2 with `/testGivenTapToStop_When<ProvenAction>_ThenStopManualIsPreserved`. Expected: FAIL (reproduces the site).
+
+- [ ] **Step 3: Apply the minimal fix at the proven site**
+
+Remove/guard the specific stray write the stack identified. Keep it surgical — a single guarded assignment or a removed wholesale reassignment. Do **not** broaden scope.
+
+- [ ] **Step 4: Run green + regression suite**
+
+Run the focused test (expect PASS), then the full `TriggerConfigurationModelTests` (expect PASS).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "fix(#294): preserve manual stop condition across <proven action>"
+```
+
+### Task 1.3: Fix a lost toggle write (Gate B only)
+
+**Files:**
+- Modify: `Foqos/Components/BlockedProfileView/StopConditionSelector.swift`
+- Test: `FoqosTests/StopConditionSelectorBindingTests.swift` (new)
+
+The proven failure is that tapping "Tap to stop" does not persist into `stopConditions.manual`. The most common cause is a custom `Binding` whose `set` is dropped during a `Form` recompose. The minimal, idiomatic fix is to route the manual toggle through the model's published property directly rather than the per-render `binding(_:)` helper, matching how the value is read elsewhere.
+
+- [ ] **Step 1: Write a red test at the binding layer**
+
+Create `FoqosTests/StopConditionSelectorBindingTests.swift` — drive the same `Binding` construction the view uses and assert a set persists:
+
+```swift
+import XCTest
+import FoqosShared
+@testable import Foqos
+
+@MainActor
+final class StopConditionSelectorBindingTests: XCTestCase {
+  func testGivenManualBinding_WhenSetTrue_ThenConditionsManualPersists() {
+    var conditions = ProfileStopConditions()
+    var changeCount = 0
+    let binding = StopConditionSelector.manualBinding(
+      conditions: Binding(get: { conditions }, set: { conditions = $0 }),
+      onConditionChange: { changeCount += 1 }
+    )
+    binding.wrappedValue = true
+    XCTAssertTrue(conditions.manual)
+    XCTAssertEqual(changeCount, 1)
+  }
+}
+```
+
+- [ ] **Step 2: Run it red**
+
+Focused run of `FoqosTests/StopConditionSelectorBindingTests`. Expected: compile failure — `manualBinding` does not exist yet.
+
+- [ ] **Step 3: Extract a testable, stable binding factory**
+
+In `StopConditionSelector`, replace the private `binding(_:)` usage for `\.manual` with a static factory the test can call, and use it for the "Tap to stop" `Toggle`:
+
+```swift
+  static func manualBinding(
+    conditions: Binding<ProfileStopConditions>,
+    onConditionChange: @escaping () -> Void
+  ) -> Binding<Bool> {
+    Binding(
+      get: { conditions.wrappedValue.manual },
+      set: { newValue in
+        conditions.wrappedValue.manual = newValue
+        onConditionChange()
+      }
+    )
+  }
+```
+
+Change the "Tap to stop" toggle (line 23) to:
+
+```swift
+      Toggle("Tap to stop", isOn: Self.manualBinding(conditions: $conditions, onConditionChange: onConditionChange))
+        .disabled(disabled)
+```
+
+Writing through `$conditions` (the outer `@Binding`) commits into `triggerConfig.stopConditions` in one hop, avoiding the per-render keyPath indirection.
+
+- [ ] **Step 4: Run green, then device re-verify**
+
+Focused test PASS; full `TriggerConfigurationModelTests` PASS. Then re-run Task 0.4 on device (with probes still present) and confirm `stopConditions.manual false->true` now appears and `validate()` passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "fix(#294): persist Tap-to-stop toggle through a stable binding"
+```
+
+### Task 1.4: Fix a validate() misread (Gate D only)
+
+**Files:**
+- Modify: `Foqos/Models/TriggerConfigurationModel.swift` or `Packages/FoqosShared/Sources/FoqosShared/ProfileStopConditions.swift`
+- Test: `FoqosTests/TriggerConfigurationModelTests.swift`
+
+- [ ] **Step 1: Write a red test from the device state**
+
+Reconstruct the exact `stopConditions` field values logged at `saveProfile begin` and assert `isValid`/`validate()`:
+
+```swift
+func testGivenDeviceStopConditions_WhenValidated_ThenIsValid() {
+  var stop = ProfileStopConditions()
+  stop.manual = true  // <plus any other true fields seen in the probe log>
+  XCTAssertTrue(stop.isValid, "isValid must be true when manual (or any condition) is set")
+}
+```
+
+- [ ] **Step 2: Run red, fix the predicate, run green.** Correct `ProfileStopConditions.isValid` (line 44-47) or the `requiresStopCondition` rule (`TriggerValidator.swift:54-58`) per the proven discrepancy. Full suite PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -am "fix(#294): correct stop-condition validity predicate"
+```
+
+### Task 1.5: Remove the probe and finalize (all non-STOP outcomes)
+
+**Files:** the three Phase 0 probe files.
+
+- [ ] **Step 1: Revert the probe commit**
+
+```bash
+git revert --no-edit "$(git log --format=%H --grep='refs #294: add temporary Tap-to-stop UI-state probe' -n 1)"
+```
+
+Never amend, never force-push.
+
+- [ ] **Step 2: Confirm no probe strings remain**
+
+```bash
+rg -n "\[#294 PROBE\]" . ; echo "rg-exit=$?"
+```
+
+Expected: `rg-exit=1` (no matches).
+
+- [ ] **Step 3: Full verification**
+
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
+  -parallel-testing-enabled NO | xcpretty
+swift-format lint --recursive .
+scripts/check-sync-guards.sh
+```
+
+Expected: full `FoqosTests` suite passes, 0 failures; lint clean; guards pass.
+
+- [ ] **Step 4: Device acceptance**
+
+Rebuild the production (non-probe) build, clean-install, and run the Task 0.4 repro. Expected: creating a profile with "Tap to stop" succeeds, the profile is created, and it syncs to the second device (this also unblocks the #286 two-device checklist).
+
+---
+
+## Maintainer Decision (Gate C — the predicted outcome)
+
+If Phase 0 does not reproduce, the code reading is confirmed: #294's mechanism does not exist in committed code, and the reporting build's source (uncommitted, since-reverted WIP edits to the two trigger files on `fix/286`) is unrecoverable. Options:
+
+1. **Close #294 as not-reproducible-on-`main`** (recommended). Ship Task 1.1 regression tests as the durable outcome. Unblock #286's verification gate immediately.
+2. **Re-test on `fix/286` HEAD** to rule out an interaction with `#286`'s committed sync changes. (Its trigger files are byte-identical to `main`, so this is expected to also not reproduce — but it closes the loop for the reporter.)
+3. **Keep #294 open pending a fresh device report** with an exportable log from a clean, committed build, if the maintainer recalls a concrete clearing behavior the probe missed.
+
+Do not choose among these as an implementer; present the evidence note and let the maintainer decide.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Phase 0 instruments every write to `stopConditions.manual` (UI-state only) and reproduces on the reference device from a named commit; the decision gate has four exhaustive outcomes; Phase 1 provides minimal, TDD, mechanism-targeted fixes plus an always-shipped regression suite; a maintainer-decision path covers the predicted not-reproducible outcome. The "seed defaults" band-aid is explicitly prohibited.
+- **Placeholder scan:** No `TBD`/`TODO`/"handle edge cases". Gate-conditional tasks state exact route conditions; the one intentionally-parameterized spot (Task 1.2, the proven mutation site) is filled from device evidence by construction and is marked as such.
+- **Type/citation consistency:** `stopConditions`/`startTriggers` (`@Published` on `TriggerConfigurationModel`), `stopConditionsDidChange()`, `startTriggersDidChange()`, `validate()`, `validationErrors`, `ProfileStopConditions.isValid`, `ProfileEditGate.editingDisabled`, `manualBinding(conditions:onConditionChange:)`, and the probe marker `[#294 PROBE]` are used consistently. All cited line numbers are re-verified in Task 0.0 before editing.
+- **Device rigor:** Physical-device repro is the authoritative acceptance test; unit tests are regression guards, not proof of the device-only `Form` timing. Builds come from `origin/main` HEAD, never a working tree with uncommitted edits.
+- **Process integrity:** Probes are reverted (never amended/force-pushed); PR titled "plans the fix for #294"; `#294` stays on its own branch, not folded into `#286`.

--- a/docs/superpowers/plans/2026-07-08-294-tap-to-stop-validation-probe.md
+++ b/docs/superpowers/plans/2026-07-08-294-tap-to-stop-validation-probe.md
@@ -32,13 +32,22 @@ An 8-hypothesis adversarial analysis (coincidence / causal / common-cause) resol
 
 ---
 
+## Maintainer approval points (folded in from PR #295 review)
+
+The maintainer approved this plan with three implementation points; each is bound into the tasks below:
+
+1. **All five facade verbs.** The enqueue-only gap hits every `SyncEngineControlling` mutation — `enqueueProfileSave`, `enqueueProfileDelete`, `enqueueLocationSave`, `enqueueLocationDelete`, `enqueueEmergencySettingsSave` — not just profile-save. The send-on-enqueue fix **and** the deferred-loss fix must cover all of them (deletes via a tombstone path, because their model is already gone by drain time — see Task 1.4).
+2. **AB-4 conformance (explicit).** Send-on-enqueue must fire **only on fresh local mutations and only after the T1 strip has run** — never flushing restored engine state — so it cannot reintroduce the #286 poison hazard. Enforced by the `isSyncReady` gate (Task 1.1) and documented in "AB-4 Conformance", with a dedicated test (Task 1.5).
+3. **The `.notAttached` swallow is the permanent-loss half**, correctly closed by deferred-drain-on-attach (Tasks 1.3–1.4).
+
 ## Global Constraints
 
-- **Chosen fix = send-on-enqueue + swallow deferred-retry** (maintainer decision). Do not implement a full startup backfill; do not touch the trigger/validation UI (it is not the defect).
-- **Two-device physical acceptance is authoritative.** The bug is a device-timing/propagation defect; the acceptance test is "create on device A, foregrounded, without starting it and without relaunching → appears on device B within seconds."
+- **Chosen fix = send-on-enqueue + deferred-drain-on-attach**, across **all five** facade verbs (approval point 1). Do not implement a full startup re-scan/backfill; do not touch the trigger/validation UI (it is not the defect).
+- **AB-4 invariant (approval point 2).** The send-on-enqueue `requestSync()` runs only when `isSyncReady == true`, a flag set only after `attachEngine` awaits `startupTask` (which runs the T1 strip). `requestSync()` is called **only** from the facade enqueue verbs (fresh local mutations) and the post-startup flush; it is never wired into `handleEvent`/restore/T1-seed. See "AB-4 Conformance".
+- **Two-device physical acceptance is authoritative.** The bug is a device-timing/propagation defect; the acceptance test is "create on device A, foregrounded, without starting it and without relaunching → appears on device B within seconds," plus edit and delete propagation.
 - **TDD.** Write the failing test first; names follow `testGivenX_WhenY_ThenZ`.
 - **The send must stay outside `handleEvent`.** `requestSync()`/`sendChanges()` may only be scheduled outside the CKSyncEngine delegate (`SyncEngineController+Cutover.swift:6-8`). All enqueue facade calls originate from UI actions (outside `handleEvent`), so calling `requestSync()` there is permitted. Do **not** add sends inside `nextRecordZoneChangeBatch`/`handleEvent`.
-- **Preserve the delete fallback contract.** Delete call sites must still receive `.notAttached` (they fall back to a local delete — `BlockedProfileView.swift:826-838`). Send-on-enqueue must run only *after* a successful enqueue, so a throwing enqueue never reaches it.
+- **Preserve the delete fallback + I2 contract.** Delete call sites must still receive `.notAttached` (they fall back to a local delete — `BlockedProfileView.swift:826-838`); send-on-enqueue runs only *after* a successful enqueue. The new tombstone-delete verb lives **inside `MutationFunnel`** (an I2-whitelisted enqueue site — `scripts/check-sync-guards.sh`), never in `ProfileSyncManager`.
 - **Single build/test stream.** Simulator UUID `B9E4A679-BDF3-4541-A59F-DA4BE21F80ED` (iPhone 17, booted). Never a device *name* in `-destination`. Use `-parallel-testing-enabled NO` if launch hangs.
 - **Branch.** Implement on `fix/294-tap-to-stop-validation` off `origin/main`. Do **not** fold into `#286`.
 - **No amend/force-push.** Revert temporary probes with normal commits.
@@ -50,11 +59,29 @@ An 8-hypothesis adversarial analysis (coincidence / causal / common-cause) resol
 ## File Structure
 
 - Modify: `Foqos/CloudKit/ProfileSyncManager.swift`
-  - Add `requestSync()` after a successful enqueue in each enqueue facade verb (`enqueueProfileSave/Delete`, `enqueueLocationSave/Delete`, `enqueueEmergencySettingsSave`).
-  - Add `deferredProfileSaveIds: Set<UUID>`; record on `.notAttached` in `enqueueProfileSave`; drain in `attachEngine` after `startupTask`.
-- Modify (tests): `FoqosTests/SyncEngineFacadeTests.swift`
-  - Update `testGivenController_WhenFacadeVerbsCalled_ThenTheyForward` for the new `requestSyncCount`; add send-on-enqueue and deferred-retry tests.
+  - Add `isSyncReady` flag (set after `startupTask` in `attachEngine`, cleared on `stop`/detach).
+  - Add gated `requestSync()` after a successful enqueue in **all five** facade verbs.
+  - Add deferred sets (`deferredProfileSaveIds`, `deferredLocationSaveIds`, `deferredDeleteRecordNames: Set<String>`, `deferredEmergencySave: Bool`); record on `.notAttached`; `drainDeferredMutations()` on attach.
+- Modify: `Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift`
+  - Add `func enqueueDeferredDelete(recordName: String)` to the protocol (tombstone-only delete for a model that is already locally gone).
+- Modify: `Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift`
+  - Implement `enqueueDeferredDelete(recordName:)` forwarding to the funnel (I10 guard).
+- Modify: `Foqos/CloudKit/SyncEngine/MutationFunnel.swift`
+  - Add `func enqueueTombstoneDelete(recordName: String)` — sets the tombstone and adds `.deleteRecord`, mirroring the tail of `enqueueDelete` (`:108-109,136-137`) without a model read.
+- Modify (tests): `FoqosTests/SyncEngineFacadeTests.swift`, `FoqosTests/Mocks/MockSyncEngineControlling.swift`
+  - Add `enqueueDeferredDelete` to the mock (record `deferredDeletes: [String]`); update `testGivenController_WhenFacadeVerbsCalled_ThenTheyForward`; add send-on-enqueue, AB-4-gate, and deferred-drain tests.
 - Optional temporary probe (reverted before merge): `Foqos/CloudKit/SyncEngine/MutationFunnel.swift`, `Foqos/CloudKit/SyncEngine/CKSyncEngineDriver.swift` — one log line at enqueue and one at `sendChanges` (with caller) for device baseline/acceptance.
+
+---
+
+## AB-4 Conformance (approval point 2)
+
+The #286 poison arises when a **restored** pending zone-delete (a `pendingDatabaseChange`) is transmitted before the **T1 strip** removes it. Send-on-enqueue must never do this. Two independent guarantees:
+
+1. **Trigger provenance.** `requestSync()` for this feature is added **only** inside the five `ProfileSyncManager` facade enqueue verbs and the post-startup flush in `attachEngine`. Those verbs are invoked exclusively by fresh local mutations (`BlockedProfileView` create/edit/clone/delete, `BlockedProfileListView` reorder/delete, emergency-settings edits). No new `requestSync`/`sendChanges` is added to `handleEvent`, `nextRecordZoneChangeBatch`, `runStartupSequence`, the T1 seed, or any restore path.
+2. **Ordering gate.** `start()` creates the `MutationFunnel` synchronously (`SyncEngineController.swift:103`) but the T1 strip runs inside the async `startupTask` (`:121`, MARK "T1 strip (AB-4…)" `:193`). So there is a window where the funnel exists yet restored poison is unstripped. The send is therefore gated on `isSyncReady`, which `attachEngine` sets to `true` **only after** `await controller.startupTask?.value` (`ProfileSyncManager.swift:176`) — i.e. after the T1 strip. In that window an enqueue still records its pending change but does **not** send; the post-startup flush (also post-T1) transmits it. Net: no send can execute before T1 strips the poison.
+
+Task 1.5 asserts both: an enqueue with `isSyncReady == false` records the change but issues **zero** `sendChanges`, and the post-startup flush issues exactly one.
 
 ---
 
@@ -120,9 +147,9 @@ Build/install/launch on the reference device (`xcrun devicectl list devices` for
 
 ---
 
-## Phase 1: Send-on-Enqueue + Deferred-Retry Fix (TDD)
+## Phase 1: Send-on-Enqueue + Deferred-Drain Fix (TDD)
 
-### Task 1.1: Send-on-enqueue for the profile-save facade
+### Task 1.1: `isSyncReady` gate + send-on-enqueue for the profile-save facade
 
 **Files:**
 - Modify: `Foqos/CloudKit/ProfileSyncManager.swift`
@@ -130,17 +157,18 @@ Build/install/launch on the reference device (`xcrun devicectl list devices` for
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `SyncEngineFacadeTests`:
+Add to `SyncEngineFacadeTests` (the harness's `setUp` leaves `manager.isSyncReady == false`, so set it explicitly):
 
 ```swift
-func testGivenAttachedController_WhenEnqueueProfileSave_ThenRequestSyncIsScheduled() throws {
+func testGivenReadyController_WhenEnqueueProfileSave_ThenRequestSyncIsScheduled() throws {
+  manager.isSyncReady = true
   let id = UUID()
   try manager.enqueueProfileSave(id)
 
   XCTAssertEqual(mock.enqueuedProfileSaves, [id], "the save is forwarded to the engine")
   XCTAssertEqual(
     mock.requestSyncCount, 1,
-    "a user-initiated profile save must trigger a prompt send, not wait for the next foreground")
+    "a ready engine flushes a user-initiated save promptly, not on the next foreground")
 }
 ```
 
@@ -150,24 +178,38 @@ func testGivenAttachedController_WhenEnqueueProfileSave_ThenRequestSyncIsSchedul
 xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
   -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
   -parallel-testing-enabled NO \
-  -only-testing:FoqosTests/SyncEngineFacadeTests/testGivenAttachedController_WhenEnqueueProfileSave_ThenRequestSyncIsScheduled | xcpretty
+  -only-testing:FoqosTests/SyncEngineFacadeTests/testGivenReadyController_WhenEnqueueProfileSave_ThenRequestSyncIsScheduled | xcpretty
 ```
 
-Expected: FAIL — `requestSyncCount` is 0 (enqueue does not currently send).
+Expected: compile failure — `isSyncReady` does not exist yet — then FAIL once it compiles (`requestSyncCount` is 0).
 
-- [ ] **Step 3: Implement send-on-enqueue in the facade**
+- [ ] **Step 3: Add the `isSyncReady` gate and send-on-enqueue**
 
-In `ProfileSyncManager.swift`, replace `enqueueProfileSave` (`:213-216`):
+In `ProfileSyncManager.swift`, add the flag near `engineController`:
+
+```swift
+  /// True once the engine is attached AND startup (incl. the AB-4 T1 strip) has completed.
+  /// Gates send-on-enqueue so a send can never flush restored state before T1 (#286 poison).
+  var isSyncReady = false
+```
+
+Replace `enqueueProfileSave` (`:213-216`):
 
 ```swift
   func enqueueProfileSave(_ id: UUID) throws {
     guard let engineController else { throw SyncEngineControllingError.notAttached }
     try engineController.enqueueProfileSave(id)
-    engineController.requestSync()
+    if isSyncReady { engineController.requestSync() }
   }
 ```
 
-(`requestSync()` runs only after a successful enqueue, so a throwing enqueue — including `.notAttached` — never reaches it.)
+In `attachEngine(...)`, inside the `if isEnabled { … }` block, after `await controller.startupTask?.value` (`:176`), add:
+
+```swift
+      isSyncReady = true
+```
+
+In the `isEnabled` off-branch that stops the engine (the `$isEnabled` sink / `stop()` path, `:56-67`), set `isSyncReady = false` so a detach can never leave sends enabled against a torn-down engine. (Task 1.3 replaces the `isSyncReady = true` line with `markSyncReadyAndFlush()`.)
 
 - [ ] **Step 4: Run it green**
 
@@ -176,7 +218,7 @@ Rerun the Step 2 command. Expected: PASS.
 - [ ] **Step 5: Commit**
 
 ```bash
-git commit -am "fix(#294): flush profile save to CloudKit immediately after enqueue"
+git commit -am "fix(#294): gate a prompt send on isSyncReady and flush profile save after enqueue"
 ```
 
 ### Task 1.2: Extend send-on-enqueue to delete/location/emergency and fix the existing forward test
@@ -187,12 +229,18 @@ git commit -am "fix(#294): flush profile save to CloudKit immediately after enqu
 
 - [ ] **Step 1: Update the existing forward test to the new contract**
 
-`testGivenController_WhenFacadeVerbsCalled_ThenTheyForward` currently asserts `mock.requestSyncCount == 1` (from `syncNow` alone). With send-on-enqueue on all five enqueue verbs, the five enqueue calls each add one. Change the assertion (`SyncEngineFacadeTests.swift:62`):
+`testGivenController_WhenFacadeVerbsCalled_ThenTheyForward` currently asserts `mock.requestSyncCount == 1` (from `syncNow` alone). With the gate, the enqueue verbs only flush when `isSyncReady`, so set it at the top of the test (after the existing forwards, before the assertions is fine too — set it before the enqueue calls):
+
+```swift
+    manager.isSyncReady = true
+```
+
+and change the count assertion (`SyncEngineFacadeTests.swift:62`):
 
 ```swift
     XCTAssertEqual(
       mock.requestSyncCount, 6,
-      "syncNow (1) + five enqueue verbs each flush once (5)")
+      "syncNow (1) + five enqueue verbs each flush once when ready (5)")
 ```
 
 - [ ] **Step 2: Run it red**
@@ -208,13 +256,13 @@ Expected: FAIL — count is 2 (only `enqueueProfileSave` from Task 1.1 sends so 
 
 - [ ] **Step 3: Add `requestSync()` to the remaining enqueue verbs**
 
-In `ProfileSyncManager.swift`, apply the same pattern to `enqueueProfileDelete` (`:217-220`), `enqueueLocationSave` (`:221-224`), `enqueueLocationDelete` (`:225-228`), and `enqueueEmergencySettingsSave` (`:229-…`): after the `try engineController.enqueue…(…)` line, add `engineController.requestSync()`. Example for delete:
+In `ProfileSyncManager.swift`, apply the same gated pattern to `enqueueProfileDelete` (`:217-220`), `enqueueLocationSave` (`:221-224`), `enqueueLocationDelete` (`:225-228`), and `enqueueEmergencySettingsSave` (`:229-…`): after the `try engineController.enqueue…(…)` line, add `if isSyncReady { engineController.requestSync() }`. Example for delete:
 
 ```swift
   func enqueueProfileDelete(_ id: UUID) throws {
     guard let engineController else { throw SyncEngineControllingError.notAttached }
     try engineController.enqueueProfileDelete(id)
-    engineController.requestSync()
+    if isSyncReady { engineController.requestSync() }
   }
 ```
 
@@ -236,7 +284,9 @@ Expected: all pass. (Note: `BlockedProfileListView` reorder enqueues N profiles 
 git commit -am "fix(#294): flush delete/location/emergency mutations after enqueue"
 ```
 
-### Task 1.3: Deferred re-enqueue so a `.notAttached` create is not lost
+### Task 1.3: Deferred re-enqueue for the save verbs so a `.notAttached` mutation is not lost
+
+Covers approval points 1 (all save-type verbs: profile save, location save, emergency save) and 3 (the swallow is the permanent-loss half). Deletes are handled in Task 1.4.
 
 **Files:**
 - Modify: `Foqos/CloudKit/ProfileSyncManager.swift`
@@ -244,10 +294,8 @@ git commit -am "fix(#294): flush delete/location/emergency mutations after enque
 
 - [ ] **Step 1: Write the failing test**
 
-The mock's `errorToThrow` makes enqueue throw. Simulate a create hitting `.notAttached`, then attach and drain:
-
 ```swift
-func testGivenNotAttached_WhenEnqueueProfileSave_ThenIdIsDeferredAndReEnqueuedOnAttach() throws {
+func testGivenNotAttached_WhenEnqueueProfileSave_ThenIdIsDeferredAndReEnqueuedOnReady() throws {
   let id = UUID()
   manager.engineController = nil                      // pre-attach window
 
@@ -255,15 +303,14 @@ func testGivenNotAttached_WhenEnqueueProfileSave_ThenIdIsDeferredAndReEnqueuedOn
     XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
   }
 
-  // Engine attaches; the deferred save must be re-enqueued and flushed.
+  // Engine attaches and startup (T1) completes; deferred saves are replayed and flushed once.
   let attached = MockSyncEngineControlling()
   manager.engineController = attached
-  manager.drainDeferredProfileSaves()
+  manager.markSyncReadyAndFlush()
 
   XCTAssertEqual(attached.enqueuedProfileSaves, [id], "the dropped save is retried on attach")
-  XCTAssertEqual(attached.requestSyncCount, 1, "the retried save is flushed")
-  XCTAssertTrue(
-    manager.hasNoDeferredProfileSaves, "the deferred set is cleared after draining")
+  XCTAssertEqual(attached.requestSyncCount, 1, "exactly one flush covers all drained mutations")
+  XCTAssertTrue(manager.hasNoDeferredMutations, "the deferred sets are cleared after draining")
 }
 ```
 
@@ -273,26 +320,31 @@ func testGivenNotAttached_WhenEnqueueProfileSave_ThenIdIsDeferredAndReEnqueuedOn
 xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
   -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
   -parallel-testing-enabled NO \
-  -only-testing:FoqosTests/SyncEngineFacadeTests/testGivenNotAttached_WhenEnqueueProfileSave_ThenIdIsDeferredAndReEnqueuedOnAttach | xcpretty
+  -only-testing:FoqosTests/SyncEngineFacadeTests/testGivenNotAttached_WhenEnqueueProfileSave_ThenIdIsDeferredAndReEnqueuedOnReady | xcpretty
 ```
 
-Expected: compile failure — `drainDeferredProfileSaves` / `hasNoDeferredProfileSaves` do not exist, and the deferred set isn't recorded yet.
+Expected: compile failure — `markSyncReadyAndFlush` / `hasNoDeferredMutations` do not exist, and nothing is recorded on `.notAttached`.
 
-- [ ] **Step 3: Implement the deferred-retry set**
+- [ ] **Step 3: Add the deferred stores and drain**
 
-In `ProfileSyncManager.swift`, add a stored property near `engineController`:
+In `ProfileSyncManager.swift`, add near `engineController` (the delete set is populated in Task 1.4):
 
 ```swift
-  /// Profile-save ids that could not be enqueued because the engine was not attached yet
-  /// (#294). Drained on `attachEngine` so a create in the pre-attach window is retried
-  /// instead of silently lost.
+  // Mutations that could not be enqueued because the engine was not attached yet (#294).
+  // Drained on attach so a mutation in the pre-attach window is retried instead of lost.
   private var deferredProfileSaveIds: Set<UUID> = []
+  private var deferredLocationSaveIds: Set<UUID> = []
+  private var deferredDeleteRecordNames: Set<String> = []   // Task 1.4
+  private var deferredEmergencySave = false
 
   /// Test seam: true when nothing is pending re-enqueue.
-  var hasNoDeferredProfileSaves: Bool { deferredProfileSaveIds.isEmpty }
+  var hasNoDeferredMutations: Bool {
+    deferredProfileSaveIds.isEmpty && deferredLocationSaveIds.isEmpty
+      && deferredDeleteRecordNames.isEmpty && !deferredEmergencySave
+  }
 ```
 
-Update `enqueueProfileSave` (from Task 1.1) to record on `.notAttached`:
+Update the three **save** facade verbs to record on `.notAttached` (shown for profile save; apply the same shape to `enqueueLocationSave` → `deferredLocationSaveIds`, and `enqueueEmergencySettingsSave` → `deferredEmergencySave = true`):
 
 ```swift
   func enqueueProfileSave(_ id: UUID) throws {
@@ -306,50 +358,189 @@ Update `enqueueProfileSave` (from Task 1.1) to record on `.notAttached`:
       deferredProfileSaveIds.insert(id)          // I10: controller exists, funnel not built yet
       throw SyncEngineControllingError.notAttached
     }
-    engineController.requestSync()
+    if isSyncReady { engineController.requestSync() }
   }
 ```
 
-Add the drain method:
+Add the drain (delete replay is added in Task 1.4) and the ready hook, and drop `requestSync()` out of the drain so exactly one flush covers everything:
 
 ```swift
-  /// Re-enqueue and flush any profile saves that were deferred while the engine was
-  /// unattached (#294). Safe to call repeatedly; ids whose profile no longer exists throw
-  /// `entityNotFound` inside the funnel and are dropped.
-  func drainDeferredProfileSaves() {
-    guard let engineController, !deferredProfileSaveIds.isEmpty else { return }
-    let ids = deferredProfileSaveIds
+  /// Replay every mutation deferred while the engine was unattached (#294). Uses the
+  /// controller-level enqueue verbs (which do not themselves send), so the single
+  /// `requestSync()` in `markSyncReadyAndFlush()` flushes them all at once. Ids whose model
+  /// no longer exists throw `entityNotFound` in the funnel and are dropped.
+  private func drainDeferredMutations() {
+    guard let engineController else { return }
+    for id in deferredProfileSaveIds { try? engineController.enqueueProfileSave(id) }
+    for id in deferredLocationSaveIds { try? engineController.enqueueLocationSave(id) }
+    for name in deferredDeleteRecordNames { engineController.enqueueDeferredDelete(recordName: name) }  // Task 1.4
+    if deferredEmergencySave { try? engineController.enqueueEmergencySettingsSave() }
     deferredProfileSaveIds.removeAll()
-    for id in ids {
-      do { try engineController.enqueueProfileSave(id) } catch {
-        Log.warning(
-          "Deferred profile re-enqueue failed for \(id): \(error.localizedDescription)",
-          category: .sync)
-      }
-    }
-    engineController.requestSync()
+    deferredLocationSaveIds.removeAll()
+    deferredDeleteRecordNames.removeAll()
+    deferredEmergencySave = false
+  }
+
+  /// Called once the engine is attached AND startup (incl. the AB-4 T1 strip) has completed.
+  /// Enables prompt sends and flushes anything enqueued while not ready — always post-T1, so
+  /// it can never transmit restored poison (AB-4, #286).
+  func markSyncReadyAndFlush() {
+    isSyncReady = true
+    drainDeferredMutations()
+    engineController?.requestSync()
   }
 ```
 
-- [ ] **Step 4: Drain on attach**
-
-In `attachEngine(...)`, inside the `if isEnabled { … }` block after `await controller.startupTask?.value` (`ProfileSyncManager.swift:170-177`), add:
+Replace the `isSyncReady = true` line added in Task 1.1 (`attachEngine`, after `await controller.startupTask?.value`) with:
 
 ```swift
-      drainDeferredProfileSaves()
+      markSyncReadyAndFlush()
 ```
 
-- [ ] **Step 5: Run it green**
+- [ ] **Step 4: Run it green**
 
-Rerun Step 2. Expected: PASS.
+Rerun Step 2. Expected: PASS. (`enqueueDeferredDelete` is not on the protocol yet — Task 1.4 adds it; if the compiler blocks here, do Task 1.4 Step 3 first, then return.)
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git commit -am "fix(#294): defer and retry profile saves dropped in the pre-attach window"
+git commit -am "fix(#294): defer and retry save-type mutations dropped before attach; flush once on ready"
 ```
 
-### Task 1.4: Full verification
+### Task 1.4: Deferred tombstone-delete so a `.notAttached` delete still propagates
+
+The delete call sites fall back to a **local** delete on `.notAttached` (`BlockedProfileView.swift:826-838`, `BlockedProfileListView.swift:188`), leaving the model gone but the remote delete un-enqueued — a re-run of `enqueueProfileDelete` would hit `entityNotFound`. Add a tombstone-only delete replayed on attach.
+
+**Files:**
+- Modify: `Foqos/CloudKit/SyncEngine/MutationFunnel.swift`, `Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift`, `Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift`, `Foqos/CloudKit/ProfileSyncManager.swift`
+- Test: `FoqosTests/SyncEngineFacadeTests.swift`, `FoqosTests/Mocks/MockSyncEngineControlling.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+func testGivenNotAttached_WhenEnqueueProfileDelete_ThenTombstoneDeleteIsReplayedOnReady() throws {
+  let id = UUID()
+  manager.engineController = nil
+
+  XCTAssertThrowsError(try manager.enqueueProfileDelete(id)) { error in
+    XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+  }
+
+  let attached = MockSyncEngineControlling()
+  manager.engineController = attached
+  manager.markSyncReadyAndFlush()
+
+  XCTAssertEqual(
+    attached.deferredDeletes, [id.uuidString],
+    "a delete dropped before attach is replayed as a tombstone delete")
+  XCTAssertEqual(attached.requestSyncCount, 1)
+  XCTAssertTrue(manager.hasNoDeferredMutations)
+}
+```
+
+- [ ] **Step 2: Run it red**
+
+Focused run of the new test. Expected: compile failure — `enqueueDeferredDelete` / `deferredDeletes` do not exist.
+
+- [ ] **Step 3: Add the tombstone-delete seam**
+
+In `MutationFunnel.swift`, add (mirrors the tail of `enqueueDelete(profileId:)` at `:108-109,136-137`, without a model read — I2-whitelisted funnel site):
+
+```swift
+  /// Enqueue a delete for a record whose model is already gone locally (a delete that fell
+  /// back to a local delete while unattached, #294). Writes the tombstone and the
+  /// `.deleteRecord`; no persisted delete because the row no longer exists.
+  func enqueueTombstoneDelete(recordName: String) {
+    let changeTag = Self.changeTag(fromSystemFields: store.systemFields(for: recordName))
+    store.setTombstone(recordName: recordName, changeTag: changeTag)
+    let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
+    driver.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
+  }
+```
+
+In `SyncEngineControlling.swift`, add to the protocol:
+
+```swift
+  func enqueueDeferredDelete(recordName: String)
+```
+
+In `SyncEngineController+Cutover.swift`, implement it (I10 guard — no-op if the funnel isn't built):
+
+```swift
+  func enqueueDeferredDelete(recordName: String) {
+    funnel?.enqueueTombstoneDelete(recordName: recordName)
+  }
+```
+
+In `MockSyncEngineControlling.swift`, add:
+
+```swift
+  private(set) var deferredDeletes: [String] = []
+  func enqueueDeferredDelete(recordName: String) { deferredDeletes.append(recordName) }
+```
+
+In `ProfileSyncManager.swift`, record the recordName on `.notAttached` in **both** delete facade verbs (`enqueueProfileDelete`, `enqueueLocationDelete`), shown for profile:
+
+```swift
+  func enqueueProfileDelete(_ id: UUID) throws {
+    guard let engineController else {
+      deferredDeleteRecordNames.insert(id.uuidString)
+      throw SyncEngineControllingError.notAttached
+    }
+    do {
+      try engineController.enqueueProfileDelete(id)
+    } catch SyncEngineControllingError.notAttached {
+      deferredDeleteRecordNames.insert(id.uuidString)
+      throw SyncEngineControllingError.notAttached
+    }
+    if isSyncReady { engineController.requestSync() }
+  }
+```
+
+- [ ] **Step 4: Run it green**
+
+Rerun the Step 1 test and the full `SyncEngineFacadeTests`. Expected: PASS. (Locations share the profile zone, so `enqueueTombstoneDelete` handles both — `MutationFunnel.zoneID` is the single zone used by `enqueueDelete(profileId:)` `:69` and `enqueueDelete(locationId:)` `:171`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "fix(#294): replay a dropped delete as a tombstone delete on attach"
+```
+
+### Task 1.5: AB-4 conformance test (no send before the T1 strip)
+
+**Files:**
+- Test: `FoqosTests/SyncEngineFacadeTests.swift`
+
+- [ ] **Step 1: Write the test**
+
+```swift
+func testGivenNotReady_WhenEnqueueProfileSave_ThenNoSendUntilReadyFlush() throws {
+  manager.isSyncReady = false            // funnel present (mock) but startup/T1 not done
+  let id = UUID()
+
+  try manager.enqueueProfileSave(id)
+  XCTAssertEqual(mock.enqueuedProfileSaves, [id], "the change is enqueued")
+  XCTAssertEqual(
+    mock.requestSyncCount, 0,
+    "no send may fire before the engine is ready — restored poison must be T1-stripped first (AB-4)")
+
+  manager.markSyncReadyAndFlush()
+  XCTAssertEqual(mock.requestSyncCount, 1, "the post-startup flush sends exactly once, post-T1")
+}
+```
+
+- [ ] **Step 2: Run it green**
+
+Focused run. Expected: PASS with the gate + `markSyncReadyAndFlush` from Tasks 1.1/1.3 already in place (no new production code — this locks the AB-4 invariant).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -am "test(#294): assert send-on-enqueue never fires before the AB-4 T1 strip"
+```
+
+### Task 1.6: Full verification
 
 **Files:** none.
 
@@ -363,7 +554,7 @@ swift-format lint --recursive .
 scripts/check-sync-guards.sh
 ```
 
-Expected: full `FoqosTests` suite passes, 0 failures; lint clean; sync guards pass (I2/I5 unaffected — `requestSync` is not a new enqueue site).
+Expected: full `FoqosTests` suite passes, 0 failures; lint clean; sync guards pass. The one new enqueue site — `MutationFunnel.enqueueTombstoneDelete` — is inside the funnel (I2-whitelisted); if `scripts/check-sync-guards.sh` maintains an allow-list of `driver.add(...)` sites, add this method to it in the same commit.
 
 - [ ] **Step 2: Revert the Phase 0 probe (if added)**
 
@@ -374,7 +565,7 @@ rg -n "\[#294 PROBE\]" . ; echo "rg-exit=$?"
 
 Expected: `rg-exit=1` (no matches).
 
-### Task 1.5: Two-device physical acceptance (authoritative)
+### Task 1.7: Two-device physical acceptance (authoritative)
 
 **Files:** none.
 
@@ -400,17 +591,17 @@ With create-time sync working, the `#286` two-device sync checklist (`docs/sync-
 
 ## Risks / notes for the reviewer
 
-- **Chattiness on bulk reorder.** `BlockedProfileListView` reorder enqueues each remaining profile in a loop; each now calls `requestSync()`. CKSyncEngine coalesces concurrent `sendChanges()`, so this is functionally correct but issues multiple send cycles. If it proves noisy in practice, a single post-loop flush is a clean follow-up (out of scope here).
-- **Deferred-retry scope.** Task 1.3 covers profile **saves** (the reported symptom). Location/emergency mutations get send-on-enqueue (promptness) but not deferred-retry; they are far less likely to hit the pre-attach window and are not the reported bug. Extending the same pattern to them is a trivial follow-up if desired.
-- **`requestSync()` also fetches.** It runs `fetchChanges()` then `sendChanges()`; fetching on enqueue is harmless (it just also pulls remote changes) and keeps the fix to a single existing verb rather than adding a send-only method to the protocol.
-- **Not a #286 change.** This fix is independent of reset poisoning; it does not alter `beginReset`/T1/AB-4 behavior.
+- **Chattiness on bulk reorder.** `BlockedProfileListView` reorder enqueues each remaining profile in a loop; each now calls `requestSync()` (when ready). CKSyncEngine coalesces concurrent `sendChanges()`, so this is functionally correct but issues multiple send cycles. If it proves noisy, a single post-loop flush is a clean follow-up (out of scope).
+- **Coverage (approval point 1).** Send-on-enqueue covers all five facade verbs; deferred-drain covers all five (saves + emergency re-enqueue by id/flag; deletes replayed as tombstone deletes). No verb is left with the enqueue-only gap or the silent-drop.
+- **`requestSync()` also fetches.** It runs `fetchChanges()` then `sendChanges()`; fetching on enqueue is harmless (it also pulls remote changes) and reuses the existing verb rather than adding a send-only protocol method.
+- **Not a #286 change; AB-4-safe (approval point 2).** This fix does not alter `beginReset`/T1/AB-4 behavior. The only sends it adds are gated on `isSyncReady` (set post-T1) and triggered only by fresh local mutations, so it cannot resend restored poison. See "AB-4 Conformance".
 
 ---
 
 ## Self-Review
 
-- **Spec coverage:** send-on-enqueue added to every enqueue facade verb (Tasks 1.1–1.2); the `.notAttached` silent-drop closed with a deferred-retry set drained on attach (Task 1.3); the existing forward test updated to the new `requestSyncCount` contract; two-device acceptance proves prompt propagation without starting or relaunching (Task 1.5). The validation/trigger UI is untouched (established as a red herring).
+- **Spec coverage (incl. all three approval points):** send-on-enqueue added to **all five** facade verbs, gated on `isSyncReady` (Tasks 1.1–1.2); the `.notAttached` silent-drop closed for all five via deferred-drain-on-attach — saves/emergency re-enqueued, deletes replayed as tombstone deletes (Tasks 1.3–1.4); AB-4 conformance enforced by the `isSyncReady` gate and asserted (Task 1.5); the existing forward test updated to the new `requestSyncCount` contract; two-device acceptance proves prompt create/edit/delete propagation without starting or relaunching (Task 1.7). The validation/trigger UI is untouched (established as a red herring).
 - **Placeholder scan:** no `TBD`/`TODO`/"handle edge cases"; every code step shows complete code and exact assertions.
-- **Type/citation consistency:** `enqueueProfileSave/Delete`, `enqueueLocationSave/Delete`, `enqueueEmergencySettingsSave`, `requestSync()`, `deferredProfileSaveIds`, `drainDeferredProfileSaves()`, `hasNoDeferredProfileSaves`, `MockSyncEngineControlling.requestSyncCount`/`enqueuedProfileSaves`/`errorToThrow`, and `attachEngine`/`startupTask` are used consistently and match the current code.
+- **Type/citation consistency:** `enqueueProfileSave/Delete`, `enqueueLocationSave/Delete`, `enqueueEmergencySettingsSave`, `enqueueDeferredDelete(recordName:)`, `MutationFunnel.enqueueTombstoneDelete(recordName:)`, `requestSync()`, `isSyncReady`, `deferredProfileSaveIds`/`deferredLocationSaveIds`/`deferredDeleteRecordNames`/`deferredEmergencySave`, `drainDeferredMutations()`, `markSyncReadyAndFlush()`, `hasNoDeferredMutations`, `MockSyncEngineControlling.requestSyncCount`/`enqueuedProfileSaves`/`deferredDeletes`/`errorToThrow`, and `attachEngine`/`startupTask` are used consistently and match the current code.
 - **Device rigor:** the two-device acceptance is authoritative; unit tests assert the send is scheduled and the drop is retried, but the propagation claim is proven on hardware.
 - **Process integrity:** probes reverted with normal commits (no amend/force-push); PR titled "plans the fix for #294"; scoped to `fix/294-tap-to-stop-validation`, not folded into `#286`.

--- a/docs/superpowers/plans/2026-07-08-294-tap-to-stop-validation-probe.md
+++ b/docs/superpowers/plans/2026-07-08-294-tap-to-stop-validation-probe.md
@@ -1,639 +1,359 @@
-# #294 — "Tap to stop" Validation Regression: Empirical Probe + Gated Fix Plan
+# #294 — New profile does not sync until an incidental foreground: Send-on-Enqueue Fix Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Prove — on a clean, known-commit device build — whether creating a new profile with "Tap to stop" actually fails validation, and if so capture the exact write that sets `stopConditions.manual = false`; only then apply a minimal fix targeted at the proven mechanism. Do **not** ship a "seed defaults" band-aid.
+**Goal:** Make user-initiated profile create/edit/delete (and location/emergency mutations) propagate to CloudKit **promptly** by triggering a CKSyncEngine send after a successful enqueue, and stop silently **losing** enqueues that hit the `.notAttached` window by deferring them for retry on attach.
 
-**Architecture:** This plan is empirical-probe-first, in the style of `docs/superpowers/plans/2026-07-07-285-rev2-empirical-two-phase-delete.md`. A pre-flight code investigation (below, and independently verified by a 3-lens adversarial panel) found that **the mechanism #294 describes cannot exist in the current committed codebase**: the symbols it cites do not exist, no new-profile manual-seeding has ever existed, and no code path clears `stopConditions.manual` true→false on the create flow. The device log therefore does not prove what the issue claims. Phase 0 instruments every write to `stopConditions.manual` (UI-state logging, not sync-chain) and reproduces on a physical device from a named commit. A decision gate with four outcomes then routes to either a targeted fix (Phase 1, TDD) or a maintainer decision (likely: #294 is a stale artifact of a lost WIP build → close/downgrade and unblock #286).
+**Architecture:** The profile-create path is *enqueue-only*: `finalizeSave → enqueueProfileSave → funnel.enqueueSave → driver.add(pendingRecordZoneChanges)` terminates at `engine.state.add()`, and the driver runs with `automaticallySync = false`, so a queued `.saveRecord` is never transmitted until an incidental `syncNow` (scenePhase `.active`, remote push, or manual "Sync Now"). The fix adds a single `requestSync()` call in the `ProfileSyncManager` enqueue facade after a successful enqueue, and a small deferred-retry set drained on `attachEngine` so a create that lands in the brief `.notAttached` window is re-enqueued instead of dropped. Verified by unit tests (`MockSyncEngineControlling.requestSyncCount`) and a two-device physical acceptance.
 
-**Tech Stack:** Swift 6, SwiftUI (`Form`/`Section`, `@Published`, custom `Binding`), SwiftData, XCTest, physical-device verification (iOS 27 device that produced the report), custom durable `Log` (category `.ui`).
+**Tech Stack:** Swift 6, `@MainActor`, CKSyncEngine (custom driver seam), SwiftData, XCTest with `MockSyncEngineControlling` / `CutoverRecordingDriver`, custom durable `Log` (category `.sync`), two-device physical verification.
 
 ---
 
-## Binding Context
+## Investigation history (why this replaced the earlier validation plan)
 
-### The report and its artifact
+The original #294 framing — "new profile with 'Tap to stop' fails validation, so no profile is created and nothing syncs" — was **falsified**. A code investigation (triple-verified by an adversarial panel) found the issue's cited symbols (`applyNewProfileDefaults`, `didLoadTriggerConfig`) do not exist and no code path clears `stopConditions.manual`. Then the maintainer supplied decisive device evidence (`docs/plans/FamilyFoqos-Logs-2026-07-08-235429.log`):
 
-- Symptom (issue #294): clean install → enable sync → create profile → choose "Tap to stop" → validation fails ("At least one stop condition is required"); no profile is created, nothing syncs.
-- Device log (present only in the original checkout, `docs/plans/` is gitignored):
-  - `docs/plans/FamilyFoqos-Logs-2026-07-08-230111.log:38`
-  - ```
-    [22:00:50] [DEBUG] [UI] TriggerConfigurationModel.swift:86 validate() - Trigger validation errors:
-    At least one stop condition is required. Start: manual=true, NFC=false, QR=false, schedule=false,
-    deepLink=false. Stop: manual=false, timer=false, NFC=false, QR=false, schedule=false, deepLink=false
-    ```
-  - Sibling log `docs/plans/FamilyFoqos-Logs-2026-07-08-230144.log` (36 lines) shows the same launch/enable-sync sequence with no validate() line (no create attempt).
+- The `22:00:50` `validate()` error was the **first** create attempt, before a stop condition was set — **correct** validation behavior on an incomplete config, and a **red herring** for the real defect. It has no effect on sync (a validation failure early-returns from `saveProfile()`; nothing is created or enqueued).
+- The profile was then created with **manual stop**, **works**, and **activates** (`22:54:08 AppBlockerUtil "Starting restrictions"`). Its **session** state syncs via `SessionSyncService` direct CAS (`22:54:09 "CAS save succeeded … seq=1"`). But the **profile record** never appears being sent by CKSyncEngine.
+- The maintainer observed the profile reached the remote device **only after starting it**, and flagged this **could be coincidence**.
 
-### Pre-flight investigation findings (all independently verified — treat as established, but re-confirm citations in Task 0.0)
+An 8-hypothesis adversarial analysis (coincidence / causal / common-cause) resolved it: the "synced after start" correlation is **coincidental** — starting the profile does not touch profile sync; the flush came from the relaunch/foreground `scenePhase == .active → syncNow` that happened around the same time. Verdicts: **H5 (create enqueues but never sends) = root cause**, **H7 (flush is scenePhase-driven) = supported**; H1/H3/H4/H6/H8 refuted.
 
-1. **The issue's cited code does not exist.** `applyNewProfileDefaults()` and `didLoadTriggerConfig` appear in **no commit** (`git log --all -S` for each = 0 results), **no stash**, **no reflog**, **no working tree**, and **no untracked file**. `BlockedProfileView.swift:596` (per the issue) is a toolbar dismiss `Button`, not an `.onAppear`.
-2. **New-profile manual seeding never existed.** `TriggerConfigurationModel` has an empty `init() {}` and bare defaults: `@Published var startTriggers = ProfileStartTriggers()` and `@Published var stopConditions = ProfileStopConditions()` (`Foqos/Models/TriggerConfigurationModel.swift:10-11,24`). `ProfileStartTriggers.manual` defaults `false` (`Foqos/Models/ProfileStartTriggers.swift:7`); `ProfileStopConditions.init` defaults `manual: false` (`Packages/FoqosShared/Sources/FoqosShared/ProfileStopConditions.swift:20`). `.onAppear` seeds **only when editing** an existing profile (`Foqos/Views/BlockedProfileView.swift:588-592`, guarded by `if let existingProfile = profile`). The introduction commit `41ff702` already had bare defaults. The **only** source line that sets `stop.manual = true` is `Foqos/Utils/TriggerMigration.swift:52` (V1→V2 migration), which is never invoked on the interactive create flow.
-3. **No code path clears `stopConditions.manual` true→false on the new-profile flow.** Traced and verified: the `binding(\.manual)` set writes only the `manual` keyPath (`StopConditionSelector.swift:148-156`); `NFCStopOption`/`QRStopOption.apply(to:)` touch only NFC/QR fields, never `manual` (`TriggerPickerOptions.swift:59-63,128-132`); `.onChange(of: nfcOption/qrOption)` and `.onChange(of: startTriggers.hasNFC/hasQR)` only re-apply NFC/QR options (`StopConditionSelector.swift:37-47,63-73`); `.onChange(of: conditions)` reassigns only the local `@State nfcOption/qrOption`, not `conditions` (`StopConditionSelector.swift:125-128`); `startTriggersDidChange()` → `validator.autoFix` only clears `sameNFC`/`sameQR` (`TriggerConfigurationModel.swift:27-30`, `TriggerValidator.swift:32-34,41-43,98-102`); `validate()` is read-only. There is **no wholesale reassignment** of `stopConditions` on the create path (only `init` and `loadFromProfile`, the latter editing-only).
-4. **The "Tap to stop" toggle is functional for new profiles.** `disabled: editingDisabled` (`BlockedProfileView.swift:382`); for `profile == nil`: `isManagedProfile = false`, `isUnlockedForEditing = true`, so `ProfileEditGate.editingDisabled(isBlocking:false, isManaged:false, …) = false` (`Foqos/Utils/ProfileEditGate.swift:15`).
-5. **`validate()` reads live state, not a stale copy** (`TriggerConfigurationModel.swift:38-39,88-89`). The log line is emitted only when `validationErrors` is non-empty, and mirrors current state. `Start: manual=true` therefore means only that the user toggled "Tap to start"; it does **not** prove seeding ran or that a stop condition was cleared.
+---
 
-### Where the defect lives (answers to two maintainer questions)
+## Root cause (established; citations re-verified in Task 0.0)
 
-- **Does the defect live on `fix/286-reset-sync-poison`?** Not in its committed code. `fix/286`'s versions of `BlockedProfileView.swift`, `TriggerConfigurationModel.swift`, `StopConditionSelector.swift`, `TriggerPickerOptions.swift`, and `TriggerValidator.swift` are **byte-identical to `origin/main`** (empty diff). The device build was `fix/286` **plus then-present uncommitted working-tree edits** to `BlockedProfileView.swift` and `TriggerConfigurationModel.swift` (both showed `M` at the start of the investigation session). Those edits were **since reverted**, were **never committed or stashed** (the two stashes touch only CloudKit sync files), and are **unrecoverable** (no dangling git blob holds them). If the defect was ever real, it lived transiently in those lost WIP edits — not in any branch's committed code.
-- **Is `main == origin/main`?** No. Local `main` (`4307654`, #289) is a strict ancestor of `origin/main` (`dff1333`, #292); they differ by three **plan-only** PRs (#290, #291, #292) that touch no code. For the trigger code they are identical. This plan's known-good build commit is `origin/main` HEAD.
-
-### Working conclusion this plan must test
-
-The most probable outcome is that **#294 does not reproduce on a clean current-`main` build**, because the described mechanism is absent from committed code and the reporting build's exact source is lost. Phase 0 exists to confirm or overturn that on device before any code is written. If it *does* reproduce, the probe will name the exact write, and Phase 1 applies a minimal fix to that write.
+1. **Create path is enqueue-only.** `BlockedProfileView.finalizeSave` (`BlockedProfileView.swift:929`) → `ProfileSyncManager.enqueueProfileSave` (`ProfileSyncManager.swift:213-216`) → `SyncEngineController+Cutover.enqueueProfileSave` (`SyncEngineController+Cutover.swift:29-32`) → `MutationFunnel.enqueueSave` (`MutationFunnel.swift:50-71`) → `CKSyncEngineDriver.add` (`CKSyncEngineDriver.swift:43-45`). The chain terminates at `engine.state.add(pendingRecordZoneChanges:)`. **No `sendChanges()`.**
+2. **No auto-send.** `CKSyncEngineDriver` sets `configuration.automaticallySync = false` (`CKSyncEngineDriver.swift:27`). The queued `.saveRecord` is inert until an explicit `driver.sendChanges()`.
+3. **The only send path is off the create path.** `requestSync()` = `driver?.fetchChanges(); driver?.sendChanges()` (`SyncEngineController+Cutover.swift:9-12`), reachable only via `ProfileSyncManager.syncNow()` (`ProfileSyncManager.swift:196-199`), whose only callers are scenePhase `.active` (`FoqosApp.swift:152`), remote push (`FoqosApp.swift:378`), and manual "Sync Now" (`SettingsView.swift:176`). **Creating or starting a profile is none of these.**
+4. **Secondary bug — silent drop.** If enqueue throws `.notAttached` (engineController nil, or the "I10" window where the controller exists but its `MutationFunnel` isn't built yet — `SyncEngineController+Cutover.swift:30`), `finalizeSave` **catches and swallows** it (`BlockedProfileView.swift:930-933`). The save is then never enqueued **and never retried** — no ordinary-relaunch backfill re-derives it (`restorableRecordNames` runs only under seed conditions). Permanent loss until the user re-edits.
+5. **Consistent with the log.** Session 1 shows `engineAttached=true` at creation yet **no** CKSyncEngine `sentRecordZoneChanges`/profile-save entry; the relaunch line 57 `"syncNow skipped: Sync isn't ready yet"` is the `.active` handler firing `syncNow` before attach finished.
 
 ---
 
 ## Global Constraints
 
-- **Phase 0 is required. No fix before device evidence.** The stated mechanism is falsified by code reading; do not re-implement it.
-- **No "seed defaults" band-aid.** Seeding `manual: true` for new profiles duplicates behavior that never existed and targets a non-existent cause. It is explicitly prohibited as a fix. (A regression **test** encoding the correct contract is allowed — see Phase 1 baseline.)
-- **Physical-device verification is authoritative.** The report is device-only; in-memory unit tests cannot reproduce SwiftUI `Form` render/commit timing. The device that produced `FamilyFoqos-Logs-2026-07-08-230111.log` (iOS 27) is the reference.
-- **Build from a named commit.** Base every build on `origin/main` HEAD (currently `dff1333`); record the exact SHA in the evidence note. Do **not** build from `fix/286` or any working tree with uncommitted edits — the whole point is a clean, reconstructable source.
-- **UI-state logging only.** Probe logs use category `.ui` and cover the trigger UI state machine. Do **not** add sync-chain (`.sync`/`.cloudKit`) logging in this plan.
-- **Temporary probe code must not ship.** Commit probes normally, then remove them with a normal revert/commit before any production fix. Never amend, never force-push (AGENTS.md).
-- **TDD for any Phase 1 code.** Write the failing test first; test names follow `testGivenX_WhenY_ThenZ`.
-- **Single build/test stream.** Simulator UUID `B9E4A679-BDF3-4541-A59F-DA4BE21F80ED` (iPhone 17, already booted). Never use a device **name** in `-destination` (clones a 16 GB sim each run — AGENTS.md). Use `-parallel-testing-enabled NO` if test launch hangs.
-- **Branching.** The implementing session branches `fix/294-tap-to-stop-validation` off `origin/main`. `#294` must **not** be folded into `#286`.
-- **PR wording.** The plan PR (this document) is titled **"plans the fix for #294"** — never "fixes #294". The eventual fix PR wording is a separate decision at that time.
-- **#294 blocks #286** and is top of the queue: `#286`'s exit criterion is the two-device sync checklist, which cannot run until profiles can be created. `#286`'s code is complete/reviewed and paused at its verification gate.
+- **Chosen fix = send-on-enqueue + swallow deferred-retry** (maintainer decision). Do not implement a full startup backfill; do not touch the trigger/validation UI (it is not the defect).
+- **Two-device physical acceptance is authoritative.** The bug is a device-timing/propagation defect; the acceptance test is "create on device A, foregrounded, without starting it and without relaunching → appears on device B within seconds."
+- **TDD.** Write the failing test first; names follow `testGivenX_WhenY_ThenZ`.
+- **The send must stay outside `handleEvent`.** `requestSync()`/`sendChanges()` may only be scheduled outside the CKSyncEngine delegate (`SyncEngineController+Cutover.swift:6-8`). All enqueue facade calls originate from UI actions (outside `handleEvent`), so calling `requestSync()` there is permitted. Do **not** add sends inside `nextRecordZoneChangeBatch`/`handleEvent`.
+- **Preserve the delete fallback contract.** Delete call sites must still receive `.notAttached` (they fall back to a local delete — `BlockedProfileView.swift:826-838`). Send-on-enqueue must run only *after* a successful enqueue, so a throwing enqueue never reaches it.
+- **Single build/test stream.** Simulator UUID `B9E4A679-BDF3-4541-A59F-DA4BE21F80ED` (iPhone 17, booted). Never a device *name* in `-destination`. Use `-parallel-testing-enabled NO` if launch hangs.
+- **Branch.** Implement on `fix/294-tap-to-stop-validation` off `origin/main`. Do **not** fold into `#286`.
+- **No amend/force-push.** Revert temporary probes with normal commits.
+- **PR wording.** Plan PR titled **"plans the fix for #294"** (not a closing keyword).
+- **#294 blocks #286** (its two-device sync checklist can't run until create-time sync works) and is top of the queue.
 
 ---
 
 ## File Structure
 
-### Phase 0 — temporary probe files (all reverted before Phase 1)
-
-- Modify temporarily: `Foqos/Models/TriggerConfigurationModel.swift`
-  - Add `didSet` observers on `startTriggers` and `stopConditions` that log every change to `.manual` with a call-stack marker. Add a state log to `loadFromProfile`.
-- Modify temporarily: `Foqos/Components/BlockedProfileView/StopConditionSelector.swift`
-  - Log the "Tap to stop" binding set; log `.manual` before/after each `apply(to:)` in the NFC/QR `onChange` handlers (to prove they never touch `manual`).
-- Modify temporarily: `Foqos/Views/BlockedProfileView.swift`
-  - Log `.onAppear` (proves no seeding for new profiles) and `saveProfile()` entry state (the value `validate()` will read).
-
-### Phase 1 — candidate production files (only if the decision gate routes to a code fix)
-
-- Modify: `Foqos/Models/TriggerConfigurationModel.swift` **and/or** `Foqos/Components/BlockedProfileView/StopConditionSelector.swift` — exact file depends on the proven mechanism (see Decision Gate).
-- Test (always shipped): `FoqosTests/TriggerConfigurationModelTests.swift` — regression tests encoding the create-flow invariants.
-- Test (conditional): `FoqosTests/StopConditionSelectorBindingTests.swift` — only if the device proves a binding/`onChange` mechanism reproducible at the model layer.
+- Modify: `Foqos/CloudKit/ProfileSyncManager.swift`
+  - Add `requestSync()` after a successful enqueue in each enqueue facade verb (`enqueueProfileSave/Delete`, `enqueueLocationSave/Delete`, `enqueueEmergencySettingsSave`).
+  - Add `deferredProfileSaveIds: Set<UUID>`; record on `.notAttached` in `enqueueProfileSave`; drain in `attachEngine` after `startupTask`.
+- Modify (tests): `FoqosTests/SyncEngineFacadeTests.swift`
+  - Update `testGivenController_WhenFacadeVerbsCalled_ThenTheyForward` for the new `requestSyncCount`; add send-on-enqueue and deferred-retry tests.
+- Optional temporary probe (reverted before merge): `Foqos/CloudKit/SyncEngine/MutationFunnel.swift`, `Foqos/CloudKit/SyncEngine/CKSyncEngineDriver.swift` — one log line at enqueue and one at `sendChanges` (with caller) for device baseline/acceptance.
 
 ---
 
-## Phase 0: Empirical Device Probe
+## Phase 0 (optional, recommended): device baseline probe
+
+Confirms on the real device that the current build enqueues-without-send, and is reused to confirm the fix flushes promptly. Skip only if you accept the unit tests + two-device acceptance as sufficient.
 
 ### Task 0.0: Refresh citations against the build commit
 
 **Files:** none (verification only).
 
-- [ ] **Step 1: Record the build commit and confirm the cited code still matches**
-
-Run from the repo root:
+- [ ] **Step 1: Confirm the root-cause anchors still match**
 
 ```bash
 git rev-parse HEAD
-git grep -n "applyNewProfileDefaults\|didLoadTriggerConfig" -- '*.swift' ; echo "grep-exit=$?"
-grep -n "Log.debug" Foqos/Models/TriggerConfigurationModel.swift | head -1
-sed -n '10,11p;24p' Foqos/Models/TriggerConfigurationModel.swift
-sed -n '588,592p' Foqos/Views/BlockedProfileView.swift
-sed -n '148,156p' Foqos/Components/BlockedProfileView/StopConditionSelector.swift
-sed -n '15p' Foqos/Utils/ProfileEditGate.swift
+sed -n '27p' Foqos/CloudKit/SyncEngine/CKSyncEngineDriver.swift          # automaticallySync = false
+sed -n '9,12p' Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift  # requestSync = fetch+send
+sed -n '196,199p' Foqos/CloudKit/ProfileSyncManager.swift                # syncNow -> requestSync
+sed -n '213,220p' Foqos/CloudKit/ProfileSyncManager.swift                # enqueueProfileSave/Delete facade
+sed -n '50,71p' Foqos/CloudKit/SyncEngine/MutationFunnel.swift           # enqueueSave ends at driver.add
+sed -n '929,936p' Foqos/Views/BlockedProfileView.swift                   # finalizeSave enqueue + notAttached swallow
 ```
 
-Expected:
-- `grep-exit=1` (no matches — the issue's symbols do not exist). **If this prints matches, STOP** — the code has diverged from this plan's premise; re-investigate before probing.
-- `TriggerConfigurationModel.swift` `Log.debug` inside `validate()` is at **line 86** (matches the device log `TriggerConfigurationModel.swift:86`).
-- Lines 10–11 are the bare `@Published var startTriggers = ProfileStartTriggers()` / `= ProfileStopConditions()`; line 24 is `init() {}`.
-- `BlockedProfileView.swift:588-592` is the `.onAppear` whose body is only `if let existingProfile = profile { triggerConfig.loadFromProfile(existingProfile) }`.
-- `ProfileEditGate.swift:15` is `isBlocking || (isManaged && !isUnlocked && mode == .child && lockActive)`.
+Expected: `automaticallySync = false`; `requestSync` = `driver?.fetchChanges(); driver?.sendChanges()`; the facade enqueue verbs guard `engineController` and forward without a send; `MutationFunnel.enqueueSave` ends at `driver.add(...)`; `finalizeSave` catches `SyncEngineControllingError.notAttached`. If any anchor drifted, update the Task references before editing.
 
-If any line number drifted (edits landed since this plan), update the Task 0.1–0.3 anchors accordingly before editing. The probe content does not change — only the insertion points.
-
-### Task 0.1: Instrument every write to `stopConditions.manual`
+### Task 0.1: Temporary enqueue/send instrumentation (optional)
 
 **Files:**
-- Modify temporarily: `Foqos/Models/TriggerConfigurationModel.swift`
+- Modify temporarily: `Foqos/CloudKit/SyncEngine/MutationFunnel.swift`, `Foqos/CloudKit/SyncEngine/CKSyncEngineDriver.swift`
 
-- [ ] **Step 1: Add `didSet` manual-change logging to both published trigger structs**
+- [ ] **Step 1: Log the enqueue**
 
-Replace lines 10–11:
-
-```swift
-  @Published var startTriggers = ProfileStartTriggers()
-  @Published var stopConditions = ProfileStopConditions()
-```
-
-with:
+In `MutationFunnel.enqueueSave(profileId:)`, after `driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])` (`MutationFunnel.swift:70`):
 
 ```swift
-  @Published var startTriggers = ProfileStartTriggers() {
-    didSet {
-      guard oldValue.manual != startTriggers.manual else { return }
-      Log.debug(
-        "[#294 PROBE] startTriggers.manual \(oldValue.manual)->\(startTriggers.manual)\n"
-          + Thread.callStackSymbols.dropFirst().prefix(10).joined(separator: "\n"),
-        category: .ui
-      )
-    }
-  }
-  @Published var stopConditions = ProfileStopConditions() {
-    didSet {
-      guard oldValue.manual != stopConditions.manual else { return }
-      Log.debug(
-        "[#294 PROBE] stopConditions.manual \(oldValue.manual)->\(stopConditions.manual)\n"
-          + Thread.callStackSymbols.dropFirst().prefix(10).joined(separator: "\n"),
-        category: .ui
-      )
-    }
-  }
+    Log.debug("[#294 PROBE] enqueued .saveRecord for profile \(profileId) (no send here)", category: .sync)
 ```
 
-`stopConditions` is a value-type struct; any field mutation through the `$triggerConfig.stopConditions` binding reassigns the whole struct and fires `didSet`. The `guard` filters to `.manual` transitions only, so this logs **exactly** the writes we care about, with the call stack that caused each one. `startTriggers` is instrumented symmetrically as a control (the log shows `start.manual=true` surviving — we want to confirm the start toggle persists identically to the stop toggle).
+- [ ] **Step 2: Log the send with its caller**
 
-- [ ] **Step 2: Log the load path (must NOT run for a new profile)**
-
-In `loadFromProfile(_:)`, immediately after the opening brace (before `startTriggers = profile.startTriggers`), add:
+In `CKSyncEngineDriver.sendChanges()` (`CKSyncEngineDriver.swift:64`), at the top:
 
 ```swift
     Log.debug(
-      "[#294 PROBE] loadFromProfile called (EDITING existing profile) id=\(profile.id)",
-      category: .ui)
+      "[#294 PROBE] sendChanges called\n"
+        + Thread.callStackSymbols.dropFirst().prefix(6).joined(separator: "\n"),
+      category: .sync)
 ```
 
-For the #294 create flow this line must **never** appear. If it does, the view is being handed a non-nil `profile` when the user thinks they are creating one — a different bug.
-
-- [ ] **Step 3: Verify the probe compiles**
+- [ ] **Step 3: Compile**
 
 ```bash
 xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
   -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
-  -parallel-testing-enabled NO \
-  -only-testing:FoqosTests/TriggerConfigurationModelTests | xcpretty
+  -parallel-testing-enabled NO -only-testing:FoqosTests/SyncEngineFacadeTests | xcpretty
 ```
 
-Expected: `TriggerConfigurationModelTests` pass (existing suite, unchanged behavior — the `didSet` only logs). If it fails to compile because `@Published` + `didSet` is rejected by the toolchain, fall back to a manual observer: rename the stored properties to `startTriggers`/`stopConditions` computed wrappers over `_startTriggersStorage` is over-engineering — instead move the log into the two call sites in Task 0.2 and skip the `didSet`. Note which path you took in the evidence note.
+Expected: pass. Commit as `refs #294: add temporary enqueue/send probe`.
 
-### Task 0.2: Instrument the selector's write sites
+- [ ] **Step 4: Device baseline**
 
-**Files:**
-- Modify temporarily: `Foqos/Components/BlockedProfileView/StopConditionSelector.swift`
-
-- [ ] **Step 1: Log the "Tap to stop" binding set**
-
-In `binding(_:)` (lines 148–156), replace the `set:` closure:
-
-```swift
-      set: { newValue in
-        conditions[keyPath: keyPath] = newValue
-        onConditionChange()
-      }
-```
-
-with:
-
-```swift
-      set: { newValue in
-        if keyPath == \ProfileStopConditions.manual {
-          Log.debug(
-            "[#294 PROBE] StopConditionSelector Tap-to-stop toggle set newValue=\(newValue)",
-            category: .ui)
-        }
-        conditions[keyPath: keyPath] = newValue
-        onConditionChange()
-      }
-```
-
-This proves whether the user's tap on "Tap to stop" reaches the binding at all.
-
-- [ ] **Step 2: Prove the NFC/QR `apply` paths never touch `manual`**
-
-Replace the NFC picker `onChange` (lines 37–40):
-
-```swift
-      .onChange(of: nfcOption) { _, newValue in
-        newValue.apply(to: &conditions)
-        onConditionChange()
-      }
-```
-
-with:
-
-```swift
-      .onChange(of: nfcOption) { _, newValue in
-        let before = conditions.manual
-        newValue.apply(to: &conditions)
-        Log.debug(
-          "[#294 PROBE] nfcOption.apply(\(newValue.rawValue)) manual \(before)->\(conditions.manual)",
-          category: .ui)
-        onConditionChange()
-      }
-```
-
-Replace the QR picker `onChange` (lines 63–66) with the analogous block, substituting `qrOption` for `nfcOption`:
-
-```swift
-      .onChange(of: qrOption) { _, newValue in
-        let before = conditions.manual
-        newValue.apply(to: &conditions)
-        Log.debug(
-          "[#294 PROBE] qrOption.apply(\(newValue.rawValue)) manual \(before)->\(conditions.manual)",
-          category: .ui)
-        onConditionChange()
-      }
-```
-
-Expected on device: every such line shows `manual X->X` (unchanged). If any shows `true->false`, that `apply` is the culprit (would contradict the code reading — capture it).
-
-- [ ] **Step 3: Verify compile**
-
-```bash
-xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
-  -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
-  -parallel-testing-enabled NO \
-  -only-testing:FoqosTests/TriggerConfigurationModelTests | xcpretty
-```
-
-Expected: pass.
-
-### Task 0.3: Instrument the create-flow boundaries
-
-**Files:**
-- Modify temporarily: `Foqos/Views/BlockedProfileView.swift`
-
-- [ ] **Step 1: Log `.onAppear` state (proves no seeding)**
-
-Replace the `.onAppear` block (lines 588–592):
-
-```swift
-        .onAppear {
-          if let existingProfile = profile {
-            triggerConfig.loadFromProfile(existingProfile)
-          }
-        }
-```
-
-with:
-
-```swift
-        .onAppear {
-          Log.debug(
-            "[#294 PROBE] BlockedProfileView.onAppear isNewProfile=\(profile == nil) "
-              + "start.manual=\(triggerConfig.startTriggers.manual) "
-              + "stop.manual=\(triggerConfig.stopConditions.manual)",
-            category: .ui)
-          if let existingProfile = profile {
-            triggerConfig.loadFromProfile(existingProfile)
-          }
-        }
-```
-
-Expected for the create flow: `isNewProfile=true start.manual=false stop.manual=false` — i.e. no seeding, both start all-false. (This directly falsifies the issue's "seeding ran" premise, or overturns the code reading if it prints `true`.)
-
-- [ ] **Step 2: Log `saveProfile()` entry state (what `validate()` will read)**
-
-In `saveProfile()`, immediately before `triggerConfig.validate()` (line 941), add:
-
-```swift
-    Log.debug(
-      "[#294 PROBE] saveProfile begin isEditing=\(isEditing) "
-        + "start.manual=\(triggerConfig.startTriggers.manual) "
-        + "stop.manual=\(triggerConfig.stopConditions.manual)",
-      category: .ui)
-```
-
-- [ ] **Step 3: Verify compile**
-
-```bash
-xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
-  -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
-  -parallel-testing-enabled NO \
-  -only-testing:FoqosTests/TriggerConfigurationModelTests | xcpretty
-```
-
-Expected: pass.
-
-- [ ] **Step 4: Commit the probe**
-
-```bash
-git add Foqos/Models/TriggerConfigurationModel.swift \
-  Foqos/Components/BlockedProfileView/StopConditionSelector.swift \
-  Foqos/Views/BlockedProfileView.swift
-git commit -m "refs #294: add temporary Tap-to-stop UI-state probe"
-```
-
-### Task 0.4: Physical-device reproduction
-
-**Files:** none.
-
-- [ ] **Step 1: Build, install, launch on the reference device**
-
-Discover the paired device UUID:
-
-```bash
-xcrun devicectl list devices
-```
-
-Build and install (substitute the discovered device id for `<DEVICE_ID>`):
-
-```bash
-xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
-  -destination 'platform=iOS,id=<DEVICE_ID>' -configuration Debug build | xcpretty
-
-xcrun devicectl device install app --device <DEVICE_ID> \
-  "$(xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
-      -destination 'platform=iOS,id=<DEVICE_ID>' -configuration Debug -showBuildSettings \
-      | awk -F' = ' '/ BUILT_PRODUCTS_DIR =/{d=$2} / FULL_PRODUCT_NAME =/{n=$2} END{print d"/"n}')"
-
-xcrun devicectl device process launch --device <DEVICE_ID> com.cynexia.family-foqos
-```
-
-- [ ] **Step 2: Run the exact repro and watch the log**
-
-Reproduce the issue's steps precisely, observing the live device console (Xcode → Window → Devices and Simulators → Open Console, or `Log` export via Settings → Diagnostics → Debug Mode → Export Logs afterward):
-
-1. Delete the app (clean install).
-2. Launch; complete onboarding as **Individual**; grant Family Controls.
-3. Enable Profile Sync (wait for `Profile Sync toggle changed: enabled=true engineAttached=true`).
-4. Tap **+** to create a new profile. → capture the `BlockedProfileView.onAppear` probe line.
-5. Enter a name.
-6. Toggle **"Tap to start"** ON. → capture `startTriggers.manual false->true`.
-7. Toggle **"Tap to stop"** ON. → **capture whether `StopConditionSelector Tap-to-stop toggle set newValue=true` AND `stopConditions.manual false->true` appear.**
-8. Do **not** touch any other trigger control.
-9. Tap the **checkmark** (Create). → capture `saveProfile begin … stop.manual=?` and, if it fails, the `validate()` line.
-10. Repeat steps 4–9 a second time, this time toggling "Tap to stop" **before** "Tap to start", to test ordering.
-
-- [ ] **Step 3: Export and save the device log next to the original evidence**
-
-Save the exported log to `docs/plans/FamilyFoqos-Logs-294-probe-<HHMMSS>.log` (gitignored; lives only in the original checkout). Keep it for the evidence note.
-
-### Task 0.5: Decision gate
-
-**Files:** none (write the evidence note into the plan thread, not a repo doc).
-
-- [ ] **Step 1: Fill in the evidence note**
-
-```markdown
-## #294 Phase 0 Evidence
-- Build commit (git rev-parse HEAD):
-- onAppear line (isNewProfile / start.manual / stop.manual):
-- After "Tap to start": startTriggers.manual line seen? (yes/no, values)
-- After "Tap to stop": "toggle set newValue=true" seen? (yes/no)
-- After "Tap to stop": "stopConditions.manual false->true" seen? (yes/no)
-- Any "stopConditions.manual true->false" line? (yes/no) — if yes, paste its call stack
-- Any "*.apply(...) manual true->false" line? (yes/no)
-- saveProfile begin stop.manual value:
-- validate() outcome (pass / which errors):
-- loadFromProfile called on create? (must be no):
-- Reproduced? (yes/no)
-- Conclusion:
-```
-
-- [ ] **Step 2: Route by outcome**
-
-**Gate A — Reproduced, and a `stopConditions.manual true->false` line was logged.** The call stack on that line names the exact mutation site (the analysis says this cannot happen from committed code, so this site is the real, previously-unseen cause). → Proceed to **Phase 1**, Task 1.2, using the logged site as the fix target. Also keep Task 1.1 (regression tests).
-
-**Gate B — Reproduced, but no `manual false->true` line ever appeared after tapping "Tap to stop"** (the toggle set line is absent or `stopConditions.manual` never went true). The user's tap is not reaching/persisting through the binding — a SwiftUI `Form`/`Binding` commit-timing bug. → Proceed to **Phase 1**, Task 1.3, plus Task 1.1.
-
-**Gate C — Not reproduced** (`stop.manual` goes `false->true` on the toggle, stays true through `saveProfile begin`, and `validate()` passes / the profile is created). This is the outcome the code reading predicts. → **STOP for maintainer decision.** #294 is a stale artifact of the lost WIP device build. Ship **only** Task 1.1 (regression tests locking in the correct contract), then recommend closing #294 and unblocking #286. See "Maintainer Decision" below.
-
-**Gate D — Reproduced, `stop.manual` is true at `saveProfile begin`, but `validate()` still reports "At least one stop condition is required."** `validate()`/`isValid` is misreading state. → Proceed to **Phase 1**, Task 1.4, plus Task 1.1.
+Build/install/launch on the reference device (`xcrun devicectl list devices` for the id). With sync enabled and engine attached, create a profile and **stay foregrounded** (do not background, relaunch, or start it). Expected: the `[#294 PROBE] enqueued .saveRecord` line appears with **no** following `[#294 PROBE] sendChanges called` — confirming the record is queued but never sent. This is the bug, reproduced deterministically.
 
 ---
 
-## Phase 1: Gated Fix
+## Phase 1: Send-on-Enqueue + Deferred-Retry Fix (TDD)
 
-Task 1.1 ships in **every** non-STOP outcome (and is the sole code change under Gate C). Tasks 1.2–1.4 are mutually exclusive and selected by the gate.
-
-### Task 1.1: Regression tests for the create-flow invariants (always)
+### Task 1.1: Send-on-enqueue for the profile-save facade
 
 **Files:**
-- Test: `FoqosTests/TriggerConfigurationModelTests.swift`
+- Modify: `Foqos/CloudKit/ProfileSyncManager.swift`
+- Test: `FoqosTests/SyncEngineFacadeTests.swift`
 
-These encode the behavior the code reading proved and that any fix must preserve. They pass on current `main` (they are guardrails), and would fail if a future change reintroduces new-profile all-false-then-cleared behavior. They are **not** a "seed defaults" change — they assert the model contract only.
+- [ ] **Step 1: Write the failing test**
 
-- [ ] **Step 1: Write the failing/guard tests**
-
-Add to `TriggerConfigurationModelTests` (match the file's existing `@MainActor` / setup conventions; `TriggerConfigurationModel` is `@MainActor`):
+Add to `SyncEngineFacadeTests`:
 
 ```swift
-func testGivenNewModel_WhenInitialized_ThenStartAndStopAreAllFalse() {
-  let model = TriggerConfigurationModel()
-  XCTAssertFalse(model.startTriggers.manual)
-  XCTAssertFalse(model.stopConditions.manual)
-  XCTAssertFalse(model.stopConditions.isValid)
-}
+func testGivenAttachedController_WhenEnqueueProfileSave_ThenRequestSyncIsScheduled() throws {
+  let id = UUID()
+  try manager.enqueueProfileSave(id)
 
-func testGivenTapToStopSelected_WhenStartTriggersChange_ThenStopManualIsPreserved() {
-  let model = TriggerConfigurationModel()
-  // User picks "Tap to stop".
-  model.stopConditions.manual = true
-  model.stopConditionsDidChange()
-  XCTAssertTrue(model.stopConditions.manual)
-
-  // User then picks "Tap to start"; start-change auto-fix must not clear manual stop.
-  model.startTriggers.manual = true
-  model.startTriggersDidChange()
-
-  XCTAssertTrue(
-    model.stopConditions.manual,
-    "changing start triggers must not clear an already-selected manual stop condition")
-  XCTAssertTrue(model.validationErrors.isEmpty, "manual start + manual stop is a valid config")
-}
-
-func testGivenManualStartAndStop_WhenValidated_ThenNoErrors() {
-  let model = TriggerConfigurationModel()
-  model.startTriggers.manual = true
-  model.stopConditions.manual = true
-  model.validate()
-  XCTAssertTrue(model.validationErrors.isEmpty)
-}
-
-func testGivenManualStartOnly_WhenValidated_ThenRequiresStopCondition() {
-  let model = TriggerConfigurationModel()
-  model.startTriggers.manual = true
-  model.validate()
-  XCTAssertTrue(
-    model.validationErrors.contains("At least one stop condition is required"),
-    "this is the exact device-log error; it is correct when no stop condition is set")
+  XCTAssertEqual(mock.enqueuedProfileSaves, [id], "the save is forwarded to the engine")
+  XCTAssertEqual(
+    mock.requestSyncCount, 1,
+    "a user-initiated profile save must trigger a prompt send, not wait for the next foreground")
 }
 ```
 
-- [ ] **Step 2: Run the tests**
+- [ ] **Step 2: Run it red**
 
 ```bash
 xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
   -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
   -parallel-testing-enabled NO \
-  -only-testing:FoqosTests/TriggerConfigurationModelTests | xcpretty
+  -only-testing:FoqosTests/SyncEngineFacadeTests/testGivenAttachedController_WhenEnqueueProfileSave_ThenRequestSyncIsScheduled | xcpretty
 ```
 
-Expected: **all pass on current `main`** (they are regression guards, not red-first). If `testGivenTapToStopSelected_WhenStartTriggersChange_ThenStopManualIsPreserved` fails, the device mechanism reproduces at the model layer — record it and re-route to Task 1.2.
+Expected: FAIL — `requestSyncCount` is 0 (enqueue does not currently send).
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 3: Implement send-on-enqueue in the facade**
 
-```bash
-git add FoqosTests/TriggerConfigurationModelTests.swift
-git commit -m "test(#294): lock in new-profile trigger invariants (manual stop preserved)"
-```
-
-### Task 1.2: Fix a proven mutation site (Gate A only)
-
-**Files:**
-- Modify: the file/line named by the `true->false` call stack from Task 0.5.
-- Test: `FoqosTests/TriggerConfigurationModelTests.swift` (or `StopConditionSelectorBindingTests.swift` if the site is view-layer).
-
-- [ ] **Step 1: Write a red test reproducing the proven site**
-
-Translate the logged call stack into the smallest failing assertion. Example shape (fill the actual trigger action from the stack — e.g. if toggling "Timer" cleared `manual`):
+In `ProfileSyncManager.swift`, replace `enqueueProfileSave` (`:213-216`):
 
 ```swift
-func testGivenTapToStop_When<ProvenAction>_ThenStopManualIsPreserved() {
-  let model = TriggerConfigurationModel()
-  model.stopConditions.manual = true
-  // <invoke exactly the mutation the call stack showed, e.g.:>
-  // model.stopConditions.timer = true ; model.stopConditionsDidChange()
-  XCTAssertTrue(model.stopConditions.manual)
-}
+  func enqueueProfileSave(_ id: UUID) throws {
+    guard let engineController else { throw SyncEngineControllingError.notAttached }
+    try engineController.enqueueProfileSave(id)
+    engineController.requestSync()
+  }
 ```
 
-- [ ] **Step 2: Run it red**
+(`requestSync()` runs only after a successful enqueue, so a throwing enqueue — including `.notAttached` — never reaches it.)
 
-Run the focused command from Task 1.1 Step 2 with `/testGivenTapToStop_When<ProvenAction>_ThenStopManualIsPreserved`. Expected: FAIL (reproduces the site).
+- [ ] **Step 4: Run it green**
 
-- [ ] **Step 3: Apply the minimal fix at the proven site**
-
-Remove/guard the specific stray write the stack identified. Keep it surgical — a single guarded assignment or a removed wholesale reassignment. Do **not** broaden scope.
-
-- [ ] **Step 4: Run green + regression suite**
-
-Run the focused test (expect PASS), then the full `TriggerConfigurationModelTests` (expect PASS).
+Rerun the Step 2 command. Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git commit -am "fix(#294): preserve manual stop condition across <proven action>"
+git commit -am "fix(#294): flush profile save to CloudKit immediately after enqueue"
 ```
 
-### Task 1.3: Fix a lost toggle write (Gate B only)
+### Task 1.2: Extend send-on-enqueue to delete/location/emergency and fix the existing forward test
 
 **Files:**
-- Modify: `Foqos/Components/BlockedProfileView/StopConditionSelector.swift`
-- Test: `FoqosTests/StopConditionSelectorBindingTests.swift` (new)
+- Modify: `Foqos/CloudKit/ProfileSyncManager.swift`
+- Test: `FoqosTests/SyncEngineFacadeTests.swift`
 
-The proven failure is that tapping "Tap to stop" does not persist into `stopConditions.manual`. The most common cause is a custom `Binding` whose `set` is dropped during a `Form` recompose. The minimal, idiomatic fix is to route the manual toggle through the model's published property directly rather than the per-render `binding(_:)` helper, matching how the value is read elsewhere.
+- [ ] **Step 1: Update the existing forward test to the new contract**
 
-- [ ] **Step 1: Write a red test at the binding layer**
-
-Create `FoqosTests/StopConditionSelectorBindingTests.swift` — drive the same `Binding` construction the view uses and assert a set persists:
+`testGivenController_WhenFacadeVerbsCalled_ThenTheyForward` currently asserts `mock.requestSyncCount == 1` (from `syncNow` alone). With send-on-enqueue on all five enqueue verbs, the five enqueue calls each add one. Change the assertion (`SyncEngineFacadeTests.swift:62`):
 
 ```swift
-import XCTest
-import FoqosShared
-@testable import Foqos
+    XCTAssertEqual(
+      mock.requestSyncCount, 6,
+      "syncNow (1) + five enqueue verbs each flush once (5)")
+```
 
-@MainActor
-final class StopConditionSelectorBindingTests: XCTestCase {
-  func testGivenManualBinding_WhenSetTrue_ThenConditionsManualPersists() {
-    var conditions = ProfileStopConditions()
-    var changeCount = 0
-    let binding = StopConditionSelector.manualBinding(
-      conditions: Binding(get: { conditions }, set: { conditions = $0 }),
-      onConditionChange: { changeCount += 1 }
-    )
-    binding.wrappedValue = true
-    XCTAssertTrue(conditions.manual)
-    XCTAssertEqual(changeCount, 1)
+- [ ] **Step 2: Run it red**
+
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
+  -parallel-testing-enabled NO \
+  -only-testing:FoqosTests/SyncEngineFacadeTests/testGivenController_WhenFacadeVerbsCalled_ThenTheyForward | xcpretty
+```
+
+Expected: FAIL — count is 2 (only `enqueueProfileSave` from Task 1.1 sends so far), not 6.
+
+- [ ] **Step 3: Add `requestSync()` to the remaining enqueue verbs**
+
+In `ProfileSyncManager.swift`, apply the same pattern to `enqueueProfileDelete` (`:217-220`), `enqueueLocationSave` (`:221-224`), `enqueueLocationDelete` (`:225-228`), and `enqueueEmergencySettingsSave` (`:229-…`): after the `try engineController.enqueue…(…)` line, add `engineController.requestSync()`. Example for delete:
+
+```swift
+  func enqueueProfileDelete(_ id: UUID) throws {
+    guard let engineController else { throw SyncEngineControllingError.notAttached }
+    try engineController.enqueueProfileDelete(id)
+    engineController.requestSync()
   }
+```
+
+- [ ] **Step 4: Run it green**
+
+Rerun Step 2. Expected: PASS. Then run the whole file:
+
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
+  -parallel-testing-enabled NO -only-testing:FoqosTests/SyncEngineFacadeTests | xcpretty
+```
+
+Expected: all pass. (Note: `BlockedProfileListView` reorder enqueues N profiles in a loop, producing N `requestSync()` calls; CKSyncEngine coalesces concurrent `sendChanges()`, so this is chatty but functionally correct. A batched flush is a possible future optimization, out of scope.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "fix(#294): flush delete/location/emergency mutations after enqueue"
+```
+
+### Task 1.3: Deferred re-enqueue so a `.notAttached` create is not lost
+
+**Files:**
+- Modify: `Foqos/CloudKit/ProfileSyncManager.swift`
+- Test: `FoqosTests/SyncEngineFacadeTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+The mock's `errorToThrow` makes enqueue throw. Simulate a create hitting `.notAttached`, then attach and drain:
+
+```swift
+func testGivenNotAttached_WhenEnqueueProfileSave_ThenIdIsDeferredAndReEnqueuedOnAttach() throws {
+  let id = UUID()
+  manager.engineController = nil                      // pre-attach window
+
+  XCTAssertThrowsError(try manager.enqueueProfileSave(id)) { error in
+    XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+  }
+
+  // Engine attaches; the deferred save must be re-enqueued and flushed.
+  let attached = MockSyncEngineControlling()
+  manager.engineController = attached
+  manager.drainDeferredProfileSaves()
+
+  XCTAssertEqual(attached.enqueuedProfileSaves, [id], "the dropped save is retried on attach")
+  XCTAssertEqual(attached.requestSyncCount, 1, "the retried save is flushed")
+  XCTAssertTrue(
+    manager.hasNoDeferredProfileSaves, "the deferred set is cleared after draining")
 }
 ```
 
 - [ ] **Step 2: Run it red**
 
-Focused run of `FoqosTests/StopConditionSelectorBindingTests`. Expected: compile failure — `manualBinding` does not exist yet.
+```bash
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' \
+  -parallel-testing-enabled NO \
+  -only-testing:FoqosTests/SyncEngineFacadeTests/testGivenNotAttached_WhenEnqueueProfileSave_ThenIdIsDeferredAndReEnqueuedOnAttach | xcpretty
+```
 
-- [ ] **Step 3: Extract a testable, stable binding factory**
+Expected: compile failure — `drainDeferredProfileSaves` / `hasNoDeferredProfileSaves` do not exist, and the deferred set isn't recorded yet.
 
-In `StopConditionSelector`, replace the private `binding(_:)` usage for `\.manual` with a static factory the test can call, and use it for the "Tap to stop" `Toggle`:
+- [ ] **Step 3: Implement the deferred-retry set**
+
+In `ProfileSyncManager.swift`, add a stored property near `engineController`:
 
 ```swift
-  static func manualBinding(
-    conditions: Binding<ProfileStopConditions>,
-    onConditionChange: @escaping () -> Void
-  ) -> Binding<Bool> {
-    Binding(
-      get: { conditions.wrappedValue.manual },
-      set: { newValue in
-        conditions.wrappedValue.manual = newValue
-        onConditionChange()
+  /// Profile-save ids that could not be enqueued because the engine was not attached yet
+  /// (#294). Drained on `attachEngine` so a create in the pre-attach window is retried
+  /// instead of silently lost.
+  private var deferredProfileSaveIds: Set<UUID> = []
+
+  /// Test seam: true when nothing is pending re-enqueue.
+  var hasNoDeferredProfileSaves: Bool { deferredProfileSaveIds.isEmpty }
+```
+
+Update `enqueueProfileSave` (from Task 1.1) to record on `.notAttached`:
+
+```swift
+  func enqueueProfileSave(_ id: UUID) throws {
+    guard let engineController else {
+      deferredProfileSaveIds.insert(id)
+      throw SyncEngineControllingError.notAttached
+    }
+    do {
+      try engineController.enqueueProfileSave(id)
+    } catch SyncEngineControllingError.notAttached {
+      deferredProfileSaveIds.insert(id)          // I10: controller exists, funnel not built yet
+      throw SyncEngineControllingError.notAttached
+    }
+    engineController.requestSync()
+  }
+```
+
+Add the drain method:
+
+```swift
+  /// Re-enqueue and flush any profile saves that were deferred while the engine was
+  /// unattached (#294). Safe to call repeatedly; ids whose profile no longer exists throw
+  /// `entityNotFound` inside the funnel and are dropped.
+  func drainDeferredProfileSaves() {
+    guard let engineController, !deferredProfileSaveIds.isEmpty else { return }
+    let ids = deferredProfileSaveIds
+    deferredProfileSaveIds.removeAll()
+    for id in ids {
+      do { try engineController.enqueueProfileSave(id) } catch {
+        Log.warning(
+          "Deferred profile re-enqueue failed for \(id): \(error.localizedDescription)",
+          category: .sync)
       }
-    )
+    }
+    engineController.requestSync()
   }
 ```
 
-Change the "Tap to stop" toggle (line 23) to:
+- [ ] **Step 4: Drain on attach**
+
+In `attachEngine(...)`, inside the `if isEnabled { … }` block after `await controller.startupTask?.value` (`ProfileSyncManager.swift:170-177`), add:
 
 ```swift
-      Toggle("Tap to stop", isOn: Self.manualBinding(conditions: $conditions, onConditionChange: onConditionChange))
-        .disabled(disabled)
+      drainDeferredProfileSaves()
 ```
 
-Writing through `$conditions` (the outer `@Binding`) commits into `triggerConfig.stopConditions` in one hop, avoiding the per-render keyPath indirection.
+- [ ] **Step 5: Run it green**
 
-- [ ] **Step 4: Run green, then device re-verify**
+Rerun Step 2. Expected: PASS.
 
-Focused test PASS; full `TriggerConfigurationModelTests` PASS. Then re-run Task 0.4 on device (with probes still present) and confirm `stopConditions.manual false->true` now appears and `validate()` passes.
-
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git commit -am "fix(#294): persist Tap-to-stop toggle through a stable binding"
+git commit -am "fix(#294): defer and retry profile saves dropped in the pre-attach window"
 ```
 
-### Task 1.4: Fix a validate() misread (Gate D only)
+### Task 1.4: Full verification
 
-**Files:**
-- Modify: `Foqos/Models/TriggerConfigurationModel.swift` or `Packages/FoqosShared/Sources/FoqosShared/ProfileStopConditions.swift`
-- Test: `FoqosTests/TriggerConfigurationModelTests.swift`
+**Files:** none.
 
-- [ ] **Step 1: Write a red test from the device state**
-
-Reconstruct the exact `stopConditions` field values logged at `saveProfile begin` and assert `isValid`/`validate()`:
-
-```swift
-func testGivenDeviceStopConditions_WhenValidated_ThenIsValid() {
-  var stop = ProfileStopConditions()
-  stop.manual = true  // <plus any other true fields seen in the probe log>
-  XCTAssertTrue(stop.isValid, "isValid must be true when manual (or any condition) is set")
-}
-```
-
-- [ ] **Step 2: Run red, fix the predicate, run green.** Correct `ProfileStopConditions.isValid` (line 44-47) or the `requiresStopCondition` rule (`TriggerValidator.swift:54-58`) per the proven discrepancy. Full suite PASS.
-
-- [ ] **Step 3: Commit**
-
-```bash
-git commit -am "fix(#294): correct stop-condition validity predicate"
-```
-
-### Task 1.5: Remove the probe and finalize (all non-STOP outcomes)
-
-**Files:** the three Phase 0 probe files.
-
-- [ ] **Step 1: Revert the probe commit**
-
-```bash
-git revert --no-edit "$(git log --format=%H --grep='refs #294: add temporary Tap-to-stop UI-state probe' -n 1)"
-```
-
-Never amend, never force-push.
-
-- [ ] **Step 2: Confirm no probe strings remain**
-
-```bash
-rg -n "\[#294 PROBE\]" . ; echo "rg-exit=$?"
-```
-
-Expected: `rg-exit=1` (no matches).
-
-- [ ] **Step 3: Full verification**
+- [ ] **Step 1: Full suite + guards + format**
 
 ```bash
 xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
@@ -643,30 +363,54 @@ swift-format lint --recursive .
 scripts/check-sync-guards.sh
 ```
 
-Expected: full `FoqosTests` suite passes, 0 failures; lint clean; guards pass.
+Expected: full `FoqosTests` suite passes, 0 failures; lint clean; sync guards pass (I2/I5 unaffected — `requestSync` is not a new enqueue site).
 
-- [ ] **Step 4: Device acceptance**
+- [ ] **Step 2: Revert the Phase 0 probe (if added)**
 
-Rebuild the production (non-probe) build, clean-install, and run the Task 0.4 repro. Expected: creating a profile with "Tap to stop" succeeds, the profile is created, and it syncs to the second device (this also unblocks the #286 two-device checklist).
+```bash
+git revert --no-edit "$(git log --format=%H --grep='refs #294: add temporary enqueue/send probe' -n 1)"
+rg -n "\[#294 PROBE\]" . ; echo "rg-exit=$?"
+```
+
+Expected: `rg-exit=1` (no matches).
+
+### Task 1.5: Two-device physical acceptance (authoritative)
+
+**Files:** none.
+
+- [ ] **Step 1: Build the production (non-probe) build on both devices signed into the same iCloud account.**
+
+- [ ] **Step 2: Prompt-sync acceptance**
+
+On device A: enable sync, create a profile with a manual stop condition, and **stay foregrounded** — do **not** start it, do **not** relaunch. Within a few seconds, the profile must appear on device B. (Before the fix it would not appear until A was backgrounded/foregrounded, received a push, or the user tapped "Sync Now".)
+
+- [ ] **Step 3: Edit + delete propagation**
+
+On A: edit the profile (rename) → B reflects it promptly. Delete it on A → it disappears on B promptly.
+
+- [ ] **Step 4: Regression — start still works and session sync intact**
+
+On A: start the profile → restrictions activate and the session syncs (`SessionSyncService … seq=1`) exactly as before; no duplicate/most-recent profile churn.
+
+- [ ] **Step 5: Confirm #286 is unblocked**
+
+With create-time sync working, the `#286` two-device sync checklist (`docs/sync-engine-two-device-checklist.md`) can now run. Note this on `#286`.
 
 ---
 
-## Maintainer Decision (Gate C — the predicted outcome)
+## Risks / notes for the reviewer
 
-If Phase 0 does not reproduce, the code reading is confirmed: #294's mechanism does not exist in committed code, and the reporting build's source (uncommitted, since-reverted WIP edits to the two trigger files on `fix/286`) is unrecoverable. Options:
-
-1. **Close #294 as not-reproducible-on-`main`** (recommended). Ship Task 1.1 regression tests as the durable outcome. Unblock #286's verification gate immediately.
-2. **Re-test on `fix/286` HEAD** to rule out an interaction with `#286`'s committed sync changes. (Its trigger files are byte-identical to `main`, so this is expected to also not reproduce — but it closes the loop for the reporter.)
-3. **Keep #294 open pending a fresh device report** with an exportable log from a clean, committed build, if the maintainer recalls a concrete clearing behavior the probe missed.
-
-Do not choose among these as an implementer; present the evidence note and let the maintainer decide.
+- **Chattiness on bulk reorder.** `BlockedProfileListView` reorder enqueues each remaining profile in a loop; each now calls `requestSync()`. CKSyncEngine coalesces concurrent `sendChanges()`, so this is functionally correct but issues multiple send cycles. If it proves noisy in practice, a single post-loop flush is a clean follow-up (out of scope here).
+- **Deferred-retry scope.** Task 1.3 covers profile **saves** (the reported symptom). Location/emergency mutations get send-on-enqueue (promptness) but not deferred-retry; they are far less likely to hit the pre-attach window and are not the reported bug. Extending the same pattern to them is a trivial follow-up if desired.
+- **`requestSync()` also fetches.** It runs `fetchChanges()` then `sendChanges()`; fetching on enqueue is harmless (it just also pulls remote changes) and keeps the fix to a single existing verb rather than adding a send-only method to the protocol.
+- **Not a #286 change.** This fix is independent of reset poisoning; it does not alter `beginReset`/T1/AB-4 behavior.
 
 ---
 
 ## Self-Review
 
-- **Spec coverage:** Phase 0 instruments every write to `stopConditions.manual` (UI-state only) and reproduces on the reference device from a named commit; the decision gate has four exhaustive outcomes; Phase 1 provides minimal, TDD, mechanism-targeted fixes plus an always-shipped regression suite; a maintainer-decision path covers the predicted not-reproducible outcome. The "seed defaults" band-aid is explicitly prohibited.
-- **Placeholder scan:** No `TBD`/`TODO`/"handle edge cases". Gate-conditional tasks state exact route conditions; the one intentionally-parameterized spot (Task 1.2, the proven mutation site) is filled from device evidence by construction and is marked as such.
-- **Type/citation consistency:** `stopConditions`/`startTriggers` (`@Published` on `TriggerConfigurationModel`), `stopConditionsDidChange()`, `startTriggersDidChange()`, `validate()`, `validationErrors`, `ProfileStopConditions.isValid`, `ProfileEditGate.editingDisabled`, `manualBinding(conditions:onConditionChange:)`, and the probe marker `[#294 PROBE]` are used consistently. All cited line numbers are re-verified in Task 0.0 before editing.
-- **Device rigor:** Physical-device repro is the authoritative acceptance test; unit tests are regression guards, not proof of the device-only `Form` timing. Builds come from `origin/main` HEAD, never a working tree with uncommitted edits.
-- **Process integrity:** Probes are reverted (never amended/force-pushed); PR titled "plans the fix for #294"; `#294` stays on its own branch, not folded into `#286`.
+- **Spec coverage:** send-on-enqueue added to every enqueue facade verb (Tasks 1.1–1.2); the `.notAttached` silent-drop closed with a deferred-retry set drained on attach (Task 1.3); the existing forward test updated to the new `requestSyncCount` contract; two-device acceptance proves prompt propagation without starting or relaunching (Task 1.5). The validation/trigger UI is untouched (established as a red herring).
+- **Placeholder scan:** no `TBD`/`TODO`/"handle edge cases"; every code step shows complete code and exact assertions.
+- **Type/citation consistency:** `enqueueProfileSave/Delete`, `enqueueLocationSave/Delete`, `enqueueEmergencySettingsSave`, `requestSync()`, `deferredProfileSaveIds`, `drainDeferredProfileSaves()`, `hasNoDeferredProfileSaves`, `MockSyncEngineControlling.requestSyncCount`/`enqueuedProfileSaves`/`errorToThrow`, and `attachEngine`/`startupTask` are used consistently and match the current code.
+- **Device rigor:** the two-device acceptance is authoritative; unit tests assert the send is scheduled and the drop is retried, but the propagation claim is proven on hardware.
+- **Process integrity:** probes reverted with normal commits (no amend/force-push); PR titled "plans the fix for #294"; scoped to `fix/294-tap-to-stop-validation`, not folded into `#286`.


### PR DESCRIPTION
## Summary

Plan-only PR (no production fix). Plans the fix for #294. **The title is misleading — this is not a validation bug.** Two reframes, both driven by evidence:

1. The issue's premise (validation clears `stopConditions.manual`, so no profile is created) was **falsified by code** — the cited symbols (`applyNewProfileDefaults`, `didLoadTriggerConfig`) exist nowhere, no new-profile seeding ever existed, and no path clears `manual`. The `22:00:50` `validate()` log line was the user's **first** create attempt before setting a stop condition — **correct** behavior, a **red herring**.
2. Maintainer device evidence (`FamilyFoqos-Logs-2026-07-08-235429.log`): the profile **was** created with manual stop, **works**, **activates**, and its **session** syncs (`SessionSyncService` direct CAS, `seq=1`) — but the profile **record** never syncs via CKSyncEngine. It reached the remote device **only after the profile was started**, which the maintainer flagged **could be coincidence**.

## Root cause (established)

The profile create/edit path is **enqueue-only**: `finalizeSave → enqueueProfileSave → funnel.enqueueSave → driver.add(pendingRecordZoneChanges)` terminates at `engine.state.add()`. The driver runs `automaticallySync = false` (`CKSyncEngineDriver.swift:27`), and the only send path — `requestSync()` = `fetchChanges()` + `sendChanges()` (`SyncEngineController+Cutover.swift:9-12`) — is reachable **only** via `syncNow()` on scenePhase `.active` / remote push / manual "Sync Now". Creating *or* starting a profile is none of those, so a created profile sits unsent until an incidental foreground. Secondary bug: an enqueue that hits `.notAttached` is caught and **swallowed** (`BlockedProfileView.swift:930-933`) and never retried → permanent loss.

## Hypotheses and how they confirmed the cause

To separate coincidence from causation (per the maintainer's "could be coincidence"), the "why did it sync only after start?" question was decomposed into **8 mutually-exhaustive hypotheses** spanning causal / coincidence / common-cause, then each was handed to an **independent adversarial subagent** told to *refute* it using code-path analysis + the device log. Verdicts:

| # | Category | Hypothesis | Verdict | Why (code/log) |
|---|---|---|---|---|
| **H5** | causal-at-creation | Create **enqueues but never sends** | ✅ **SUPPORTED — root cause** | Create path ends at `engine.state.add()`; `automaticallySync=false`; no `sendChanges` on the path. |
| **H7** | coincidence | Flush is **scenePhase-driven** (`.active`→`syncNow`), not start-semantic | ✅ **SUPPORTED** | Only send path is `syncNow`, whose callers are scenePhase/push/manual — proven by log line 57 `"syncNow skipped: not ready"`. |
| H1 | causal | **Starting** the profile triggers the send | ❌ REFUTED | Grep of `StrategyManager`/`SessionSyncService` for `syncNow\|sendChanges\|requestSync\|enqueueProfileSave` = **0 matches**; activation only does a session CAS. |
| H2 | coincidence | **Relaunch/cutover** flushed it | ⚠️ Refined | Attach itself only *fetches*; the flush is a **post-attach** `.active` `syncNow`, not cutover-on-attach. |
| H3 | common cause | **Readiness** state machine gates both halves | ❌ REFUTED | Engine was already `engineAttached=true` **at creation**; readiness wasn't the creation-half cause. |
| H4 | causal | A **reconcile/backfill** on start/launch sent it | ❌ REFUTED | The only re-scan (`restorableRecordNames`) runs **only** under seed conditions, not ordinary relaunch; no session-start enqueue exists. |
| H6 | coincidence | Origin sent at creation; **remote fetched** late | ❌ REFUTED | Origin log has **no send entry** at creation; the delay is origin-side. |
| H8 | coincidence/common | **#286/AB-4** first-run window suppressed then cleared | ❌ REFUTED | `automaticallySync=false` is **permanent**, not self-clearing; AB-4's T1 strip scopes to *restored* deletes, not fresh saves. |

**How this confirms the cause:** every causal-by-start hypothesis (H1, H4) and every alternative coincidence/common-cause hypothesis (H3, H6, H8) was independently refuted against the code and log, leaving only **H5 + H7** standing — the create path never sends, and the eventual flush was a lifecycle `syncNow`. That is: **starting the profile was coincidental; the defect is a missing send-trigger on enqueue.** The two load-bearing code facts (create path terminates at `engine.state.add()`; `requestSync`/`syncNow` is the sole send path) were then re-verified by hand, not just taken from the agents.

## The fix (maintainer-chosen: send-on-enqueue + swallow fix)

- Add `engineController.requestSync()` after a successful enqueue in the `ProfileSyncManager` facade verbs → prompt propagation.
- Add `deferredProfileSaveIds`, recorded on `.notAttached` and drained on `attachEngine` → the pre-attach window no longer loses a create.
- TDD via `MockSyncEngineControlling.requestSyncCount` (the existing forward test asserting `requestSyncCount == 1` moves to `6` — the red-first signal); **two-device physical acceptance** ("create foregrounded, don't start, don't relaunch → appears on device B") is authoritative.

## Notes

- Plan only — implementation + two-device verification is a separate session.
- **#294 blocks #286** (its two-device sync checklist can't run until create-time sync works) and is top of the queue.
- Title is "plans the fix for #294" — deliberately not a closing keyword.