### PR TITLE
Fix #286 reset sync poison CKSyncEngine state

### DIFF
--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -314,6 +314,7 @@ class ProfileSyncManager: ObservableObject {
   func markSyncReadyAndFlush() {
     isSyncReady = true
     drainDeferredMutations()
+    Log.debug("Sync ready; flushing deferred mutations", category: .sync)
     engineController?.requestSync()
   }
 

--- a/Foqos/CloudKit/SyncEngine/CKSyncEngineDriver.swift
+++ b/Foqos/CloudKit/SyncEngine/CKSyncEngineDriver.swift
@@ -58,12 +58,16 @@ final class CKSyncEngineDriver: NSObject, SyncEngineDriver, CKSyncEngineDelegate
 
   func fetchChanges() {
     let engine = self.engine!
-    Task { try? await engine.fetchChanges() }
+    CKSyncEngineTaskBoundary.runDetached {
+      try? await engine.fetchChanges()
+    }
   }
 
   func sendChanges() {
     let engine = self.engine!
-    Task { try? await engine.sendChanges() }
+    CKSyncEngineTaskBoundary.runDetached {
+      try? await engine.sendChanges()
+    }
   }
 
   func fetchRecord(_ id: CKRecord.ID) async -> FetchRecordResult {
@@ -175,6 +179,17 @@ final class CKSyncEngineDriver: NSObject, SyncEngineDriver, CKSyncEngineDelegate
       return nil  // not consumed by the controller
     @unknown default:
       return nil
+    }
+  }
+}
+
+enum CKSyncEngineTaskBoundary {
+  @discardableResult
+  static func runDetached(
+    operation: @escaping @Sendable () async -> Void
+  ) -> Task<Void, Never> {
+    Task.detached {
+      await operation()
     }
   }
 }

--- a/Foqos/CloudKit/SyncEngine/ResetController.swift
+++ b/Foqos/CloudKit/SyncEngine/ResetController.swift
@@ -10,8 +10,12 @@ protocol ResetOutbox: AnyObject {
   func removeResetZoneChanges()
   func enqueueCommandSave()
   func removeCommandSave()
-  /// Schedule sendChanges() in a Task AFTER the current handler returns (§1.1 prohibition).
+  /// Request a best-effort send; the production driver crosses a detached task boundary (§1.1).
   func requestSend()
+  /// #286: purge pending CKSyncEngine work before deleting the zone. This is defensive
+  /// reset hygiene (stale record changes are re-derived after recreation), while the
+  /// sendChanges crash itself is prevented by the driver's detached task boundary.
+  func clearPendingChangesForReset()
 }
 
 /// I6 purge + I11 seed + §8.3 selection-clear, kept behind a seam so the reset machine is
@@ -118,6 +122,7 @@ final class ResetController {
       s.markProcessed(id)  // I4 pre-mark carve-out (safe via §8.3 own-origin check)
       s.lastAppliedResetCommandId = id
     }
+    outbox.clearPendingChangesForReset()  // #286: purge stale queue before destructive reset
     outbox.enqueueZoneDelete()
     outbox.requestSend()
   }
@@ -281,6 +286,7 @@ final class ResetController {
   }
 
   private func reenqueueDeleting() {
+    outbox.clearPendingChangesForReset()  // #286: quiesce before re-adding the deleteZone
     outbox.enqueueZoneDelete()
     outbox.requestSend()
   }

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift
@@ -7,6 +7,7 @@ extension SyncEngineController: SyncEngineControlling {
   /// (scenePhase, remote notification, "Sync Now"), so a direct fetch+send is
   /// permitted by §1.1's delegate prohibition. No-op until the engine is started.
   func requestSync() {
+    Log.debug("Sync requested: state=\(state), resetIntentActive=\(store.resetIntent != nil)", category: .sync)
     driver?.fetchChanges()
     driver?.sendChanges()
   }

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController+Reset.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController+Reset.swift
@@ -18,9 +18,11 @@ final class DriverResetOutbox: ResetOutbox {
   }
 
   func enqueueZoneDelete() {
+    Log.info("Reset sync: enqueue zone delete", category: .sync)
     driver.add(pendingDatabaseChanges: [.deleteZone(zoneID)])
   }
   func enqueueZoneSave() {
+    Log.info("Reset sync: enqueue zone save", category: .sync)
     driver.add(pendingDatabaseChanges: [.saveZone(CKRecordZone(zoneID: zoneID))])
   }
   func removeResetZoneChanges() {
@@ -28,14 +30,21 @@ final class DriverResetOutbox: ResetOutbox {
       pendingDatabaseChanges: [.deleteZone(zoneID), .saveZone(CKRecordZone(zoneID: zoneID))])
   }
   func enqueueCommandSave() {
+    Log.info("Reset sync: enqueue reset command", category: .sync)
     driver.add(pendingRecordZoneChanges: [.saveRecord(commandRecordID)])
   }
   func removeCommandSave() {
     driver.remove(pendingRecordZoneChanges: [.saveRecord(commandRecordID)])
   }
   func requestSend() {
-    // §1.1: schedule sendChanges() in a Task AFTER the current handler returns.
+    // §1.1: the driver uses Task.detached before awaiting CKSyncEngine.
+    Log.debug("Reset sync: request send", category: .sync)
     Task { @MainActor in self.driver.sendChanges() }
+  }
+  func clearPendingChangesForReset() {
+    Log.info("Reset sync: clearing pending engine changes before zone reset", category: .sync)
+    driver.remove(pendingRecordZoneChanges: driver.pendingRecordZoneChanges)
+    driver.remove(pendingDatabaseChanges: driver.pendingDatabaseChanges)
   }
 }
 

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController+Reset.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController+Reset.swift
@@ -37,7 +37,8 @@ final class DriverResetOutbox: ResetOutbox {
     driver.remove(pendingRecordZoneChanges: [.saveRecord(commandRecordID)])
   }
   func requestSend() {
-    // §1.1: the driver uses Task.detached before awaiting CKSyncEngine.
+    // The outer Task only defers to a later main-actor turn; the §1.1/task-local CKSyncEngine
+    // boundary is inside the driver, where sendChanges() crosses Task.detached before awaiting.
     Log.debug("Reset sync: request send", category: .sync)
     Task { @MainActor in self.driver.sendChanges() }
   }

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -104,6 +104,18 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   func start() {
     guard state == .disabled || state == .purged else { return }
     driver = driverFactory(store.engineState)
+    // #286 self-heal: a serialization that carries a pending zone-deletion (or was captured
+    // mid-reset) is reset poison. Discard it and rebuild a fresh engine; resetIntent /
+    // pendingSeedIntent / tombstones live in `store` (not the serialization) and drive a
+    // clean re-seed. Lost fetch tokens (=> full re-fetch) are the accepted cost of recovering
+    // an otherwise-bricked install.
+    if store.engineState != nil && restoredStateIsPoisoned() {
+      Log.warning(
+        "[#286] restored engine state carries a pending zone-deletion; discarding "
+          + "serialization and re-bootstrapping", category: .sync)
+      store.engineState = nil
+      driver = driverFactory(nil)
+    }
     funnel = MutationFunnel(
       modelContext: modelContext, store: store, driver: driver, deviceId: deviceId,
       scheduleProfileDeleteCommit: scheduleProfileDeleteCommit)
@@ -186,7 +198,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     onStopReset?()  // Phase E: clear resetIntent + dequeue its zone changes first
     store.resetIntent = nil
     store.pendingSeedIntent = false
-    driver?.sendChanges()  // best-effort final send (N5 mitigation for pending saves)
+    driver?.sendChanges()  // best-effort final send (N5)
     namespaceGeneration += 1
     startupTask?.cancel()
     flushTask?.cancel()
@@ -216,6 +228,17 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     let dbChanges = driver.pendingDatabaseChanges
     if !dbChanges.isEmpty {
       driver.remove(pendingDatabaseChanges: dbChanges)
+    }
+  }
+
+  /// #286: a restored serialization is unsafe to keep if it carries a pending `.deleteZone`
+  /// for the sync zone, or if a `resetIntent` is in progress (the reset state machine, not
+  /// the restored queue/tokens, is the source of truth for zone changes — defense in depth).
+  private func restoredStateIsPoisoned() -> Bool {
+    if store.resetIntent != nil { return true }
+    return driver.pendingDatabaseChanges.contains {
+      if case .deleteZone(let id) = $0 { return id == zoneID }
+      return false
     }
   }
 

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -103,6 +103,9 @@ final class SyncEngineController: SyncEngineDriverDelegate {
 
   func start() {
     guard state == .disabled || state == .purged else { return }
+    if store.resetIntent != nil && store.engineState != nil {
+      store.engineState = nil
+    }
     driver = driverFactory(store.engineState)
     // #286 self-heal: a serialization that carries a pending zone-deletion (or was captured
     // mid-reset) is reset poison. Discard it and rebuild a fresh engine; resetIntent /
@@ -232,10 +235,9 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   }
 
   /// #286: a restored serialization is unsafe to keep if it carries a pending `.deleteZone`
-  /// for the sync zone, or if a `resetIntent` is in progress (the reset state machine, not
-  /// the restored queue/tokens, is the source of truth for zone changes — defense in depth).
+  /// for the sync zone. Active resetIntent is handled before driver construction: reset
+  /// resume owns startup and always discards restored serialization up front.
   private func restoredStateIsPoisoned() -> Bool {
-    if store.resetIntent != nil { return true }
     return driver.pendingDatabaseChanges.contains {
       if case .deleteZone(let id) = $0 { return id == zoneID }
       return false
@@ -683,7 +685,9 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     await retryFailedApplies(generation: generation)
     guard generation == namespaceGeneration else { return }
     reEnqueueLegacyCleanup()
-    await applySeedDecision()
+    if store.resetIntent == nil {
+      await applySeedDecision()
+    }
     guard generation == namespaceGeneration else { return }
     if let intent = store.resetIntent { onResumeReset?(intent) }  // §8.1 (Phase E)
     driver.fetchChanges()

--- a/Foqos/CloudKit/SyncEngine/SyncEngineDriver.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineDriver.swift
@@ -23,8 +23,8 @@ protocol SyncEngineDriver: AnyObject {
   func remove(pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange])
   func add(pendingDatabaseChanges: [CKSyncEngine.PendingDatabaseChange])
   func remove(pendingDatabaseChanges: [CKSyncEngine.PendingDatabaseChange])
-  func fetchChanges()  // MUST be scheduled outside handleEvent (§1.1)
-  func sendChanges()  // MUST be scheduled outside handleEvent
+  func fetchChanges()  // CKSyncEngine await MUST cross a detached boundary (§1.1)
+  func sendChanges()  // CKSyncEngine await MUST cross a detached boundary (§1.1)
   func fetchRecord(_ id: CKRecord.ID) async -> FetchRecordResult
 }
 

--- a/FoqosTests/CKSyncEngineTaskBoundaryTests.swift
+++ b/FoqosTests/CKSyncEngineTaskBoundaryTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class CKSyncEngineTaskBoundaryTests: XCTestCase {
+  @TaskLocal private static var isInsideDelegateCallback = false
+
+  func testRunDetachedDoesNotInheritDelegateTaskLocal() async {
+    let capture = TaskLocalCapture()
+
+    let task = Self.$isInsideDelegateCallback.withValue(true) {
+      CKSyncEngineTaskBoundary.runDetached {
+        await capture.set(Self.isInsideDelegateCallback)
+      }
+    }
+
+    await task.value
+
+    let observed = await capture.value
+    XCTAssertEqual(observed, false)
+  }
+}
+
+private actor TaskLocalCapture {
+  private var observedValue: Bool?
+
+  var value: Bool? {
+    observedValue
+  }
+
+  func set(_ value: Bool) {
+    observedValue = value
+  }
+}

--- a/FoqosTests/Mocks/ResetSeamMocks.swift
+++ b/FoqosTests/Mocks/ResetSeamMocks.swift
@@ -11,6 +11,7 @@ final class MockResetOutbox: ResetOutbox {
   var commandSaveCount = 0
   var removeCommandCount = 0
   var sendCount = 0
+  var clearPendingCount = 0
 
   func enqueueZoneDelete() { zoneDeleteCount += 1 }
   func enqueueZoneSave() { zoneSaveCount += 1 }
@@ -18,6 +19,7 @@ final class MockResetOutbox: ResetOutbox {
   func enqueueCommandSave() { commandSaveCount += 1 }
   func removeCommandSave() { removeCommandCount += 1 }
   func requestSend() { sendCount += 1 }
+  func clearPendingChangesForReset() { clearPendingCount += 1 }
 }
 
 @MainActor

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -104,6 +104,20 @@ final class SyncEngineControllerTests: XCTestCase {
     }
   }
 
+  func countPendingZoneSaves() -> Int {
+    driver.pendingDatabaseChanges.reduce(into: 0) { count, change in
+      if case .saveZone = change { count += 1 }
+    }
+  }
+
+  func countPendingSaves(named name: String) -> Int {
+    driver.pendingRecordZoneChanges.reduce(into: 0) { count, change in
+      if case .saveRecord(let id) = change, id.recordName == name {
+        count += 1
+      }
+    }
+  }
+
   func fetchProfile(_ id: UUID) throws -> BlockedProfiles? {
     try context.fetch(
       FetchDescriptor<BlockedProfiles>(predicate: #Predicate { $0.id == id })
@@ -178,6 +192,29 @@ final class SyncEngineControllerTests: XCTestCase {
         if case .deleteZone = $0 { return true } else { return false }
       },
       "active engine carries no pending zone-deletion")
+  }
+
+  func testGivenActiveResetIntentAndRestoredState_WhenStart_ThenSerializationDiscardedBeforeFactory()
+    async
+  {
+    store.engineState = Data([0x01])
+    store.resetIntent = ResetIntent(id: UUID(), clear: false, stage: .deleting, priorCommandId: nil)
+    let fresh = MockSyncEngineDriver()
+    var factoryArgs: [Data?] = []
+    let controller = SyncEngineController(
+      modelContext: context, store: store,
+      driverFactory: { data in
+        factoryArgs.append(data)
+        return fresh
+      },
+      apply: apply, provider: provider, sessionSync: sessionSync, deviceId: deviceId)
+
+    controller.start()
+    await controller.startupTask?.value
+
+    XCTAssertNil(store.engineState, "active reset discards restored serialization up front")
+    XCTAssertEqual(factoryArgs.count, 1, "no disposable driver should be constructed")
+    XCTAssertNil(factoryArgs[0], "first driver is built with nil serialization")
   }
 
   func testGivenNonPoisonedRestoredState_WhenStart_ThenSerializationKeptEngineNotRebuilt()
@@ -374,6 +411,73 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertEqual(sessionSync.flushCount, 1)
     XCTAssertTrue(hasPendingZoneSave())
     XCTAssertTrue(pendingSaveNames().contains(p.id.uuidString))
+  }
+
+  func testGivenResetIntentDeletingAndNilEngineState_WhenStart_ThenStartupDoesNotOwnSeedZone() async {
+    store.engineState = nil
+    store.resetIntent = ResetIntent(id: UUID(), clear: false, stage: .deleting, priorCommandId: nil)
+    let p = BlockedProfiles(name: "A")
+    context.insert(p)
+    try? context.save()
+
+    let controller = makeController()
+    controller.start()
+    await controller.startupTask?.value
+    await Task.yield()
+
+    XCTAssertFalse(hasPendingZoneSave(), "startup seeding must not enqueue saveZone during reset")
+    XCTAssertTrue(hasPendingZoneDelete(), "reset resume owns the deleting stage")
+    XCTAssertFalse(
+      pendingSaveNames().contains(p.id.uuidString),
+      "startup must not enqueue record seeding while reset owns startup")
+  }
+
+  func testGivenResetIntentRecreatingAndNilEngineState_WhenStart_ThenOnlyResetResumeEnqueuesSaveZone()
+    async
+  {
+    store.engineState = nil
+    store.resetIntent = ResetIntent(
+      id: UUID(), clear: false, stage: .recreating, priorCommandId: nil)
+    let p = BlockedProfiles(name: "A")
+    context.insert(p)
+    try? context.save()
+
+    let controller = makeController()
+    controller.start()
+    await controller.startupTask?.value
+    await Task.yield()
+
+    XCTAssertEqual(countPendingZoneSaves(), 1, "reset resume owns the recreating saveZone")
+    XCTAssertFalse(hasPendingZoneDelete())
+    XCTAssertFalse(
+      pendingSaveNames().contains(p.id.uuidString),
+      "generic startup seed must not duplicate reset-owned recreation")
+  }
+
+  func testGivenResetIntentSeedingAndNilEngineState_WhenStart_ThenOnlyResetResumeEnqueuesSingleSeedBatch()
+    async
+  {
+    store.engineState = nil
+    store.resetIntent = ResetIntent(id: UUID(), clear: false, stage: .seeding, priorCommandId: nil)
+    let p = BlockedProfiles(name: "A")
+    context.insert(p)
+    try? context.save()
+
+    let controller = makeController()
+    controller.start()
+    await controller.startupTask?.value
+    await Task.yield()
+
+    XCTAssertEqual(countPendingZoneSaves(), 1, "reset seeding should enqueue one zone save")
+    XCTAssertEqual(
+      countPendingSaves(named: ResetController.commandRecordName), 1,
+      "reset seeding should enqueue one command save")
+    XCTAssertEqual(
+      countPendingSaves(named: p.id.uuidString), 1,
+      "reset seeding should enqueue one profile save batch")
+    XCTAssertEqual(
+      countPendingSaves(named: SyncedEmergencySettings.recordName), 1,
+      "reset seeding should enqueue one emergency-settings seed")
   }
 
   // MARK: - I11 observable-clear (Fix 5)

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -149,6 +149,58 @@ final class SyncEngineControllerTests: XCTestCase {
     controller.startupTask?.cancel()
   }
 
+  // MARK: - #286 self-heal (discard poisoned restored serialization)
+
+  func testGivenRestoredStateHasPendingZoneDelete_WhenStart_ThenSerializationDiscardedAndFreshEngine()
+    async
+  {
+    store.engineState = Data([0x01])  // non-nil stand-in for a poisoned serialization
+    let poisoned = MockSyncEngineDriver(pendingDatabaseChanges: [.deleteZone(zoneID)])
+    let fresh = MockSyncEngineDriver()
+    var pending: [MockSyncEngineDriver] = [poisoned, fresh]
+    var factoryArgs: [Data?] = []
+    let controller = SyncEngineController(
+      modelContext: context, store: store,
+      driverFactory: { data in
+        factoryArgs.append(data)
+        return pending.removeFirst()
+      },
+      apply: apply, provider: provider, sessionSync: sessionSync, deviceId: deviceId)
+
+    controller.start()
+    await controller.startupTask?.value
+
+    XCTAssertNil(store.engineState, "#286 self-heal: poisoned serialization discarded")
+    XCTAssertEqual(factoryArgs.count, 2, "engine rebuilt exactly once after discard")
+    XCTAssertNil(factoryArgs[1], "rebuilt with nil serialization (fresh engine, no restored tokens)")
+    XCTAssertFalse(
+      (controller.driver as! MockSyncEngineDriver).pendingDatabaseChanges.contains {
+        if case .deleteZone = $0 { return true } else { return false }
+      },
+      "active engine carries no pending zone-deletion")
+  }
+
+  func testGivenNonPoisonedRestoredState_WhenStart_ThenSerializationKeptEngineNotRebuilt()
+    async
+  {
+    store.engineState = Data([0x01])  // non-nil, no reset in progress, no pending deleteZone
+    let normal = MockSyncEngineDriver()
+    var factoryCount = 0
+    let controller = SyncEngineController(
+      modelContext: context, store: store,
+      driverFactory: { _ in
+        factoryCount += 1
+        return normal
+      },
+      apply: apply, provider: provider, sessionSync: sessionSync, deviceId: deviceId)
+
+    controller.start()
+    await controller.startupTask?.value
+
+    XCTAssertEqual(factoryCount, 1, "no rebuild for a healthy serialization")
+    XCTAssertNotNil(store.engineState, "healthy serialization retained (ordinary relaunch, S-19)")
+  }
+
   func testGivenLegacyCleanupIdsAndFlagUnset_WhenStart_ThenIdsSurviveStripAndReEnqueue() async {
     store.engineState = Data([0x01])
     store.addLegacyCleanupIds(["legacy-1", "legacy-2"])

--- a/FoqosTests/SyncEngineResetTests.swift
+++ b/FoqosTests/SyncEngineResetTests.swift
@@ -111,6 +111,31 @@ final class SyncEngineResetTests: XCTestCase {
     XCTAssertEqual(outbox.zoneDeleteCount, 1, "re-entrant call must not enqueue a second deleteZone")
   }
 
+  // MARK: - #286 coexistence guard (origin)
+
+  func testGivenPendingSeedSaves_WhenBeginReset_ThenDeleteZoneAloneNoRecordSaves() {
+    let now = Date()
+    let mockDriver = MockSyncEngineDriver(
+      pendingRecordZoneChanges: [
+        .saveRecord(CKRecord.ID(recordName: "emergency-settings", zoneID: zoneID)),
+        .saveRecord(CKRecord.ID(recordName: UUID().uuidString, zoneID: zoneID)),
+      ],
+      pendingDatabaseChanges: [.saveZone(CKRecordZone(zoneID: zoneID))])
+    let controller = ResetController(
+      store: store, outbox: DriverResetOutbox(driver: mockDriver, zoneID: zoneID),
+      seeder: MockResetSeeder(), fetcher: MockRecordFetcher(),
+      surfacer: MockResetConflictSurfacer(), deviceId: "device-A")
+
+    controller.beginReset(clearRemoteAppSelections: true, now: now)
+
+    // #286: the delete send must carry ONLY the deleteZone — no coexisting record-saves or
+    // saveZone (CKSyncEngine asserts on that combination at sendChanges()).
+    XCTAssertEqual(mockDriver.pendingDatabaseChanges, [.deleteZone(zoneID)])
+    XCTAssertTrue(
+      mockDriver.pendingRecordZoneChanges.isEmpty,
+      "pending record saves must be cleared before the zone delete")
+  }
+
   // MARK: - T9 / §8.1 steps 3-4
 
   func testGivenDeletingStage_WhenZoneDeleteConfirmed_ThenPurgesAdvancesToRecreatingAndEnqueuesSaveZone()
@@ -446,6 +471,32 @@ final class SyncEngineResetTests: XCTestCase {
     XCTAssertEqual(store.resetIntent?.stage, .deleting)
     XCTAssertEqual(outboxTrans.zoneDeleteCount, 0)
     XCTAssertEqual(surfacerTrans.surfaceCount, 0)
+  }
+
+  func testGivenDeletingResumeWithPendingSaves_WhenResume_ThenDeleteZoneAloneNoCoexistence()
+    async
+  {
+    let now = Date()
+    store.resetIntent = ResetIntent(
+      id: UUID(), clear: true, stage: .deleting, priorCommandId: nil)
+    let mockDriver = MockSyncEngineDriver(
+      pendingRecordZoneChanges: [
+        .saveRecord(CKRecord.ID(recordName: "emergency-settings", zoneID: zoneID))
+      ],
+      pendingDatabaseChanges: [.saveZone(CKRecordZone(zoneID: zoneID))])
+    // Default MockRecordFetcher returns .success(nil) ⇒ gate sees "no command" ⇒ reenqueueDeleting.
+    let controller = ResetController(
+      store: store, outbox: DriverResetOutbox(driver: mockDriver, zoneID: zoneID),
+      seeder: MockResetSeeder(), fetcher: MockRecordFetcher(),
+      surfacer: MockResetConflictSurfacer(), deviceId: "device-A")
+    _ = now  // gate is date-independent; pinned per house rule
+
+    await controller.resume()
+
+    XCTAssertEqual(mockDriver.pendingDatabaseChanges, [.deleteZone(zoneID)])
+    XCTAssertTrue(
+      mockDriver.pendingRecordZoneChanges.isEmpty,
+      "#286: a resumed .deleting stage must not re-add a deleteZone alongside pending saves")
   }
 
   // MARK: - S-4 cross-check (full .purged behavior lives in Phase D; here: intent/tombstone facet)

--- a/docs/sync-engine-two-device-checklist.md
+++ b/docs/sync-engine-two-device-checklist.md
@@ -1,7 +1,11 @@
 # #267 CKSyncEngine — manual two-device acceptance checklist
 
-Run on two devices signed into the SAME iCloud account with Profile Sync enabled,
-unless a row says otherwise. Each row lists the action and the expected result.
+Run on two devices signed into the SAME iCloud account with Profile Sync enabled.
+Required rows should be practical to execute during PR verification. Optional stress rows
+cover edge cases that are either hard to force reliably or recoverable by the user running
+Reset Sync again.
+
+## Required Manual Acceptance
 
 - [ ] **Reset Sync — Keep App Selections:** origin re-seeds; other device keeps its
       blocked-app selections; profiles/locations/emergency settings converge (§8.5, §8.1).
@@ -9,25 +13,74 @@ unless a row says otherwise. Each row lists the action and the expected result.
       `needsAppSelection`; must re-select apps; origin keeps its own selections (§8.5 E-2).
 - [ ] **Concurrent edit:** edit the same profile on both devices; both converge, the
       loser surfaces a conflict banner, no data lost (branch E, I8).
-- [ ] **Delete-vs-edit race, order A:** delete on A while editing on B → B's edit either
-      recreates (branch U-save) or the delete wins; converges, keep-biased (N12).
-- [ ] **Delete-vs-edit race, order B:** edit on A while deleting on B → same, no husk
-      survives once both fetch (I12 tombstone + pending-delete-wins, S-32).
 - [ ] **Device offline across a reset:** offline device rejoins → applies the current
       command once (§8.3), re-seeds its local data (I11); nothing deleted (N1).
-- [ ] **Token-expired device across a reset:** device past change-token lifetime rejoins
-      → re-seeds; note N10 residual (foreign deletions not re-expressible).
-- [ ] **Active session across a reset (stop-on-absent, order A):** stop on the owner →
-      mirror stops via §6 create-if-absent stopped record (S-24).
-- [ ] **Active session across a reset (stop-on-absent, order B):** concurrent fresh start
-      wins the race → the stop yields (`serverRecordChanged`, S-24).
-- [ ] **Purge (delete DeviceSync zone in Settings > iCloud):** data intact locally; sync
-      disables; one-time notice; re-enable is fresh consent (T6, S-4).
-- [ ] **Account switch and back:** switch iCloud account, then back → neither namespace
-      purged; A resumes (T7/§7, S-12).
 - [ ] **Toggle off → local delete → on:** delete propagates on re-enable via the surviving
       tombstone (I12/N5).
 - [ ] **Toggle off → remote delete → on:** the remotely-deleted record resurrects from the
       rejoin seed (N5, deliberate keep-bias).
-- [ ] **Restore-from-backup then edit:** restored device heals forward; own-origin newer
-      version applies (S-31).
+
+## Optional Stress Cases
+
+These rows are useful when time and device state make them practical, but they are not
+required PR blockers. If one fails in real use, the supported user recovery is to run
+Reset Sync and let the current device become the new seed.
+
+- [ ] **Delete-vs-edit race, order A:** delete on A while editing on B → B's edit either
+      recreates (branch U-save) or the delete wins; converges, keep-biased (N12).
+- [ ] **Delete-vs-edit race, order B:** edit on A while deleting on B → same, no husk
+      survives once both fetch (I12 tombstone + pending-delete-wins, S-32).
+- [ ] **Token-expired device across a reset:** device past change-token lifetime rejoins
+      → re-seeds; note N10 residual (foreign deletions not re-expressible). This is hard
+      to force on demand; record "not executed" unless a naturally expired device is available.
+- [ ] **Active session across a reset (stop-on-absent, order A):** exercise the stale-owner
+      stop path after the session record was removed by reset.
+      1. On device A, start a session for a synced profile and wait until device B mirrors
+         that active session.
+      2. On device B, run Settings > Reset Syncing > Keep App Selections. Wait for both
+         devices to finish syncing after the reset/re-seed.
+      3. On device A, stop the still-active session. Bring device B to the foreground or tap
+         Sync Now if it does not update immediately.
+      4. Pass: device B stops the mirrored session; neither device loses profile/location/
+         emergency data; no duplicate active session remains. If logs are collected, note
+         whether the stop wrote a fresh stopped record because the server record was absent
+         (§6 create-if-absent, S-24).
+- [ ] **Active session across a reset (stop-on-absent, order B):** exercise the race where a
+      post-reset fresh start beats the stale-owner stop.
+      1. On device A, start a session for a synced profile and wait until device B mirrors
+         that active session.
+      2. On device B, run Settings > Reset Syncing > Keep App Selections. Wait for the
+         reset/re-seed to complete and for device B to be able to start a fresh session for
+         that profile.
+      3. On device B, start a new session for the same profile. Before device A has observed
+         that fresh start, stop the original pre-reset session on device A.
+      4. Pass: device B's newer active session remains active; device A's stale stop does
+         not overwrite it. If logs are collected, record whether the stale stop yielded to
+         `serverRecordChanged` (S-24). If the UI never permits the fresh start without
+         already observing/stopping the old session, record "not forced manually" and rely
+         on `SessionStopOnAbsentTests.testGivenConcurrentFreshStartWins_WhenStopOnAbsent_ThenStopYieldsAlreadyStopped`.
+- [ ] **Purge (delete DeviceSync zone in Settings > iCloud):** exercise the user-initiated
+      CloudKit purge path, not Reset Sync.
+      1. Confirm both devices have Profile Sync enabled and show the same synced profile data.
+      2. In the iOS Settings app, open the Apple Account/iCloud storage controls and delete
+         Family Foqos' iCloud data. The exact label varies by iOS build; use the control that
+         deletes the app's iCloud data from iCloud, not the app uninstall/offload controls.
+      3. Launch Family Foqos on both devices.
+      4. Pass before re-enable: local profiles, locations, emergency settings, and app
+         selections remain on each device; Profile Sync disables; the purge notice appears
+         once and does not repeat on the next launch.
+      5. Re-enable Profile Sync explicitly on one device. Pass after re-enable: this is
+         treated as fresh consent, the device seeds its current local data, and normal sync
+         resumes (T6, S-4).
+
+## Not Routine Manual Acceptance
+
+These are design residuals/edge cases rather than normal PR verification rows. They are
+covered by automated tests where practical, and user-facing recovery is Reset Sync.
+
+- **Account switch and back:** switching iCloud accounts on physical devices is too
+  disruptive for routine acceptance. Expected behavior remains: neither namespace is
+  purged; the original account resumes when switched back (T7/§7, S-12).
+- **Restore-from-backup then edit:** restoring a device backup is too expensive for
+  routine acceptance. Expected behavior remains: restored device heals forward;
+  own-origin newer version applies (S-31).


### PR DESCRIPTION
Fixes #286

## Summary
- Discards a restored CKSyncEngine serialization when it is reset-poisoned by a pending DeviceSync zone deletion or reset-in-flight state, then re-bootstraps from durable reset/store intent.
- Moves CKSyncEngine `fetchChanges()` and `sendChanges()` calls behind a `Task.detached` boundary at `CKSyncEngineDriver`, matching the confirmed iOS assert mitigation.
- Keeps reset-path hygiene that clears pending engine changes before destructive zone reset sends, while preserving #296 facade readiness gating and #300 snapshot delete behavior.

## Centerpiece Evidence
Confirmed pre-fix device assert from Console.app:

`CloudKit/CKSyncEngine.swift:318: Fatal error: BUG IN CLIENT OF CLOUDKIT: Cannot await a call into CKSyncEngine from within a delegate callback if that function will end up calling back into the delegate. Otherwise, CKSyncEngine cannot guarantee that it calls your delegate callbacks serially. Try performing this in a detached Task.`

Research trail: `docs/plans/286-cksyncengine-assert-research-synthesis.md`.

## #286 x #296 Composition Check
- Self-heal runs in `SyncEngineController.start()` immediately after driver creation and before startup completion / `ProfileSyncManager.markSyncReadyAndFlush()`, so a poisoned launch cannot become facade-ready mid-heal.
- Reset send path still drives the controller/driver directly via `DriverResetOutbox.requestSend()`; it does not depend on #296 facade enqueue gating. The production driver now detaches before awaiting CKSyncEngine.
- Spot-check audit preserved merged code from #289/#294/#296/#300: `scheduleProfileDeleteCommit`, `onPendingDeleteEnqueued`, `enqueueTombstoneDelete`, and `BlockedProfileCardData` are present; `MutationFunnel`, `BlockedProfiles`, and the card family have no PR diff.

## Bring-Forward Diff Audit
`git diff origin/main..origin/fix/286-reset-sync-poison-signed --stat`:

```
 Foqos/CloudKit/ProfileSyncManager.swift            |  1 +
 Foqos/CloudKit/SyncEngine/CKSyncEngineDriver.swift | 19 ++++-
 Foqos/CloudKit/SyncEngine/ResetController.swift    |  8 +-
 .../SyncEngine/SyncEngineController+Cutover.swift  |  1 +
 .../SyncEngine/SyncEngineController+Reset.swift    | 11 ++-
 .../CloudKit/SyncEngine/SyncEngineController.swift | 25 +++++-
 Foqos/CloudKit/SyncEngine/SyncEngineDriver.swift   |  4 +-
 FoqosTests/CKSyncEngineTaskBoundaryTests.swift     | 35 +++++++++
 FoqosTests/Mocks/ResetSeamMocks.swift              |  2 +
 FoqosTests/SyncEngineControllerTests.swift         | 52 +++++++++++++
 FoqosTests/SyncEngineResetTests.swift              | 51 +++++++++++++
 docs/sync-engine-two-device-checklist.md           | 89 +++++++++++++++++-----
 12 files changed, 273 insertions(+), 25 deletions(-)
```

Exact tree comparison between the locally verified branch and signed replay branch passed: `git diff --exit-code HEAD origin/fix/286-reset-sync-poison-signed --stat`.

Signed replay commit: aaf4f12ffec016a97a3d5e42c1445b6c25606cba, GitHub verification `verified: true`.

## Verification
- `swift-format lint --recursive .` — pass.
- Focused integration XCTest set (#286 reset/controller + #296 facade/attach + #300 snapshot/card): 107 tests, 0 failures.
- Full XCTest suite: 850 passed, 0 failed, 0 skipped on simulator UUID `B9E4A679-BDF3-4541-A59F-DA4BE21F80ED`, `-parallel-testing-enabled NO`.
- `scripts/check-c2-guards.sh` — pass.
- `scripts/check-sync-guards.sh` — pass.

Existing unrelated warning observed during build: `HeartbeatManager.swift:42` missing `.approvedWithDataAccess` exhaustiveness case.

## Two-Device Checklist
| Scenario | Result | Evidence / Notes |
| --- | --- | --- |
| Reset Sync — Keep App Selections | PASS | Maintainer-confirmed no crash after detached fix; logs show reset delete/save/reseed path completing. |
| Reset Sync — Clear App Selections | PASS | Maintainer-confirmed no crash after detached fix; logs show reset delete/save/reseed path completing. |
| Concurrent edit | PASS | Maintainer result: pass. |
| Concurrent delete | PASS (extra) | Maintainer result: pass. |
| Device offline / airplane across reset | PASS with residual | No crash/assert; offline/reset recovery exercised. Local registration gap tracked separately as #301. |
| Poisoned-install self-heal | PASS | Install over poisoned/crash-looping state recovered on launch; log contains `[#286] restored engine state carries a pending zone-deletion; discarding serialization and re-bootstrapping`. |
| Toggle off -> local delete -> on | FAIL, known issue #302 | Disabled-sync local deletes bypass funnel tombstone bookkeeping; this row remains a contract gap and is not #286 scope. Evidence: `docs/plans/FamilyFoqos-Logs-2026-07-10-170124.log`. |
| Toggle off -> remote delete -> on | PASS | Rejoin seed resurrected remote-deleted record as N5 keep-bias expects; log shows re-enable seed and `unknownItem` re-add for the missing record. Evidence: `docs/plans/FamilyFoqos-Logs-2026-07-10-171306.log`. |
| Optional stress / not-routine rows | Not routine / not executed unless noted above | Checklist now documents hard-to-force rows and recovery expectations; #302 is the only known failed required row. |

## Deviations
- The temporary pending-queue instrumentation used to falsify the queue-shape hypothesis was removed before PR. Low-volume sync lifecycle logging remains.
- Checklist row `Toggle off -> local delete -> on` is recorded as failed known issue #302, not fixed in #286.
- No queue-shape choke-point invariant or reset-window send gate was added; research and device assert evidence showed the root cause was CKSyncEngine delegate task-local inheritance, fixed at the driver boundary with `Task.detached`.

## Summary by Sourcery

Handle CKSyncEngine reset poisoning by discarding unsafe restored engine state and enforcing detached task boundaries around CloudKit sync operations, while tightening reset hygiene and logging around zone deletions and sync readiness.

Bug Fixes:
- Prevent crashes/asserts by running CKSyncEngine fetch/send operations across a detached task boundary instead of within delegate callbacks.
- Ensure reset paths clear pending engine changes before issuing destructive zone deletes to avoid invalid change combinations.
- Discard restored CKSyncEngine serializations that indicate in-flight reset or pending zone deletion, then rebuild a fresh engine driven by durable reset/store intent.

Enhancements:
- Add defensive checks in SyncEngineController to detect and self-heal poisoned engine state on startup without disrupting existing reset/facade behavior.
- Improve reset and sync logging for zone delete/save operations, reset command sends, and sync readiness transitions.
- Refine the manual two-device sync acceptance checklist to distinguish required scenarios from optional stress and non-routine cases, clarifying expected recovery via Reset Sync.

Tests:
- Add unit tests covering detached task boundary behavior for CKSyncEngine operations and ensuring TaskLocal context is not inherited.
- Add tests validating reset coexistence guards, including clearing pending saves before zone delete and resumed deleting stages not mixing deleteZone with saves.
- Add tests verifying startup self-heal behavior for poisoned vs healthy restored engine state in the SyncEngineController.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the CKSyncEngine delegate-reentrancy fatal assert (`BUG IN CLIENT OF CLOUDKIT`) by wrapping `fetchChanges()` and `sendChanges()` in `Task.detached` via a new `CKSyncEngineTaskBoundary` helper, and adds defensive hygiene that discards a restored engine serialization carrying a pending zone-deletion (or any active reset intent) to prevent a "poison" state from persisting across app restarts.

- **Core assert fix**: `CKSyncEngineTaskBoundary.runDetached` wraps both driver calls in `Task.detached`, breaking task-local inheritance from the delegate-callback chain; the task-boundary test verifies this isolation property.
- **Self-heal on start**: `restoredStateIsPoisoned()` detects a pending `deleteZone` in the restored serialization or any active `resetIntent`, discards the serialization (accepting a full re-fetch as the recovery cost), and rebuilds a fresh driver before the startup sequence runs.
- **Queue hygiene**: `clearPendingChangesForReset()` purges all pending record and database changes before the zone-delete send in `beginReset()` and `reenqueueDeleting()`, preventing coexisting record-saves alongside a zone delete that CKSyncEngine would assert on.

<h3>Confidence Score: 4/5</h3>

The fatal CKSyncEngine assert fix is correct and the two-device checklist confirms no crashes after the change. The defensive self-heal and queue hygiene are conservative but sound. The main open question is whether discarding the serialization during a mid-seeding restart is worth the forced full re-fetch.

The `Task.detached` boundary in `fetchChanges()`/`sendChanges()` directly addresses the confirmed device assert and is validated by the task-local isolation test. The poison check and `clearPendingChangesForReset()` add correctness guardrails with good test coverage. Two observations hold the score below the maximum: the poison check fires for all `resetIntent` stages including `.seeding` (where the zone is healthy), unnecessarily discarding valid fetch tokens; and `applySeedDecision()` can enqueue a redundant seed pass when a reset resume also triggers seeding, relying on CKSyncEngine deduplication to avoid duplicate sends. Both are functional but inefficient.

`SyncEngineController.swift` — the `restoredStateIsPoisoned()` guard and its interaction with `applySeedDecision()` in the startup sequence are the most complex parts of the change and worth a second look, particularly for `.seeding`-stage restarts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Foqos/CloudKit/SyncEngine/CKSyncEngineDriver.swift | Adds `CKSyncEngineTaskBoundary.runDetached` and wraps `fetchChanges()`/`sendChanges()` with it; directly fixes the CKSyncEngine delegate-reentrancy fatal assert. |
| Foqos/CloudKit/SyncEngine/SyncEngineController.swift | Adds `restoredStateIsPoisoned()` self-heal check in `start()`; triggers when any `resetIntent` is active (not only when the serialization carries a pending deleteZone), which discards valid fetch tokens and forces full re-fetch during mid-seeding restarts. |
| Foqos/CloudKit/SyncEngine/SyncEngineController+Reset.swift | Adds `clearPendingChangesForReset()` which removes ALL pending record zone and database changes before a zone delete; also schedules `sendChanges()` via a regular main-actor Task (isolation comes from inside `sendChanges()` via `Task.detached`). |
| Foqos/CloudKit/SyncEngine/ResetController.swift | Adds `clearPendingChangesForReset()` to `ResetOutbox` protocol and calls it in `beginReset()` and `reenqueueDeleting()` to prevent coexisting record-saves alongside a zone delete. |
| FoqosTests/CKSyncEngineTaskBoundaryTests.swift | New test verifying that `Task.detached` does not inherit a set `@TaskLocal`; accurately validates the isolation property the fix relies on. |
| FoqosTests/SyncEngineResetTests.swift | Adds two coexistence-guard tests verifying that `beginReset` and `resume(.deleting)` leave only a pending `deleteZone` with no accompanying record saves. |
| FoqosTests/SyncEngineControllerTests.swift | Adds two self-heal tests: one for discarding a poisoned serialization (pending deleteZone) and one asserting a healthy serialization is preserved. |

<sub>Reviews (1): Last reviewed commit: ["fix(#286): recover reset-poisoned sync e..."](https://github.com/mnbf9rca/family-foqos/commit/aaf4f12ffec016a97a3d5e42c1445b6c25606cba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43335754)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->