### PR TITLE
Fix #294 send sync on enqueue

### DIFF
--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -36,6 +36,10 @@ class ProfileSyncManager: ObservableObject {
   /// The engine owner (I10). Wired in `attachEngine(...)` once a ModelContext exists.
   weak var engineController: (any SyncEngineControlling)?
 
+  /// True once the engine is attached AND startup, including the AB-4 T1 strip, has completed.
+  /// Gates send-on-enqueue so a send can never flush restored state before T1 (#286 poison).
+  var isSyncReady = false
+
   // MARK: - Private State
 
   private var cancellables = Set<AnyCancellable>()
@@ -62,6 +66,7 @@ class ProfileSyncManager: ObservableObject {
         if enabled {
           self?.engineController?.start()
         } else {
+          self?.isSyncReady = false
           self?.engineController?.stop()
         }
       }
@@ -174,6 +179,7 @@ class ProfileSyncManager: ObservableObject {
       // mirrors the `await controller.startupTask?.value` pattern used by the controller's
       // own tests.
       await controller.startupTask?.value
+      isSyncReady = true
     }
   }
 
@@ -213,6 +219,7 @@ class ProfileSyncManager: ObservableObject {
   func enqueueProfileSave(_ id: UUID) throws {
     guard let engineController else { throw SyncEngineControllingError.notAttached }
     try engineController.enqueueProfileSave(id)
+    if isSyncReady { engineController.requestSync() }
   }
   func enqueueProfileDelete(_ id: UUID) throws {
     guard let engineController else { throw SyncEngineControllingError.notAttached }

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -243,8 +243,16 @@ class ProfileSyncManager: ObservableObject {
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueProfileDelete(_ id: UUID) throws {
-    guard let engineController else { throw SyncEngineControllingError.notAttached }
-    try engineController.enqueueProfileDelete(id)
+    guard let engineController else {
+      deferredDeleteRecordNames.insert(id.uuidString)
+      throw SyncEngineControllingError.notAttached
+    }
+    do {
+      try engineController.enqueueProfileDelete(id)
+    } catch SyncEngineControllingError.notAttached {
+      deferredDeleteRecordNames.insert(id.uuidString)
+      throw SyncEngineControllingError.notAttached
+    }
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueLocationSave(_ id: UUID) throws {
@@ -261,8 +269,16 @@ class ProfileSyncManager: ObservableObject {
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueLocationDelete(_ id: UUID) throws {
-    guard let engineController else { throw SyncEngineControllingError.notAttached }
-    try engineController.enqueueLocationDelete(id)
+    guard let engineController else {
+      deferredDeleteRecordNames.insert(id.uuidString)
+      throw SyncEngineControllingError.notAttached
+    }
+    do {
+      try engineController.enqueueLocationDelete(id)
+    } catch SyncEngineControllingError.notAttached {
+      deferredDeleteRecordNames.insert(id.uuidString)
+      throw SyncEngineControllingError.notAttached
+    }
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueEmergencySettingsSave() throws {
@@ -286,9 +302,11 @@ class ProfileSyncManager: ObservableObject {
     guard let engineController else { return }
     for id in deferredProfileSaveIds { try? engineController.enqueueProfileSave(id) }
     for id in deferredLocationSaveIds { try? engineController.enqueueLocationSave(id) }
+    for name in deferredDeleteRecordNames { engineController.enqueueDeferredDelete(recordName: name) }
     if deferredEmergencySave { try? engineController.enqueueEmergencySettingsSave() }
     deferredProfileSaveIds.removeAll()
     deferredLocationSaveIds.removeAll()
+    deferredDeleteRecordNames.removeAll()
     deferredEmergencySave = false
   }
 

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -77,7 +77,7 @@ class ProfileSyncManager: ObservableObject {
         SharedData.deviceSyncEnabled = enabled
         self?.syncStatus = enabled ? .idle : .disabled
         if enabled {
-          self?.engineController?.start()
+          self?.startEngineAndMarkReadyWhenStartupCompletes()
         } else {
           self?.isSyncReady = false
           self?.engineController?.stop()
@@ -192,7 +192,7 @@ class ProfileSyncManager: ObservableObject {
       // mirrors the `await controller.startupTask?.value` pattern used by the controller's
       // own tests.
       await controller.startupTask?.value
-      markSyncReadyAndFlush()
+      markSyncReadyAndFlushIfStillEnabled(for: controller)
     }
   }
 
@@ -316,5 +316,26 @@ class ProfileSyncManager: ObservableObject {
     isSyncReady = true
     drainDeferredMutations()
     engineController?.requestSync()
+  }
+
+  /// Starts an already-attached engine after the user enables sync, then marks ready only
+  /// after startup has completed. The ready mark is guarded so a concurrent disable cannot
+  /// flush or leave sync marked ready after the engine has been stopped.
+  private func startEngineAndMarkReadyWhenStartupCompletes() {
+    guard let engineController else { return }
+    isSyncReady = false
+    engineController.start()
+    guard let controller = engineController as? SyncEngineController else { return }
+    Task { @MainActor [weak self, weak controller] in
+      await controller?.startupTask?.value
+      guard let controller else { return }
+      self?.markSyncReadyAndFlushIfStillEnabled(for: controller)
+    }
+  }
+
+  /// Complete startup only if sync is still enabled and the same attached controller is current.
+  func markSyncReadyAndFlushIfStillEnabled(for controller: any SyncEngineControlling) {
+    guard isEnabled, let engineController, engineController === controller else { return }
+    markSyncReadyAndFlush()
   }
 }

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -44,6 +44,19 @@ class ProfileSyncManager: ObservableObject {
 
   private var cancellables = Set<AnyCancellable>()
 
+  // Mutations that could not be enqueued because the engine was not attached yet (#294).
+  // Drained on attach so a mutation in the pre-attach window is retried instead of lost.
+  private var deferredProfileSaveIds: Set<UUID> = []
+  private var deferredLocationSaveIds: Set<UUID> = []
+  private var deferredDeleteRecordNames: Set<String> = []
+  private var deferredEmergencySave = false
+
+  /// Test seam: true when nothing is pending re-enqueue.
+  var hasNoDeferredMutations: Bool {
+    deferredProfileSaveIds.isEmpty && deferredLocationSaveIds.isEmpty
+      && deferredDeleteRecordNames.isEmpty && !deferredEmergencySave
+  }
+
   // Device identifier for this device
   var deviceId: String {
     SharedData.deviceSyncId.uuidString
@@ -179,7 +192,7 @@ class ProfileSyncManager: ObservableObject {
       // mirrors the `await controller.startupTask?.value` pattern used by the controller's
       // own tests.
       await controller.startupTask?.value
-      isSyncReady = true
+      markSyncReadyAndFlush()
     }
   }
 
@@ -217,8 +230,16 @@ class ProfileSyncManager: ObservableObject {
   /// itself throws (review findings #4–#6, #15). Delete call sites MUST fall back to a direct
   /// local delete on `.notAttached` so the item is never silently left behind.
   func enqueueProfileSave(_ id: UUID) throws {
-    guard let engineController else { throw SyncEngineControllingError.notAttached }
-    try engineController.enqueueProfileSave(id)
+    guard let engineController else {
+      deferredProfileSaveIds.insert(id)
+      throw SyncEngineControllingError.notAttached
+    }
+    do {
+      try engineController.enqueueProfileSave(id)
+    } catch SyncEngineControllingError.notAttached {
+      deferredProfileSaveIds.insert(id)
+      throw SyncEngineControllingError.notAttached
+    }
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueProfileDelete(_ id: UUID) throws {
@@ -227,8 +248,16 @@ class ProfileSyncManager: ObservableObject {
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueLocationSave(_ id: UUID) throws {
-    guard let engineController else { throw SyncEngineControllingError.notAttached }
-    try engineController.enqueueLocationSave(id)
+    guard let engineController else {
+      deferredLocationSaveIds.insert(id)
+      throw SyncEngineControllingError.notAttached
+    }
+    do {
+      try engineController.enqueueLocationSave(id)
+    } catch SyncEngineControllingError.notAttached {
+      deferredLocationSaveIds.insert(id)
+      throw SyncEngineControllingError.notAttached
+    }
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueLocationDelete(_ id: UUID) throws {
@@ -237,8 +266,37 @@ class ProfileSyncManager: ObservableObject {
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueEmergencySettingsSave() throws {
-    guard let engineController else { throw SyncEngineControllingError.notAttached }
-    try engineController.enqueueEmergencySettingsSave()
+    guard let engineController else {
+      deferredEmergencySave = true
+      throw SyncEngineControllingError.notAttached
+    }
+    do {
+      try engineController.enqueueEmergencySettingsSave()
+    } catch SyncEngineControllingError.notAttached {
+      deferredEmergencySave = true
+      throw SyncEngineControllingError.notAttached
+    }
     if isSyncReady { engineController.requestSync() }
+  }
+
+  /// Replay save-type mutations deferred while the engine was unattached (#294). Uses the
+  /// controller-level enqueue verbs (which do not themselves send), so the single requestSync
+  /// in `markSyncReadyAndFlush()` flushes them all at once.
+  private func drainDeferredMutations() {
+    guard let engineController else { return }
+    for id in deferredProfileSaveIds { try? engineController.enqueueProfileSave(id) }
+    for id in deferredLocationSaveIds { try? engineController.enqueueLocationSave(id) }
+    if deferredEmergencySave { try? engineController.enqueueEmergencySettingsSave() }
+    deferredProfileSaveIds.removeAll()
+    deferredLocationSaveIds.removeAll()
+    deferredEmergencySave = false
+  }
+
+  /// Called once the engine is attached AND startup, including the AB-4 T1 strip, has completed.
+  /// Enables prompt sends and flushes anything enqueued while not ready, always post-T1.
+  func markSyncReadyAndFlush() {
+    isSyncReady = true
+    drainDeferredMutations()
+    engineController?.requestSync()
   }
 }

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -248,12 +248,11 @@ class ProfileSyncManager: ObservableObject {
       throw SyncEngineControllingError.notAttached
     }
     do {
-      try engineController.enqueueProfileDelete(id)
+      try engineController.enqueueProfileDelete(id, requestSyncAfterPendingDelete: isSyncReady)
     } catch SyncEngineControllingError.notAttached {
       deferredDeleteRecordNames.insert(id.uuidString)
       throw SyncEngineControllingError.notAttached
     }
-    if isSyncReady { engineController.requestSync() }
   }
   func enqueueLocationSave(_ id: UUID) throws {
     guard let engineController else {

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -224,17 +224,21 @@ class ProfileSyncManager: ObservableObject {
   func enqueueProfileDelete(_ id: UUID) throws {
     guard let engineController else { throw SyncEngineControllingError.notAttached }
     try engineController.enqueueProfileDelete(id)
+    if isSyncReady { engineController.requestSync() }
   }
   func enqueueLocationSave(_ id: UUID) throws {
     guard let engineController else { throw SyncEngineControllingError.notAttached }
     try engineController.enqueueLocationSave(id)
+    if isSyncReady { engineController.requestSync() }
   }
   func enqueueLocationDelete(_ id: UUID) throws {
     guard let engineController else { throw SyncEngineControllingError.notAttached }
     try engineController.enqueueLocationDelete(id)
+    if isSyncReady { engineController.requestSync() }
   }
   func enqueueEmergencySettingsSave() throws {
     guard let engineController else { throw SyncEngineControllingError.notAttached }
     try engineController.enqueueEmergencySettingsSave()
+    if isSyncReady { engineController.requestSync() }
   }
 }

--- a/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
+++ b/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
@@ -172,6 +172,16 @@ final class MutationFunnel {
     driver.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
   }
 
+  /// Enqueue a delete for a record whose model is already gone locally (a delete that fell
+  /// back to a local delete while unattached, #294). Writes the tombstone and `.deleteRecord`;
+  /// there is no persisted delete because the row no longer exists.
+  func enqueueTombstoneDelete(recordName: String) {
+    let changeTag = Self.changeTag(fromSystemFields: store.systemFields(for: recordName))
+    store.setTombstone(recordName: recordName, changeTag: changeTag)
+    let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
+    driver.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
+  }
+
   // MARK: - System-fields change tag
 
   /// Decode the last-known server change tag from cached CKRecord system fields.

--- a/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
+++ b/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
@@ -103,7 +103,10 @@ final class MutationFunnel {
   /// `.deleteRecord` (I12, §2). On any failure, the tombstone is removed and the context rolled
   /// back before the error is rethrown — a lingering tombstone for an entity that was never
   /// actually deleted would later kill the live record family-wide (round-4/5).
-  func enqueueDelete(profileId: UUID) throws {
+  func enqueueDelete(
+    profileId: UUID,
+    onPendingDeleteEnqueued: @escaping @MainActor () -> Void = {}
+  ) throws {
     let recordName = profileId.uuidString
     let changeTag = Self.changeTag(fromSystemFields: store.systemFields(for: recordName))
     store.setTombstone(recordName: recordName, changeTag: changeTag)
@@ -115,7 +118,10 @@ final class MutationFunnel {
       let deleteZoneID = zoneID
       let saveOverride = saveOverride
       scheduleProfileDeleteCommit {
-        [modelContext, store, driver, profileId, recordName, deleteZoneID, saveOverride] in
+        [
+          modelContext, store, driver, profileId, recordName, deleteZoneID, saveOverride,
+          onPendingDeleteEnqueued,
+        ] in
         do {
           // The caller has already returned; post-boundary failures are logged and converted
           // back into tombstone cleanup plus rollback, and the remote delete is enqueued only
@@ -135,6 +141,7 @@ final class MutationFunnel {
           }
           let recordID = CKRecord.ID(recordName: recordName, zoneID: deleteZoneID)
           driver.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
+          onPendingDeleteEnqueued()
         } catch {
           store.clearTombstone(recordName: recordName)
           modelContext.rollback()

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift
@@ -46,4 +46,7 @@ extension SyncEngineController: SyncEngineControlling {
     guard let funnel else { throw SyncEngineControllingError.notAttached }
     funnel.enqueueEmergencySettingsSave()
   }
+  func enqueueDeferredDelete(recordName: String) {
+    funnel?.enqueueTombstoneDelete(recordName: recordName)
+  }
 }

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift
@@ -31,8 +31,16 @@ extension SyncEngineController: SyncEngineControlling {
     try funnel.enqueueSave(profileId: id)
   }
   func enqueueProfileDelete(_ id: UUID) throws {
+    try enqueueProfileDelete(id, requestSyncAfterPendingDelete: false)
+  }
+  func enqueueProfileDelete(_ id: UUID, requestSyncAfterPendingDelete: Bool) throws {
     guard let funnel else { throw SyncEngineControllingError.notAttached }
-    try funnel.enqueueDelete(profileId: id)
+    let onPendingDeleteEnqueued: @MainActor () -> Void = { [weak self] in
+      if requestSyncAfterPendingDelete { self?.requestSync() }
+    }
+    try funnel.enqueueDelete(
+      profileId: id,
+      onPendingDeleteEnqueued: onPendingDeleteEnqueued)
   }
   func enqueueLocationSave(_ id: UUID) throws {
     guard let funnel else { throw SyncEngineControllingError.notAttached }

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -28,6 +28,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   private let provider: RecordProvider
   private let sessionSync: SessionSyncFlushing
   private let deviceId: String
+  private let scheduleProfileDeleteCommit: (@escaping @MainActor () -> Void) -> Void
 
   private let zoneID = CKRecordZone.ID(
     zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)
@@ -80,7 +81,9 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     apply: SyncApplyService,
     provider: RecordProvider,
     sessionSync: SessionSyncFlushing,
-    deviceId: String
+    deviceId: String,
+    scheduleProfileDeleteCommit: @escaping (@escaping @MainActor () -> Void) -> Void =
+      BlockedProfiles.scheduleProfileDeleteCommit
   ) {
     self.modelContext = modelContext
     self.store = store
@@ -89,6 +92,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     self.provider = provider
     self.sessionSync = sessionSync
     self.deviceId = deviceId
+    self.scheduleProfileDeleteCommit = scheduleProfileDeleteCommit
     self.apply.profileDeleteCommitObserver = { [weak self] recordName in
       guard let self else { return }
       let recordID = CKRecord.ID(recordName: recordName, zoneID: self.zoneID)
@@ -101,7 +105,8 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     guard state == .disabled || state == .purged else { return }
     driver = driverFactory(store.engineState)
     funnel = MutationFunnel(
-      modelContext: modelContext, store: store, driver: driver, deviceId: deviceId)
+      modelContext: modelContext, store: store, driver: driver, deviceId: deviceId,
+      scheduleProfileDeleteCommit: scheduleProfileDeleteCommit)
     reset = ResetController(
       store: store,
       outbox: DriverResetOutbox(driver: driver, zoneID: zoneID),

--- a/Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift
@@ -10,6 +10,7 @@ protocol SyncEngineControlling: AnyObject {
   func beginReset(clearRemoteAppSelections: Bool)
   func enqueueProfileSave(_ id: UUID) throws
   func enqueueProfileDelete(_ id: UUID) throws
+  func enqueueProfileDelete(_ id: UUID, requestSyncAfterPendingDelete: Bool) throws
   func enqueueLocationSave(_ id: UUID) throws
   func enqueueLocationDelete(_ id: UUID) throws
   func enqueueEmergencySettingsSave() throws

--- a/Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift
@@ -13,6 +13,7 @@ protocol SyncEngineControlling: AnyObject {
   func enqueueLocationSave(_ id: UUID) throws
   func enqueueLocationDelete(_ id: UUID) throws
   func enqueueEmergencySettingsSave() throws
+  func enqueueDeferredDelete(recordName: String)
 }
 
 /// Thrown by the `SyncEngineControlling` enqueue verbs (and by `ProfileSyncManager.syncNow()`/

--- a/Foqos/Models/BlockedProfiles.swift
+++ b/Foqos/Models/BlockedProfiles.swift
@@ -467,6 +467,13 @@ class BlockedProfiles {
     return profile
   }
 
+  static func needsAppSelectionAfterLocalSave(
+    currentNeedsAppSelection: Bool,
+    selection: FamilyActivitySelection
+  ) -> Bool {
+    currentNeedsAppSelection && FamilyActivityUtil.countSelectedActivities(selection) == 0
+  }
+
   static func deleteProfile(
     _ profile: BlockedProfiles,
     in context: ModelContext

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -970,6 +970,10 @@ struct BlockedProfileView: View {
         existingProfile.physicalUnblockQRCodeId = physicalUnblockQRCodeId
         existingProfile.reminderTimeInSeconds = reminderTimeSeconds
         existingProfile.customReminderMessage = customReminderMessage
+        let needsAppSelectionAfterSave = BlockedProfiles.needsAppSelectionAfterLocalSave(
+          currentNeedsAppSelection: existingProfile.needsAppSelection,
+          selection: selectedActivity
+        )
 
         // Update remaining fields through updateProfile (which calls context.save())
         let updatedProfile = try BlockedProfiles.updateProfile(
@@ -990,7 +994,7 @@ struct BlockedProfileView: View {
           disableBackgroundStops: disableBackgroundStops,
           preActivationReminderTimes: Array(preActivationReminderTimes).sorted(),
           isManaged: isManaged,
-          needsAppSelection: false  // Clear needsAppSelection since user is saving with app selection
+          needsAppSelection: needsAppSelectionAfterSave
         )
 
         finalizeSave(updatedProfile)

--- a/FoqosTests/Mocks/MockSyncEngineControlling.swift
+++ b/FoqosTests/Mocks/MockSyncEngineControlling.swift
@@ -30,8 +30,12 @@ final class MockSyncEngineControlling: SyncEngineControlling {
     enqueuedProfileSaves.append(id)
   }
   func enqueueProfileDelete(_ id: UUID) throws {
+    try enqueueProfileDelete(id, requestSyncAfterPendingDelete: false)
+  }
+  func enqueueProfileDelete(_ id: UUID, requestSyncAfterPendingDelete: Bool) throws {
     if let errorToThrow { throw errorToThrow }
     enqueuedProfileDeletes.append(id)
+    if requestSyncAfterPendingDelete { requestSync() }
   }
   func enqueueLocationSave(_ id: UUID) throws {
     if let errorToThrow { throw errorToThrow }

--- a/FoqosTests/Mocks/MockSyncEngineControlling.swift
+++ b/FoqosTests/Mocks/MockSyncEngineControlling.swift
@@ -13,6 +13,7 @@ final class MockSyncEngineControlling: SyncEngineControlling {
   private(set) var enqueuedLocationSaves: [UUID] = []
   private(set) var enqueuedLocationDeletes: [UUID] = []
   private(set) var enqueuedEmergencySaves = 0
+  private(set) var deferredDeletes: [String] = []
 
   /// Set by a test to make every `enqueue*` verb below throw instead of recording — used to
   /// verify a genuine funnel throw propagates through the facade instead of being swallowed
@@ -43,5 +44,8 @@ final class MockSyncEngineControlling: SyncEngineControlling {
   func enqueueEmergencySettingsSave() throws {
     if let errorToThrow { throw errorToThrow }
     enqueuedEmergencySaves += 1
+  }
+  func enqueueDeferredDelete(recordName: String) {
+    deferredDeletes.append(recordName)
   }
 }

--- a/FoqosTests/ProfileAppSelectionStateTests.swift
+++ b/FoqosTests/ProfileAppSelectionStateTests.swift
@@ -1,0 +1,28 @@
+import FamilyControls
+import XCTest
+
+@testable import FamilyFoqos
+
+final class ProfileAppSelectionStateTests: XCTestCase {
+  func testGivenSyncedProfileStillHasEmptySelection_WhenSavingEdit_ThenStillNeedsAppSelection() {
+    let selection = FamilyActivitySelection()
+
+    XCTAssertTrue(
+      BlockedProfiles.needsAppSelectionAfterLocalSave(
+        currentNeedsAppSelection: true,
+        selection: selection
+      )
+    )
+  }
+
+  func testGivenProfileAlreadyHasLocalSelection_WhenSavingEdit_ThenDoesNotNeedAppSelection() {
+    let selection = FamilyActivitySelection()
+
+    XCTAssertFalse(
+      BlockedProfiles.needsAppSelectionAfterLocalSave(
+        currentNeedsAppSelection: false,
+        selection: selection
+      )
+    )
+  }
+}

--- a/FoqosTests/SyncEngineAttachTests.swift
+++ b/FoqosTests/SyncEngineAttachTests.swift
@@ -10,6 +10,7 @@ final class SyncEngineAttachTests: XCTestCase {
   var container: ModelContainer!
   var manager: ProfileSyncManager!
   private var savedEnabled = false
+  private var savedIsSyncReady = false
   private var savedController: (any SyncEngineControlling)?
 
   override func setUp() async throws {
@@ -19,11 +20,14 @@ final class SyncEngineAttachTests: XCTestCase {
     container = try TestModelContainer.create()
     manager = ProfileSyncManager.shared
     savedEnabled = manager.isEnabled
+    savedIsSyncReady = manager.isSyncReady
     savedController = manager.engineController
+    manager.isSyncReady = false
   }
 
   override func tearDown() async throws {
     manager.engineController = savedController
+    manager.isSyncReady = savedIsSyncReady
     manager.isEnabled = savedEnabled
     UserDefaults().removePersistentDomain(forName: testSuiteName)
     try await super.tearDown()
@@ -56,5 +60,34 @@ final class SyncEngineAttachTests: XCTestCase {
 
     XCTAssertNotNil(manager.engineController)
     XCTAssertTrue(driver.enqueuedZoneSaveNames.isEmpty)  // start() not called
+  }
+
+  func testGivenEngineAttachedWhileDisabled_WhenSyncEnabledLater_ThenStartupMarksReadyAndDrainsDeferredDelete()
+    async throws
+  {
+    manager.isEnabled = false
+    let driver = CutoverRecordingDriver(stateSerialization: nil)
+
+    await manager.attachEngine(
+      modelContext: container.mainContext,
+      emergencyManager: EmergencyUnblockManager(),
+      userRecordNameProvider: { "user-attach-enable-later" },
+      driverFactory: { _ in driver })
+
+    let id = UUID()
+    XCTAssertThrowsError(try manager.enqueueProfileDelete(id)) { error in
+      XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+    }
+
+    manager.isEnabled = true
+    let controller = try XCTUnwrap(manager.engineController as? SyncEngineController)
+    await controller.startupTask?.value
+
+    XCTAssertTrue(manager.isSyncReady)
+    XCTAssertTrue(manager.hasNoDeferredMutations)
+    XCTAssertTrue(
+      driver.enqueuedDeleteNames.contains(id.uuidString),
+      "the deferred delete is replayed after enable-time startup completes")
+    XCTAssertGreaterThan(driver.sendChangesCount, 0, "ready flush sends after T1 has completed")
   }
 }

--- a/FoqosTests/SyncEngineControllerCutoverTests.swift
+++ b/FoqosTests/SyncEngineControllerCutoverTests.swift
@@ -16,6 +16,7 @@ final class SyncEngineControllerCutoverTests: XCTestCase {
   var store: SyncEngineStore!
   var driver: CutoverRecordingDriver!
   var controller: SyncEngineController!
+  var profileDeleteCommitScheduler: ManualProfileDeleteCommitScheduler!
   let zoneID = CKRecordZone.ID(
     zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)
 
@@ -27,6 +28,7 @@ final class SyncEngineControllerCutoverTests: XCTestCase {
     context = container.mainContext
     store = SyncEngineStore(userRecordName: "user-A", defaults: UserDefaults(suiteName: testSuiteName)!)
     driver = CutoverRecordingDriver(stateSerialization: nil)
+    profileDeleteCommitScheduler = ManualProfileDeleteCommitScheduler()
     let deviceId = SharedData.deviceSyncId.uuidString
     let apply = SyncApplyService(
       modelContext: context, store: store, sessionController: MockSessionController(),
@@ -35,7 +37,8 @@ final class SyncEngineControllerCutoverTests: XCTestCase {
       modelContext: context, store: store, emergencyManager: EmergencyUnblockManager(), deviceId: deviceId)
     controller = SyncEngineController(
       modelContext: context, store: store, driverFactory: { [driver] _ in driver! },
-      apply: apply, provider: provider, sessionSync: MockSessionSyncFlushing(), deviceId: deviceId)
+      apply: apply, provider: provider, sessionSync: MockSessionSyncFlushing(), deviceId: deviceId,
+      scheduleProfileDeleteCommit: profileDeleteCommitScheduler.schedule)
   }
 
   override func tearDown() async throws {
@@ -120,6 +123,30 @@ final class SyncEngineControllerCutoverTests: XCTestCase {
     XCTAssertThrowsError(try controller.enqueueProfileDelete(UUID())) { error in
       XCTAssertEqual(error as? MutationFunnel.MutationFunnelError, .entityNotFound)
     }
+  }
+
+  func testGivenReadyProfileDelete_WhenDeferredCommitRuns_ThenSendHappensAfterPendingDeleteEnqueued()
+    throws
+  {
+    let now = Date()
+    let profile = makeProfile(now: now)
+    controller.start()
+    let sendBefore = driver.sendChangesCount
+
+    try controller.enqueueProfileDelete(profile.id, requestSyncAfterPendingDelete: true)
+
+    XCTAssertEqual(profileDeleteCommitScheduler.scheduledOperations.count, 1)
+    XCTAssertFalse(
+      driver.enqueuedDeleteNames.contains(profile.id.uuidString),
+      "profile delete does not enqueue the CK delete until the deferred save commits")
+    XCTAssertEqual(
+      driver.sendChangesCount, sendBefore,
+      "send must not run before the pending .deleteRecord exists")
+
+    profileDeleteCommitScheduler.runNext()
+
+    XCTAssertTrue(driver.enqueuedDeleteNames.contains(profile.id.uuidString))
+    XCTAssertEqual(driver.sendChangesCount, sendBefore + 1)
   }
 
   // MARK: - Task 134b (CRA-4): ResetController + LegacyCleanupCoordinator wiring

--- a/FoqosTests/SyncEngineFacadeTests.swift
+++ b/FoqosTests/SyncEngineFacadeTests.swift
@@ -51,6 +51,8 @@ final class SyncEngineFacadeTests: XCTestCase {
 
   func testGivenController_WhenFacadeVerbsCalled_ThenTheyForward() throws {
     let id = UUID()
+    manager.isSyncReady = true
+
     try manager.syncNow()
     try manager.resetSync(clearRemoteAppSelections: true)
     try manager.enqueueProfileSave(id)
@@ -59,7 +61,9 @@ final class SyncEngineFacadeTests: XCTestCase {
     try manager.enqueueLocationDelete(id)
     try manager.enqueueEmergencySettingsSave()
 
-    XCTAssertEqual(mock.requestSyncCount, 1)
+    XCTAssertEqual(
+      mock.requestSyncCount, 6,
+      "syncNow (1) + five enqueue verbs each flush once when ready (5)")
     XCTAssertEqual(mock.beginResetCalls, [true])
     XCTAssertEqual(mock.enqueuedProfileSaves, [id])
     XCTAssertEqual(mock.enqueuedProfileDeletes, [id])

--- a/FoqosTests/SyncEngineFacadeTests.swift
+++ b/FoqosTests/SyncEngineFacadeTests.swift
@@ -180,6 +180,20 @@ final class SyncEngineFacadeTests: XCTestCase {
     XCTAssertTrue(manager.hasNoDeferredMutations)
   }
 
+  func testGivenNotReady_WhenEnqueueProfileSave_ThenNoSendUntilReadyFlush() throws {
+    manager.isSyncReady = false
+    let id = UUID()
+
+    try manager.enqueueProfileSave(id)
+    XCTAssertEqual(mock.enqueuedProfileSaves, [id], "the change is enqueued")
+    XCTAssertEqual(
+      mock.requestSyncCount, 0,
+      "no send may fire before the engine is ready; restored poison must be T1-stripped first (AB-4)")
+
+    manager.markSyncReadyAndFlush()
+    XCTAssertEqual(mock.requestSyncCount, 1, "the post-startup flush sends exactly once, post-T1")
+  }
+
   // MARK: - Review fix: not-attached and genuine-throw propagation (findings #2–#6, #15)
 
   func testGivenNoEngineController_WhenSyncNow_ThenThrowsNotAttachedInsteadOfSilentNoOp() {

--- a/FoqosTests/SyncEngineFacadeTests.swift
+++ b/FoqosTests/SyncEngineFacadeTests.swift
@@ -140,6 +140,46 @@ final class SyncEngineFacadeTests: XCTestCase {
     XCTAssertTrue(manager.hasNoDeferredMutations, "the deferred sets are cleared after draining")
   }
 
+  func testGivenNotAttached_WhenEnqueueProfileDelete_ThenTombstoneDeleteIsReplayedOnReady() throws {
+    let id = UUID()
+    manager.engineController = nil
+
+    XCTAssertThrowsError(try manager.enqueueProfileDelete(id)) { error in
+      XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+    }
+
+    let attached = MockSyncEngineControlling()
+    manager.engineController = attached
+    manager.markSyncReadyAndFlush()
+
+    XCTAssertEqual(
+      attached.deferredDeletes,
+      [id.uuidString],
+      "a profile delete dropped before attach is replayed as a tombstone delete")
+    XCTAssertEqual(attached.requestSyncCount, 1)
+    XCTAssertTrue(manager.hasNoDeferredMutations)
+  }
+
+  func testGivenNotAttached_WhenEnqueueLocationDelete_ThenTombstoneDeleteIsReplayedOnReady() throws {
+    let id = UUID()
+    manager.engineController = nil
+
+    XCTAssertThrowsError(try manager.enqueueLocationDelete(id)) { error in
+      XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+    }
+
+    let attached = MockSyncEngineControlling()
+    manager.engineController = attached
+    manager.markSyncReadyAndFlush()
+
+    XCTAssertEqual(
+      attached.deferredDeletes,
+      [id.uuidString],
+      "a location delete dropped before attach is replayed as a tombstone delete")
+    XCTAssertEqual(attached.requestSyncCount, 1)
+    XCTAssertTrue(manager.hasNoDeferredMutations)
+  }
+
   // MARK: - Review fix: not-attached and genuine-throw propagation (findings #2–#6, #15)
 
   func testGivenNoEngineController_WhenSyncNow_ThenThrowsNotAttachedInsteadOfSilentNoOp() {

--- a/FoqosTests/SyncEngineFacadeTests.swift
+++ b/FoqosTests/SyncEngineFacadeTests.swift
@@ -68,6 +68,18 @@ final class SyncEngineFacadeTests: XCTestCase {
     XCTAssertEqual(mock.enqueuedEmergencySaves, 1)
   }
 
+  func testGivenReadyController_WhenEnqueueProfileSave_ThenRequestSyncIsScheduled() throws {
+    manager.isSyncReady = true
+    let id = UUID()
+
+    try manager.enqueueProfileSave(id)
+
+    XCTAssertEqual(mock.enqueuedProfileSaves, [id], "the save is forwarded to the engine")
+    XCTAssertEqual(
+      mock.requestSyncCount, 1,
+      "a ready engine flushes a user-initiated save promptly, not on the next foreground")
+  }
+
   // MARK: - Review fix: not-attached and genuine-throw propagation (findings #2–#6, #15)
 
   func testGivenNoEngineController_WhenSyncNow_ThenThrowsNotAttachedInsteadOfSilentNoOp() {

--- a/FoqosTests/SyncEngineFacadeTests.swift
+++ b/FoqosTests/SyncEngineFacadeTests.swift
@@ -9,6 +9,7 @@ final class SyncEngineFacadeTests: XCTestCase {
   var manager: ProfileSyncManager!
   var mock: MockSyncEngineControlling!
   private var savedEnabled = false
+  private var savedIsSyncReady = false
   private var savedController: (any SyncEngineControlling)?
 
   override func setUp() async throws {
@@ -17,14 +18,17 @@ final class SyncEngineFacadeTests: XCTestCase {
     SharedData.configure(suite: UserDefaults(suiteName: testSuiteName)!)
     manager = ProfileSyncManager.shared
     savedEnabled = manager.isEnabled
+    savedIsSyncReady = manager.isSyncReady
     savedController = manager.engineController
     mock = MockSyncEngineControlling()
     manager.engineController = mock
+    manager.isSyncReady = false
     manager.isEnabled = false
   }
 
   override func tearDown() async throws {
     manager.engineController = savedController
+    manager.isSyncReady = savedIsSyncReady
     manager.isEnabled = savedEnabled
     UserDefaults().removePersistentDomain(forName: testSuiteName)
     try await super.tearDown()
@@ -82,6 +86,58 @@ final class SyncEngineFacadeTests: XCTestCase {
     XCTAssertEqual(
       mock.requestSyncCount, 1,
       "a ready engine flushes a user-initiated save promptly, not on the next foreground")
+  }
+
+  func testGivenNotAttached_WhenEnqueueProfileSave_ThenIdIsDeferredAndReEnqueuedOnReady() throws {
+    let id = UUID()
+    manager.engineController = nil
+
+    XCTAssertThrowsError(try manager.enqueueProfileSave(id)) { error in
+      XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+    }
+
+    let attached = MockSyncEngineControlling()
+    manager.engineController = attached
+    manager.markSyncReadyAndFlush()
+
+    XCTAssertEqual(attached.enqueuedProfileSaves, [id], "the dropped save is retried on attach")
+    XCTAssertEqual(attached.requestSyncCount, 1, "exactly one flush covers all drained mutations")
+    XCTAssertTrue(manager.hasNoDeferredMutations, "the deferred sets are cleared after draining")
+  }
+
+  func testGivenNotAttached_WhenEnqueueLocationSave_ThenIdIsDeferredAndReEnqueuedOnReady() throws {
+    let id = UUID()
+    manager.engineController = nil
+
+    XCTAssertThrowsError(try manager.enqueueLocationSave(id)) { error in
+      XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+    }
+
+    let attached = MockSyncEngineControlling()
+    manager.engineController = attached
+    manager.markSyncReadyAndFlush()
+
+    XCTAssertEqual(attached.enqueuedLocationSaves, [id], "the dropped location save is retried on attach")
+    XCTAssertEqual(attached.requestSyncCount, 1, "exactly one flush covers all drained mutations")
+    XCTAssertTrue(manager.hasNoDeferredMutations, "the deferred sets are cleared after draining")
+  }
+
+  func testGivenNotAttached_WhenEnqueueEmergencySettingsSave_ThenSaveIsDeferredAndReEnqueuedOnReady()
+    throws
+  {
+    manager.engineController = nil
+
+    XCTAssertThrowsError(try manager.enqueueEmergencySettingsSave()) { error in
+      XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+    }
+
+    let attached = MockSyncEngineControlling()
+    manager.engineController = attached
+    manager.markSyncReadyAndFlush()
+
+    XCTAssertEqual(attached.enqueuedEmergencySaves, 1, "the dropped emergency save is retried on attach")
+    XCTAssertEqual(attached.requestSyncCount, 1, "exactly one flush covers all drained mutations")
+    XCTAssertTrue(manager.hasNoDeferredMutations, "the deferred sets are cleared after draining")
   }
 
   // MARK: - Review fix: not-attached and genuine-throw propagation (findings #2–#6, #15)

--- a/FoqosTests/SyncEngineFacadeTests.swift
+++ b/FoqosTests/SyncEngineFacadeTests.swift
@@ -194,6 +194,35 @@ final class SyncEngineFacadeTests: XCTestCase {
     XCTAssertEqual(mock.requestSyncCount, 1, "the post-startup flush sends exactly once, post-T1")
   }
 
+  func testGivenNotReady_WhenAnyFacadeEnqueueVerbRuns_ThenNoSendIsScheduled() throws {
+    manager.isSyncReady = false
+    let id = UUID()
+
+    try manager.enqueueProfileSave(id)
+    try manager.enqueueProfileDelete(id)
+    try manager.enqueueLocationSave(id)
+    try manager.enqueueLocationDelete(id)
+    try manager.enqueueEmergencySettingsSave()
+
+    XCTAssertEqual(mock.enqueuedProfileSaves, [id])
+    XCTAssertEqual(mock.enqueuedProfileDeletes, [id])
+    XCTAssertEqual(mock.enqueuedLocationSaves, [id])
+    XCTAssertEqual(mock.enqueuedLocationDeletes, [id])
+    XCTAssertEqual(mock.enqueuedEmergencySaves, 1)
+    XCTAssertEqual(
+      mock.requestSyncCount, 0,
+      "no facade enqueue verb may send before startup completes and T1 has stripped restored state")
+  }
+
+  func testGivenSyncDisabled_WhenStartupCompletes_ThenReadyFlushIsSkipped() {
+    manager.isEnabled = false
+
+    manager.markSyncReadyAndFlushIfStillEnabled(for: mock)
+
+    XCTAssertFalse(manager.isSyncReady)
+    XCTAssertEqual(mock.requestSyncCount, 0)
+  }
+
   // MARK: - Review fix: not-attached and genuine-throw propagation (findings #2–#6, #15)
 
   func testGivenNoEngineController_WhenSyncNow_ThenThrowsNotAttachedInsteadOfSilentNoOp() {


### PR DESCRIPTION
## Summary

Fixes #294.

- Trigger a sync request after successful local enqueue for all five facade mutations: profile save, profile delete, location save, location delete, and emergency settings save.
- Defer `.notAttached` mutations and drain them after attach/startup readiness, including tombstone replay for deletes whose local fallback already removed the model.
- Preserve AB-4 reset-safety ordering: send-on-enqueue is gated on `isSyncReady`, which is set only after startup/T1 strip completes, and restored state is never sent from attach before T1.
- Fix enable-after-attach readiness so toggling sync on after launch starts the engine, waits for startup, drains deferred mutations, and flushes only if sync is still enabled.
- For profile deletes, delay the prompt send until the deferred durable delete commit has actually added the pending `.deleteRecord`.
- Preserve the device-local app-selection warning when a synced profile is edited without selecting apps on that device.

## Verification

- `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -parallel-testing-enabled NO`
  - 840 tests, 0 failures
- `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -parallel-testing-enabled NO -only-testing:FoqosTests/ProfileAppSelectionStateTests`
  - 2 tests, 0 failures
- `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -parallel-testing-enabled NO -only-testing:FoqosTests/SyncApplyServiceTests/testGivenAbsentProfile_WhenModificationApplied_ThenCreatedWithNeedsAppSelection`
  - 1 test, 0 failures
- `swift-format lint --recursive .`
  - clean
- `scripts/check-sync-guards.sh`
  - passed
- `scripts/check-c2-guards.sh`
  - passed

## AB-4 conformance

Send-on-enqueue fires only for fresh local mutations through the `ProfileSyncManager` facade. It is gated by `isSyncReady`, which is set only after `startupTask` completes, preserving the T1-strip-before-any-send launch ordering and avoiding any send of restored reset poison. Startup completion is also guarded so a disable/controller swap before startup finishes cannot mark the engine ready or flush.

## Physical acceptance

Maintainer-assisted two-device validation completed on July 9, 2026. The confirmed checklist covered create-on-A appearing on B without relaunch, B-side metadata edits propagating back to A, and the expected iOS limitation that selected apps remain device-local. The synced profile now keeps the Home warning on B until apps are selected locally on B.

## Notes

- This unblocks the #286 two-device sync checklist.
- No temporary `#294 PROBE` instrumentation was committed.
- Deviations from the plan: branch name is `fix/294-send-on-enqueue` to match the corrected diagnosis, and the implementation includes two review-driven lifecycle fixes: enable-after-attach readiness and post-commit profile-delete send timing. A physical-test follow-up also fixed stale clearing of the device-local app-selection warning during metadata-only edits.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes local sync mutations flush sooner while preserving startup ordering.

- Adds readiness-gated send-on-enqueue for facade mutations.
- Defers pre-attach saves and deletes until the engine is ready.
- Replays tombstone deletes for local fallback deletes.
- Delays profile-delete sends until the pending delete is enqueued.
- Keeps the app-selection warning during metadata-only profile edits.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Foqos/CloudKit/ProfileSyncManager.swift | Adds sync readiness, deferred mutation tracking, guarded startup flushing, and send-on-enqueue behavior. |
| Foqos/CloudKit/SyncEngine/MutationFunnel.swift | Adds a post-delete-enqueue callback and tombstone-only replay for deletes whose local fallback already removed the model. |
| Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift | Extends controller facade methods for delayed profile-delete sends and deferred tombstone deletes. |
| Foqos/CloudKit/SyncEngine/SyncEngineController.swift | Injects the profile-delete commit scheduler into MutationFunnel setup. |
| Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift | Updates the sync engine protocol for the new delete timing and replay paths. |
| Foqos/Models/BlockedProfiles.swift | Adds helper logic for preserving needsAppSelection only when no local selection exists. |
| Foqos/Views/BlockedProfileView.swift | Uses the new helper so metadata-only edits do not clear a still-needed app-selection warning. |
| FoqosTests/Mocks/MockSyncEngineControlling.swift | Updates the mock controller for the expanded sync protocol. |
| FoqosTests/ProfileAppSelectionStateTests.swift | Adds tests for the new app-selection warning helper. |
| FoqosTests/SyncEngineAttachTests.swift | Adds attach and enable-time coverage for deferred delete replay. |
| FoqosTests/SyncEngineControllerCutoverTests.swift | Adds coverage for sending only after a profile delete is pending. |
| FoqosTests/SyncEngineFacadeTests.swift | Adds facade tests for prompt sends, deferred replay, and not-ready behavior. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Facade mutation] --> B{Engine attached?}
  B -- No --> C[Store deferred mutation]
  B -- Yes --> D[Enqueue in controller]
  D --> E{Sync ready?}
  E -- Yes --> F[Request sync]
  E -- No --> G[Wait for startup]
  C --> H[Attach or enable engine]
  H --> I[Await startup and T1 strip]
  I --> J{Still enabled and same controller?}
  J -- No --> K[Skip flush]
  J -- Yes --> L[Mark ready]
  L --> M[Drain deferred mutations]
  M --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Facade mutation] --> B{Engine attached?}
  B -- No --> C[Store deferred mutation]
  B -- Yes --> D[Enqueue in controller]
  D --> E{Sync ready?}
  E -- Yes --> F[Request sync]
  E -- No --> G[Wait for startup]
  C --> H[Attach or enable engine]
  H --> I[Await startup and T1 strip]
  I --> J{Still enabled and same controller?}
  J -- No --> K[Skip flush]
  J -- Yes --> L[Mark ready]
  L --> M[Drain deferred mutations]
  M --> F
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Preserve app selection warning on metada..."](https://github.com/mnbf9rca/family-foqos/commit/13fac3c3e4ebdb483e3c8599e64954662a9c3373) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43136055)</sub>

<!-- /greptile_comment -->