### PR TITLE
Fix #297 BlockedProfileCard snapshot rendering

### DIFF
--- a/Foqos/Components/BlockedProfileCards/BlockedProfileCard.swift
+++ b/Foqos/Components/BlockedProfileCards/BlockedProfileCard.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct BlockedProfileCard: View {
   @EnvironmentObject var themeManager: ThemeManager
 
-  let profile: BlockedProfiles
+  let data: BlockedProfileCardData
 
   var isActive: Bool = false
   var isBreakAvailable: Bool = false
@@ -40,17 +40,17 @@ struct BlockedProfileCard: View {
         // Header section - Profile name, edit button, and indicators
         HStack {
           VStack(alignment: .leading, spacing: 10) {
-            Text(profile.name)
+            Text(data.name)
               .font(.title3)
               .fontWeight(.bold)
               .foregroundColor(.primary)
 
             // Using the new ProfileIndicators component
             ProfileIndicators(
-              enableLiveActivity: profile.enableLiveActivity,
-              hasReminders: profile.reminderTimeInSeconds != nil,
-              enableBreaks: profile.enableBreaks,
-              enableStrictMode: profile.enableStrictMode
+              enableLiveActivity: data.enableLiveActivity,
+              hasReminders: data.hasReminders,
+              enableBreaks: data.enableBreaks,
+              enableStrictMode: data.enableStrictMode
             )
           }
 
@@ -58,7 +58,7 @@ struct BlockedProfileCard: View {
 
           // Menu button moved to top right
           Menu {
-            if !profile.isNewerSchemaVersion {
+            if !data.isNewerSchemaVersion {
               Button(action: {
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 onEditTapped()
@@ -73,7 +73,7 @@ struct BlockedProfileCard: View {
               Label("Stats for Nerds", systemImage: "eyeglasses")
             }
 
-            if !profile.isNewerSchemaVersion {
+            if !data.isNewerSchemaVersion {
               Divider()
 
               if isActive {
@@ -111,7 +111,7 @@ struct BlockedProfileCard: View {
           }
         }
 
-        if profile.isNewerSchemaVersion {
+        if data.isNewerSchemaVersion {
           // Read-only indicator for profiles from newer app version
           HStack(spacing: 4) {
             Image(systemName: "exclamationmark.triangle.fill")
@@ -125,25 +125,25 @@ struct BlockedProfileCard: View {
           VStack(alignment: .leading, spacing: 16) {
             // Strategy and schedule side-by-side with divider
             HStack(spacing: 16) {
-              StrategyInfoView(strategyId: profile.blockingStrategyId)
+              StrategyInfoView(strategyId: data.blockingStrategyId)
 
               Divider()
                 .frame(height: 24)
 
-              ProfileScheduleRow(profile: profile, isActive: isActive)
+              ProfileScheduleRow(data: data, isActive: isActive)
             }
 
             // Using the new ProfileStatsRow component
             ProfileStatsRow(
-              selectedActivity: profile.selectedActivity,
-              sessionCount: profile.sessions.count,
-              domainsCount: profile.domains?.count ?? 0
+              selectedActivity: data.selectedActivity,
+              sessionCount: data.sessionCount,
+              domainsCount: data.domainsCount
             )
           }
         }
 
         // Show app selection banner if needed (not for newer schema profiles)
-        if profile.needsAppSelection && !profile.isNewerSchemaVersion {
+        if data.needsAppSelection && !data.isNewerSchemaVersion {
           Button(action: {
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
             onAppSelectionTapped()
@@ -155,7 +155,7 @@ struct BlockedProfileCard: View {
 
         Spacer(minLength: 4)
 
-        if !profile.isNewerSchemaVersion {
+        if !data.isNewerSchemaVersion {
           ProfileTimerButton(
             isActive: isActive,
             isBreakAvailable: isBreakAvailable,
@@ -182,16 +182,26 @@ struct BlockedProfileCard: View {
     Color(.systemGroupedBackground).ignoresSafeArea()
 
     VStack(spacing: 40) {
+      let work = BlockedProfiles(
+        id: UUID(),
+        name: "Work",
+        selectedActivity: FamilyActivitySelection(),
+        blockingStrategyId: NFCBlockingStrategy.id,
+        enableLiveActivity: true,
+        reminderTimeInSeconds: 3600
+      )
+      let gaming = BlockedProfiles(
+        id: UUID(),
+        name: "Gaming",
+        selectedActivity: FamilyActivitySelection(),
+        blockingStrategyId: QRCodeBlockingStrategy.id,
+        enableLiveActivity: true,
+        reminderTimeInSeconds: 3600
+      )
+
       // Inactive card
       BlockedProfileCard(
-        profile: BlockedProfiles(
-          id: UUID(),
-          name: "Work",
-          selectedActivity: FamilyActivitySelection(),
-          blockingStrategyId: NFCBlockingStrategy.id,
-          enableLiveActivity: true,
-          reminderTimeInSeconds: 3600
-        ),
+        data: work.cardData,
         onStartTapped: {},
         onStopTapped: {},
         onEditTapped: {},
@@ -200,14 +210,7 @@ struct BlockedProfileCard: View {
 
       // Active card with timer
       BlockedProfileCard(
-        profile: BlockedProfiles(
-          id: UUID(),
-          name: "Gaming",
-          selectedActivity: FamilyActivitySelection(),
-          blockingStrategyId: QRCodeBlockingStrategy.id,
-          enableLiveActivity: true,
-          reminderTimeInSeconds: 3600
-        ),
+        data: gaming.cardData,
         isActive: true,
         isBreakAvailable: true,
         elapsedTime: 1845,  // 30 minutes and 45 seconds

--- a/Foqos/Components/BlockedProfileCards/BlockedProfileCardData.swift
+++ b/Foqos/Components/BlockedProfileCards/BlockedProfileCardData.swift
@@ -1,0 +1,68 @@
+import FamilyControls
+import FoqosShared
+import Foundation
+
+/// Immutable value snapshot of everything the BlockedProfileCard family renders.
+/// NOT a SwiftData model — holding a value (never the live `@Model`) is what makes the
+/// card crash-proof against a re-render on a deleted profile (see #297). The compiler now
+/// forbids handing the card a live model, which is the regression guard.
+struct BlockedProfileCardData {
+  let id: UUID
+  let name: String
+  let isNewerSchemaVersion: Bool
+  let enableLiveActivity: Bool
+  let hasReminders: Bool
+  let enableBreaks: Bool
+  let enableStrictMode: Bool
+  let blockingStrategyId: String?
+  let selectedActivity: FamilyActivitySelection
+  let sessionCount: Int
+  let domainsCount: Int
+  let needsAppSelection: Bool
+
+  let schedule: BlockedProfileSchedule?
+  let startTriggers: ProfileStartTriggers
+  let stopConditions: ProfileStopConditions
+  let startSchedule: ProfileScheduleTime?
+  let stopSchedule: ProfileScheduleTime?
+  let strategyData: Data?
+  let profileSchemaVersion: Int
+  let scheduleIsOutOfSync: Bool
+}
+
+extension BlockedProfiles {
+  /// Build the card snapshot. MUST be called only on a valid (non-zombie) model — callers
+  /// gate via `.valid` / `SafeModelView` before invoking. Reads live attributes/relationships.
+  ///
+  /// TRIPWIRE (#297 edit-propagation): this MUST be evaluated inside an observation-tracked
+  /// SwiftUI body (the carousel's `SafeModelView` content closure). Those tracked reads register
+  /// the `@Observable` dependencies that make a legitimate edit rebuild the snapshot. Do NOT
+  /// memoize it, cache it on the model, or move the call into an `init` / stored property / out of
+  /// the render path — that silently stops the card updating on edits while still compiling and
+  /// passing the zombie test. Verified by `testGivenModelMutated_WhenCardDataRebuilt_ThenReflectsChange`
+  /// and the device-gate edit step.
+  var cardData: BlockedProfileCardData {
+    BlockedProfileCardData(
+      id: id,
+      name: name,
+      isNewerSchemaVersion: isNewerSchemaVersion,
+      enableLiveActivity: enableLiveActivity,
+      hasReminders: reminderTimeInSeconds != nil,
+      enableBreaks: enableBreaks,
+      enableStrictMode: enableStrictMode,
+      blockingStrategyId: blockingStrategyId,
+      selectedActivity: selectedActivity,
+      sessionCount: sessions.count,
+      domainsCount: domains?.count ?? 0,
+      needsAppSelection: needsAppSelection,
+      schedule: schedule,
+      startTriggers: startTriggers,
+      stopConditions: stopConditions,
+      startSchedule: startSchedule,
+      stopSchedule: stopSchedule,
+      strategyData: strategyData,
+      profileSchemaVersion: profileSchemaVersion,
+      scheduleIsOutOfSync: scheduleIsOutOfSync
+    )
+  }
+}

--- a/Foqos/Components/BlockedProfileCards/BlockedProfileCardData.swift
+++ b/Foqos/Components/BlockedProfileCards/BlockedProfileCardData.swift
@@ -2,6 +2,12 @@ import FamilyControls
 import FoqosShared
 import Foundation
 
+// REGRESSION GUARD (#297): BlockedProfileCard / ProfileScheduleRow accept ONLY this value type.
+// They can no longer hold a live BlockedProfiles @Model, so a re-render can never read a
+// vacated store row. Reintroducing `let profile: BlockedProfiles` on those views is a
+// compile-time-visible regression. The runtime proof is
+// BlockedProfileCardDataTests.testGivenCardDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap.
+
 /// Immutable value snapshot of everything the BlockedProfileCard family renders.
 /// NOT a SwiftData model — holding a value (never the live `@Model`) is what makes the
 /// card crash-proof against a re-render on a deleted profile (see #297). The compiler now

--- a/Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift
+++ b/Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift
@@ -143,7 +143,10 @@ struct BlockedProfileCarousel: View {
             ForEach(validProfiles) { profile in
               SafeModelView(profile) { profile in
                 BlockedProfileCard(
-                  profile: profile,
+                  // Built only on a valid model, inside this observation-tracked body. These
+                  // tracked reads register dependencies so legitimate edits rebuild the snapshot
+                  // in place. Do not hoist or memoize this call; see the `cardData` tripwire.
+                  data: profile.cardData,
                   isActive: profile.id == activeSessionProfileId,
                   isBreakAvailable: isBreakAvailable,
                   isBreakActive: isBreakActive,
@@ -160,6 +163,8 @@ struct BlockedProfileCarousel: View {
                   oneMoreMinuteStartTime: oneMoreMinuteStartTime,
                   onOneMoreMinuteTapped: { onOneMoreMinuteTapped(profile) }
                 )
+              } placeholder: {
+                Color.clear.frame(minHeight: cardHeight)
               }
               .containerRelativeFrame(.horizontal)
             }

--- a/Foqos/Components/BlockedProfileCards/ProfileScheduleRow.swift
+++ b/Foqos/Components/BlockedProfileCards/ProfileScheduleRow.swift
@@ -1,29 +1,29 @@
 import SwiftUI
 
 struct ProfileScheduleRow: View {
-  let profile: BlockedProfiles
+  let data: BlockedProfileCardData
   let isActive: Bool
 
-  private var hasLegacySchedule: Bool { profile.schedule?.isActive == true }
+  private var hasLegacySchedule: Bool { data.schedule?.isActive == true }
 
   private var hasV2Schedule: Bool {
     let hasStart =
-      profile.startTriggers.schedule
-      && profile.startSchedule?.isActive == true
+      data.startTriggers.schedule
+      && data.startSchedule?.isActive == true
     let hasStop =
-      profile.stopConditions.schedule
-      && profile.stopSchedule?.isActive == true
+      data.stopConditions.schedule
+      && data.stopSchedule?.isActive == true
     return hasStart || hasStop
   }
 
   private var hasSchedule: Bool { hasLegacySchedule || hasV2Schedule }
 
   private var isTimerStrategy: Bool {
-    if profile.stopConditions.timer { return true }
+    if data.stopConditions.timer { return true }
     // Legacy fallback: V1 profiles have nil stopConditionsData, so
     // stopConditions.timer defaults false even for timer strategies.
-    if profile.profileSchemaVersion < 2 {
-      let id = profile.blockingStrategyId
+    if data.profileSchemaVersion < 2 {
+      let id = data.blockingStrategyId
       return id == NFCTimerBlockingStrategy.id
         || id == QRTimerBlockingStrategy.id
         || id == ShortcutTimerBlockingStrategy.id
@@ -32,7 +32,7 @@ struct ProfileScheduleRow: View {
   }
 
   private var timerDuration: Int? {
-    guard let strategyData = profile.strategyData else { return nil }
+    guard let strategyData = data.strategyData else { return nil }
     let timerData = StrategyTimerData.toStrategyTimerData(from: strategyData)
     return timerData.durationInMinutes
   }
@@ -40,15 +40,15 @@ struct ProfileScheduleRow: View {
   private var daysLine: String {
     if hasV2Schedule {
       var allDays = Set<Weekday>()
-      if let start = profile.startSchedule, profile.startTriggers.schedule {
+      if let start = data.startSchedule, data.startTriggers.schedule {
         allDays.formUnion(start.days)
       }
-      if let stop = profile.stopSchedule, profile.stopConditions.schedule {
+      if let stop = data.stopSchedule, data.stopConditions.schedule {
         allDays.formUnion(stop.days)
       }
       return Array(allDays).compactDaysText()
     }
-    guard let schedule = profile.schedule, schedule.isActive else { return "" }
+    guard let schedule = data.schedule, schedule.isActive else { return "" }
     return schedule.days
       .compactDaysText()
   }
@@ -56,11 +56,11 @@ struct ProfileScheduleRow: View {
   private var timeLine: String? {
     if hasV2Schedule {
       let startText =
-        profile.startTriggers.schedule
-        ? profile.startSchedule?.formattedTime : nil
+        data.startTriggers.schedule
+        ? data.startSchedule?.formattedTime : nil
       let stopText =
-        profile.stopConditions.schedule
-        ? profile.stopSchedule?.formattedTime : nil
+        data.stopConditions.schedule
+        ? data.stopSchedule?.formattedTime : nil
       if let s = startText, let e = stopText {
         return "\(s) - \(e)"
       } else if let s = startText {
@@ -70,7 +70,7 @@ struct ProfileScheduleRow: View {
       }
       return nil
     }
-    guard let schedule = profile.schedule, schedule.isActive else { return nil }
+    guard let schedule = data.schedule, schedule.isActive else { return nil }
     let start = formattedTimeString(hour24: schedule.startHour, minute: schedule.startMinute)
     let end = formattedTimeString(hour24: schedule.endHour, minute: schedule.endMinute)
     return "\(start) - \(end)"
@@ -87,7 +87,7 @@ struct ProfileScheduleRow: View {
     HStack(spacing: 4) {
       // Icon
       Group {
-        if profile.scheduleIsOutOfSync || (hasSchedule && isTimerStrategy) {
+        if data.scheduleIsOutOfSync || (hasSchedule && isTimerStrategy) {
           Image(systemName: "exclamationmark.triangle.fill")
             .foregroundColor(.red)
         }
@@ -95,7 +95,7 @@ struct ProfileScheduleRow: View {
       .font(.body)
 
       VStack(alignment: .leading, spacing: 2) {
-        if profile.scheduleIsOutOfSync {
+        if data.scheduleIsOutOfSync {
           Text("Schedule Out of Sync")
             .font(.caption2)
             .lineLimit(2)
@@ -142,20 +142,22 @@ struct ProfileScheduleRow: View {
 }
 
 #Preview {
+  let profile = BlockedProfiles(
+    name: "Test",
+    blockingStrategyId: NFCBlockingStrategy.id,
+    schedule: .init(
+      days: [.monday, .wednesday, .friday],
+      startHour: 9,
+      startMinute: 0,
+      endHour: 17,
+      endMinute: 0,
+      updatedAt: Date()
+    )
+  )
+
   VStack(spacing: 20) {
     ProfileScheduleRow(
-      profile: BlockedProfiles(
-        name: "Test",
-        blockingStrategyId: NFCBlockingStrategy.id,
-        schedule: .init(
-          days: [.monday, .wednesday, .friday],
-          startHour: 9,
-          startMinute: 0,
-          endHour: 17,
-          endMinute: 0,
-          updatedAt: Date()
-        )
-      ),
+      data: profile.cardData,
       isActive: false
     )
   }

--- a/Foqos/Utils/SafeModelView.swift
+++ b/Foqos/Utils/SafeModelView.swift
@@ -16,18 +16,26 @@ import SwiftUI
 ///   }
 /// }
 /// ```
-struct SafeModelView<Model: PersistentModel, Content: View>: View {
+struct SafeModelView<Model: PersistentModel, Content: View, Placeholder: View>: View {
   let model: Model
   let content: (Model) -> Content
+  let placeholder: () -> Placeholder
 
-  init(_ model: Model, @ViewBuilder content: @escaping (Model) -> Content) {
+  init(
+    _ model: Model,
+    @ViewBuilder content: @escaping (Model) -> Content,
+    @ViewBuilder placeholder: @escaping () -> Placeholder = { EmptyView() }
+  ) {
     self.model = model
     self.content = content
+    self.placeholder = placeholder
   }
 
   var body: some View {
     if model.isPersistentModelValid {
       content(model)
+    } else {
+      placeholder()
     }
   }
 }

--- a/FoqosTests/BlockedProfileCardDataTests.swift
+++ b/FoqosTests/BlockedProfileCardDataTests.swift
@@ -1,0 +1,77 @@
+import FamilyControls
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class BlockedProfileCardDataTests: XCTestCase {
+  private var container: ModelContainer!
+  private var context: ModelContext!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    container = try TestModelContainer.create()
+    context = container.mainContext
+  }
+
+  override func tearDown() async throws {
+    context = nil
+    container = nil
+    try await super.tearDown()
+  }
+
+  func testGivenProfile_WhenCardData_ThenMapsScalarAndDerivedFields() throws {
+    let profile = BlockedProfiles(
+      id: UUID(), name: "Work", selectedActivity: FamilyActivitySelection(),
+      blockingStrategyId: NFCBlockingStrategy.id, enableLiveActivity: true,
+      reminderTimeInSeconds: 3600
+    )
+    context.insert(profile)
+
+    let data = profile.cardData
+
+    XCTAssertEqual(data.id, profile.id)
+    XCTAssertEqual(data.name, "Work")
+    XCTAssertTrue(data.enableLiveActivity)
+    XCTAssertTrue(data.hasReminders)
+    XCTAssertEqual(data.blockingStrategyId, NFCBlockingStrategy.id)
+    XCTAssertEqual(data.sessionCount, 0)
+    XCTAssertEqual(data.domainsCount, 0)
+    XCTAssertFalse(data.isNewerSchemaVersion)
+    XCTAssertEqual(data.profileSchemaVersion, BlockedProfiles.currentSchemaVersion)
+  }
+
+  func testGivenModelMutated_WhenCardDataRebuilt_ThenReflectsChange() throws {
+    let profile = BlockedProfiles(
+      id: UUID(), name: "Before", selectedActivity: FamilyActivitySelection())
+    context.insert(profile)
+
+    let before = profile.cardData
+    XCTAssertEqual(before.name, "Before")
+
+    profile.name = "After"
+    let after = profile.cardData
+
+    XCTAssertEqual(after.name, "After")
+    XCTAssertEqual(before.name, "Before")
+  }
+
+  func testGivenCardDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap() throws {
+    let profile = BlockedProfiles(
+      id: UUID(), name: "Gaming", selectedActivity: FamilyActivitySelection(),
+      blockingStrategyId: QRCodeBlockingStrategy.id
+    )
+    context.insert(profile)
+    try context.save()
+
+    let data = profile.cardData
+
+    context.delete(profile)
+    try context.save()
+
+    XCTAssertFalse(profile.isPersistentModelValid)
+    XCTAssertEqual(data.name, "Gaming")
+    XCTAssertEqual(data.blockingStrategyId, QRCodeBlockingStrategy.id)
+  }
+}

--- a/FoqosTests/ProfileScheduleRowDataTests.swift
+++ b/FoqosTests/ProfileScheduleRowDataTests.swift
@@ -36,4 +36,66 @@ final class ProfileScheduleRowDataTests: XCTestCase {
     XCTAssertEqual(data.profileSchemaVersion, profile.profileSchemaVersion)
     XCTAssertEqual(data.blockingStrategyId, profile.blockingStrategyId)
   }
+
+  func testGivenV2ScheduleProfile_WhenCardData_ThenStartStopTriggerAndScheduleFieldsMatchModel() throws {
+    let now = Date()
+    let profile = BlockedProfiles(name: "SchedV2", blockingStrategyId: NFCBlockingStrategy.id)
+    var startTriggers = ProfileStartTriggers()
+    startTriggers.schedule = true
+    var stopConditions = ProfileStopConditions(manual: true)
+    stopConditions.timer = true
+    let beforeStartSchedule = ProfileScheduleTime(
+      days: [.monday, .friday],
+      hour: 9, minute: 0,
+      updatedAt: now
+    )
+    let beforeStopSchedule = ProfileScheduleTime(
+      days: [.saturday, .sunday],
+      hour: 17, minute: 30,
+      updatedAt: now
+    )
+    profile.startTriggers = startTriggers
+    profile.stopConditions = stopConditions
+    profile.startSchedule = beforeStartSchedule
+    profile.stopSchedule = beforeStopSchedule
+    context.insert(profile)
+
+    let before = profile.cardData
+    XCTAssertEqual(before.startTriggers, startTriggers)
+    XCTAssertEqual(before.stopConditions, stopConditions)
+    XCTAssertEqual(before.startSchedule, beforeStartSchedule)
+    XCTAssertEqual(before.stopSchedule, beforeStopSchedule)
+
+    var afterStartTriggers = startTriggers
+    afterStartTriggers.schedule = false
+    profile.startTriggers = afterStartTriggers
+
+    var afterStopConditions = stopConditions
+    afterStopConditions.schedule = true
+    profile.stopConditions = afterStopConditions
+
+    let afterStartSchedule = ProfileScheduleTime(
+      days: [.tuesday, .thursday],
+      hour: 14, minute: 45,
+      updatedAt: now
+    )
+    let afterStopSchedule = ProfileScheduleTime(
+      days: [.wednesday, .saturday],
+      hour: 23, minute: 15,
+      updatedAt: now
+    )
+    profile.startSchedule = afterStartSchedule
+    profile.stopSchedule = afterStopSchedule
+
+    let after = profile.cardData
+    XCTAssertEqual(before.startTriggers, startTriggers)
+    XCTAssertEqual(before.stopConditions, stopConditions)
+    XCTAssertEqual(before.startSchedule, beforeStartSchedule)
+    XCTAssertEqual(before.stopSchedule, beforeStopSchedule)
+
+    XCTAssertEqual(after.startTriggers, afterStartTriggers)
+    XCTAssertEqual(after.stopConditions, afterStopConditions)
+    XCTAssertEqual(after.startSchedule, afterStartSchedule)
+    XCTAssertEqual(after.stopSchedule, afterStopSchedule)
+  }
 }

--- a/FoqosTests/ProfileScheduleRowDataTests.swift
+++ b/FoqosTests/ProfileScheduleRowDataTests.swift
@@ -1,0 +1,39 @@
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class ProfileScheduleRowDataTests: XCTestCase {
+  private var container: ModelContainer!
+  private var context: ModelContext!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    container = try TestModelContainer.create()
+    context = container.mainContext
+  }
+
+  override func tearDown() async throws {
+    context = nil
+    container = nil
+    try await super.tearDown()
+  }
+
+  func testGivenLegacyScheduleProfile_WhenCardData_ThenScheduleFlagsMatchModel() throws {
+    let now = Date()
+    let profile = BlockedProfiles(
+      name: "Sched", blockingStrategyId: NFCBlockingStrategy.id,
+      schedule: .init(
+        days: [.monday, .friday], startHour: 9, startMinute: 0,
+        endHour: 17, endMinute: 0, updatedAt: now))
+    context.insert(profile)
+
+    let data = profile.cardData
+
+    XCTAssertEqual(data.schedule?.isActive, profile.schedule?.isActive)
+    XCTAssertEqual(data.scheduleIsOutOfSync, profile.scheduleIsOutOfSync)
+    XCTAssertEqual(data.profileSchemaVersion, profile.profileSchemaVersion)
+    XCTAssertEqual(data.blockingStrategyId, profile.blockingStrategyId)
+  }
+}


### PR DESCRIPTION
Fixes #297

## Summary
- Render `BlockedProfileCard` / `ProfileScheduleRow` from immutable `BlockedProfileCardData` snapshots instead of live `BlockedProfiles` SwiftData models.
- Build the snapshot inside `BlockedProfileCarousel`'s `SafeModelView` valid/render path so deleted-row re-renders cannot touch vacated SwiftData attributes, while legitimate edits still rebuild the snapshot.
- Keep card actions in carousel scope so closures still operate on live valid models.
- Add runtime snapshot/zombie regression coverage plus schedule-row snapshot coverage.

This unblocks #286's two-device checklist, which was blocked by the swipe-delete crash.

## Verification
- Full suite: `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -parallel-testing-enabled NO | xcpretty`
  - Result: 844 tests, 0 failures.
- `swift-format lint --recursive .`
  - Result: pass.
- `./scripts/check-c2-guards.sh`
  - Result: pass.
- `./scripts/check-sync-guards.sh`
  - Result: pass.
- Card-family signature guard:
  - `rg -n '^\s*let profile: BlockedProfiles' Foqos/Components/BlockedProfileCards`
  - Result: no declarations found.

## Device Gate
Physical device: yes.
Debugger detached: yes.
Commit/source checked before device run: `ef1343f` on `fix/297-card-snapshot-rendering`; Xcode workspace was `/Users/rob/Downloads/git/family-foqos/FamilyFoqos.xcodeproj`.

Execution order reported by maintainer:

| Scenario | Result |
| --- | --- |
| Swipe-delete, multi-profile | Profile 1 created, profiles 2-11 deleted; pass, 0 crashes |
| Swipe-delete, last-profile | Profile 1 deleted, repeated for profiles 12-20; pass, 0 crashes |
| Manage minus-delete, last-profile | Profiles 21-30; pass, 0 crashes |
| Manage minus-delete, multi-profile | Profiles 31-40; pass, 0 crashes |
| Edit propagation, name with app Home carousel visible | pass |
| Edit propagation, schedule with app Home carousel visible | pass |

Exported log: `docs/plans/FamilyFoqos-Logs-2026-07-10-110304.log`

Log note: the exported app log contains no crash/fatal/exception markers in the gate window. It does not include the commit SHA line in the exported log text, so the commit/source evidence is from the pre-run Xcode/project/branch/HEAD verification.

## Deviations
- Task 2's `ProfileScheduleRow` conversion was committed with the card/carousel conversion to avoid leaving a non-compiling intermediate commit. The implemented code still follows the plan's ordering and architecture.

## Summary by Sourcery

Render blocked profile cards and schedule rows from immutable snapshot data instead of live SwiftData models to prevent crashes when profiles are deleted, and add regression tests around the new snapshot behavior.

New Features:
- Introduce BlockedProfileCardData as an immutable snapshot model for blocked profile card and schedule row rendering.

Bug Fixes:
- Prevent crashes caused by SwiftUI re-renders reading from deleted BlockedProfiles SwiftData models by decoupling UI from live models.

Enhancements:
- Extend SafeModelView to support a placeholder view when the underlying model becomes invalid.
- Update BlockedProfileCard, ProfileScheduleRow, and their previews to consume BlockedProfileCardData snapshots built inside the SafeModelView render path.

Tests:
- Add BlockedProfileCardDataTests to verify snapshot mapping, edit propagation, and safety after model deletion.
- Add ProfileScheduleRowDataTests to verify schedule-related fields and flags in BlockedProfileCardData stay in sync with the underlying model.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the swipe-delete crash (#297) by introducing `BlockedProfileCardData`, an immutable value-type snapshot, and threading it through `BlockedProfileCard` and `ProfileScheduleRow` in place of the live `BlockedProfiles` SwiftData model. The snapshot is built inside `BlockedProfileCarousel`'s `SafeModelView` content closure so SwiftUI's `@Observable` tracking still fires on edits, while a deleted model can no longer reach card rendering. `SafeModelView` gains a `Placeholder` type parameter (default `EmptyView`) to keep the carousel layout stable during the deletion animation race.

- `BlockedProfileCardData` is a pure struct capturing all rendered fields; `BlockedProfiles.cardData` must be called only on a valid model and must stay inside the observation-tracked body — both constraints are enforced by `SafeModelView` gating and documented tripwire comments.
- Action closures (`onStartTapped`, `onEditTapped`, etc.) deliberately retain the live `profile` reference in carousel scope, which is safe because `SafeModelView` only renders them when `isPersistentModelValid` is true.
- `BlockedProfileCardDataTests` adds zombie-safety, mutation-independence, and field-mapping coverage; `ProfileScheduleRowDataTests` adds legacy-schedule snapshot coverage but leaves V2 schedule fields untested.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the snapshot pattern correctly breaks the live-model dependency in card rendering without losing edit reactivity, and device-gate results confirm zero crashes across all deletion scenarios.

The core crash fix is architecturally sound: `BlockedProfileCardData` is a pure value type, the snapshot is built inside the observation-tracked closure so edits propagate, and `SafeModelView` gates all live-model reads. The only gap is that `ProfileScheduleRowDataTests` doesn't cover V2 schedule fields — an oversight in test breadth, not a defect in the shipped code.

`FoqosTests/ProfileScheduleRowDataTests.swift` would benefit from a V2-schedule round-trip test. All production files are straightforward and low-risk.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Foqos/Components/BlockedProfileCards/BlockedProfileCardData.swift | New immutable value snapshot struct that decouples card rendering from the live SwiftData model. The `cardData` computed property on `BlockedProfiles` is well-guarded, and `reminderTimeInSeconds` is collapsed to `hasReminders: Bool` (sufficient for current card consumers). |
| Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift | Correctly places `profile.cardData` inside the `SafeModelView` observation-tracked content closure so edits still propagate; action closures retain the live model reference in carousel scope as designed. Added placeholder for zombie state. |
| Foqos/Utils/SafeModelView.swift | Added generic `Placeholder` type parameter and `placeholder` closure with a default of `EmptyView()`, maintaining full backward compatibility for existing call sites. The else-branch now renders the placeholder instead of silently producing no view. |
| Foqos/Components/BlockedProfileCards/BlockedProfileCard.swift | Straightforward substitution of `profile: BlockedProfiles` with `data: BlockedProfileCardData`; all field accesses updated. Preview updated to build `BlockedProfiles` instances and call `.cardData` rather than passing models directly. |
| Foqos/Components/BlockedProfileCards/ProfileScheduleRow.swift | Migrated from `profile: BlockedProfiles` to `data: BlockedProfileCardData`; all computed properties updated consistently. No logic changes. |
| FoqosTests/BlockedProfileCardDataTests.swift | Three targeted tests: field-mapping correctness, mutation-then-rebuild independence, and zombie-safety after deletion. Covers the core regression vector from #297. |
| FoqosTests/ProfileScheduleRowDataTests.swift | Single test verifies legacy-schedule fields round-trip correctly through `cardData`. Missing coverage for V2 schedule fields (`startTriggers`, `stopConditions`, `startSchedule`, `stopSchedule`) which are also mapped and consumed by `ProfileScheduleRow`. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant SwiftUI
    participant ForEach
    participant SafeModelView
    participant BlockedProfileCard
    participant BlockedProfileCardData

    SwiftUI->>ForEach: Re-render (profile deleted)
    ForEach->>SafeModelView: SafeModelView(profile)
    SafeModelView->>SafeModelView: model.isPersistentModelValid?
    alt model is valid
        SafeModelView->>BlockedProfileCardData: profile.cardData (observation-tracked)
        Note over BlockedProfileCardData: Immutable value snapshot copied here
        BlockedProfileCardData-->>SafeModelView: BlockedProfileCardData
        SafeModelView->>BlockedProfileCard: BlockedProfileCard(data: snapshot)
        BlockedProfileCard-->>SwiftUI: Render card UI
    else model is zombie
        SafeModelView-->>SwiftUI: placeholder (Color.clear)
    end

    Note over SwiftUI,BlockedProfileCardData: On edit: @Observable re-triggers body,<br/>SafeModelView re-evaluates cardData<br/>so card reflects new values
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant SwiftUI
    participant ForEach
    participant SafeModelView
    participant BlockedProfileCard
    participant BlockedProfileCardData

    SwiftUI->>ForEach: Re-render (profile deleted)
    ForEach->>SafeModelView: SafeModelView(profile)
    SafeModelView->>SafeModelView: model.isPersistentModelValid?
    alt model is valid
        SafeModelView->>BlockedProfileCardData: profile.cardData (observation-tracked)
        Note over BlockedProfileCardData: Immutable value snapshot copied here
        BlockedProfileCardData-->>SafeModelView: BlockedProfileCardData
        SafeModelView->>BlockedProfileCard: BlockedProfileCard(data: snapshot)
        BlockedProfileCard-->>SwiftUI: Render card UI
    else model is zombie
        SafeModelView-->>SwiftUI: placeholder (Color.clear)
    end

    Note over SwiftUI,BlockedProfileCardData: On edit: @Observable re-triggers body,<br/>SafeModelView re-evaluates cardData<br/>so card reflects new values
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(#297): document type-signature regr..."](https://github.com/mnbf9rca/family-foqos/commit/ef1343fda0aa49be7017c1b1bdc78b6059f71d90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43264469)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->