### PR TITLE
plans the fix for #302, #301, #298

### DIFF
--- a/docs/superpowers/plans/2026-07-10-263-followups-302-301-298.md
+++ b/docs/superpowers/plans/2026-07-10-263-followups-302-301-298.md
@@ -1,0 +1,1016 @@
+# Epic #263 follow-ups (#302, #301, #298) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This plan is **self-contained** — it assumes no prior Claude session/project memory (the implementer may be Codex). Read `AGENTS.md` at the repo root first; it overrides everything here.
+
+**Goal:** Ship three independent epic-#263 follow-up fixes as ONE branch / ONE PR (the "F+I bundle" pattern — three self-contained mini-plans, executed and reviewed in sequence, merged together):
+- **#302** — a local delete made while device sync is **disabled** writes no durable tombstone, so it never propagates when sync is re-enabled. Fix: write the durable delete-intent tombstone (no engine enqueue) so I12 re-enable replay finds it.
+- **#301** — a profile whose schedule/trigger config arrives via sync is persisted on the receiving device but its DeviceActivity schedule is **never registered**, so the schedule never fires and the "Fix Schedule" warning persists across foregrounds until the user manually taps it.
+- **#298** — apply the PR #300 value-snapshot rendering pattern to the five remaining latent zombie-`@Model` twin views (`LockedProfileCard`, `ProfileRow`, `SessionRow`, `SavedLocationCard`, `LocationReferenceRow`).
+
+**Architecture:** Each mini-plan is a focused, TDD-first change on `main` at base commit `c1e3c2f`. #302 reuses the existing durable tombstone store behind the sync facade; #301 reconciles DeviceActivity registration (the current reconciler is mis-gated); #298 is a mechanical replay of the #300 snapshot pattern per view. The three are code-independent (different subsystems: sync-funnel, DeviceActivity, SwiftUI views), so they can be implemented in any order **except** that #301 is **stacked on the A4′ bundle** (see its header). Commit each mini-plan's tasks under its own `(#N)` scope.
+
+**Tech Stack:** Swift 6, SwiftUI, SwiftData (`cloudKitDatabase: .none`), CloudKit `CKSyncEngine`, `DeviceActivity` / `FamilyControls`, XCTest, Xcode 26. Test simulator: boot an iPhone 17 sim **ONCE** by UUID (see AGENTS.md — never by device name) and reuse it.
+
+## Global Constraints
+
+Every task's requirements implicitly include this section. Values copied verbatim from `AGENTS.md`.
+
+- **Base commit `c1e3c2f`** (`main` tip: "Fix #286 reset sync poison CKSyncEngine state (#303)"). Re-verify every citation before writing code (each mini-plan opens with a Task 0 that does this and records the SHA it verified against).
+- **NEVER force-commit or amend.** New commits only; `git revert` to undo. **Request code review before merging** (AGENTS.md).
+- **One implementation stream per machine.** Do not run parallel builds/tests. This is one bundle/PR.
+- **`@SafeQuery`, never raw `@Query`** (pre-commit hook rejects `@Query`).
+- **`swift-format` clean** (pre-commit auto-formats staged Swift). 2-space indent, ~100–120 col.
+- **`Log` for all logging** (never `print`). Categories: `.sync`, `.timer`, `.ui`, `.strategy` etc. per AGENTS.md. Never log lock codes / personal identifiers; UUIDs, timestamps, profile names are acceptable.
+- **No new SwiftData schema** in any mini-plan — snapshots are plain in-memory structs, tombstones are existing `UserDefaults` state. Do not add `@Attribute`/`@Relationship`.
+- **Lock-check rule:** gate child-only behaviour on `appModeManager.currentMode == .child`, never `!= .parent`.
+- **Pin time in tests:** capture a single `let now = Date()` per test and derive all other dates from it; inject `now:` where the method under test accepts it.
+- **Do not create GitHub labels** (repo rule; not code-relevant but noted for parity).
+- **PR title/body wording:** this bundle IMPLEMENTS the three issues, so its commits use conventional-commit types scoped to the issue (`fix(#N)`/`feat(#N)`/`test(#N)`/`refactor(#N)` — as each task prescribes). (The separate plan-only PR that INTRODUCES this document must be titled **"plans the fix for #302, #301, #298"**, never "fixes".)
+
+---
+
+## Mini-plan A — #302: durable tombstone on a disabled-sync local delete
+
+### A. Problem (device-observed, checklist row)
+
+The design's **manual two-device checklist** (`docs/plans/2026-07-02-sync-engine-design.md:698-699`) contains the exact row this fixes:
+
+> toggle off → local delete → on (delete propagates via tombstone, N5); toggle off → remote delete → on (resurrects, N5)
+
+Today the **local-delete half** is broken. When `ProfileSyncManager.isEnabled == false`, all three delete call sites take a bare-local-delete `else` branch that never records a delete-intent tombstone:
+- `Foqos/Views/BlockedProfileListView.swift:198` — `try BlockedProfiles.deleteProfile(profile, in: context)`
+- `Foqos/Views/BlockedProfileView.swift:842` — `try BlockedProfiles.deleteProfile(profileToDelete, in: modelContext)`
+- `Foqos/Views/SavedLocationsView.swift:222` — `try SavedLocation.delete(location, in: context)`
+
+Because no tombstone is written, I12 re-enable replay (`SyncEngineController.recoverDeleteIntents`) has nothing to find, so the deletion never propagates to the family's other devices when sync is toggled back on.
+
+### B. Contract grounding (verified at `c1e3c2f`)
+
+- **N5 deletion carve-out** (`design.md:729-736`): "Local *deletions* are **not** lost: tombstones survive T11 and re-propagate via I12 at re-enable — as recovered intents they are verify-before-delete'd, so they propagate iff the record was not remotely modified during the disabled window (else: cleared + surfaced, keep-biased)." → The tombstone written while disabled is exactly what N5 requires to exist.
+- **I12 replay** (`design.md:270-295`): recovery at controller start; for each tombstoned id with no pending `.deleteRecord`: *entity still present locally ⇒ **abort** (clear tombstone, enqueue nothing)*; *entity absent, recovered intent ⇒ **verify-before-delete*** (fetch by `CKRecord.ID`; enqueue delete only if absent or matching stored change tag; different/absent tag ⇒ clear + surface, do not delete). → The disabled-window tombstone is a "recovered intent" and rides this path verbatim; **no new replay logic is needed** — only the tombstone must exist.
+- **`deleteTombstones` survive T11** (`design.md:213`, `:331`): toggle-off discards `engineState` (pending unsent saves lost) but the tombstone dictionary explicitly survives.
+
+### C. Round-4/5 "kill-the-record" hazard — explicit conformance argument
+
+The only verbatim statement of the hazard is the **funnel delete-path atomicity rule** (`design.md:161-169`):
+
+> **delete path:** (1) persist a **delete-intent tombstone** … *in the same `withLock` scope as* — and before returning from — the operation that deletes the entity; (2) require the entity delete to succeed — **if it fails, remove the tombstone … AND `context.rollback()`** … (round-4/5: a lingering tombstone would later kill the live record family-wide …).
+
+The corpus-mapping rolls this up as SAFE in rows **D-1** (`corpus-mapping.md:63`, "never toward … orphaned deletes"), **D-4** (`:66`, toggle-off/on row) and **E-4** (`:78`, "killed delete-enqueues by I12 tombstones — recorded intent, never absence inference"). The acceptance-corpus predates tombstones; its relevant framing is **E-3** (`acceptance-corpus.md:110`, keep-biased safety asymmetry) and **E-4** (`:111`, "Normal deletion propagation must keep working").
+
+**This fix's conformance (stronger than the funnel's own rule):** the disabled-window tombstone is written **only after the local delete durably commits** (the #289 deferred-commit boundary). A never-deleted / rolled-back entity therefore **never** receives a tombstone at all — strictly stronger than the funnel's "write-then-clear-on-failure", so the round-4/5 lingering-tombstone hazard is structurally impossible on this path. As defence-in-depth, I12's *entity-still-present ⇒ abort* branch (`design.md:275-277`) is the second guarantee: even a hypothetical stray tombstone whose entity is still present is cleared without enqueuing a delete. The mini-plan adds a test for both layers (Task A3).
+
+### D. MAINTAINER DECISIONS
+
+**MD-A1 — Facade seam for the driver-free tombstone write (RESOLVED, recommend Option A; flag for maintainer confirmation).**
+When sync is disabled, `ProfileSyncManager.engineController` is **non-nil** (attach always runs) but `SyncEngineController.funnel` is **nil** (created only in `start()`); `SyncEngineController.store` is a non-optional `let` (`SyncEngineController.swift:25`) and is always available. So a tombstone write must reach `store.setTombstone` **without** the funnel/driver.
+- **Option A (recommended):** add a store-only verb `recordDisabledDeleteTombstone(recordName:)` to the `SyncEngineControlling` facade, implemented in `SyncEngineController+Cutover.swift` as `store.setTombstone(recordName:, changeTag: MutationFunnel.changeTag(fromSystemFields: store.systemFields(for: recordName)))`. Reuses the exact `enqueueTombstoneDelete` pair (`MutationFunnel.swift:186-187`) **minus** the `driver.add` at `:189`. `ProfileSyncManager` exposes a thin wrapper the three views call.
+- Option B: eagerly construct the funnel in `attachEngine` even when disabled and add `funnel.writeTombstoneOnly` — larger blast radius (the funnel assumes a live driver elsewhere).
+- Option C: expose `store` through the UI and call `setTombstone` directly — leaks the store, bypasses the I2 single-seam discipline.
+- **Recommendation: A.** Smallest change; keeps the driver-free write behind the same facade seam as the other enqueue verbs. **Maintainer confirm:** whether the verb name / seam is acceptable, and (see MD-A2) whether a symmetric clear verb is wanted.
+
+**Design note A2 (not a maintainer decision — a forced consequence of write-after-commit).** Because the tombstone write happens **after** a successful `modelContext.save()` (profiles) / synchronous `SavedLocation.delete` (locations), there is no failure arm to compensate: if the commit throws, we simply never write the tombstone. So no symmetric `clearDisabledDeleteTombstone` verb is required, and this is what makes the round-4/5 argument in §C hold structurally. (The funnel's own before-delete write needs the clear-on-failure arm; this path deliberately does not.) Nothing for the maintainer to decide here — the "symmetric clear verb?" touchpoint is folded into MD-A1's confirm ask.
+
+**MD-A3 — Adjacent latent gap: the in-memory `.notAttached` deferred-delete path (ESCALATE — maintainer to decide fold-vs-file).** `ProfileSyncManager.deferredDeleteRecordNames` (the `.notAttached` fallback drained on attach via `enqueueDeferredDelete → funnel.enqueueTombstoneDelete`) is **in-memory only**: a delete that hits the `.notAttached` catch and is then app-killed before `markSyncReadyAndFlush` drains it is silently lost — the same *class* of bug as #302 but on the enabled-but-not-yet-attached path. **Recommendation:** keep #302 scoped to the `isEnabled == false` branch (as titled); **file the `.notAttached` durability gap as a separate issue** rather than widening this PR. Maintainer: confirm file-separately vs fold-in.
+
+### Task A0: Citation refresh (MANDATORY — do this first, no code)
+
+Verify the code still matches this plan before writing anything. If any diverge, STOP and reconcile.
+
+- [ ] **Step 1: Record the base SHA.** Run `git rev-parse HEAD` and confirm it is `c1e3c2f` (or note the newer SHA and re-grep everything below against it).
+- [ ] **Step 2: Confirm the three disabled `else` branches** exist and are bare local deletes:
+
+```bash
+grep -nF -e 'try BlockedProfiles.deleteProfile(profile, in: context)' Foqos/Views/BlockedProfileListView.swift
+grep -nF -e 'try BlockedProfiles.deleteProfile(profileToDelete, in: modelContext)' Foqos/Views/BlockedProfileView.swift
+grep -nF -e 'try SavedLocation.delete(location, in: context)' Foqos/Views/SavedLocationsView.swift
+```
+Expected: each returns a line inside a `// Sync disabled` `else` block (`BlockedProfileListView.swift:198`, `BlockedProfileView.swift:842`, `SavedLocationsView.swift:222` at `c1e3c2f`).
+
+- [ ] **Step 3: Confirm the store/funnel seam:**
+
+```bash
+grep -nF -e 'let store: SyncEngineStore' -e 'var funnel: MutationFunnel?' Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+grep -nF -e 'func setTombstone' -e 'func systemFields(for' Foqos/CloudKit/SyncEngine/SyncEngineStore.swift
+grep -nF -e 'static func changeTag(fromSystemFields' -e 'func enqueueTombstoneDelete' Foqos/CloudKit/SyncEngine/MutationFunnel.swift
+grep -nF -e 'func enqueueDeferredDelete(recordName' Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift
+```
+Expected: `store` is a non-optional `let` (`:25`); `funnel` is optional (`:41`); `setTombstone(recordName:changeTag:)`, `systemFields(for:)`, `changeTag(fromSystemFields:)` and `enqueueTombstoneDelete(recordName:)` all exist. The last confirms the facade already has a store/funnel-only verb to mirror.
+
+- [ ] **Step 4: Confirm the I12 replay entry point** so the test in A3 targets the real symbol: `grep -nF 'recoverDeleteIntents' Foqos/CloudKit/SyncEngine/SyncEngineController.swift` (expected `~:807`, called from `runStartupSequence`). Read it to confirm the *entity-present ⇒ clear-without-enqueue* branch (`~:811-814`).
+
+### Task A1: Add the driver-free `recordDisabledDeleteTombstone` facade verb
+
+**Files:**
+- Modify: `Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift` (protocol requirement)
+- Modify: `Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift` (implementation)
+- Modify: `Foqos/CloudKit/ProfileSyncManager.swift` (thin UI wrapper)
+- Modify: the `MockSyncEngineControlling` spy (in `FoqosTests/` — find with `grep -rln 'class MockSyncEngineControlling'`)
+- Test: `FoqosTests/SyncEngineStoreTombstoneTests.swift` (store-level) and `FoqosTests/SyncEngineFacadeTests.swift` (facade wrapper)
+
+**Interfaces:**
+- Produces: `SyncEngineControlling.recordDisabledDeleteTombstone(recordName: String)` (no-throw; pure durable write). Tasks A2 consume `ProfileSyncManager.recordDisabledDeleteTombstone(recordName:)`.
+
+- [ ] **Step 1: Write the failing store-level test** (append to `FoqosTests/SyncEngineStoreTombstoneTests.swift`). This proves the write-without-driver persists exactly the change tag that `MutationFunnel.changeTag(fromSystemFields:)` derives from the cached systemFields — the same pair `enqueueTombstoneDelete` uses. **Note:** `CKRecord.recordChangeTag` is server-assigned and read-only, so a locally-built record's tag is `nil`; a non-nil server tag is *not fabricable* in a store-only unit test, so the "non-nil matching-tag ⇒ delete enqueued" guarantee lives in the A3 **driver-level** test (where the tag is a literal `String`). This test asserts the write captures *whatever the decoder yields*.
+
+```swift
+// Mirror of MutationFunnelTests.encodedSystemFields (private there) — copy it into this file.
+private func encodedSystemFields(recordName: String) -> Data {
+  let record = CKRecord(
+    recordType: SyncedProfile.recordType,
+    recordID: CKRecord.ID(
+      recordName: recordName,
+      zoneID: CKRecordZone.ID(
+        zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)))
+  let archiver = NSKeyedArchiver(requiringSecureCoding: true)
+  record.encodeSystemFields(with: archiver)
+  archiver.finishEncoding()
+  return archiver.encodedData
+}
+
+func testGivenCachedSystemFields_WhenDisabledTombstoneWritten_ThenTagMatchesDecoder() {
+  let store = SyncEngineStore(userRecordName: "userA", defaults: defaults)
+  let systemFields = encodedSystemFields(recordName: "p1")
+  store.setSystemFields(systemFields, for: "p1")
+
+  // The disabled-path write: the exact pair enqueueTombstoneDelete uses (MutationFunnel.swift:186-187), minus driver.add.
+  let expectedTag = MutationFunnel.changeTag(fromSystemFields: store.systemFields(for: "p1"))
+  store.setTombstone(recordName: "p1", changeTag: expectedTag)
+
+  let reloaded = SyncEngineStore(userRecordName: "userA", defaults: defaults)
+  XCTAssertTrue(reloaded.deleteTombstones.keys.contains("p1"))
+  XCTAssertEqual(reloaded.deleteTombstones["p1"] ?? nil, expectedTag)  // captures whatever the decoder yields
+}
+
+func testGivenNeverSyncedRecord_WhenDisabledTombstoneWritten_ThenNilTagKeyPresent() {
+  let store = SyncEngineStore(userRecordName: "userA", defaults: defaults)
+  store.setTombstone(
+    recordName: "p2",
+    changeTag: MutationFunnel.changeTag(fromSystemFields: store.systemFields(for: "p2")))
+  let map = SyncEngineStore(userRecordName: "userA", defaults: defaults).deleteTombstones
+  XCTAssertTrue(map.keys.contains("p2"))     // recorded intent…
+  XCTAssertNil(map["p2"] ?? nil)             // …never synced ⇒ nil tag (I12 handles as absent-tag)
+}
+```
+
+This mirrors `MutationFunnelTests.swift:56-61` (the `encodedSystemFields` helper) and its assertion idiom at `:373-376` (`store.deleteTombstones[recordName] ?? nil == MutationFunnel.changeTag(fromSystemFields: systemFields)`). `CloudKitConstants.syncZoneName` is the zone name used across the sync layer (e.g. `MutationFunnel.swift:43`).
+
+- [ ] **Step 2: Run to verify it fails/compiles.** Boot the sim once (see AGENTS.md), then:
+```
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=<UUID>' -only-testing:FoqosTests/SyncEngineStoreTombstoneTests | xcpretty
+```
+Expected: PASS (these two tests exercise only existing `store`/`MutationFunnel.changeTag` API — they lock in the exact call pair the facade verb will wrap). If `MutationFunnel.changeTag(fromSystemFields:)` is not accessible from tests, confirm it is `static` and `internal` (it is at `MutationFunnel.swift:196`); `@testable import FamilyFoqos` exposes it.
+
+- [ ] **Step 3: Add the protocol requirement** (`SyncEngineControlling.swift`, after `enqueueDeferredDelete(recordName:)`):
+
+```swift
+  /// Durable delete-intent tombstone written on a LOCAL delete made while sync is DISABLED
+  /// (#302). The funnel/driver do not exist when disabled, so this touches only the durable
+  /// `SyncEngineStore` (no `.deleteRecord` enqueue). Written ONLY after the entity's local
+  /// delete has durably committed, so a rolled-back delete never leaves a tombstone. I12
+  /// re-enable replay (`recoverDeleteIntents`) consumes it as a recovered intent.
+  func recordDisabledDeleteTombstone(recordName: String)
+```
+
+- [ ] **Step 4: Implement it** (`SyncEngineController+Cutover.swift`, alongside the other verbs):
+
+```swift
+  func recordDisabledDeleteTombstone(recordName: String) {
+    // Mirrors enqueueTombstoneDelete (MutationFunnel.swift:186-187) MINUS the driver.add at
+    // :189 — a pure durable write, valid even though `funnel` is nil while sync is disabled.
+    store.setTombstone(
+      recordName: recordName,
+      changeTag: MutationFunnel.changeTag(fromSystemFields: store.systemFields(for: recordName)))
+  }
+```
+
+- [ ] **Step 5: Add the `ProfileSyncManager` wrapper** (`ProfileSyncManager.swift`, next to the other enqueue verbs). Unlike the throwing enqueue verbs, this is best-effort: if `engineController` is nil (the practically-unreachable disabled-*and*-pre-attach window — see MD-A3), log and no-op rather than throw, because the caller is already in a local-delete path.
+
+```swift
+  /// #302: record a durable delete-intent tombstone for a local delete made while sync is
+  /// disabled, so it re-propagates via I12 on re-enable. Best-effort: no-throw. Callers invoke
+  /// this AFTER the local delete has durably committed (write-after-commit — see plan MD-A2).
+  func recordDisabledDeleteTombstone(recordName: String) {
+    guard let engineController else {
+      Log.warning(
+        "Disabled-delete tombstone dropped: engine not attached yet (\(recordName))",
+        category: .sync)
+      return
+    }
+    engineController.recordDisabledDeleteTombstone(recordName: recordName)
+  }
+```
+
+- [ ] **Step 6: Add the verb to the `MockSyncEngineControlling` spy** so facade tests can assert it. Match the spy's existing counter/last-arg style, e.g.:
+
+```swift
+  private(set) var recordedDisabledTombstones: [String] = []
+  func recordDisabledDeleteTombstone(recordName: String) {
+    recordedDisabledTombstones.append(recordName)
+  }
+```
+
+- [ ] **Step 7: Write the failing facade test** (`SyncEngineFacadeTests.swift`) — proves the wrapper forwards to the controller and the nil-controller path is a safe no-op:
+
+```swift
+func testGivenController_WhenRecordDisabledTombstone_ThenForwardedToController() {
+  manager.isEnabled = false           // disabled path
+  manager.recordDisabledDeleteTombstone(recordName: "p1")
+  XCTAssertEqual(mock.recordedDisabledTombstones, ["p1"])
+}
+
+func testGivenNoController_WhenRecordDisabledTombstone_ThenNoCrashNoForward() {
+  manager.engineController = nil
+  manager.recordDisabledDeleteTombstone(recordName: "p1")  // must not throw/crash
+  XCTAssertEqual(mock.recordedDisabledTombstones, [])       // dropped, logged
+}
+```
+
+- [ ] **Step 8: Run to verify all pass:**
+```
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=<UUID>' -only-testing:FoqosTests/SyncEngineStoreTombstoneTests -only-testing:FoqosTests/SyncEngineFacadeTests | xcpretty
+```
+Expected: all green.
+
+- [ ] **Step 9: Commit**
+```bash
+git add Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift \
+        Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift \
+        Foqos/CloudKit/ProfileSyncManager.swift FoqosTests/
+git commit -m "feat(#302): driver-free recordDisabledDeleteTombstone facade verb"
+```
+
+### Task A2: Write the tombstone from the three disabled delete branches (write-after-commit)
+
+**Files:**
+- Modify: `Foqos/Views/BlockedProfileListView.swift` (`deleteProfiles(at:)`, disabled branch `:195-199` + the shared `scheduleProfileDeleteCommit` block)
+- Modify: `Foqos/Views/BlockedProfileView.swift` (disabled branch `:838-850`)
+- Modify: `Foqos/Views/SavedLocationsView.swift` (`:220-224`)
+
+**Interfaces:**
+- Consumes: `ProfileSyncManager.recordDisabledDeleteTombstone(recordName:)` (Task A1).
+
+> **Views aren't unit-testable here** — the acceptance is the two-device checklist row (Task A3 encodes it at the funnel/store level, and the device gate in Final Verification runs the literal toggle-off→delete→on flow). These steps are exact source edits; the compile + Task A3 + device gate are the checks.
+
+- [ ] **Step 1: `BlockedProfileListView.swift`** — the deletes happen in a loop, but the durable commit is the shared `reorderProfiles` save inside `scheduleProfileDeleteCommit`. Collect the disabled-deleted ids, then write tombstones **after** that save succeeds.
+
+  a. Just before the `for index in offsets` loop (inside `do {` at `~:175`), add:
+```swift
+      var disabledDeletedRecordNames: [String] = []
+```
+  b. In the disabled `else` branch (`:195-199`), record the id (delete is still local + deferred):
+```swift
+        } else {
+          // Sync disabled — the funnel would no-op (I2 is only reachable once the engine has
+          // started), so delete locally directly. #302: remember the id so we can write a
+          // durable delete tombstone AFTER the reorder save commits (write-after-commit).
+          try BlockedProfiles.deleteProfile(profile, in: context)
+          disabledDeletedRecordNames.append(profileId.uuidString)
+        }
+```
+  c. Inside the `scheduleProfileDeleteCommit` closure, **after** `try BlockedProfiles.reorderProfiles(remainingProfiles, in: context)` (whose `context.save()` is the durable commit) and before/after the enqueue loop, add:
+```swift
+          // #302: the local deletes above are now durably committed by reorderProfiles' save,
+          // so record their delete-intent tombstones. Write-after-commit ⇒ a failed/rolled-back
+          // delete never leaves a tombstone (plan §C round-4/5 conformance).
+          for recordName in disabledDeletedRecordNames {
+            profileSyncManager.recordDisabledDeleteTombstone(recordName: recordName)
+          }
+```
+  Place this write inside the `do` that already wraps the reorder (so a thrown reorder skips the tombstone writes — exactly the write-after-commit guarantee).
+
+- [ ] **Step 2: `BlockedProfileView.swift`** — the disabled branch deletes then commits in its own `scheduleProfileDeleteCommit`. Write the tombstone inside that closure after `try modelContext.save()` succeeds:
+```swift
+                    } else {
+                      // Sync disabled — delete locally directly.
+                      try BlockedProfiles.deleteProfile(profileToDelete, in: modelContext)
+                      let deletedRecordName = profileToDelete.id.uuidString  // capture before zombie
+                      BlockedProfiles.scheduleProfileDeleteCommit {
+                        do {
+                          try modelContext.save()
+                          // #302: durable tombstone AFTER the commit succeeds.
+                          profileSyncManager.recordDisabledDeleteTombstone(
+                            recordName: deletedRecordName)
+                        } catch {
+                          showError(message: error.localizedDescription)
+                        }
+                      }
+                    }
+```
+  (Capture `profileToDelete.id.uuidString` into `deletedRecordName` **before** the deferred closure — the model may be a zombie by the time the closure runs, per #285/#289.)
+
+- [ ] **Step 3: `SavedLocationsView.swift`** — `SavedLocation.delete` saves synchronously, so the tombstone is written immediately after it returns:
+```swift
+      } else {
+        // Sync disabled — delete locally directly.
+        let deletedRecordName = location.id.uuidString  // capture before delete
+        try SavedLocation.delete(location, in: context)  // saves internally (durable commit)
+        // #302: SavedLocation.delete already committed, so record the tombstone now.
+        profileSyncManager.recordDisabledDeleteTombstone(recordName: deletedRecordName)
+      }
+```
+  Confirm `profileSyncManager` is in scope in `SavedLocationsView` (grep `@EnvironmentObject.*ProfileSyncManager` / `profileSyncManager`); if the view accesses sync via a different property name, use that. If the view has no `ProfileSyncManager` reference at all, inject it as `@EnvironmentObject private var profileSyncManager: ProfileSyncManager` (it is provided app-wide — confirm via `grep -rn "environmentObject(.*ProfileSyncManager" Foqos`).
+
+- [ ] **Step 4: Build the app** (whole target, since these are view edits with no unit test):
+```
+xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -configuration Debug -destination 'generic/platform=iOS Simulator' build | xcpretty
+```
+Expected: `BUILD SUCCEEDED`.
+
+- [ ] **Step 5: Commit**
+```bash
+git add Foqos/Views/BlockedProfileListView.swift Foqos/Views/BlockedProfileView.swift Foqos/Views/SavedLocationsView.swift
+git commit -m "fix(#302): write durable delete tombstone from disabled-sync local deletes (write-after-commit)"
+```
+
+### Task A3: Acceptance + round-4/5 conformance tests (funnel/store level)
+
+**Files:**
+- Test: **`FoqosTests/SyncEngineControllerTests.swift`** — the I12 replay harness already lives there under `// MARK: - I12 delete-intent recovery` (`~:540`). Add the one net-new acceptance case there (do not create a new file).
+
+**Interfaces:**
+- Consumes: `SyncEngineStore.setTombstone` + the existing I12 replay harness. **`recoverDeleteIntents` is `private`** — it is NOT called directly and does NOT appear in `FoqosTests/`; the existing tests drive it via `controller.start()` + `await controller.startupTask?.value`. Mirror that harness (mock driver + injected server record) exactly — do **not** invent a new controller-construction path.
+- **Existing coverage (verify before writing):** Steps 2 and 3 below are **already present** as `testGivenRecoveredTombstoneDifferentTag_WhenRecover_ThenClearedConflictSurfacedNoDelete` (N5 keep-bias) and `testGivenTombstoneEntityPresent_WhenRecover_ThenAbortAndClear` (round-4/5 guard); Step 1's acceptance is largely covered by `testGivenRecoveredTombstoneMatchingTag_WhenRecover_ThenDeleteEnqueuedTombstoneRetained`. So the **net-new work is at most ONE case**: a tombstone written by the *disabled path* (via `store.setTombstone`, not the funnel) drives the same matching-tag delete on re-enable — reusing that harness. If a step is already covered verbatim, reference the existing test in a comment rather than duplicating it.
+
+- [ ] **Step 1: Write the ACCEPTANCE test** — the checklist row "toggle off → local delete → on → delete propagates". Structure (fill in with the existing replay-test harness):
+
+```swift
+// #302 acceptance (design.md:698-699): a tombstone written while sync is DISABLED must, on
+// re-enable, drive an I12 recovered-intent delete that ENQUEUES a .deleteRecord — provided the
+// server record was NOT remotely modified during the disabled window (N5 keep-bias).
+func testGivenDisabledDeleteTombstone_WhenReEnabledAndServerTagMatches_ThenDeleteEnqueued() throws {
+  // Arrange: a previously-synced record p1 with cached systemFields (server tag "srvTag").
+  //   entity ABSENT locally (the disabled delete already removed it), tombstone("p1","srvTag").
+  //   server fetch returns p1 with change tag "srvTag" (NOT remotely modified).
+  // Act: run recoverDeleteIntents (the re-enable path).
+  // Assert: exactly one .deleteRecord(p1) was enqueued on the (mock) driver; tombstone cleared.
+}
+```
+
+- [ ] **Step 2: Write the N5 keep-bias test** — remote-modified during the disabled window ⇒ NOT deleted:
+
+```swift
+// N5 keep-bias (design.md:733-734): if the server record was remotely modified during the
+// disabled window (change tag differs), the recovered intent must CLEAR + surface, NOT delete.
+func testGivenDisabledDeleteTombstone_WhenReEnabledAndServerTagDiffers_ThenNoDeleteAndConflictSurfaced() throws {
+  // Arrange: tombstone("p1","srvTag") but server fetch returns p1 with tag "newerTag".
+  // Act: recoverDeleteIntents.
+  // Assert: NO .deleteRecord enqueued; tombstone cleared; a conflict entry surfaced.
+}
+```
+
+- [ ] **Step 3: Write the round-4/5 conformance test** — the entity-present abort guard (defence-in-depth for a stray tombstone):
+
+```swift
+// Round-4/5 (design.md:166 + I12:275-277): a tombstone whose entity is STILL PRESENT locally
+// must ABORT — clear the tombstone, enqueue nothing (never kill a live record).
+func testGivenTombstoneButEntityStillPresent_WhenRecover_ThenClearedAndNoDeleteEnqueued() throws {
+  // Arrange: tombstone("p1", …) AND profile p1 still exists in the local context.
+  // Act: recoverDeleteIntents.
+  // Assert: NO .deleteRecord enqueued; tombstone cleared.
+}
+```
+
+- [ ] **Step 4: Run to verify the net-new case fails, then passes** once the disabled-path tombstone is written (Task A2) and replay runs. Steps 2/3 already exist (see Interfaces) — do NOT duplicate; reference them in a comment. Run:
+```
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=<UUID>' -only-testing:FoqosTests/SyncEngineControllerTests | xcpretty
+```
+
+- [ ] **Step 5: Commit**
+```bash
+git add FoqosTests/
+git commit -m "test(#302): disabled-delete tombstone re-enable replay (acceptance + N5 keep-bias + round-4/5 guard)"
+```
+
+---
+
+## Mini-plan B — #301: register synced profiles' schedules on the receiving device
+
+> **⚠ STACKED ON A4′ — DO NOT START UNTIL A4′ HAS MERGED, AND CITATION-REFRESH FIRST.**
+> A4′ (`docs/superpowers/plans/2026-07-07-a4-location-sync-integrity.md`) lands first and **rewrites `deleteLocalLocation` + adds `private var zoneID` in `SyncApplyService.swift`, and adds new post-deletion drains in `SyncEngineController.swift`**. A3′ (`…-a3-sync-conflict-semantics.md`) may also have landed and independently edits `SyncApplyService.swift` (profile tie-break `:270-281`, `applyFetchedDeletion`, new `applyUnblockEventModification`). **Therefore every `SyncApplyService.swift` / `SyncEngineController.swift` line number in this mini-plan is provisional** — re-derive every citation **by symbol** against the actual post-A4′ `main` before writing code (Task B0 does this).
+
+### B. Problem (device-observed)
+
+`SyncApplyService` imports only `CloudKit`/`Foundation`/`SwiftData` and **never touches the DeviceActivity framework** (verified: `grep DeviceActivity Foqos/CloudKit/SyncEngine/SyncApplyService.swift` = no matches). When a profile create/update whose schedule/trigger config changed arrives via sync, `createLocalProfile` / `updateLocalProfile` copy the schedule fields into SwiftData but **nothing registers the OS-level `DeviceActivitySchedule`**. Contrast the local edit path: `BlockedProfileView.finalizeSave` calls `DeviceActivityCenterUtil.scheduleTimerActivity(for: profile)` (`BlockedProfileView.swift:927`) right after saving. On the receiving device that call never happens, so:
+- `BlockedProfiles.scheduleIsOutOfSync` (`BlockedProfiles.swift:223-238`) stays `true` (schedule present, no registered activity) → the **"Fix Schedule" warning persists** (`BlockedProfileView.swift:284`), and
+- the schedule **never fires on device B** until the user manually taps Fix Schedule (which routes through `saveProfile → finalizeSave → scheduleTimerActivity`).
+
+**Why the foreground reconciler doesn't already cover it (the crux the user asked to resolve).** The only automatic registration path for existing profiles is `PreActivationReminderScheduler.rescheduleAllReminders(context:)` (`PreActivationReminderScheduler.swift:33-56`, called on foreground from `FoqosApp.swift:161`/`:260`). Its per-profile guard is:
+
+```swift
+guard profile.preActivationReminderEnabled, hasActiveSchedule else { continue }
+```
+
+`preActivationReminderEnabled` is computed as `!preActivationReminderTimes.isEmpty` (`BlockedProfiles.swift:84-86`). **A synced profile with an active schedule but no reminder times selected fails this guard every foreground**, so `scheduleTimerActivity` is never called and the warning persists indefinitely. This is a **mis-gating bug**: registration (`try center.startMonitoring(…)`, `DeviceActivityCenterUtil.swift:70`) is *unconditional once a schedule exists* — only the reminder-notification tail (`:73-78`) needs `preActivationReminderTimes`. The reconciler couples two independent concerns: it withholds **schedule registration** because **reminders** are off.
+
+### C. MAINTAINER DECISION — MD-B1: the fix seam (ESCALATE; strong recommendation below)
+
+The user asked to "say whether widening the reconciler filter is the cleaner seam than hooking apply." **Determination: widening is the cleaner root-cause seam** — but the acceptance ("schedule fires on device B *without a manual Fix Schedule*") and the user's "coalesce across a fetch, not per-record" instruction want registration to also happen **on the fetch**, not only on the next foreground. The recommended design does **both** through **one** reconcile function:
+
+- **Option A — hook `SyncApplyService` per-record** (the apply-agent's first instinct): rejected. It injects a DeviceActivity cross-layer dependency into a pure-SwiftData apply service running on the CKSyncEngine apply path (main-actor/threading concerns, B-7 "fetch handlers return synchronously"), must thread through 4 apply branches, and calls `scheduleTimerActivity` once per record (the user explicitly said *not* per-record).
+- **Option B — widen the reconciler filter only** (foreground): drop `preActivationReminderEnabled` from the guard. One-line root-cause fix; reuses the idempotent funnel; fixes **all** unregistration causes (sync, migration, iOS-dropped monitoring), not just sync. But it reconciles **only on foreground** — a schedule whose interval arrives while device B stays backgrounded after the fetch would not register in time.
+- **Option C — RECOMMENDED: one reconcile pass, called from BOTH foreground AND the fetch-cycle boundary (coalesced).** Extract/rename the reconciler into `reconcileScheduleRegistrations(context:)` that, for every profile with an active start/legacy schedule, calls the idempotent `scheduleTimerActivity` (dropping the reminder gate — that gate stays *inside* the reminder-notification tail where it belongs). Call it (i) from the existing foreground/onAppear sites (fixes the persistent warning across foregrounds — root cause), and (ii) **once per fetch cycle** at `SyncEngineController.handleDidFetchChanges` (`~:610`) after applies (satisfies "coalesce across a fetch" and "fires on device B without a manual Fix Schedule"). Deletion de-registration already works (`deleteProfile → removeScheduleTimerActivities`, `BlockedProfiles.swift:497`, invoked from `SyncApplyService` apply-delete) and `cleanUpGhostSchedules` removes orphans — so this mini-plan only ADDS registration; it never removes.
+
+**Why C respects `cleanUpGhostSchedules` (StrategyManager.swift:1335-1384):** ghost cleanup removes a schedule activity **only** when the profile has *no* active start/legacy schedule (`:1361` `if !hasScheduledStart && !hasLegacySchedule`), and skips on DB error (`:1378`, fail-safe). Registration only ADDS activities for profiles that *have* an active schedule. The two operate on disjoint sets (has-schedule vs no-schedule) and key on the same name (bare profile-UUID `DeviceActivityName`), so a batch re-registration can never be nuked by cleanup and vice-versa. **Do not** change cleanup to key off registration state (that would let it delete a just-registered live schedule).
+
+**Maintainer, please confirm:** (1) Option C (both seams) vs Option B (foreground-only, simpler, accepts the backgrounded-interval gap); (2) whether to rename `rescheduleAllReminders` → `reconcileScheduleRegistrations` (recommended: the method already registers schedules; the name is a misnomer) or keep the name and only widen the guard (minimal diff). The tasks below implement **Option C with the rename**; if the maintainer picks B, drop Task B2 and skip the rename.
+
+### D. `needsAppSelection` — the semantic scope boundary (and a device probe)
+
+**FamilyControls app-selection tokens are device-local.** A `FamilyActivitySelection`'s opaque tokens do not transfer across devices, so `createLocalProfile` sets `needsAppSelection = true` (`SyncApplyService.swift:367`, unconditional; default is `false` at `BlockedProfiles.swift:96`) for **every** freshly-synced profile on device B. **Consequence (important):** a fresh cross-device sync is *definitionally* `needsAppSelection == true`, and its schedule cannot meaningfully block anything until the user selects apps on device B. Registering a DeviceActivity interval for such a profile would fire and call `appBlocker.activateRestrictions(for: profile)` (`ScheduleTimerActivity.swift:127`) with an empty selection — pointless at best, spurious at worst.
+
+**Therefore `reconcileScheduleRegistrations` gates on `!profile.needsAppSelection` as the correct default** — not merely a probe-dependent safety. This means the fix's guaranteed win is: **for any profile usable on this device (app-selected) with an active schedule, its DeviceActivity schedule now auto-registers** (no manual "Fix Schedule" tap) — which today it does not, because the only automatic path (`rescheduleAllReminders`) is gated behind the reminder pref. Completing app selection on device B routes through the local save → `scheduleTimerActivity` path AND flips `needsAppSelection` to `false`, so the next foreground/fetch reconcile then registers automatically. The bug this fixes is the **missing auto-registration for app-selected scheduled profiles** (a synced update to an already-selected profile, or a profile after its apps are selected on B) — where today the warning persists across foregrounds forever.
+
+- [ ] **PROBE (device, no debugger) — confirms the gate, doesn't change the default:** create a scheduled profile on device A, sync to B **without** completing app selection, and force a reconcile on B with the `!needsAppSelection` gate **removed** (a throwaway build). Observe when the interval fires: does an empty `FamilyActivitySelection` (a) no-op harmlessly, (b) post a spurious "scheduled profile didn't start" notification, or (c) activate an invalid restriction set? **Record the result in the PR.** Cannot be determined from code (an Xcode stream is held; do not run it in this planning session).
+- **Interpretation:** (b)/(c) ⇒ the `!needsAppSelection` gate is **required** (keep it — Task B1's default). (a) ⇒ the gate is **optional** (registering early is harmless); still recommended to keep it, since registering blocking for un-selected apps has no user value. Either way, **Task B1 ships the gated variant** and the B3 acceptance is stated for the app-selected case (below).
+
+### Task B0: Citation refresh against post-A4′ `main` (MANDATORY — no code)
+
+- [ ] **Step 1: Confirm A4′ (and any A3′) merged.** `git log --oneline -20` and confirm a commit like "Fix … location sync integrity (A4′)" is in the base. If A4′ is NOT merged, **STOP** — this mini-plan is blocked.
+- [ ] **Step 2: Re-derive every SyncApplyService/controller citation by symbol** (portable fixed-string greps; line numbers in this doc are provisional):
+```bash
+grep -nF -e 'private func applyDecodedProfile' -e 'private func createLocalProfile' \
+  -e 'private func updateLocalProfile' -e 'private func deleteLocalProfile' \
+  -e 'private var zoneID' -e 'storeSystemFields(record)' \
+  Foqos/CloudKit/SyncEngine/SyncApplyService.swift
+grep -nF -e 'private func handleFetchedRecordZoneChanges' -e 'private func handleDidFetchChanges' \
+  -e 'apply.drainReenqueues()' Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+```
+  Assert post-A4′ state: `private var zoneID` now EXISTS in `SyncApplyService.swift`; `handleDidFetchChanges` still exists as the fetch-cycle delimiter; A4′'s post-deletions drain is present. Record the fresh line numbers here before editing.
+- [ ] **Step 3: Confirm the reconciler + funnel symbols:**
+```bash
+grep -nF -e 'static func rescheduleAllReminders' -e 'DeviceActivityCenterUtil.scheduleTimerActivity' \
+  Foqos/Utils/PreActivationReminderScheduler.swift
+grep -nF -e 'var preActivationReminderEnabled' -e 'var scheduleIsOutOfSync' Foqos/Models/BlockedProfiles.swift
+grep -nF -e 'static func scheduleTimerActivity' -e 'try center.startMonitoring' Foqos/Utils/DeviceActivityCenterUtil.swift
+grep -nF -e 'func cleanUpGhostSchedules' -e 'if !hasScheduledStart && !hasLegacySchedule' Foqos/Utils/StrategyManager.swift
+grep -rnF 'rescheduleAllReminders' Foqos   # every call site the rename must update
+```
+- [ ] **Step 4: Record the base SHA** you verified against in a comment at the top of Task B1's commit.
+
+### Task B1: Extract `reconcileScheduleRegistrations` (widen the gate) and call it from foreground
+
+**Files:**
+- Modify: `Foqos/Utils/PreActivationReminderScheduler.swift` (add `reconcileScheduleRegistrations`; keep `rescheduleAllReminders` behaviour for reminders or fold — see Step 3)
+- Modify: `Foqos/FoqosApp.swift` (the two call sites `:161`, `:260`)
+- Test: `FoqosTests/PreActivationReminderSchedulerTests.swift` (create if absent — grep first)
+
+**Interfaces:**
+- Produces: `PreActivationReminderScheduler.reconcileScheduleRegistrations(context:)` — registers the DeviceActivity schedule for every profile with an active start/legacy schedule (reminder-gate-independent). Task B2 calls the same function per fetch cycle.
+
+- [ ] **Step 1: Write the failing test.** The DeviceActivity side effect (`scheduleTimerActivity → center.startMonitoring`) is **not deterministic in the sim** (without FamilyControls authorization `startMonitoring` throws and is caught, `DeviceActivityCenterUtil.swift:79-81`), so do **not** assert `scheduleIsOutOfSync`. Instead extract the reconcile's **eligibility predicate** into a pure static and test *that* — deterministic, no DeviceActivity/authorization needed. `ProfileScheduleTime(days:hour:minute:)` has `isActive == !days.isEmpty` (`ProfileScheduleTime.swift:23`), so a non-empty `days` is active.
+
+```swift
+@MainActor
+func testGivenScheduledAppSelectedProfileNoReminders_WhenEligibility_ThenTrue() throws {
+  let context = try ctx()   // ModelContainer(for: BlockedProfiles.self, inMemory).mainContext
+  let profile = BlockedProfiles(name: "Synced", selectedActivity: FamilyActivitySelection())
+  profile.startTriggers.schedule = true
+  profile.startSchedule = ProfileScheduleTime(days: [.monday, .tuesday], hour: 9, minute: 0)
+  profile.needsAppSelection = false    // app-selected on THIS device
+  // preActivationReminderTimes intentionally EMPTY ⇒ the OLD guard would have skipped this.
+  context.insert(profile)
+  XCTAssertTrue(PreActivationReminderScheduler.isEligibleForScheduleReconcile(profile))
+}
+
+@MainActor
+func testGivenScheduledButNeedsAppSelection_WhenEligibility_ThenFalse() throws {
+  let context = try ctx()
+  let profile = BlockedProfiles(name: "Unselected", selectedActivity: FamilyActivitySelection())
+  profile.startTriggers.schedule = true
+  profile.startSchedule = ProfileScheduleTime(days: [.monday], hour: 8, minute: 30)
+  profile.needsAppSelection = true     // fresh cross-device sync (§D: tokens are device-local)
+  context.insert(profile)
+  XCTAssertFalse(PreActivationReminderScheduler.isEligibleForScheduleReconcile(profile))
+}
+```
+(If `needsAppSelection` turns out to be computed rather than a settable stored property — confirm in B0 — drive it via the underlying selection state instead of assigning it directly.)
+
+- [ ] **Step 2: Run to verify it fails** (`-only-testing:FoqosTests/PreActivationReminderSchedulerTests`). Expected: FAIL — `isEligibleForScheduleReconcile` undefined.
+
+- [ ] **Step 3: Implement** (`PreActivationReminderScheduler.swift`) — the testable predicate plus the reconcile pass that uses it:
+
+```swift
+  /// #301: a profile is eligible for automatic DeviceActivity schedule registration iff it has
+  /// an active start/legacy schedule AND its apps are selected on THIS device. The
+  /// needsAppSelection gate is the semantic default (§D): FamilyControls tokens are device-local,
+  /// so a freshly-synced profile registers only after its apps are selected on this device.
+  static func isEligibleForScheduleReconcile(_ profile: BlockedProfiles) -> Bool {
+    let hasActiveSchedule =
+      (profile.startTriggers.schedule && profile.startSchedule?.isActive == true)
+      || profile.schedule?.isActive == true
+    return hasActiveSchedule && !profile.needsAppSelection
+  }
+
+  /// #301: register the DeviceActivity schedule for every ELIGIBLE profile, independent of whether
+  /// pre-activation REMINDERS are enabled (the mis-gating this fixes). `scheduleTimerActivity` is
+  /// idempotent (stop+re-register each call) and self-gating, so this is safe every foreground and
+  /// once per sync fetch. Reminder notifications remain gated inside `scheduleTimerActivity`'s tail
+  /// on `preActivationReminderTimes`. Respects `cleanUpGhostSchedules` (disjoint: this only ADDS
+  /// has-schedule activities).
+  static func reconcileScheduleRegistrations(context: ModelContext) {
+    do {
+      let profiles = try BlockedProfiles.fetchProfiles(in: context)
+      for profile in profiles where isEligibleForScheduleReconcile(profile) {
+        DeviceActivityCenterUtil.scheduleTimerActivity(for: profile)
+      }
+      Log.debug("Reconciled DeviceActivity schedule registrations", category: .timer)
+    } catch {
+      Log.error(
+        "Failed to reconcile schedule registrations: \(error.localizedDescription)",
+        category: .timer)
+    }
+  }
+```
+
+  Then (per MD-B1 rename) **rename** `rescheduleAllReminders` to `reconcileScheduleRegistrations` and update every call site from Task B0 Step 3, **or** keep `rescheduleAllReminders` as a thin caller of the new function. Recommended: rename — the old method already delegated all real work to `scheduleTimerActivity` (which schedules reminders internally), so no separate reminder loop is needed.
+
+- [ ] **Step 4: Update the foreground call sites** (`FoqosApp.swift:161` and `:260`) to call `PreActivationReminderScheduler.reconcileScheduleRegistrations(context: container.mainContext)`.
+
+- [ ] **Step 5: Run to verify it passes** (`-only-testing:FoqosTests/PreActivationReminderSchedulerTests`), then build the whole target. Expected: PASS + `BUILD SUCCEEDED`.
+
+- [ ] **Step 6: Commit**
+```bash
+git add Foqos/Utils/PreActivationReminderScheduler.swift Foqos/FoqosApp.swift FoqosTests/
+git commit -m "fix(#301): reconcile schedule registration independent of reminder pref (widen + rename)"
+```
+
+### Task B2: Register once per sync fetch cycle (coalesced) at the controller boundary
+
+**Files:**
+- Modify: `Foqos/CloudKit/SyncEngine/SyncEngineController.swift` (`handleDidFetchChanges`, symbol-located in B0)
+- Test: `FoqosTests/SyncEngineControllerTests.swift` (or the file that already drives `handleDidFetchChanges` — grep to find it)
+
+**Interfaces:**
+- Consumes: `PreActivationReminderScheduler.reconcileScheduleRegistrations(context:)` (Task B1). The controller has the apply `ModelContext` (the same one `SyncApplyService` uses) — reuse it; do not create a new context.
+
+> **Coalescing rationale (the user's "batch across a fetch not per-record"):** `handleDidFetchChanges` is the true fetch-cycle delimiter (it already spawns the `retryFailedApplies` sweep). Calling `reconcileScheduleRegistrations` **once** here — after all per-record applies in the cycle have committed — registers every touched profile's schedule in a single pass, rather than N per-record calls. It also naturally covers the two non-fetch apply sites (`serverRecordChanged` reconciliation, `retryFailedApplies`) on their next fetch cycle, and is idempotent so re-running is harmless.
+
+- [ ] **Step 1: Write the failing test** — after a fetch cycle that applied a scheduled profile, the controller reconciles registration. Mirror the existing `handleDidFetchChanges`/fetch-cycle test harness (grep `handleDidFetchChanges` / `didFetchChanges` in `FoqosTests`). Assert `reconcileScheduleRegistrations` ran (inject a test seam or assert the resulting `scheduleIsOutOfSync == false` on the applied profile). Skeleton:
+
+```swift
+@MainActor
+func testGivenFetchCycleAppliedScheduledProfile_WhenDidFetchChanges_ThenSchedulesReconciled() throws {
+  // Arrange: controller wired to an in-memory context holding a scheduled, non-app-selection-
+  //   pending profile whose DeviceActivity is NOT yet registered.
+  // Act: drive the .didFetchChanges event (handleDidFetchChanges).
+  // Assert: reconcileScheduleRegistrations was invoked for the apply context (schedule registered).
+}
+```
+
+- [ ] **Step 2: Run to verify it fails.** Expected: FAIL (no reconcile call yet).
+
+- [ ] **Step 3: Implement** — in `handleDidFetchChanges`, after the existing body (state transition + `retryFailedApplies` task spawn), add a synchronous reconcile call (DeviceActivity registration must stay on the main actor and return synchronously — B-7):
+
+```swift
+    // #301: a fetch cycle may have applied profiles whose schedule/trigger config changed;
+    // register their DeviceActivity schedules once, coalesced across the whole cycle (not
+    // per-record). Idempotent + self-gating; respects cleanUpGhostSchedules (adds only).
+    PreActivationReminderScheduler.reconcileScheduleRegistrations(context: modelContext)
+```
+  The controller's apply context is `private let modelContext: ModelContext` (`SyncEngineController.swift:24`) — the same one handed to `SyncApplyService`. `SyncEngineController` is `@MainActor`, so this DeviceActivity call is main-actor-safe, matching `BlockedProfileView.finalizeSave`. (Confirm the property name in B0 in case A4′/A3′ renamed it.)
+
+- [ ] **Step 4: Reconcile with A4′'s drains** — the `apply.drainReenqueues()` machinery **already exists at base** `c1e3c2f` (defined `SyncApplyService.swift:50`; called in `SyncEngineController.swift:364`, `:495`, and `:721` inside `retryFailedApplies`). A4′ *adds an additional* post-deletion drain call site; it does not introduce the drain itself. The reconcile call is **independent** of all drains (it registers schedules; the drains re-push repaired location refs) and must not interfere. Confirm ordering: the reconcile runs in `handleDidFetchChanges`, which fires *after* `handleFetchedRecordZoneChanges` for the cycle — so all applies (and every drain) have already run. No coupling.
+
+- [ ] **Step 5: Run the test + full suite slice**, then build:
+```
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=<UUID>' -only-testing:FoqosTests/SyncEngineControllerTests -only-testing:FoqosTests/PreActivationReminderSchedulerTests | xcpretty
+```
+Expected: green.
+
+- [ ] **Step 6: Commit**
+```bash
+git add Foqos/CloudKit/SyncEngine/SyncEngineController.swift FoqosTests/
+git commit -m "fix(#301): reconcile schedule registration once per sync fetch cycle (coalesced)"
+```
+
+### Task B3: Device acceptance (gate before merge)
+
+> Acceptance is stated for the **app-selected** case (per §D: a fresh cross-device sync is `needsAppSelection == true` and must have its apps selected on device B before its schedule can block anything — a FamilyControls token-locality constraint, not a #301 defect).
+
+- [ ] **DEVICE GATE (required):** Two devices, same iCloud account, sync ENABLED. On device A, create/edit a profile with an active schedule (schedule set, **reminders off** — the exact repro). Let it sync to device B and **complete app selection on device B** (so `needsAppSelection == false`). Now, **without tapping "Fix Schedule"**: (a) the "Fix Schedule" warning clears on the next foreground (Task B1) **and/or** immediately after the sync fetch (Task B2), and (b) when the schedule interval arrives, the schedule **fires on device B**. Capture an exported log (Settings footer must show a real commit SHA, no `+wip`) on the PR.
+- [ ] **DEVICE GATE — needsAppSelection (from §D probe):** confirm the gated default is honoured — a synced profile that has **not** had apps selected on B does not post a spurious notification / activate an invalid restriction. Record the §D probe result (a/b/c) in the PR body.
+
+---
+
+## Mini-plan C — #298: apply the #300 snapshot pattern to the five twin views
+
+### C. The pattern (from PR #300, `docs/superpowers/plans/2026-07-10-297-blockedprofilecard-snapshot-rendering.md`)
+
+PR #300 fixed `BlockedProfileCard`'s zombie-`@Model` crash by having the view render from an **immutable value snapshot** instead of the live SwiftData `@Model`. #298 replays that *exact* pattern for the five remaining latent twins. Each conversion has four parts (this is mechanical — do the same thing five times):
+
+1. **Per-view value snapshot struct** `XxxData` (a plain `struct`, NOT a `@Model`, NOT persisted/synced) holding only the value fields the view renders.
+2. **Builder** `extension <Model> { var xxxData: XxxData { … } }` that reads the live attributes/relationships — called **only** on a valid (non-zombie) model.
+3. **Construction behind the validity gate, inside the observation-tracked body.** Build `model.xxxData` at the call site **inside the existing `SafeModelView`/`.valid` closure** — the tracked reads register the `@Observable` dependencies so a legitimate edit rebuilds the snapshot in place. Add the **do-not-memoize tripwire comment** at every construction site (copy the wording from `BlockedProfileCardData.swift:43-49`).
+4. **Type-signature-as-regression-guard.** After the view takes only `XxxData`, it can no longer hold a live `@Model`, so the crash class is unrepresentable — reintroducing `let x: <Model>` is a compile error. Add the `REGRESSION GUARD (#298)` comment (mirror `BlockedProfileCardData.swift:5-14`) and a runtime zombie-survival test per view.
+
+**Reference tripwire text to copy verbatim into each builder** (from `BlockedProfileCardData.swift:43-49`):
+> `TRIPWIRE (#297 edit-propagation): this MUST be evaluated inside an observation-tracked SwiftUI body … Do NOT memoize it, cache it on the model, or move the call into an init / stored property / out of the render path — that silently stops the view updating on edits while still compiling and passing the zombie test.`
+(Re-tag it `#298` and name the view's freshness test.)
+
+**Scope note:** all five are **already rendered behind a validity gate** (four via `SafeModelView`, one — `ProfileRow` — confirm in C0); the residual risk is identical to #297: the gate filters at *creation*, but a re-render on an already-mounted row after a post-save delete still dereferences the live `@Model`. The snapshot removes the live model from the view subtree entirely.
+
+### Two views need a NON-trivial snapshot shape (flagged)
+
+- **`SessionRow`** renders **derived display strings** via `extension BlockedProfileSession` (`formattedDate`, `formattedDuration`, `timeRangeText`, `breakRangeText`, …). Its snapshot holds the **raw fields** and the six formatting helpers are **relocated onto `SessionRowData`** (faithful to #297, where `BlockedProfileCardData` holds raw fields and the view computes). The extension is used **only** by this file (verify in C0), so relocating — not duplicating — is safe.
+- **`LocationReferenceRow`** holds a live `SavedLocation` (`@Model`) **and** a `@Binding var reference: ProfileLocationReference`. `ProfileLocationReference` is a **`Codable` value struct** (`Packages/FoqosShared/Sources/FoqosShared/GeofenceRule.swift:46-58`), **not** a `@Model`, and the row **mutates** it (`reference.radiusOverrideMeters = …`). So this is a **mixed** shape: snapshot only the `location` into a value; **keep the `@Binding reference` exactly as-is**. Do not value-copy the reference (that breaks the two-way write).
+
+### Task C0: Citation refresh (MANDATORY — no code)
+
+- [ ] **Step 1: Record base SHA** (`git rev-parse HEAD`, expect `c1e3c2f`).
+- [ ] **Step 2: Confirm each view's `@Model` reads + construction site + gate:**
+```bash
+grep -nF 'struct LockedProfileCard' Foqos/Views/Child/ChildDashboardView.swift        # body @ ~:351; ctor @ ~:283 (SafeModelView)
+grep -nF 'ProfileRow(profile' Foqos/Views/BlockedProfileListView.swift                # ctor @ ~:71 — CONFIRM the gate (.valid or SafeModelView)
+grep -nF 'SessionRow(session' Foqos/Views/BlockedProfileSessionsView.swift            # ctors @ ~:55 (activeSession, UNGATED) and ~:63 (SafeModelView)
+grep -nF 'SavedLocationCard(' Foqos/Views/SavedLocationsView.swift                    # ctor @ ~:76 (SafeModelView)
+grep -nF 'LocationReferenceRow(' Foqos/Components/BlockedProfileView/GeofencePicker.swift  # ctor @ ~:104 (SafeModelView)
+grep -rnF 'extension BlockedProfileSession' Foqos                                     # confirm the formatting extension is used ONLY by SessionRow.swift
+```
+Confirm the reads listed per task below still match. **Flag if `ProfileRow`'s `:71` call is behind `.valid` vs `SafeModelView`** (its snapshot must be built inside whichever gate closure exists; if `ForEach(profiles.valid)` with no per-item `SafeModelView`, build the snapshot inside the `ForEach` body — a `.valid` element is confirmed-valid at that point).
+- [ ] **Step 3: Confirm `isPersistentModelValid`** exists (`Foqos/Utils/Extensions.swift`) for the zombie tests, and that `BlockedProfileCardDataTests.swift` is the naming/setup template to mirror.
+
+### Task C1: `ProfileRow` → `ProfileRowData`
+
+**Files:** Modify `Foqos/Components/BlockedProfileView/BlockedProfileRow.swift`; Modify caller `Foqos/Views/BlockedProfileListView.swift` (`:71`); Test `FoqosTests/TwinViewSnapshotTests.swift` (create).
+
+**Model reads:** `profile.name`, `profile.updatedAt`, `profile.selectedActivity` (via `FamilyActivityUtil.countSelectedActivities`).
+
+- [ ] **Step 1: Failing test** (create `TwinViewSnapshotTests.swift`, mirror `BlockedProfileCardDataTests`):
+```swift
+import FamilyControls
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+final class TwinViewSnapshotTests: XCTestCase {
+  @MainActor private func ctx() throws -> ModelContext {
+    try ModelContainer(
+      for: BlockedProfiles.self,
+      configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+    ).mainContext
+  }
+
+  @MainActor
+  func testGivenProfile_WhenProfileRowData_ThenMapsFields() throws {
+    let context = try ctx()
+    let now = Date()
+    let profile = BlockedProfiles(
+      name: "School", selectedActivity: FamilyActivitySelection(),
+      createdAt: now, updatedAt: now)
+    context.insert(profile)
+    let data = profile.profileRowData
+    XCTAssertEqual(data.id, profile.id)
+    XCTAssertEqual(data.name, "School")
+    XCTAssertEqual(data.updatedAt, now)
+    XCTAssertEqual(data.selectedItemsCount, 0)
+  }
+
+  @MainActor
+  func testGivenProfileRowDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap() throws {
+    let context = try ctx()
+    let profile = BlockedProfiles(name: "School", selectedActivity: FamilyActivitySelection())
+    context.insert(profile); try context.save()
+    let data = profile.profileRowData
+    context.delete(profile); try context.save()
+    XCTAssertFalse(profile.isPersistentModelValid)   // zombie now
+    XCTAssertEqual(data.name, "School")              // snapshot survives (live read would trap)
+  }
+}
+```
+- [ ] **Step 2: Run → FAIL** (`-only-testing:FoqosTests/TwinViewSnapshotTests`): `value of type 'BlockedProfiles' has no member 'profileRowData'`.
+- [ ] **Step 3: Add the struct + builder** (new file `Foqos/Components/BlockedProfileView/ProfileRowData.swift`):
+```swift
+import FamilyControls
+import Foundation
+
+// REGRESSION GUARD (#298): ProfileRow accepts ONLY this value type — it can no longer hold a
+// live BlockedProfiles @Model, so a re-render can never read a vacated store row. Reintroducing
+// `let profile: BlockedProfiles` on the view is a compile-time-visible regression.
+struct ProfileRowData {
+  let id: UUID
+  let name: String
+  let updatedAt: Date
+  let selectedItemsCount: Int
+}
+
+extension BlockedProfiles {
+  /// TRIPWIRE (#298 edit-propagation): build ONLY inside the observation-tracked body (the
+  /// caller's `.valid`/SafeModelView closure). Do NOT memoize/cache/hoist into an init — that
+  /// silently stops ProfileRow updating on edits while still compiling and passing the zombie
+  /// test. Guarded by testGivenProfileRowData…NoTrap and the caller-site tripwire comment.
+  var profileRowData: ProfileRowData {
+    ProfileRowData(
+      id: id, name: name, updatedAt: updatedAt,
+      selectedItemsCount: FamilyActivityUtil.countSelectedActivities(selectedActivity))
+  }
+}
+```
+- [ ] **Step 4: Convert the view** (`BlockedProfileRow.swift`): replace `let profile: BlockedProfiles` with `let data: ProfileRowData`; `formattedUpdateTime` reads `data.updatedAt` (keep the `RelativeDateTimeFormatter` + `Date()` at render — display-only); `selectedItemsCount` becomes `data.selectedItemsCount`; `Text(profile.name)` → `Text(data.name)`. Update the `#Preview` to `ProfileRow(data: BlockedProfiles(name: "⌛ School Hours", selectedActivity: FamilyActivitySelection(), createdAt: Date(), updatedAt: Date().addingTimeInterval(-3600)).profileRowData)`.
+- [ ] **Step 5: Convert the caller** (`BlockedProfileListView.swift:71`), building the snapshot inside the validity gate with the tripwire comment:
+```swift
+          // #298: build the snapshot ONLY here inside the validity gate (observation-tracked);
+          // do NOT hoist/memoize — see the profileRowData tripwire.
+          ProfileRow(data: p.profileRowData)
+```
+(Use the gate closure variable name confirmed in C0 — `p` if `SafeModelView(profile) { p in … }`, or the `ForEach(profiles.valid)` element if `.valid`.)
+- [ ] **Step 6: Run tests + build.** Expected: green + `BUILD SUCCEEDED`, and `grep -nF 'let profile: BlockedProfiles' Foqos/Components/BlockedProfileView/BlockedProfileRow.swift` returns nothing.
+- [ ] **Step 7: Commit** `git commit -m "refactor(#298): ProfileRow renders from ProfileRowData value snapshot"`.
+
+### Task C2: `SessionRow` → `SessionRowData` (raw fields + relocated helpers)
+
+**Files:** Modify `Foqos/Components/Sessions/SessionRow.swift`; Modify caller `Foqos/Views/BlockedProfileSessionsView.swift` (`:55` **ungated activeSession** + `:63`); Test add to `TwinViewSnapshotTests.swift`.
+
+**Model reads (all via the extension):** `startTime`, `endTime`, `breakStartTime`, `breakEndTime`, `isActive`, `duration()`.
+
+- [ ] **Step 1: Failing tests** (append). Assert the relocated formatters produce identical strings from the snapshot, and the zombie survival:
+```swift
+  @MainActor
+  func testGivenSessionRowData_WhenFormatted_ThenMatchesRawFieldLogic() throws {
+    let now = Date()
+    let data = SessionRowData(
+      startTime: now, endTime: now.addingTimeInterval(3600),
+      breakStartTime: nil, breakEndTime: nil, isActive: false, durationSeconds: 3600)
+    XCTAssertEqual(data.formattedDuration, "1h 0m")
+    XCTAssertEqual(data.timeRangeText.contains("→"), true)
+    XCTAssertNil(data.breakRangeText)
+  }
+
+  @MainActor
+  func testGivenSessionRowDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap() throws {
+    let context = try ctx()
+    let profile = BlockedProfiles(name: "P", selectedActivity: FamilyActivitySelection())
+    context.insert(profile)
+    let session = BlockedProfileSession.createSession(in: context, withTag: "t", withProfile: profile)
+    try context.save()
+    let data = session.sessionRowData
+    context.delete(session); try context.save()
+    XCTAssertFalse(session.isPersistentModelValid)
+    _ = data.timeRangeText   // must not trap (would trap on session.startTime if live)
+  }
+```
+(Confirm the `BlockedProfileSession` factory used elsewhere in tests — grep `FoqosTests` for how sessions are built; reuse that exact constructor.)
+- [ ] **Step 2: Run → FAIL** (`sessionRowData` / `SessionRowData` undefined).
+- [ ] **Step 3: Struct + builder + relocated helpers** (`SessionRow.swift` — move the `extension BlockedProfileSession` computed props onto `SessionRowData`, keeping the bodies byte-for-byte except `startTime`→`self.startTime` etc.):
+```swift
+// REGRESSION GUARD (#298): SessionRow accepts ONLY this value type — it can no longer hold a live
+// BlockedProfileSession @Model, so a re-render can never read a vacated store row.
+struct SessionRowData {
+  let startTime: Date
+  let endTime: Date?
+  let breakStartTime: Date?
+  let breakEndTime: Date?
+  let isActive: Bool
+  let durationSeconds: TimeInterval
+
+  var formattedDate: String {
+    let calendar = Calendar.current
+    if calendar.isDateInToday(startTime) { return "Today" }
+    if calendar.isDateInYesterday(startTime) { return "Yesterday" }
+    let f = DateFormatter(); f.dateStyle = .medium; f.timeStyle = .none
+    return f.string(from: startTime)
+  }
+  var formattedStartTime: String { startTime.formatted(date: .omitted, time: .shortened) }
+  var formattedEndTime: String? { endTime?.formatted(date: .omitted, time: .shortened) }
+  var timeRangeText: String {
+    if let e = formattedEndTime { return "\(formattedStartTime) → \(e)" }
+    return "Started \(formattedStartTime)"
+  }
+  var breakRangeText: String? {
+    guard let breakStartTime else { return nil }
+    let s = breakStartTime.formatted(date: .omitted, time: .shortened)
+    if let breakEndTime {
+      return "Break \(s) → \(breakEndTime.formatted(date: .omitted, time: .shortened))"
+    }
+    return isActive ? "Break \(s) (ongoing)" : "Break \(s)"
+  }
+  var formattedDuration: String {
+    let minutes = Int(durationSeconds) / 60
+    let hours = minutes / 60, rem = minutes % 60
+    return hours > 0 ? "\(hours)h \(rem)m" : "\(minutes)m"
+  }
+}
+
+extension BlockedProfileSession {
+  // TRIPWIRE (#298): build ONLY inside the SafeModelView closure; do NOT hoist/memoize.
+  var sessionRowData: SessionRowData {
+    SessionRowData(
+      startTime: startTime, endTime: endTime, breakStartTime: breakStartTime,
+      breakEndTime: breakEndTime, isActive: isActive, durationSeconds: duration())
+  }
+}
+```
+Then **delete** the old `extension BlockedProfileSession { … formattedDate … }` block from `SessionRow.swift` (its six props are now on `SessionRowData`). Change the view to `let data: SessionRowData` and repoint `session.X` → `data.X`. Add the `REGRESSION GUARD (#298)` header comment.
+- [ ] **Step 4: Convert both callers** (`BlockedProfileSessionsView.swift`). The `:63` past-sessions loop is behind `SafeModelView(session) { s in … }` — change to `SessionRow(data: s.sessionRowData)` with a tripwire comment. The **`:55` activeSession path is UNGATED** — wrap it so the snapshot is built on a valid model:
+```swift
+        if let activeSession {
+          Section("Active Session") {
+            // #298: activeSession is a live @Model — gate before snapshotting (was ungated).
+            SafeModelView(activeSession) { s in SessionRow(data: s.sessionRowData) }
+          }
+        }
+```
+- [ ] **Step 5: Run tests + build.** Green + no `let session: BlockedProfileSession` remaining in `SessionRow.swift`; confirm the extension move didn't break other callers (`grep -rn '\.formattedDuration\|\.timeRangeText\|\.breakRangeText\|\.formattedDate' Foqos` — all should resolve to `SessionRowData` now; if any live-model caller remains, it was NOT the only user — STOP and reconcile).
+- [ ] **Step 6: Commit** `git commit -m "refactor(#298): SessionRow renders from SessionRowData; relocate formatters onto the value type"`.
+
+### Task C3: `SavedLocationCard` → `SavedLocationCardData`
+
+**Files:** Modify `Foqos/Components/Settings/SavedLocationCard.swift`; Modify caller `Foqos/Views/SavedLocationsView.swift` (`:76`); Test add.
+
+**Model reads:** `location.name`, `location.isLocked`, `location.defaultRadiusMeters`.
+
+- [ ] **Step 1: Failing test** (append) — map + zombie survival:
+```swift
+  @MainActor
+  func testGivenSavedLocationCardDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap() throws {
+    let context = try ModelContainer(
+      for: SavedLocation.self,
+      configurations: ModelConfiguration(isStoredInMemoryOnly: true)).mainContext
+    let loc = SavedLocation(name: "Home", latitude: 0, longitude: 0, defaultRadiusMeters: 500)
+    context.insert(loc); try context.save()
+    let data = loc.savedLocationCardData
+    XCTAssertEqual(data.name, "Home")
+    XCTAssertEqual(data.defaultRadiusMeters, 500)
+    context.delete(loc); try context.save()
+    XCTAssertFalse(loc.isPersistentModelValid)
+    XCTAssertEqual(data.name, "Home")   // snapshot survives
+  }
+```
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Struct + builder** (new file `Foqos/Components/Settings/SavedLocationCardData.swift`):
+```swift
+import Foundation
+
+// REGRESSION GUARD (#298): SavedLocationCard accepts ONLY this value type (no live SavedLocation).
+struct SavedLocationCardData {
+  let id: UUID
+  let name: String
+  let isLocked: Bool
+  let defaultRadiusMeters: Double
+}
+
+extension SavedLocation {
+  // TRIPWIRE (#298): build ONLY inside the SafeModelView closure; do NOT hoist/memoize.
+  var savedLocationCardData: SavedLocationCardData {
+    SavedLocationCardData(
+      id: id, name: name, isLocked: isLocked, defaultRadiusMeters: defaultRadiusMeters)
+  }
+}
+```
+- [ ] **Step 4: Convert the view** (`SavedLocationCard.swift`): `let location: SavedLocation` → `let location: SavedLocationCardData` (keep the param name `location` so the body's `location.name` / `location.isLocked` / `location.defaultRadiusMeters` reads are unchanged; `SavedLocation.formatRadius(location.defaultRadiusMeters)` stays — `formatRadius` is a static, unaffected). Keep `onTap`/`inUseByProfile`. Update the three `#Preview` cards to `.savedLocationCardData` (build in-memory `SavedLocation`, then `.savedLocationCardData`).
+- [ ] **Step 5: Convert the caller** (`SavedLocationsView.swift:76`), inside the existing `SafeModelView(location) { loc in … }`:
+```swift
+                // #298: snapshot inside the validity gate; do NOT hoist — see tripwire.
+                SavedLocationCard(
+                  location: loc.savedLocationCardData,
+                  onTap: { handleEdit(loc) },   // closure keeps the live `loc` (gate scope) — OK
+                  inUseByProfile: locationsInUseByActiveProfiles[loc.id])
+```
+(The `onTap` closure legitimately captures the live `loc` — it runs on tap, inside the gate scope, exactly like #300's carousel `on*Tapped` closures. Only the *view's stored data* must be a value.)
+- [ ] **Step 6: Run tests + build.** Green; no `let location: SavedLocation` in the card.
+- [ ] **Step 7: Commit** `git commit -m "refactor(#298): SavedLocationCard renders from SavedLocationCardData"`.
+
+### Task C4: `LocationReferenceRow` → `LocationReferenceRowData` (mixed: snapshot location, keep binding)
+
+**Files:** Modify `Foqos/Components/BlockedProfileView/LocationReferenceRow.swift`; Modify caller `Foqos/Components/BlockedProfileView/GeofencePicker.swift` (`:104`); Test add.
+
+**Model reads (of the `@Model` only):** `location.name`, `location.isLocked`, `location.defaultRadiusMeters`. The `@Binding var reference: ProfileLocationReference` is a value struct — **keep it**.
+
+- [ ] **Step 1: Failing test** (append) — zombie survival of the location snapshot:
+```swift
+  @MainActor
+  func testGivenLocationReferenceRowDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap() throws {
+    let context = try ModelContainer(
+      for: SavedLocation.self,
+      configurations: ModelConfiguration(isStoredInMemoryOnly: true)).mainContext
+    let loc = SavedLocation(name: "Office", latitude: 0, longitude: 0, defaultRadiusMeters: 1000)
+    context.insert(loc); try context.save()
+    let data = loc.locationReferenceRowData
+    context.delete(loc); try context.save()
+    XCTAssertFalse(loc.isPersistentModelValid)
+    XCTAssertEqual(data.name, "Office")
+    XCTAssertEqual(data.defaultRadiusMeters, 1000)
+  }
+```
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Struct + builder** (new file `Foqos/Components/BlockedProfileView/LocationReferenceRowData.swift`):
+```swift
+import Foundation
+
+// REGRESSION GUARD (#298): LocationReferenceRow's LOCATION is this value type (no live SavedLocation).
+// The `reference` binding stays a two-way @Binding — ProfileLocationReference is a value struct.
+struct LocationReferenceRowData {
+  let id: UUID
+  let name: String
+  let isLocked: Bool
+  let defaultRadiusMeters: Double
+}
+
+extension SavedLocation {
+  // TRIPWIRE (#298): build ONLY inside the SafeModelView closure; do NOT hoist/memoize.
+  var locationReferenceRowData: LocationReferenceRowData {
+    LocationReferenceRowData(
+      id: id, name: name, isLocked: isLocked, defaultRadiusMeters: defaultRadiusMeters)
+  }
+}
+```
+- [ ] **Step 4: Convert the view** (`LocationReferenceRow.swift`): replace `let location: SavedLocation` with `let location: LocationReferenceRowData`; **leave `@Binding var reference`, `isSelected`, `onToggle` untouched**. The body reads `location.name`/`location.isLocked`/`location.defaultRadiusMeters` — unchanged (same names). `effectiveRadius`, the `Reset` button (`location.defaultRadiusMeters`), and the slider `onChange` (`location.defaultRadiusMeters`) all keep working against the value. Update the three `#Preview`s: build each `SavedLocation(...).locationReferenceRowData` for the `location:` arg (keep the `reference:`/`isSelected:`/`onToggle:` args as-is).
+- [ ] **Step 5: Convert the caller** (`GeofencePicker.swift:104`), inside the existing `SafeModelView(location) { loc in … }` — snapshot the location, keep the binding:
+```swift
+                // #298: snapshot the location inside the gate; the reference stays a live binding.
+                LocationReferenceRow(
+                  location: loc.locationReferenceRowData,
+                  reference: binding,          // ProfileLocationReference value binding — unchanged
+                  isSelected: isSelected,
+                  onToggle: { selected in /* unchanged body */ })
+```
+- [ ] **Step 6: Run tests + build.** Green; no `let location: SavedLocation` in the row; the `reference` binding still mutates (`selectedLocationIds`/`locationReferences` still update on slider changes — spot-check in the build).
+- [ ] **Step 7: Commit** `git commit -m "refactor(#298): LocationReferenceRow snapshots the location, keeps the reference binding"`.
+
+### Task C5: `LockedProfileCard` → `LockedProfileCardData`
+
+**Files:** Modify `Foqos/Views/Child/ChildDashboardView.swift` (struct `~:351` + caller `~:283`); Test add.
+
+**Model reads:** `profile.name`, `FamilyActivityUtil.countSelectedActivities(profile.selectedActivity)`.
+
+- [ ] **Step 1: Failing test** (append):
+```swift
+  @MainActor
+  func testGivenLockedProfileCardDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap() throws {
+    let context = try ctx()
+    let profile = BlockedProfiles(name: "Managed", selectedActivity: FamilyActivitySelection())
+    context.insert(profile); try context.save()
+    let data = profile.lockedProfileCardData
+    context.delete(profile); try context.save()
+    XCTAssertFalse(profile.isPersistentModelValid)
+    XCTAssertEqual(data.name, "Managed")
+    XCTAssertEqual(data.appsBlockedCount, 0)
+  }
+```
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Struct + builder** (new file `Foqos/Views/Child/LockedProfileCardData.swift`):
+```swift
+import FamilyControls
+import Foundation
+
+// REGRESSION GUARD (#298): LockedProfileCard accepts ONLY this value type (no live BlockedProfiles).
+struct LockedProfileCardData {
+  let id: UUID
+  let name: String
+  let appsBlockedCount: Int
+}
+
+extension BlockedProfiles {
+  // TRIPWIRE (#298): build ONLY inside the SafeModelView closure; do NOT hoist/memoize.
+  var lockedProfileCardData: LockedProfileCardData {
+    LockedProfileCardData(
+      id: id, name: name,
+      appsBlockedCount: FamilyActivityUtil.countSelectedActivities(selectedActivity))
+  }
+}
+```
+- [ ] **Step 4: Convert the view** (`ChildDashboardView.swift:351-381`): `let profile: BlockedProfiles` → `let data: LockedProfileCardData`; `Text(profile.name)` → `Text(data.name)`; the apps-blocked `Text` → `Text("\(data.appsBlockedCount) apps blocked")`.
+- [ ] **Step 5: Convert the caller** (`:283-284`), inside the existing `SafeModelView(profile) { p in … }`:
+```swift
+              // #298: snapshot inside the validity gate; do NOT hoist — see tripwire.
+              LockedProfileCard(data: p.lockedProfileCardData)
+```
+- [ ] **Step 6: Run tests + build.** Green; no `let profile: BlockedProfiles` on `LockedProfileCard`.
+- [ ] **Step 7: Commit** `git commit -m "refactor(#298): LockedProfileCard renders from LockedProfileCardData"`.
+
+---
+
+## Final verification (whole PR)
+
+- [ ] **Full suite green** on the booted sim (UUID destination, single boot):
+```
+xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=<UUID>' | xcpretty
+```
+- [ ] **`swift-format lint --recursive .` clean.**
+- [ ] **#298 no live-model twins remain:**
+```bash
+grep -rn 'let profile: BlockedProfiles'  Foqos/Components/BlockedProfileView/BlockedProfileRow.swift Foqos/Views/Child/ChildDashboardView.swift
+grep -rn 'let session: BlockedProfileSession' Foqos/Components/Sessions/SessionRow.swift
+grep -rn 'let location: SavedLocation' Foqos/Components/Settings/SavedLocationCard.swift Foqos/Components/BlockedProfileView/LocationReferenceRow.swift
+```
+All three must return **nothing** (the five views hold no live `@Model`).
+- [ ] **#302 DEVICE GATE (required, no debugger):** one device, sync **toggled OFF**. Delete a profile (both via list swipe/`onDelete` and via the profile detail delete) and a saved location. Toggle sync **ON**. Confirm each deletion **propagates to a second device** (the family's other device sees them removed). Then repeat the N5 keep-bias case: while sync is off on device A, delete profile X; on device B (sync on) **edit** profile X; toggle A on → X is **kept** (conflict surfaced), not deleted. Capture an exported log (real commit SHA, no `+wip`) on the PR.
+- [ ] **#301 DEVICE GATE (required):** the Task B3 two-device schedule-fires-without-Fix-Schedule flow, plus the §D `needsAppSelection` probe result recorded.
+- [ ] **#298 DEVICE GATE (required, no debugger):** reproduce the #297 class for each surface — delete the underlying model while its twin is on-screen (child dashboard locked cards; profile list rows; a profile's session list incl. the **active** session; saved-locations list; geofence picker rows), ≥10 cycles each. Expected: **zero crashes**. Edit-propagation spot-check: rename a profile / rename a saved location and confirm the row/card updates **in place** (proves the snapshot rebuilds on legitimate edits — the one way the pattern rots).
+- [ ] **Request code review** (AGENTS.md: review before merge). Reference #302, #301, #298 and epic #263. Note #301's A4′ stacking in the PR description.
+
+## Out of scope (do NOT do here)
+- **#302:** the `.notAttached` in-memory deferred-delete durability gap (MD-A3) — file separately unless the maintainer folds it in.
+- **#301:** any change to `cleanUpGhostSchedules`' removal semantics; any DeviceActivity dependency added *inside* `SyncApplyService` (the reconcile lives in the controller boundary + reconciler, not the pure-data apply service).
+- **#298:** any view NOT in the five-view list; `BlockedProfileCard`/`ProfileScheduleRow` (already done in #300).
+
+## Self-review checklist (planner ran this)
+
+- **Spec coverage:**
+  - #302 ✓ — durable tombstone via existing store, no engine enqueue (A1); write-after-commit at the #289 boundary from all three disabled branches (A2); converges with `enqueueTombstoneDelete`'s `store.setTombstone`+`MutationFunnel.changeTag` pair, does not duplicate (A1 Step 4); acceptance = the exact `design.md:698-699` checklist row (A3 Step 1); round-4/5 conformance argued against `§2:161-169` + I12 entity-present guard and tested (A3 Step 3); N5 keep-bias tested (A3 Step 2); adjacent `.notAttached` gap escalated (MD-A3).
+  - #301 ✓ — reconcile after apply of create/update whose config changed (B2, coalesced per fetch); remote-delete de-registration confirmed already-present (`deleteProfile:497`, §B); "why rescheduleAllReminders doesn't cover it" resolved = the `preActivationReminderEnabled` eligibility filter (§B), and widening-vs-hooking answered = widen is the cleaner seam, escalated as MD-B1 with Option C (both seams); batch/coalesce across a fetch not per-record (B2); `cleanUpGhostSchedules` semantics respected + argued disjoint (MD-B1); A4′ stacking + symbol-level citation-refresh in the header + B0; `needsAppSelection` required device probe (§D).
+  - #298 ✓ — five views, per-view value snapshot built behind the validity gate inside the observation-tracked body (C1–C5 Step 5), do-not-memoize tripwire at each construction site + builder, type-signature-as-regression-guard comment + per-view zombie-survival test; the two non-trivial shapes flagged (SessionRow relocated helpers; LocationReferenceRow mixed snapshot+binding).
+- **Placeholder scan:** every code step shows real code, **except** the A3 acceptance/keep-bias/round-4/5 cases and the B2 fetch-cycle case, which are deliberately Arrange/Act/Assert **outline skeletons** — because they must reuse the *existing* harnesses (`SyncEngineControllerTests`' I12 `recoverDeleteIntents` harness at `~:540`; the `handleDidFetchChanges` fetch-cycle harness) rather than construct a new one, and A3 Steps 2/3 already exist verbatim. Field types are copied from the verified source (`BlockedProfileCardData.swift`, the five view files, `MutationFunnel.swift`, `PreActivationReminderScheduler.swift`, `ProfileScheduleTime.swift`). #301 line numbers are explicitly provisional and re-derived by symbol in B0 (post-A4′).
+- **Type consistency:** `recordDisabledDeleteTombstone(recordName:)` used identically across protocol/impl/wrapper/mock; `reconcileScheduleRegistrations(context:)` consistent B1↔B2; each `XxxData`/`xxxData` builder name matches its view and test (`profileRowData`, `sessionRowData`, `savedLocationCardData`, `locationReferenceRowData`, `lockedProfileCardData`).
+- **Known soft spots to verify during Task 0s:** (a) #301's exact line numbers post-A4′/A3′ — B0 re-greps by symbol; (b) the DeviceActivity test seam used by the existing suite — B1/B2 reuse it rather than inventing; (c) the `BlockedProfileSession` factory + `CKRecord`-with-systemFields test helper — C2/A1 reuse the established ones; (d) whether `ProfileRow`'s caller gate is `.valid` or `SafeModelView` — C0 flags it.


### PR DESCRIPTION
## Plans the fix for #302, #301, #298 (epic #263 follow-ups)

**Plan-only PR** (no code changes) — one branch, one PR bundling three self-contained mini-plans (the F+I pattern), each executed and reviewed in sequence. Plan doc: `docs/superpowers/plans/2026-07-10-263-followups-302-301-298.md`.

### Mini-plan A — #302: durable tombstone on a disabled-sync local delete
A local delete made while sync is **disabled** writes no delete-intent tombstone, so it never propagates on re-enable (the `design.md:698-699` checklist row "toggle off → local delete → on"). Fix: a driver-free `recordDisabledDeleteTombstone` facade verb (`store.setTombstone` + `MutationFunnel.changeTag(fromSystemFields:)`, no engine enqueue), written **after** the local delete durably commits (#289 boundary) from all three disabled branches. Round-4/5 "kill-the-record" conformance argued explicitly (write-after-commit ⇒ a rolled-back delete never leaves a tombstone; I12 entity-present abort as defence-in-depth) + N5 keep-bias.

### Mini-plan B — #301: register synced profiles' schedules on the receiving device
`SyncApplyService` persists a synced schedule but never registers the DeviceActivity schedule, so it never fires and "Fix Schedule" persists. Root cause resolved: the foreground reconciler `rescheduleAllReminders` is **mis-gated** behind the reminder pref (`preActivationReminderEnabled`). **MAINTAINER DECISION (MD-B1):** widening the reconciler is the cleaner seam than hooking apply — recommended **Option C**: one `reconcileScheduleRegistrations` pass called from foreground **and** coalesced once per fetch cycle. `needsAppSelection` gate is semantically correct (FamilyControls tokens are device-local) + a required device probe. **⚠ Stacked on A4′** — header carries a symbol-level citation-refresh.

### Mini-plan C — #298: apply the #300 snapshot pattern to the five twin views
Mechanical replay of the PR #300 value-snapshot pattern for `LockedProfileCard`, `ProfileRow`, `SessionRow`, `SavedLocationCard`, `LocationReferenceRow` — per-view snapshot built behind the validity gate inside the observation-tracked body, do-not-memoize tripwire + type-signature regression guard + per-view zombie-survival test. Two non-trivial shapes flagged (`SessionRow` relocated formatters; `LocationReferenceRow` snapshot-location-keep-binding).

### Provenance
Grounded against HEAD `c1e3c2f` with SHA-pinned, adversarially-verified citations, then a per-mini-plan adversarial review pass (13 findings, all resolved). Genuine maintainer decisions escalated (MD-A1 facade seam, MD-A3 adjacent `.notAttached` gap, MD-B1 seam, §D device probe). Implementation is a separate session per mini-plan.

Refs epic #263.

## Summary by Sourcery

Add a detailed implementation plan document for epic #263 follow-up work covering issues #302, #301, and #298, to guide future code changes without modifying the current codebase.

Documentation:
- Document a structured, test-driven plan to fix disabled-sync deletion tombstones (#302).
- Document a plan to reconcile DeviceActivity schedule registration for synced profiles, including foreground and fetch-cycle behavior (#301).
- Document a plan to convert five SwiftUI twin views to value-snapshot rendering to avoid zombie @Model crashes (#298).