### PR TITLE
A3′ sync conflict semantics

### DIFF
--- a/Foqos/CloudKit/CloudKitNetworkService+Commands.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Commands.swift
@@ -7,10 +7,9 @@ extension CloudKitNetworkService {
 
   /// Outcome of attempting to save a FamilyCommand. `.alreadyPending` means the deterministic
   /// recordName collided with a still-pending identical command, an idempotent success (#222).
-  enum CommandSaveOutcome: Equatable { case sent, alreadyPending, failed }
+  enum CommandSaveOutcome: Equatable { case alreadyPending, failed }
 
-  static func classifyCommandSave(error: Error?) -> CommandSaveOutcome {
-    guard let error else { return .sent }
+  static func classifyCommandSave(error: Error) -> CommandSaveOutcome {
     if let ckError = error as? CKError, ckError.code == .serverRecordChanged {
       return .alreadyPending
     }
@@ -30,8 +29,6 @@ extension CloudKitNetworkService {
       Log.info("Command sent successfully", category: .cloudKit)
     } catch {
       switch Self.classifyCommandSave(error: error) {
-      case .sent:
-        break
       case .alreadyPending:
         // #222: the deterministic recordName means an identical command is already queued.
         Log.info(

--- a/Foqos/CloudKit/CloudKitNetworkService+Commands.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Commands.swift
@@ -5,6 +5,18 @@ extension CloudKitNetworkService {
 
   // MARK: - Family Commands
 
+  /// Outcome of attempting to save a FamilyCommand. `.alreadyPending` means the deterministic
+  /// recordName collided with a still-pending identical command, an idempotent success (#222).
+  enum CommandSaveOutcome: Equatable { case sent, alreadyPending, failed }
+
+  static func classifyCommandSave(error: Error?) -> CommandSaveOutcome {
+    guard let error else { return .sent }
+    if let ckError = error as? CKError, ckError.code == .serverRecordChanged {
+      return .alreadyPending
+    }
+    return .failed
+  }
+
   func sendCommand(_ command: FamilyCommand) async throws {
     Log.info("Sending command: \(command.commandType.rawValue) to child", category: .cloudKit)
 
@@ -17,8 +29,18 @@ extension CloudKitNetworkService {
       _ = try await privateDatabase.save(record)
       Log.info("Command sent successfully", category: .cloudKit)
     } catch {
-      Log.error("Failed to send command: \(error)", category: .cloudKit)
-      throw CloudKitError.saveFailed(error)
+      switch Self.classifyCommandSave(error: error) {
+      case .sent:
+        break
+      case .alreadyPending:
+        // #222: the deterministic recordName means an identical command is already queued.
+        Log.info(
+          "Command already pending (serverRecordChanged) - idempotent success",
+          category: .cloudKit)
+      case .failed:
+        Log.error("Failed to send command: \(error)", category: .cloudKit)
+        throw CloudKitError.saveFailed(error)
+      }
     }
   }
 

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -50,11 +50,14 @@ class ProfileSyncManager: ObservableObject {
   private var deferredLocationSaveIds: Set<UUID> = []
   private var deferredDeleteRecordNames: Set<String> = []
   private var deferredEmergencySave = false
+  private var deferredEmergencyUnblockEvents: [String: SyncedEmergencyUnblockEvent] = [:]
+  private var deferredEmergencyEpochSave = false
 
   /// Test seam: true when nothing is pending re-enqueue.
   var hasNoDeferredMutations: Bool {
     deferredProfileSaveIds.isEmpty && deferredLocationSaveIds.isEmpty
       && deferredDeleteRecordNames.isEmpty && !deferredEmergencySave
+      && deferredEmergencyUnblockEvents.isEmpty && !deferredEmergencyEpochSave
   }
 
   // Device identifier for this device
@@ -293,20 +296,70 @@ class ProfileSyncManager: ObservableObject {
     }
     if isSyncReady { engineController.requestSync() }
   }
+  func enqueueEmergencyUnblockEvent(_ event: SyncedEmergencyUnblockEvent) throws {
+    guard let engineController else {
+      deferredEmergencyUnblockEvents[event.recordName] = event
+      throw SyncEngineControllingError.notAttached
+    }
+    do {
+      try engineController.enqueueEmergencyUnblockEvent(event)
+    } catch SyncEngineControllingError.notAttached {
+      deferredEmergencyUnblockEvents[event.recordName] = event
+      throw SyncEngineControllingError.notAttached
+    }
+    if isSyncReady { engineController.requestSync() }
+  }
+  func enqueueEmergencyEpochSave() throws {
+    guard let engineController else {
+      deferredEmergencyEpochSave = true
+      throw SyncEngineControllingError.notAttached
+    }
+    do {
+      try engineController.enqueueEmergencyEpochSave()
+    } catch SyncEngineControllingError.notAttached {
+      deferredEmergencyEpochSave = true
+      throw SyncEngineControllingError.notAttached
+    }
+    if isSyncReady { engineController.requestSync() }
+  }
+  func enqueueEmergencyUnblockEventDelete(_ recordName: String) throws {
+    guard let engineController else {
+      deferredDeleteRecordNames.insert(recordName)
+      throw SyncEngineControllingError.notAttached
+    }
+    do {
+      try engineController.enqueueEmergencyUnblockEventDelete(recordName)
+    } catch SyncEngineControllingError.notAttached {
+      deferredDeleteRecordNames.insert(recordName)
+      throw SyncEngineControllingError.notAttached
+    }
+    if isSyncReady { engineController.requestSync() }
+  }
 
   /// Replay save-type mutations deferred while the engine was unattached (#294). Uses the
   /// controller-level enqueue verbs (which do not themselves send), so the single requestSync
   /// in `markSyncReadyAndFlush()` flushes them all at once.
   private func drainDeferredMutations() {
     guard let engineController else { return }
+    // #221 deferred safety: epoch saves are max-merged, event saves are write-once/idempotent
+    // by recordName, and GC deletes drain through the existing tombstone path. These operations
+    // need no sequencing guarantee relative to each other or to a fetched remote epoch.
     for id in deferredProfileSaveIds { try? engineController.enqueueProfileSave(id) }
     for id in deferredLocationSaveIds { try? engineController.enqueueLocationSave(id) }
     for name in deferredDeleteRecordNames { engineController.enqueueDeferredDelete(recordName: name) }
     if deferredEmergencySave { try? engineController.enqueueEmergencySettingsSave() }
+    for name in deferredEmergencyUnblockEvents.keys.sorted() {
+      if let event = deferredEmergencyUnblockEvents[name] {
+        try? engineController.enqueueEmergencyUnblockEvent(event)
+      }
+    }
+    if deferredEmergencyEpochSave { try? engineController.enqueueEmergencyEpochSave() }
     deferredProfileSaveIds.removeAll()
     deferredLocationSaveIds.removeAll()
     deferredDeleteRecordNames.removeAll()
     deferredEmergencySave = false
+    deferredEmergencyUnblockEvents.removeAll()
+    deferredEmergencyEpochSave = false
   }
 
   /// Called once the engine is attached AND startup, including the AB-4 T1 strip, has completed.

--- a/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
+++ b/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
@@ -96,6 +96,20 @@ final class MutationFunnel {
     driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
   }
 
+  /// Enqueue a write-once emergency-unblock event (I2, #221). The event is already persisted by
+  /// `EmergencyUnblockManager.consumeUnblockEvent`; this only schedules its CKSyncEngine save.
+  func enqueueEmergencyUnblockEvent(_ event: SyncedEmergencyUnblockEvent) {
+    let recordID = CKRecord.ID(recordName: event.recordName, zoneID: zoneID)
+    driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+  }
+
+  /// Enqueue the fixed-name reset-epoch record. There is no version bump: the epoch value itself
+  /// is merged by monotonic max on apply.
+  func enqueueEmergencyEpochSave() {
+    let recordID = CKRecord.ID(recordName: SyncedEmergencyEpoch.recordName, zoneID: zoneID)
+    driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+  }
+
   // MARK: - Delete paths
 
   /// Persist a delete-intent tombstone (recordName -> last-known server change tag, nil if never
@@ -187,6 +201,13 @@ final class MutationFunnel {
     store.setTombstone(recordName: recordName, changeTag: changeTag)
     let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
     driver.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
+  }
+
+  /// Delete a write-once emergency-unblock event through the explicit delete path (#221 GC).
+  /// The facade's not-attached fallback reuses `enqueueTombstoneDelete(recordName:)`, so deferred
+  /// drains share the existing tombstone/delete replay semantics.
+  func enqueueEmergencyUnblockEventDelete(_ recordName: String) {
+    enqueueTombstoneDelete(recordName: recordName)
   }
 
   // MARK: - System-fields change tag

--- a/Foqos/CloudKit/SyncEngine/RecordProvider.swift
+++ b/Foqos/CloudKit/SyncEngine/RecordProvider.swift
@@ -30,6 +30,12 @@ final class RecordProvider {
     if recordName == SyncedEmergencySettings.recordName {
       return emergencyRecord()
     }
+    if recordName == SyncedEmergencyEpoch.recordName {
+      return emergencyEpochRecord()
+    }
+    if recordName.hasPrefix(SyncedEmergencyUnblockEvent.recordNamePrefix) {
+      return emergencyUnblockEventRecord(recordName: recordName)
+    }
     if recordName.hasPrefix("ProfileSession_") {
       // Session records are owned by SessionSyncService (CAS), never materialized here.
       return nil
@@ -44,6 +50,10 @@ final class RecordProvider {
       return locationRecord(location)
     }
     return nil
+  }
+
+  func restorableEmergencyRecordNames() -> [String] {
+    [SyncedEmergencyEpoch.recordName] + emergencyManager.allUnblockEventRecordNames()
   }
 
   private func profileRecord(_ profile: BlockedProfiles) -> CKRecord? {
@@ -74,6 +84,25 @@ final class RecordProvider {
       recordType: SyncedEmergencySettings.recordType,
       freshRecordID: CKRecord.ID(recordName: SyncedEmergencySettings.recordName, zoneID: zoneID))
     synced.updateCKRecord(record)
+    return record
+  }
+
+  private func emergencyEpochRecord() -> CKRecord? {
+    let record = materialize(
+      recordName: SyncedEmergencyEpoch.recordName,
+      recordType: SyncedEmergencyEpoch.recordType,
+      freshRecordID: CKRecord.ID(recordName: SyncedEmergencyEpoch.recordName, zoneID: zoneID))
+    emergencyManager.currentEpochRecord().updateCKRecord(record)
+    return record
+  }
+
+  private func emergencyUnblockEventRecord(recordName: String) -> CKRecord? {
+    guard let event = emergencyManager.eventRecord(forRecordName: recordName) else { return nil }
+    let record = materialize(
+      recordName: recordName,
+      recordType: SyncedEmergencyUnblockEvent.recordType,
+      freshRecordID: CKRecord.ID(recordName: recordName, zoneID: zoneID))
+    event.updateCKRecord(record)
     return record
   }
 

--- a/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
@@ -74,6 +74,10 @@ final class SyncApplyService {
       return applyLocationModification(record)
     case SyncedEmergencySettings.recordType:
       return applyEmergencyModification(record)
+    case SyncedEmergencyUnblockEvent.recordType:
+      return applyUnblockEventModification(record)
+    case SyncedEmergencyEpoch.recordType:
+      return applyEmergencyEpochModification(record)
     case ProfileSessionRecord.recordType:
       return applySessionModification(record)
     default:
@@ -94,6 +98,10 @@ final class SyncApplyService {
       return deleteLocalProfile(recordName: recordName)
     case SyncedLocation.recordType:
       return deleteLocalLocation(recordName: recordName)
+    case SyncedEmergencyUnblockEvent.recordType:
+      emergencyManager.removeUnblockEvent(recordName: recordName)
+      clearDeletionBookkeeping(recordName: recordName)
+      return .deleted
     case ProfileSessionRecord.recordType:
       return stopSessionForDeletedRecord(recordName: recordName)
     default:
@@ -211,6 +219,15 @@ final class SyncApplyService {
 
   // MARK: - Profile apply (I9 gate + E-1 + equal-version divergence)
 
+  /// #218 deterministic tie-break for equal-version, payload-differing conflicts. Both devices
+  /// choose the same winner: newer `updatedAt`, then lexicographically lower `originDeviceId`.
+  static func remoteWinsProfileTie(remote: SyncedProfile, local: SyncedProfile) -> Bool {
+    if remote.updatedAt != local.updatedAt {
+      return remote.updatedAt > local.updatedAt
+    }
+    return remote.originDeviceId < local.originDeviceId
+  }
+
   private func applyProfileModification(_ record: CKRecord) -> ApplyOutcome {
     guard let synced = SyncedProfile(from: record) else {
       Log.info("Ignoring undecodable SyncedProfile record", category: .sync)
@@ -268,17 +285,28 @@ final class SyncApplyService {
       storeSystemFields(record)
       return .applied
     } else if synced.version == existing.syncVersion {
-      // Equal-version divergence (§5.1): payload-differing ⇒ conflict now.
+      // Equal-version divergence (§5.1): payload-differing => deterministic tie-break (#218).
       let localSynced = SyncedProfile(from: existing, originDeviceId: deviceId)
       if SyncPayloadEquality.profilesPayloadEqual(synced, localSynced) {
         return .applied  // payload-equal echo ⇒ no-op
       }
-      existing.syncVersion += 1
-      try commit()
-      pendingReenqueues.append(record.recordID)
-      SyncConflictManager.shared.addConflict(
-        profileId: existing.id, profileName: existing.name)
-      return .applied
+      if Self.remoteWinsProfileTie(remote: synced, local: localSynced) {
+        // Remote wins: adopt its already-published payload without re-enqueuing.
+        updateLocalProfile(existing, from: synced)
+        try commit()
+        storeSystemFields(record)
+        SyncConflictManager.shared.addDivergenceConflict(
+          profileId: existing.id, profileName: existing.name)
+        return .applied
+      } else {
+        // Local wins: bump above the tie and re-enqueue through the existing I2 exception.
+        existing.syncVersion += 1
+        try commit()
+        pendingReenqueues.append(record.recordID)
+        SyncConflictManager.shared.addDivergenceConflict(
+          profileId: existing.id, profileName: existing.name)
+        return .applied
+      }
     } else {
       // Older incoming version ⇒ no-op.
       return .applied
@@ -454,6 +482,32 @@ final class SyncApplyService {
     }
     emergencyManager.applyRemoteEmergencySettings(remote)
     store.removeFailedApply(recordName: record.recordID.recordName)  // supersession (§5.6)
+    storeSystemFields(record)
+    return .applied
+  }
+
+  // MARK: - Emergency unblock event apply
+
+  private func applyUnblockEventModification(_ record: CKRecord) -> ApplyOutcome {
+    guard let event = SyncedEmergencyUnblockEvent(from: record) else {
+      Log.info("Ignoring undecodable EmergencyUnblockEvent record", category: .sync)
+      return .ignored
+    }
+    emergencyManager.mergeRemoteUnblockEvent(event)
+    store.removeFailedApply(recordName: record.recordID.recordName)
+    storeSystemFields(record)
+    return .applied
+  }
+
+  private func applyEmergencyEpochModification(_ record: CKRecord) -> ApplyOutcome {
+    guard let remote = SyncedEmergencyEpoch(from: record) else {
+      Log.info("Ignoring undecodable EmergencyResetEpoch record", category: .sync)
+      return .ignored
+    }
+    // #221 monotonic-max channel: no version gate. max() is order-independent, so a deferred
+    // local epoch drain and a fetched remote epoch converge regardless of arrival order.
+    emergencyManager.adoptRemoteEpoch(remote.epoch)
+    store.removeFailedApply(recordName: record.recordID.recordName)
     storeSystemFields(record)
     return .applied
   }

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift
@@ -55,6 +55,18 @@ extension SyncEngineController: SyncEngineControlling {
     guard let funnel else { throw SyncEngineControllingError.notAttached }
     funnel.enqueueEmergencySettingsSave()
   }
+  func enqueueEmergencyUnblockEvent(_ event: SyncedEmergencyUnblockEvent) throws {
+    guard let funnel else { throw SyncEngineControllingError.notAttached }
+    funnel.enqueueEmergencyUnblockEvent(event)
+  }
+  func enqueueEmergencyEpochSave() throws {
+    guard let funnel else { throw SyncEngineControllingError.notAttached }
+    funnel.enqueueEmergencyEpochSave()
+  }
+  func enqueueEmergencyUnblockEventDelete(_ recordName: String) throws {
+    guard let funnel else { throw SyncEngineControllingError.notAttached }
+    funnel.enqueueEmergencyUnblockEventDelete(recordName)
+  }
   func enqueueDeferredDelete(recordName: String) {
     funnel?.enqueueTombstoneDelete(recordName: recordName)
   }

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -376,6 +376,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
 
   private static let scopedTypes: Set<String> = [
     SyncedProfile.recordType, SyncedLocation.recordType, SyncedEmergencySettings.recordType,
+    SyncedEmergencyEpoch.recordType,
   ]
 
   /// Routes each confirmed save/delete and each failed save/delete (§5.3). Confirmed saves
@@ -554,7 +555,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
 
   /// Compares the local entity's version/timestamp against the server record's, per
   /// recordType (§5.3 branch C local-wins re-add).
-  private func localIsStrictlyNewer(
+  func localIsStrictlyNewer(
     _ recordType: String, name: String, server: CKRecord
   ) -> Bool {
     switch recordType {
@@ -581,6 +582,11 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       let localVersion = localRecord[SyncedEmergencySettings.FieldKey.version.rawValue] as? Int ?? 0
       let serverVersion = server[SyncedEmergencySettings.FieldKey.version.rawValue] as? Int ?? 0
       return localVersion > serverVersion
+    case SyncedEmergencyEpoch.recordType:
+      guard let localRecord = provider.record(forRecordName: name) else { return false }
+      let localEpoch = localRecord[SyncedEmergencyEpoch.FieldKey.epoch.rawValue] as? Int ?? 0
+      let serverEpoch = server[SyncedEmergencyEpoch.FieldKey.epoch.rawValue] as? Int ?? 0
+      return localEpoch > serverEpoch
     default:
       return false
     }
@@ -949,6 +955,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     let locations = (try? modelContext.fetch(FetchDescriptor<SavedLocation>())) ?? []
     names.append(contentsOf: locations.map { $0.id.uuidString })
     names.append(SyncedEmergencySettings.recordName)
+    names.append(contentsOf: provider.restorableEmergencyRecordNames())
     return names.filter { provider.record(forRecordName: $0) != nil }
   }
 

--- a/Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift
@@ -14,6 +14,9 @@ protocol SyncEngineControlling: AnyObject {
   func enqueueLocationSave(_ id: UUID) throws
   func enqueueLocationDelete(_ id: UUID) throws
   func enqueueEmergencySettingsSave() throws
+  func enqueueEmergencyUnblockEvent(_ event: SyncedEmergencyUnblockEvent) throws
+  func enqueueEmergencyEpochSave() throws
+  func enqueueEmergencyUnblockEventDelete(_ recordName: String) throws
   func enqueueDeferredDelete(recordName: String)
 }
 

--- a/Foqos/CloudKit/SyncModels.swift
+++ b/Foqos/CloudKit/SyncModels.swift
@@ -197,7 +197,17 @@ struct SyncedProfile: Codable, Equatable {
     order = record[FieldKey.order.rawValue] as? Int ?? 0
     enableLiveActivity = record[FieldKey.enableLiveActivity.rawValue] as? Bool ?? false
     if let reminderInt = record[FieldKey.reminderTimeInSeconds.rawValue] as? Int {
-      reminderTimeInSeconds = UInt32(reminderInt)
+      // #265: range-check the narrowing cast (same defensive-decode discipline as the
+      // `UInt8(exactly:)` sibling below, and as the C1/#275 clamp for out-of-domain values).
+      // Invalid CloudKit data degrades to "no reminder" instead of trapping the inbound apply.
+      if let bounded = UInt32(exactly: reminderInt) {
+        reminderTimeInSeconds = bounded
+      } else {
+        Log.warning(
+          "Ignoring out-of-range reminderTimeInSeconds \(reminderInt) from synced profile",
+          category: .sync)
+        reminderTimeInSeconds = nil
+      }
     } else {
       reminderTimeInSeconds = nil
     }
@@ -553,6 +563,106 @@ struct SyncedEmergencySettings: Codable, Equatable {
     self.version = version
     self.lastModified = lastModified
     self.originDeviceId = originDeviceId
+  }
+}
+
+// MARK: - Synced Emergency Reset Epoch
+
+/// The current emergency-unblock reset epoch, synced as a single fixed-name record and merged by
+/// max() so all devices converge on one agreed epoch boundary (#221). This deliberately does not
+/// ride the versioned emergency-settings config record.
+struct SyncedEmergencyEpoch: Codable, Equatable {
+  var epoch: Int
+
+  static let recordType = "EmergencyResetEpoch"
+  static let recordName = "emergency-reset-epoch"
+
+  enum FieldKey: String {
+    case epoch
+  }
+
+  func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
+    let record = CKRecord(
+      recordType: Self.recordType,
+      recordID: CKRecord.ID(recordName: Self.recordName, zoneID: zoneID))
+    updateCKRecord(record)
+    return record
+  }
+
+  func updateCKRecord(_ record: CKRecord) {
+    record[FieldKey.epoch.rawValue] = epoch
+  }
+
+  init(epoch: Int) {
+    self.epoch = epoch
+  }
+
+  init?(from record: CKRecord) {
+    guard record.recordType == Self.recordType,
+      let epoch = record[FieldKey.epoch.rawValue] as? Int
+    else {
+      return nil
+    }
+    self.epoch = epoch
+  }
+}
+
+// MARK: - Synced Emergency Unblock Event
+
+/// One immutable record per consumed emergency unblock. Union-merged across devices (write-once,
+/// unique recordName), so concurrent unblocks never collide (#221).
+struct SyncedEmergencyUnblockEvent: Codable, Equatable {
+  var id: UUID
+  var deviceId: String
+  var consumedAt: Date
+  var resetEpoch: Int
+
+  static let recordType = "EmergencyUnblockEvent"
+  static let recordNamePrefix = "EmergencyUnblock_"
+  var recordName: String { Self.recordNamePrefix + id.uuidString }
+
+  enum FieldKey: String {
+    case id
+    case deviceId
+    case consumedAt
+    case resetEpoch
+  }
+
+  func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
+    let record = CKRecord(
+      recordType: Self.recordType,
+      recordID: CKRecord.ID(recordName: recordName, zoneID: zoneID))
+    updateCKRecord(record)
+    return record
+  }
+
+  func updateCKRecord(_ record: CKRecord) {
+    record[FieldKey.id.rawValue] = id.uuidString
+    record[FieldKey.deviceId.rawValue] = deviceId
+    record[FieldKey.consumedAt.rawValue] = consumedAt
+    record[FieldKey.resetEpoch.rawValue] = resetEpoch
+  }
+
+  init(id: UUID, deviceId: String, consumedAt: Date, resetEpoch: Int) {
+    self.id = id
+    self.deviceId = deviceId
+    self.consumedAt = consumedAt
+    self.resetEpoch = resetEpoch
+  }
+
+  init?(from record: CKRecord) {
+    guard record.recordType == Self.recordType,
+      let idString = record[FieldKey.id.rawValue] as? String,
+      let id = UUID(uuidString: idString),
+      let consumedAt = record[FieldKey.consumedAt.rawValue] as? Date,
+      let resetEpoch = record[FieldKey.resetEpoch.rawValue] as? Int
+    else {
+      return nil
+    }
+    self.id = id
+    self.deviceId = record[FieldKey.deviceId.rawValue] as? String ?? ""
+    self.consumedAt = consumedAt
+    self.resetEpoch = resetEpoch
   }
 }
 

--- a/Foqos/Models/SyncConflictManager.swift
+++ b/Foqos/Models/SyncConflictManager.swift
@@ -9,6 +9,7 @@ final class SyncConflictManager: ObservableObject {
 
   @Published var conflictedProfiles: [UUID: String] = [:]  // ID → name (older device edited)
   @Published var newerVersionProfiles: [UUID: String] = [:]  // ID → name (this device outdated)
+  @Published var divergenceProfiles: [UUID: String] = [:]  // ID → name (concurrent edit)
   @Published var showConflictBanner: Bool = false
   @Published var resetWasSuperseded: Bool = false  // profile-less: a reset request did not run
 
@@ -31,7 +32,14 @@ final class SyncConflictManager: ObservableObject {
     showConflictBanner = true
   }
 
+  /// Records a same-version concurrent edit resolved by the deterministic tie-break (#218).
+  func addDivergenceConflict(profileId: UUID, profileName: String) {
+    divergenceProfiles[profileId] = profileName
+    showConflictBanner = true
+  }
+
   func dismissBanner() {
+    divergenceProfiles.removeAll()
     showConflictBanner = false
     resetWasSuperseded = false
   }
@@ -39,7 +47,8 @@ final class SyncConflictManager: ObservableObject {
   func clearConflict(profileId: UUID) {
     conflictedProfiles.removeValue(forKey: profileId)
     newerVersionProfiles.removeValue(forKey: profileId)
-    if conflictedProfiles.isEmpty && newerVersionProfiles.isEmpty {
+    divergenceProfiles.removeValue(forKey: profileId)
+    if conflictedProfiles.isEmpty && newerVersionProfiles.isEmpty && divergenceProfiles.isEmpty {
       showConflictBanner = false
     }
   }
@@ -47,6 +56,7 @@ final class SyncConflictManager: ObservableObject {
   func clearAll() {
     conflictedProfiles.removeAll()
     newerVersionProfiles.removeAll()
+    divergenceProfiles.removeAll()
     showConflictBanner = false
     resetWasSuperseded = false
   }
@@ -57,6 +67,19 @@ final class SyncConflictManager: ObservableObject {
 
   var shouldShowOlderDeviceBanner: Bool {
     !conflictedProfiles.isEmpty && showConflictBanner
+  }
+
+  var shouldShowDivergenceBanner: Bool {
+    !divergenceProfiles.isEmpty && showConflictBanner
+  }
+
+  var divergenceMessage: String {
+    if divergenceProfiles.count == 1, let name = divergenceProfiles.values.first {
+      return "\"\(name)\" was changed on another device. Keeping the most recently edited copy."
+    } else {
+      return
+        "Several profiles were changed on more than one device. Keeping the most recently edited copies."
+    }
   }
 
   var conflictMessage: String {

--- a/Foqos/Models/SyncConflictManager.swift
+++ b/Foqos/Models/SyncConflictManager.swift
@@ -44,6 +44,12 @@ final class SyncConflictManager: ObservableObject {
     resetWasSuperseded = false
   }
 
+  func dismissDivergenceBanner() {
+    divergenceProfiles.removeAll()
+    showConflictBanner =
+      !conflictedProfiles.isEmpty || !newerVersionProfiles.isEmpty || resetWasSuperseded
+  }
+
   func clearConflict(profileId: UUID) {
     conflictedProfiles.removeValue(forKey: profileId)
     newerVersionProfiles.removeValue(forKey: profileId)

--- a/Foqos/Utils/EmergencyUnblockManager.swift
+++ b/Foqos/Utils/EmergencyUnblockManager.swift
@@ -254,8 +254,7 @@ class EmergencyUnblockManager: ObservableObject {
   }
 
   #if DEBUG
-    func seedForTesting(allowance: Int, epoch: Int) {
-      _ = allowance
+    func seedForTesting(epoch: Int) {
       currentResetEpoch = epoch
       unblockEvents = []
       objectWillChange.send()

--- a/Foqos/Utils/EmergencyUnblockManager.swift
+++ b/Foqos/Utils/EmergencyUnblockManager.swift
@@ -41,31 +41,29 @@ class EmergencyUnblockManager: ObservableObject {
 
   private let geofenceEvaluator: GeofenceEvaluator
   private let profileSyncManager: ProfileSyncManager
+  private let defaults: UserDefaults
 
   init(
+    defaults: UserDefaults = .standard,
     geofenceEvaluator: GeofenceEvaluator = .shared,
     profileSyncManager: ProfileSyncManager = .shared
   ) {
+    self.defaults = defaults
     self.geofenceEvaluator = geofenceEvaluator
     self.profileSyncManager = profileSyncManager
   }
 
   private enum DefaultsKey {
-    static let unblocksRemaining = "family_foqos_emergency_unblocks_remaining"
     static let resetPeriodInDays = "family_foqos_emergency_unblocks_reset_period_in_days"
     static let lastResetDate = "family_foqos_last_emergency_unblocks_reset_date"
     static let settingsLocked = "family_foqos_emergency_settings_locked"
     static let settingsVersion = "family_foqos_emergency_settings_version"
   }
 
-  @Published private var emergencyUnblocksRemaining: Int =
-    UserDefaults.standard.object(forKey: DefaultsKey.unblocksRemaining) != nil
-    ? UserDefaults.standard.integer(forKey: DefaultsKey.unblocksRemaining)
-    : 3
-  {
-    didSet {
-      UserDefaults.standard.set(emergencyUnblocksRemaining, forKey: DefaultsKey.unblocksRemaining)
-    }
+  private enum LedgerKey {
+    static let events = "family_foqos_emergency_unblock_events"
+    static let resetEpoch = "family_foqos_emergency_reset_epoch"
+    static let allowance = 3
   }
 
   @Published private var emergencyUnblocksResetPeriodInDays: Int =
@@ -119,7 +117,29 @@ class EmergencyUnblockManager: ObservableObject {
   // MARK: - Queries
 
   func getRemainingEmergencyUnblocks() -> Int {
-    return emergencyUnblocksRemaining
+    let consumed = unblockEvents.filter { $0.resetEpoch == currentResetEpoch }.count
+    return max(0, LedgerKey.allowance - consumed)
+  }
+
+  var currentResetEpoch: Int {
+    get { defaults.integer(forKey: LedgerKey.resetEpoch) }
+    set { defaults.set(newValue, forKey: LedgerKey.resetEpoch) }
+  }
+
+  private var unblockEvents: [SyncedEmergencyUnblockEvent] {
+    get {
+      guard let data = defaults.data(forKey: LedgerKey.events),
+        let events = try? JSONDecoder().decode([SyncedEmergencyUnblockEvent].self, from: data)
+      else {
+        return []
+      }
+      return events
+    }
+    set {
+      if let data = try? JSONEncoder().encode(newValue) {
+        defaults.set(data, forKey: LedgerKey.events)
+      }
+    }
   }
 
   func getNextResetDate() -> Date? {
@@ -145,6 +165,108 @@ class EmergencyUnblockManager: ObservableObject {
     emergencySettingsLockedStorage
   }
 
+  /// Records a locally-consumed unblock as an immutable event at the current epoch and returns it
+  /// for the caller to enqueue through the funnel. The sync push is deliberately separate.
+  func consumeUnblockEvent(now: Date) -> SyncedEmergencyUnblockEvent {
+    let event = SyncedEmergencyUnblockEvent(
+      id: UUID(),
+      deviceId: SharedData.deviceSyncId.uuidString,
+      consumedAt: now,
+      resetEpoch: currentResetEpoch)
+    var all = unblockEvents
+    all.append(event)
+    unblockEvents = all
+    objectWillChange.send()
+    return event
+  }
+
+  /// Union insert of a remote event, idempotent by event id.
+  func mergeRemoteUnblockEvent(_ event: SyncedEmergencyUnblockEvent) {
+    var all = unblockEvents
+    guard !all.contains(where: { $0.id == event.id }) else { return }
+    all.append(event)
+    unblockEvents = all
+    objectWillChange.send()
+  }
+
+  func eventRecord(forRecordName recordName: String) -> SyncedEmergencyUnblockEvent? {
+    unblockEvents.first { $0.recordName == recordName }
+  }
+
+  func allUnblockEventRecordNames() -> [String] {
+    unblockEvents.map { $0.recordName }
+  }
+
+  /// Events from epochs strictly older than the merged monotonic epoch are safe to prune (#221).
+  func staleUnblockEventRecordNames() -> [String] {
+    unblockEvents.filter { $0.resetEpoch < currentResetEpoch }.map { $0.recordName }
+  }
+
+  func removeUnblockEvent(recordName: String) {
+    unblockEvents = unblockEvents.filter { $0.recordName != recordName }
+    objectWillChange.send()
+  }
+
+  func garbageCollectStaleUnblockEvents() {
+    let stale = staleUnblockEventRecordNames()
+    guard !stale.isEmpty else { return }
+    for name in stale {
+      removeUnblockEvent(recordName: name)
+      if profileSyncManager.isEnabled {
+        do {
+          try profileSyncManager.enqueueEmergencyUnblockEventDelete(name)
+        } catch {
+          Log.warning(
+            "enqueueEmergencyUnblockEventDelete skipped: \(error.localizedDescription)",
+            category: .sync)
+        }
+      }
+    }
+  }
+
+  /// #221: record a consumed unblock as an immutable event and push it through the funnel.
+  /// Extracted so the record+enqueue behavior is unit-testable without a live session.
+  @discardableResult
+  func recordAndEnqueueUnblock(now: Date = Date()) -> SyncedEmergencyUnblockEvent {
+    let event = consumeUnblockEvent(now: now)
+    if profileSyncManager.isEnabled {
+      do {
+        try profileSyncManager.enqueueEmergencyUnblockEvent(event)
+      } catch {
+        Log.warning(
+          "enqueueEmergencyUnblockEvent skipped: \(error.localizedDescription)", category: .sync)
+      }
+    }
+    return event
+  }
+
+  /// Adopt a remote epoch by max with no version gate. The merge is commutative, idempotent, and
+  /// order-independent, so drain/fetch ordering cannot lower or clobber the reset boundary.
+  func adoptRemoteEpoch(_ epoch: Int) {
+    let merged = max(currentResetEpoch, epoch)
+    guard merged != currentResetEpoch else { return }
+    currentResetEpoch = merged
+    objectWillChange.send()
+  }
+
+  func currentEpochRecord() -> SyncedEmergencyEpoch {
+    SyncedEmergencyEpoch(epoch: currentResetEpoch)
+  }
+
+  #if DEBUG
+    func seedForTesting(allowance: Int, epoch: Int) {
+      _ = allowance
+      currentResetEpoch = epoch
+      unblockEvents = []
+      objectWillChange.send()
+    }
+
+    func advanceResetEpochForTesting() {
+      currentResetEpoch += 1
+      objectWillChange.send()
+    }
+  #endif
+
   // MARK: - Mutations
 
   func setResetPeriodInDays(_ days: Int) {
@@ -159,9 +281,12 @@ class EmergencyUnblockManager: ObservableObject {
   }
 
   func resetEmergencyUnblocks() {
-    emergencyUnblocksRemaining = 3
+    currentResetEpoch += 1
     lastEmergencyUnblocksResetDateTimestamp = Date().timeIntervalSinceReferenceDate
+    pushEmergencyEpochToCloudKit()
     pushEmergencySettingsToCloudKit()
+    garbageCollectStaleUnblockEvents()
+    objectWillChange.send()
   }
 
   func checkAndResetEmergencyUnblocks() {
@@ -179,9 +304,12 @@ class EmergencyUnblockManager: ObservableObject {
 
     // Check if the reset period has elapsed
     if elapsedTime >= periodInSeconds {
-      emergencyUnblocksRemaining = 3
+      currentResetEpoch += 1
       lastEmergencyUnblocksResetDateTimestamp = Date().timeIntervalSinceReferenceDate
+      pushEmergencyEpochToCloudKit()
       pushEmergencySettingsToCloudKit()
+      garbageCollectStaleUnblockEvents()
+      objectWillChange.send()
     }
   }
 
@@ -193,9 +321,10 @@ class EmergencyUnblockManager: ObservableObject {
   func emergencyUnblock(
     context: ModelContext,
     activeSession: BlockedProfileSession?,
-    onUnblock: @escaping (ModelContext, BlockedProfileSession) -> Void
+    onUnblock: @escaping (ModelContext, BlockedProfileSession) -> Void,
+    now: Date = Date()
   ) async throws(EmergencyUnblockError) {
-    guard emergencyUnblocksRemaining > 0 else {
+    guard getRemainingEmergencyUnblocks() > 0 else {
       throw .noUnblocksRemaining
     }
 
@@ -213,20 +342,19 @@ class EmergencyUnblockManager: ObservableObject {
       )
     }
 
-    performEmergencyUnblock(context: context, session: activeSession, onUnblock: onUnblock)
+    performEmergencyUnblock(context: context, session: activeSession, onUnblock: onUnblock, now: now)
   }
 
   /// Actually perform the emergency unblock (called after all checks pass)
   private func performEmergencyUnblock(
     context: ModelContext,
     session: BlockedProfileSession,
-    onUnblock: @escaping (ModelContext, BlockedProfileSession) -> Void
+    onUnblock: @escaping (ModelContext, BlockedProfileSession) -> Void,
+    now: Date = Date()
   ) {
     onUnblock(context, session)
 
-    // Decrement the remaining emergency unblocks
-    emergencyUnblocksRemaining -= 1
-    pushEmergencySettingsToCloudKit()
+    recordAndEnqueueUnblock(now: now)
 
     // Refresh widgets when emergency unblock ends session
     WidgetCenter.shared.reloadTimelines(ofKind: "ProfileControlWidget")
@@ -236,18 +364,18 @@ class EmergencyUnblockManager: ObservableObject {
 
   /// Apply emergency settings received from CloudKit sync
   func applyRemoteEmergencySettings(_ remote: SyncedEmergencySettings) {
-    emergencyUnblocksRemaining = remote.unblocksRemaining
     emergencyUnblocksResetPeriodInDays = remote.resetPeriodInDays
     lastEmergencyUnblocksResetDateTimestamp = remote.lastResetDate.timeIntervalSinceReferenceDate
     emergencySettingsLockedStorage = remote.settingsLocked
     emergencySettingsVersion = remote.version
+    objectWillChange.send()
   }
 
   /// Snapshot of the current emergency settings for CKRecord materialization (RecordProvider).
   /// Reads the current version verbatim — never bumps (I2: version bumps only in MutationFunnel).
   func currentEmergencySettings(deviceId: String, now: Date = Date()) -> SyncedEmergencySettings {
     SyncedEmergencySettings(
-      unblocksRemaining: emergencyUnblocksRemaining,
+      unblocksRemaining: getRemainingEmergencyUnblocks(),
       resetPeriodInDays: emergencyUnblocksResetPeriodInDays,
       lastResetDate: Date(
         timeIntervalSinceReferenceDate: lastEmergencyUnblocksResetDateTimestamp),
@@ -267,6 +395,16 @@ class EmergencyUnblockManager: ObservableObject {
       try profileSyncManager.enqueueEmergencySettingsSave()
     } catch {
       Log.warning("enqueueEmergencySettingsSave skipped: \(error.localizedDescription)", category: .sync)
+    }
+  }
+
+  private func pushEmergencyEpochToCloudKit() {
+    guard profileSyncManager.isEnabled else { return }
+
+    do {
+      try profileSyncManager.enqueueEmergencyEpochSave()
+    } catch {
+      Log.warning("enqueueEmergencyEpochSave skipped: \(error.localizedDescription)", category: .sync)
     }
   }
 }

--- a/Foqos/Views/HomeView.swift
+++ b/Foqos/Views/HomeView.swift
@@ -169,7 +169,7 @@ struct HomeView: View {
           if syncConflictManager.shouldShowDivergenceBanner {
             SyncConflictBanner(
               message: syncConflictManager.divergenceMessage,
-              onDismiss: { syncConflictManager.dismissBanner() }
+              onDismiss: { syncConflictManager.dismissDivergenceBanner() }
             )
             .padding(.vertical, 8)
           } else if syncConflictManager.shouldShowNewerVersionBanner {

--- a/Foqos/Views/HomeView.swift
+++ b/Foqos/Views/HomeView.swift
@@ -166,7 +166,13 @@ struct HomeView: View {
           )
           .padding(.horizontal, 16)
 
-          if syncConflictManager.shouldShowNewerVersionBanner {
+          if syncConflictManager.shouldShowDivergenceBanner {
+            SyncConflictBanner(
+              message: syncConflictManager.divergenceMessage,
+              onDismiss: { syncConflictManager.dismissBanner() }
+            )
+            .padding(.vertical, 8)
+          } else if syncConflictManager.shouldShowNewerVersionBanner {
             SyncConflictBanner(
               message: syncConflictManager.newerVersionMessage,
               onDismiss: { syncConflictManager.dismissBanner() }

--- a/FoqosTests/EmergencyUnblockConsumeTests.swift
+++ b/FoqosTests/EmergencyUnblockConsumeTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class EmergencyUnblockConsumeTests: XCTestCase {
+
+  private var emgSuite: String!
+  private var emgDefaults: UserDefaults!
+  private var savedController: (any SyncEngineControlling)?
+  private var savedEnabled = false
+  private var savedIsSyncReady = false
+  private var mock: MockSyncEngineControlling!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    emgSuite = "Consume-emg-\(UUID().uuidString)"
+    emgDefaults = UserDefaults(suiteName: emgSuite)!
+    savedController = ProfileSyncManager.shared.engineController
+    savedEnabled = ProfileSyncManager.shared.isEnabled
+    savedIsSyncReady = ProfileSyncManager.shared.isSyncReady
+    mock = MockSyncEngineControlling()
+    ProfileSyncManager.shared.engineController = mock
+    ProfileSyncManager.shared.isSyncReady = true
+    ProfileSyncManager.shared.isEnabled = true
+  }
+
+  override func tearDown() async throws {
+    ProfileSyncManager.shared.engineController = savedController
+    ProfileSyncManager.shared.isSyncReady = savedIsSyncReady
+    ProfileSyncManager.shared.isEnabled = savedEnabled
+    emgDefaults.removePersistentDomain(forName: emgSuite)
+    try await super.tearDown()
+  }
+
+  func testGivenSyncEnabled_WhenRecordAndEnqueueUnblock_ThenEventEnqueuedAndRemainingDrops() {
+    let now = Date()
+    let manager = EmergencyUnblockManager(defaults: emgDefaults, profileSyncManager: .shared)
+    manager.seedForTesting(allowance: 3, epoch: 1)
+
+    manager.recordAndEnqueueUnblock(now: now)
+
+    XCTAssertEqual(manager.getRemainingEmergencyUnblocks(), 2)
+    XCTAssertEqual(mock.enqueuedEmergencyUnblockEvents.count, 1, "one event pushed through the funnel")
+    XCTAssertEqual(mock.enqueuedEmergencyUnblockEvents.first?.resetEpoch, 1)
+  }
+
+  func testGivenConsumedUnblocks_WhenReset_ThenEpochAdvancesAndRemainingRestored() {
+    let now = Date()
+    let manager = EmergencyUnblockManager(defaults: emgDefaults, profileSyncManager: .shared)
+    manager.seedForTesting(allowance: 3, epoch: 1)
+    manager.recordAndEnqueueUnblock(now: now)
+    manager.recordAndEnqueueUnblock(now: now)
+    XCTAssertEqual(manager.getRemainingEmergencyUnblocks(), 1)
+
+    manager.resetEmergencyUnblocks()
+
+    XCTAssertEqual(manager.currentResetEpoch, 2, "reset advances the epoch")
+    XCTAssertEqual(manager.getRemainingEmergencyUnblocks(), 3, "prior-epoch events no longer count")
+    XCTAssertEqual(mock.enqueuedEmergencyEpochSaves, 1, "reset pushes the monotonic-max epoch")
+  }
+}

--- a/FoqosTests/EmergencyUnblockConsumeTests.swift
+++ b/FoqosTests/EmergencyUnblockConsumeTests.swift
@@ -36,7 +36,7 @@ final class EmergencyUnblockConsumeTests: XCTestCase {
   func testGivenSyncEnabled_WhenRecordAndEnqueueUnblock_ThenEventEnqueuedAndRemainingDrops() {
     let now = Date()
     let manager = EmergencyUnblockManager(defaults: emgDefaults, profileSyncManager: .shared)
-    manager.seedForTesting(allowance: 3, epoch: 1)
+    manager.seedForTesting(epoch: 1)
 
     manager.recordAndEnqueueUnblock(now: now)
 
@@ -48,7 +48,7 @@ final class EmergencyUnblockConsumeTests: XCTestCase {
   func testGivenConsumedUnblocks_WhenReset_ThenEpochAdvancesAndRemainingRestored() {
     let now = Date()
     let manager = EmergencyUnblockManager(defaults: emgDefaults, profileSyncManager: .shared)
-    manager.seedForTesting(allowance: 3, epoch: 1)
+    manager.seedForTesting(epoch: 1)
     manager.recordAndEnqueueUnblock(now: now)
     manager.recordAndEnqueueUnblock(now: now)
     XCTAssertEqual(manager.getRemainingEmergencyUnblocks(), 1)

--- a/FoqosTests/EmergencyUnblockEventLedgerTests.swift
+++ b/FoqosTests/EmergencyUnblockEventLedgerTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class EmergencyUnblockEventLedgerTests: XCTestCase {
+
+  private var suiteName: String!
+  private var defaults: UserDefaults!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "EmergencyLedger-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+  }
+
+  override func tearDown() async throws {
+    defaults.removePersistentDomain(forName: suiteName)
+    try await super.tearDown()
+  }
+
+  func testGivenThreeAllowance_WhenTwoEventsInEpoch_ThenRemainingIsOne() {
+    let now = Date()
+    let manager = EmergencyUnblockManager(defaults: defaults)
+    manager.seedForTesting(allowance: 3, epoch: 1)
+
+    _ = manager.consumeUnblockEvent(now: now)
+    _ = manager.consumeUnblockEvent(now: now)
+
+    XCTAssertEqual(manager.getRemainingEmergencyUnblocks(), 1)
+  }
+
+  func testGivenConcurrentEventsFromTwoDevices_WhenMerged_ThenBothCount() {
+    let now = Date()
+    let manager = EmergencyUnblockManager(defaults: defaults)
+    manager.seedForTesting(allowance: 3, epoch: 1)
+
+    let localEvent = manager.consumeUnblockEvent(now: now)
+    let remoteEvent = SyncedEmergencyUnblockEvent(
+      id: UUID(), deviceId: "other", consumedAt: now, resetEpoch: 1)
+    manager.mergeRemoteUnblockEvent(remoteEvent)
+
+    XCTAssertEqual(manager.getRemainingEmergencyUnblocks(), 1, "two distinct events both count")
+    XCTAssertNotEqual(localEvent.id, remoteEvent.id)
+  }
+
+  func testGivenReDeliveredEvent_WhenMergedTwice_ThenCountsOnce() {
+    let now = Date()
+    let manager = EmergencyUnblockManager(defaults: defaults)
+    manager.seedForTesting(allowance: 3, epoch: 1)
+    let event = SyncedEmergencyUnblockEvent(
+      id: UUID(), deviceId: "x", consumedAt: now, resetEpoch: 1)
+
+    manager.mergeRemoteUnblockEvent(event)
+    manager.mergeRemoteUnblockEvent(event)
+
+    XCTAssertEqual(manager.getRemainingEmergencyUnblocks(), 2)
+  }
+
+  func testGivenOldEpochEvents_WhenEpochAdvances_ThenTheyStopCounting() {
+    let now = Date()
+    let manager = EmergencyUnblockManager(defaults: defaults)
+    manager.seedForTesting(allowance: 3, epoch: 1)
+
+    _ = manager.consumeUnblockEvent(now: now)
+    _ = manager.consumeUnblockEvent(now: now)
+    manager.advanceResetEpochForTesting()
+
+    XCTAssertEqual(manager.getRemainingEmergencyUnblocks(), 3, "prior-epoch events don't count")
+  }
+
+  func testRemainingClampsAtZero() {
+    let now = Date()
+    let manager = EmergencyUnblockManager(defaults: defaults)
+    manager.seedForTesting(allowance: 3, epoch: 1)
+
+    for _ in 0..<5 {
+      _ = manager.consumeUnblockEvent(now: now)
+    }
+
+    XCTAssertEqual(manager.getRemainingEmergencyUnblocks(), 0, "never negative")
+  }
+}

--- a/FoqosTests/EmergencyUnblockEventLedgerTests.swift
+++ b/FoqosTests/EmergencyUnblockEventLedgerTests.swift
@@ -22,7 +22,7 @@ final class EmergencyUnblockEventLedgerTests: XCTestCase {
   func testGivenThreeAllowance_WhenTwoEventsInEpoch_ThenRemainingIsOne() {
     let now = Date()
     let manager = EmergencyUnblockManager(defaults: defaults)
-    manager.seedForTesting(allowance: 3, epoch: 1)
+    manager.seedForTesting(epoch: 1)
 
     _ = manager.consumeUnblockEvent(now: now)
     _ = manager.consumeUnblockEvent(now: now)
@@ -33,7 +33,7 @@ final class EmergencyUnblockEventLedgerTests: XCTestCase {
   func testGivenConcurrentEventsFromTwoDevices_WhenMerged_ThenBothCount() {
     let now = Date()
     let manager = EmergencyUnblockManager(defaults: defaults)
-    manager.seedForTesting(allowance: 3, epoch: 1)
+    manager.seedForTesting(epoch: 1)
 
     let localEvent = manager.consumeUnblockEvent(now: now)
     let remoteEvent = SyncedEmergencyUnblockEvent(
@@ -47,7 +47,7 @@ final class EmergencyUnblockEventLedgerTests: XCTestCase {
   func testGivenReDeliveredEvent_WhenMergedTwice_ThenCountsOnce() {
     let now = Date()
     let manager = EmergencyUnblockManager(defaults: defaults)
-    manager.seedForTesting(allowance: 3, epoch: 1)
+    manager.seedForTesting(epoch: 1)
     let event = SyncedEmergencyUnblockEvent(
       id: UUID(), deviceId: "x", consumedAt: now, resetEpoch: 1)
 
@@ -60,7 +60,7 @@ final class EmergencyUnblockEventLedgerTests: XCTestCase {
   func testGivenOldEpochEvents_WhenEpochAdvances_ThenTheyStopCounting() {
     let now = Date()
     let manager = EmergencyUnblockManager(defaults: defaults)
-    manager.seedForTesting(allowance: 3, epoch: 1)
+    manager.seedForTesting(epoch: 1)
 
     _ = manager.consumeUnblockEvent(now: now)
     _ = manager.consumeUnblockEvent(now: now)
@@ -72,7 +72,7 @@ final class EmergencyUnblockEventLedgerTests: XCTestCase {
   func testRemainingClampsAtZero() {
     let now = Date()
     let manager = EmergencyUnblockManager(defaults: defaults)
-    manager.seedForTesting(allowance: 3, epoch: 1)
+    manager.seedForTesting(epoch: 1)
 
     for _ in 0..<5 {
       _ = manager.consumeUnblockEvent(now: now)

--- a/FoqosTests/EmergencyUnblockGCTests.swift
+++ b/FoqosTests/EmergencyUnblockGCTests.swift
@@ -36,7 +36,7 @@ final class EmergencyUnblockGCTests: XCTestCase {
   func testGivenStaleEpochEvents_WhenGC_ThenRemovedLocallyAndDeletesEnqueued() {
     let now = Date()
     let manager = EmergencyUnblockManager(defaults: emgDefaults, profileSyncManager: .shared)
-    manager.seedForTesting(allowance: 3, epoch: 1)
+    manager.seedForTesting(epoch: 1)
     let e1 = manager.consumeUnblockEvent(now: now)
     let e2 = manager.consumeUnblockEvent(now: now)
     manager.advanceResetEpochForTesting()

--- a/FoqosTests/EmergencyUnblockGCTests.swift
+++ b/FoqosTests/EmergencyUnblockGCTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class EmergencyUnblockGCTests: XCTestCase {
+
+  private var emgSuite: String!
+  private var emgDefaults: UserDefaults!
+  private var savedController: (any SyncEngineControlling)?
+  private var savedEnabled = false
+  private var savedIsSyncReady = false
+  private var mock: MockSyncEngineControlling!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    emgSuite = "GC-emg-\(UUID().uuidString)"
+    emgDefaults = UserDefaults(suiteName: emgSuite)!
+    savedController = ProfileSyncManager.shared.engineController
+    savedEnabled = ProfileSyncManager.shared.isEnabled
+    savedIsSyncReady = ProfileSyncManager.shared.isSyncReady
+    mock = MockSyncEngineControlling()
+    ProfileSyncManager.shared.engineController = mock
+    ProfileSyncManager.shared.isSyncReady = true
+    ProfileSyncManager.shared.isEnabled = true
+  }
+
+  override func tearDown() async throws {
+    ProfileSyncManager.shared.engineController = savedController
+    ProfileSyncManager.shared.isSyncReady = savedIsSyncReady
+    ProfileSyncManager.shared.isEnabled = savedEnabled
+    emgDefaults.removePersistentDomain(forName: emgSuite)
+    try await super.tearDown()
+  }
+
+  func testGivenStaleEpochEvents_WhenGC_ThenRemovedLocallyAndDeletesEnqueued() {
+    let now = Date()
+    let manager = EmergencyUnblockManager(defaults: emgDefaults, profileSyncManager: .shared)
+    manager.seedForTesting(allowance: 3, epoch: 1)
+    let e1 = manager.consumeUnblockEvent(now: now)
+    let e2 = manager.consumeUnblockEvent(now: now)
+    manager.advanceResetEpochForTesting()
+
+    manager.garbageCollectStaleUnblockEvents()
+
+    XCTAssertEqual(mock.enqueuedEmergencyUnblockEventDeletes.count, 2, "one delete per stale event")
+    XCTAssertTrue(mock.enqueuedEmergencyUnblockEventDeletes.contains(e1.recordName))
+    XCTAssertTrue(mock.enqueuedEmergencyUnblockEventDeletes.contains(e2.recordName))
+    XCTAssertTrue(manager.staleUnblockEventRecordNames().isEmpty, "stale events pruned locally")
+  }
+}

--- a/FoqosTests/EmergencyUnblockManagerSnapshotTests.swift
+++ b/FoqosTests/EmergencyUnblockManagerSnapshotTests.swift
@@ -30,7 +30,7 @@ final class EmergencyUnblockManagerSnapshotTests: XCTestCase {
   func testGivenAppliedState_WhenSnapshotRequested_ThenReflectsCurrentValuesWithoutBump() {
     let now = Date()
     let manager = EmergencyUnblockManager(defaults: defaults)
-    manager.seedForTesting(allowance: 3, epoch: 1)
+    manager.seedForTesting(epoch: 1)
     _ = manager.consumeUnblockEvent(now: now)
     let remote = SyncedEmergencySettings(
       unblocksRemaining: 99,

--- a/FoqosTests/EmergencyUnblockManagerSnapshotTests.swift
+++ b/FoqosTests/EmergencyUnblockManagerSnapshotTests.swift
@@ -4,24 +4,36 @@ import XCTest
 
 @MainActor
 final class EmergencyUnblockManagerSnapshotTests: XCTestCase {
+  private var suiteName: String!
+  private var defaults: UserDefaults!
   private let defaultsKeys = [
-    "family_foqos_emergency_unblocks_remaining",
     "family_foqos_emergency_unblocks_reset_period_in_days",
     "family_foqos_last_emergency_unblocks_reset_date",
     "family_foqos_emergency_settings_locked",
     "family_foqos_emergency_settings_version",
+    "family_foqos_emergency_unblock_events",
+    "family_foqos_emergency_reset_epoch",
   ]
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "EmergencySnapshot-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+  }
 
   override func tearDown() async throws {
     for key in defaultsKeys { UserDefaults.standard.removeObject(forKey: key) }
+    defaults.removePersistentDomain(forName: suiteName)
     try await super.tearDown()
   }
 
   func testGivenAppliedState_WhenSnapshotRequested_ThenReflectsCurrentValuesWithoutBump() {
     let now = Date()
-    let manager = EmergencyUnblockManager()
+    let manager = EmergencyUnblockManager(defaults: defaults)
+    manager.seedForTesting(allowance: 3, epoch: 1)
+    _ = manager.consumeUnblockEvent(now: now)
     let remote = SyncedEmergencySettings(
-      unblocksRemaining: 2,
+      unblocksRemaining: 99,
       resetPeriodInDays: 14,
       lastResetDate: now,
       settingsLocked: true,
@@ -33,7 +45,7 @@ final class EmergencyUnblockManagerSnapshotTests: XCTestCase {
 
     let snapshot = manager.currentEmergencySettings(deviceId: "device-A", now: now)
 
-    XCTAssertEqual(snapshot.unblocksRemaining, 2)
+    XCTAssertEqual(snapshot.unblocksRemaining, 2, "count is derived from current-epoch events")
     XCTAssertEqual(snapshot.resetPeriodInDays, 14)
     XCTAssertEqual(snapshot.settingsLocked, true)
     XCTAssertEqual(snapshot.version, 9, "snapshot must carry the current version verbatim (no bump)")

--- a/FoqosTests/EmergencyUnblockUnionApplyTests.swift
+++ b/FoqosTests/EmergencyUnblockUnionApplyTests.swift
@@ -29,7 +29,7 @@ final class EmergencyUnblockUnionApplyTests: XCTestCase {
     container = try TestModelContainer.create()
     context = container.mainContext
     emergencyManager = EmergencyUnblockManager(defaults: emgDefaults)
-    emergencyManager.seedForTesting(allowance: 3, epoch: 1)
+    emergencyManager.seedForTesting(epoch: 1)
   }
 
   override func tearDown() async throws {

--- a/FoqosTests/EmergencyUnblockUnionApplyTests.swift
+++ b/FoqosTests/EmergencyUnblockUnionApplyTests.swift
@@ -1,0 +1,156 @@
+import CloudKit
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class EmergencyUnblockUnionApplyTests: XCTestCase {
+
+  private var container: ModelContainer!
+  private var context: ModelContext!
+  private var store: SyncEngineStore!
+  private var emergencyManager: EmergencyUnblockManager!
+  private var storeDefaults: UserDefaults!
+  private var emgDefaults: UserDefaults!
+  private var storeSuite: String!
+  private var emgSuite: String!
+  private let zoneID = CKRecordZone.ID(
+    zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)
+
+  override func setUp() async throws {
+    try await super.setUp()
+    storeSuite = "UnionApply-store-\(UUID().uuidString)"
+    emgSuite = "UnionApply-emg-\(UUID().uuidString)"
+    storeDefaults = UserDefaults(suiteName: storeSuite)!
+    emgDefaults = UserDefaults(suiteName: emgSuite)!
+    SharedData.configure(suite: UserDefaults(suiteName: "UnionApply-shared-\(UUID().uuidString)")!)
+    store = SyncEngineStore(userRecordName: "user-1", defaults: storeDefaults)
+    container = try TestModelContainer.create()
+    context = container.mainContext
+    emergencyManager = EmergencyUnblockManager(defaults: emgDefaults)
+    emergencyManager.seedForTesting(allowance: 3, epoch: 1)
+  }
+
+  override func tearDown() async throws {
+    storeDefaults.removePersistentDomain(forName: storeSuite)
+    emgDefaults.removePersistentDomain(forName: emgSuite)
+    try await super.tearDown()
+  }
+
+  private func makeService() -> SyncApplyService {
+    SyncApplyService(
+      modelContext: context,
+      store: store,
+      sessionController: MockSessionController(),
+      emergencyManager: emergencyManager,
+      deviceId: "device-A")
+  }
+
+  func testGivenRemoteUnblockEvent_WhenApplied_ThenMergedAndCountDrops() {
+    let now = Date()
+    let apply = makeService()
+    let event = SyncedEmergencyUnblockEvent(id: UUID(), deviceId: "peer", consumedAt: now, resetEpoch: 1)
+    let record = event.toCKRecord(in: zoneID)
+
+    _ = apply.applyFetchedModification(record, isPendingDeleteOrTombstoned: { _ in false })
+    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 2)
+
+    _ = apply.applyFetchedModification(record, isPendingDeleteOrTombstoned: { _ in false })
+    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 2, "idempotent union")
+  }
+
+  func testGivenRemoteEpoch_WhenApplied_ThenAdoptedByMaxRegardlessOfOrder() {
+    let apply = makeService()
+
+    _ = apply.applyFetchedModification(
+      SyncedEmergencyEpoch(epoch: 3).toCKRecord(in: zoneID),
+      isPendingDeleteOrTombstoned: { _ in false })
+    XCTAssertEqual(emergencyManager.currentResetEpoch, 3, "higher epoch adopted")
+
+    _ = apply.applyFetchedModification(
+      SyncedEmergencyEpoch(epoch: 2).toCKRecord(in: zoneID),
+      isPendingDeleteOrTombstoned: { _ in false })
+    XCTAssertEqual(emergencyManager.currentResetEpoch, 3, "lower epoch never lowers it")
+  }
+
+  func testGivenUnblockEventDeletion_WhenApplied_ThenRemovedFromLedgerIdempotently() {
+    let now = Date()
+    let apply = makeService()
+    let event = SyncedEmergencyUnblockEvent(id: UUID(), deviceId: "peer", consumedAt: now, resetEpoch: 1)
+    _ = apply.applyFetchedModification(
+      event.toCKRecord(in: zoneID), isPendingDeleteOrTombstoned: { _ in false })
+    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 2)
+
+    let recordID = CKRecord.ID(recordName: event.recordName, zoneID: zoneID)
+    let outcome = apply.applyFetchedDeletion(
+      recordID: recordID, recordType: SyncedEmergencyUnblockEvent.recordType)
+
+    XCTAssertEqual(outcome, .deleted)
+    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 3, "event removed from ledger")
+    _ = apply.applyFetchedDeletion(recordID: recordID, recordType: SyncedEmergencyUnblockEvent.recordType)
+    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 3, "delete replay is idempotent")
+  }
+
+  func testGivenPeerPrunedBeforeEpochSeen_ThenNeverUnderCounts() {
+    let now = Date()
+    let apply = makeService()
+    let e1 = SyncedEmergencyUnblockEvent(id: UUID(), deviceId: "peer", consumedAt: now, resetEpoch: 1)
+    let e2 = SyncedEmergencyUnblockEvent(id: UUID(), deviceId: "peer", consumedAt: now, resetEpoch: 1)
+    emergencyManager.mergeRemoteUnblockEvent(e1)
+    emergencyManager.mergeRemoteUnblockEvent(e2)
+    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 1)
+
+    _ = apply.applyFetchedDeletion(
+      recordID: CKRecord.ID(recordName: e1.recordName, zoneID: zoneID),
+      recordType: SyncedEmergencyUnblockEvent.recordType)
+    _ = apply.applyFetchedDeletion(
+      recordID: CKRecord.ID(recordName: e2.recordName, zoneID: zoneID),
+      recordType: SyncedEmergencyUnblockEvent.recordType)
+
+    XCTAssertGreaterThanOrEqual(
+      emergencyManager.getRemainingEmergencyUnblocks(), 1,
+      "deletions-before-epoch can only over-count, never wrongly deny")
+
+    _ = apply.applyFetchedModification(
+      SyncedEmergencyEpoch(epoch: 2).toCKRecord(in: zoneID),
+      isPendingDeleteOrTombstoned: { _ in false })
+    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 3)
+  }
+
+  func testGivenEpochBumpArrivesWithoutEvents_ThenCountResetsAndOldEventsInert() {
+    let now = Date()
+    let apply = makeService()
+    let e1 = SyncedEmergencyUnblockEvent(id: UUID(), deviceId: "peer", consumedAt: now, resetEpoch: 1)
+    let e2 = SyncedEmergencyUnblockEvent(id: UUID(), deviceId: "peer", consumedAt: now, resetEpoch: 1)
+    emergencyManager.mergeRemoteUnblockEvent(e1)
+    emergencyManager.mergeRemoteUnblockEvent(e2)
+    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 1)
+
+    _ = apply.applyFetchedModification(
+      SyncedEmergencyEpoch(epoch: 2).toCKRecord(in: zoneID),
+      isPendingDeleteOrTombstoned: { _ in false })
+
+    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 3)
+    emergencyManager.mergeRemoteUnblockEvent(
+      SyncedEmergencyUnblockEvent(id: UUID(), deviceId: "peer", consumedAt: now, resetEpoch: 1))
+    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 3, "old-epoch events are inert")
+  }
+
+  func testGivenEventsArriveBeforeEpoch_ThenCountedOnlyAfterEpochAdopted() {
+    let now = Date()
+    let apply = makeService()
+    let event = SyncedEmergencyUnblockEvent(id: UUID(), deviceId: "peer", consumedAt: now, resetEpoch: 2)
+
+    _ = apply.applyFetchedModification(
+      event.toCKRecord(in: zoneID), isPendingDeleteOrTombstoned: { _ in false })
+    XCTAssertEqual(
+      emergencyManager.getRemainingEmergencyUnblocks(), 3,
+      "future-epoch events are inert until the epoch record arrives")
+
+    _ = apply.applyFetchedModification(
+      SyncedEmergencyEpoch(epoch: 2).toCKRecord(in: zoneID),
+      isPendingDeleteOrTombstoned: { _ in false })
+    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 2)
+  }
+}

--- a/FoqosTests/FamilyCommandSaveOutcomeTests.swift
+++ b/FoqosTests/FamilyCommandSaveOutcomeTests.swift
@@ -1,0 +1,27 @@
+import CloudKit
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class FamilyCommandSaveOutcomeTests: XCTestCase {
+
+  func testGivenNoError_WhenClassifying_ThenSent() {
+    XCTAssertEqual(CloudKitNetworkService.classifyCommandSave(error: nil), .sent)
+  }
+
+  func testGivenServerRecordChanged_WhenClassifying_ThenAlreadyPending() {
+    let error = CKError(.serverRecordChanged)
+    XCTAssertEqual(CloudKitNetworkService.classifyCommandSave(error: error), .alreadyPending)
+  }
+
+  func testGivenOtherCKError_WhenClassifying_ThenFailed() {
+    let error = CKError(.networkUnavailable)
+    XCTAssertEqual(CloudKitNetworkService.classifyCommandSave(error: error), .failed)
+  }
+
+  func testGivenNonCKError_WhenClassifying_ThenFailed() {
+    struct Boom: Error {}
+    XCTAssertEqual(CloudKitNetworkService.classifyCommandSave(error: Boom()), .failed)
+  }
+}

--- a/FoqosTests/FamilyCommandSaveOutcomeTests.swift
+++ b/FoqosTests/FamilyCommandSaveOutcomeTests.swift
@@ -6,10 +6,6 @@ import XCTest
 @MainActor
 final class FamilyCommandSaveOutcomeTests: XCTestCase {
 
-  func testGivenNoError_WhenClassifying_ThenSent() {
-    XCTAssertEqual(CloudKitNetworkService.classifyCommandSave(error: nil), .sent)
-  }
-
   func testGivenServerRecordChanged_WhenClassifying_ThenAlreadyPending() {
     let error = CKError(.serverRecordChanged)
     XCTAssertEqual(CloudKitNetworkService.classifyCommandSave(error: error), .alreadyPending)

--- a/FoqosTests/Mocks/MockSyncEngineControlling.swift
+++ b/FoqosTests/Mocks/MockSyncEngineControlling.swift
@@ -13,6 +13,9 @@ final class MockSyncEngineControlling: SyncEngineControlling {
   private(set) var enqueuedLocationSaves: [UUID] = []
   private(set) var enqueuedLocationDeletes: [UUID] = []
   private(set) var enqueuedEmergencySaves = 0
+  private(set) var enqueuedEmergencyUnblockEvents: [SyncedEmergencyUnblockEvent] = []
+  private(set) var enqueuedEmergencyEpochSaves = 0
+  private(set) var enqueuedEmergencyUnblockEventDeletes: [String] = []
   private(set) var deferredDeletes: [String] = []
 
   /// Set by a test to make every `enqueue*` verb below throw instead of recording — used to
@@ -48,6 +51,18 @@ final class MockSyncEngineControlling: SyncEngineControlling {
   func enqueueEmergencySettingsSave() throws {
     if let errorToThrow { throw errorToThrow }
     enqueuedEmergencySaves += 1
+  }
+  func enqueueEmergencyUnblockEvent(_ event: SyncedEmergencyUnblockEvent) throws {
+    if let errorToThrow { throw errorToThrow }
+    enqueuedEmergencyUnblockEvents.append(event)
+  }
+  func enqueueEmergencyEpochSave() throws {
+    if let errorToThrow { throw errorToThrow }
+    enqueuedEmergencyEpochSaves += 1
+  }
+  func enqueueEmergencyUnblockEventDelete(_ recordName: String) throws {
+    if let errorToThrow { throw errorToThrow }
+    enqueuedEmergencyUnblockEventDeletes.append(recordName)
   }
   func enqueueDeferredDelete(recordName: String) {
     deferredDeletes.append(recordName)

--- a/FoqosTests/MutationFunnelTests.swift
+++ b/FoqosTests/MutationFunnelTests.swift
@@ -261,6 +261,46 @@ final class MutationFunnelTests: XCTestCase {
     _ = now
   }
 
+  func testGivenUnblockEvent_WhenEnqueue_ThenEnqueuesOneSaveRecord() throws {
+    let now = Date()
+    let container = try TestModelContainer.create()
+    let syncContext = ModelContext(container)
+    let store = makeStore()
+    let driver = MockSyncEngineDriver()
+    let funnel = MutationFunnel(
+      modelContext: syncContext,
+      store: store,
+      driver: driver,
+      deviceId: "device-A"
+    )
+    let event = SyncedEmergencyUnblockEvent(
+      id: UUID(), deviceId: "device-A", consumedAt: now, resetEpoch: 1)
+
+    funnel.enqueueEmergencyUnblockEvent(event)
+
+    XCTAssertEqual(driver.pendingRecordZoneChanges, [.saveRecord(recordID(event.recordName))])
+  }
+
+  func testGivenEmergencyEpoch_WhenEnqueue_ThenEnqueuesFixedNameSaveRecord() throws {
+    let container = try TestModelContainer.create()
+    let syncContext = ModelContext(container)
+    let store = makeStore()
+    let driver = MockSyncEngineDriver()
+    let funnel = MutationFunnel(
+      modelContext: syncContext,
+      store: store,
+      driver: driver,
+      deviceId: "device-A"
+    )
+
+    funnel.enqueueEmergencyEpochSave()
+
+    XCTAssertEqual(
+      driver.pendingRecordZoneChanges,
+      [.saveRecord(recordID(SyncedEmergencyEpoch.recordName))]
+    )
+  }
+
   // MARK: - S-15 / S-29: delete writes a tombstone carrying the change tag, enqueues once
 
   func testGivenSyncedProfile_WhenEnqueueDelete_ThenDeleteIsMarkedBeforeDeferredSaveAndEnqueuedAfterCommit()

--- a/FoqosTests/ProfileTieBreakApplyTests.swift
+++ b/FoqosTests/ProfileTieBreakApplyTests.swift
@@ -1,0 +1,35 @@
+import CloudKit
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class ProfileTieBreakApplyTests: XCTestCase {
+
+  private func synced(name: String, updatedAt: Date, device: String) -> SyncedProfile {
+    let source = BlockedProfiles(id: UUID(), name: name, updatedAt: updatedAt)
+    return SyncedProfile(from: source, originDeviceId: device)
+  }
+
+  func testGivenTie_WhenRemoteHasNewerUpdatedAt_ThenRemoteWins() {
+    let now = Date()
+    let remote = synced(name: "R", updatedAt: now, device: "A")
+    let local = synced(name: "L", updatedAt: now.addingTimeInterval(-10), device: "B")
+    XCTAssertTrue(SyncApplyService.remoteWinsProfileTie(remote: remote, local: local))
+  }
+
+  func testGivenTie_WhenLocalHasNewerUpdatedAt_ThenLocalWins() {
+    let now = Date()
+    let remote = synced(name: "R", updatedAt: now.addingTimeInterval(-10), device: "A")
+    let local = synced(name: "L", updatedAt: now, device: "B")
+    XCTAssertFalse(SyncApplyService.remoteWinsProfileTie(remote: remote, local: local))
+  }
+
+  func testGivenEqualUpdatedAt_WhenBreaking_ThenLowerOriginDeviceIdWins() {
+    let now = Date()
+    let remote = synced(name: "R", updatedAt: now, device: "A")
+    let local = synced(name: "L", updatedAt: now, device: "B")
+    XCTAssertTrue(SyncApplyService.remoteWinsProfileTie(remote: remote, local: local))
+    XCTAssertFalse(SyncApplyService.remoteWinsProfileTie(remote: local, local: remote))
+  }
+}

--- a/FoqosTests/RecordProviderTests.swift
+++ b/FoqosTests/RecordProviderTests.swift
@@ -12,7 +12,9 @@ final class RecordProviderTests: XCTestCase {
   private var emergencyManager: EmergencyUnblockManager!
   private var suiteName: String!
   private var storeSuiteName: String!
+  private var emergencySuiteName: String!
   private var storeDefaults: UserDefaults!
+  private var emergencyDefaults: UserDefaults!
   private let deviceId = "device-A"
   private let zoneID = CKRecordZone.ID(
     zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)
@@ -22,16 +24,19 @@ final class RecordProviderTests: XCTestCase {
     suiteName = "RecordProviderTests-\(UUID().uuidString)"
     SharedData.configure(suite: UserDefaults(suiteName: suiteName)!)
     storeSuiteName = "RecordProviderTests-store-\(UUID().uuidString)"
+    emergencySuiteName = "RecordProviderTests-emg-\(UUID().uuidString)"
     storeDefaults = UserDefaults(suiteName: storeSuiteName)!
+    emergencyDefaults = UserDefaults(suiteName: emergencySuiteName)!
     store = SyncEngineStore(userRecordName: "user-1", defaults: storeDefaults)
     container = try TestModelContainer.create()
     context = container.mainContext
-    emergencyManager = EmergencyUnblockManager()
+    emergencyManager = EmergencyUnblockManager(defaults: emergencyDefaults)
   }
 
   override func tearDown() async throws {
     UserDefaults().removePersistentDomain(forName: suiteName)
     UserDefaults().removePersistentDomain(forName: storeSuiteName)
+    UserDefaults().removePersistentDomain(forName: emergencySuiteName)
     try await super.tearDown()
   }
 
@@ -92,9 +97,11 @@ final class RecordProviderTests: XCTestCase {
 
   func testGivenEmergencyRecordName_WhenMaterialized_ThenBuildsEmergencyRecord() {
     let now = Date()
+    emergencyManager.seedForTesting(allowance: 3, epoch: 1)
+    _ = emergencyManager.consumeUnblockEvent(now: now)
     emergencyManager.applyRemoteEmergencySettings(
       SyncedEmergencySettings(
-        unblocksRemaining: 2, resetPeriodInDays: 14, lastResetDate: now,
+        unblocksRemaining: 99, resetPeriodInDays: 14, lastResetDate: now,
         settingsLocked: true, version: 4, lastModified: now, originDeviceId: "remote"))
 
     let record = makeProvider().record(forRecordName: SyncedEmergencySettings.recordName)
@@ -103,6 +110,31 @@ final class RecordProviderTests: XCTestCase {
     XCTAssertEqual(record?.recordID.recordName, SyncedEmergencySettings.recordName)
     XCTAssertEqual(record?[SyncedEmergencySettings.FieldKey.unblocksRemaining.rawValue] as? Int, 2)
     XCTAssertEqual(record?[SyncedEmergencySettings.FieldKey.version.rawValue] as? Int, 4)
+  }
+
+  func testGivenEmergencyEpochRecordName_WhenMaterialized_ThenBuildsEpochRecord() {
+    emergencyManager.seedForTesting(allowance: 3, epoch: 4)
+
+    let record = makeProvider().record(forRecordName: SyncedEmergencyEpoch.recordName)
+
+    XCTAssertEqual(record?.recordType, SyncedEmergencyEpoch.recordType)
+    XCTAssertEqual(record?.recordID.recordName, SyncedEmergencyEpoch.recordName)
+    XCTAssertEqual(record?[SyncedEmergencyEpoch.FieldKey.epoch.rawValue] as? Int, 4)
+  }
+
+  func testGivenEmergencyUnblockEventRecordName_WhenMaterialized_ThenBuildsEventRecord() {
+    let now = Date()
+    emergencyManager.seedForTesting(allowance: 3, epoch: 2)
+    let event = emergencyManager.consumeUnblockEvent(now: now)
+
+    let record = makeProvider().record(forRecordName: event.recordName)
+
+    XCTAssertEqual(record?.recordType, SyncedEmergencyUnblockEvent.recordType)
+    XCTAssertEqual(record?.recordID.recordName, event.recordName)
+    XCTAssertEqual(
+      record?[SyncedEmergencyUnblockEvent.FieldKey.id.rawValue] as? String,
+      event.id.uuidString)
+    XCTAssertEqual(record?[SyncedEmergencyUnblockEvent.FieldKey.resetEpoch.rawValue] as? Int, 2)
   }
 
   func testGivenAbsentEntity_WhenMaterialized_ThenNil() {

--- a/FoqosTests/RecordProviderTests.swift
+++ b/FoqosTests/RecordProviderTests.swift
@@ -97,7 +97,7 @@ final class RecordProviderTests: XCTestCase {
 
   func testGivenEmergencyRecordName_WhenMaterialized_ThenBuildsEmergencyRecord() {
     let now = Date()
-    emergencyManager.seedForTesting(allowance: 3, epoch: 1)
+    emergencyManager.seedForTesting(epoch: 1)
     _ = emergencyManager.consumeUnblockEvent(now: now)
     emergencyManager.applyRemoteEmergencySettings(
       SyncedEmergencySettings(
@@ -113,7 +113,7 @@ final class RecordProviderTests: XCTestCase {
   }
 
   func testGivenEmergencyEpochRecordName_WhenMaterialized_ThenBuildsEpochRecord() {
-    emergencyManager.seedForTesting(allowance: 3, epoch: 4)
+    emergencyManager.seedForTesting(epoch: 4)
 
     let record = makeProvider().record(forRecordName: SyncedEmergencyEpoch.recordName)
 
@@ -124,7 +124,7 @@ final class RecordProviderTests: XCTestCase {
 
   func testGivenEmergencyUnblockEventRecordName_WhenMaterialized_ThenBuildsEventRecord() {
     let now = Date()
-    emergencyManager.seedForTesting(allowance: 3, epoch: 2)
+    emergencyManager.seedForTesting(epoch: 2)
     let event = emergencyManager.consumeUnblockEvent(now: now)
 
     let record = makeProvider().record(forRecordName: event.recordName)

--- a/FoqosTests/SyncApplyServiceTests.swift
+++ b/FoqosTests/SyncApplyServiceTests.swift
@@ -13,7 +13,9 @@ final class SyncApplyServiceTests: XCTestCase {
   private var emergencyManager: EmergencyUnblockManager!
   private var suiteName: String!
   private var storeSuiteName: String!
+  private var emergencySuiteName: String!
   private var storeDefaults: UserDefaults!
+  private var emergencyDefaults: UserDefaults!
   private let deviceId = "device-A"
   private let zoneID = CKRecordZone.ID(
     zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)
@@ -23,12 +25,14 @@ final class SyncApplyServiceTests: XCTestCase {
     suiteName = "SyncApplyServiceTests-\(UUID().uuidString)"
     SharedData.configure(suite: UserDefaults(suiteName: suiteName)!)
     storeSuiteName = "SyncApplyServiceTests-store-\(UUID().uuidString)"
+    emergencySuiteName = "SyncApplyServiceTests-emg-\(UUID().uuidString)"
     storeDefaults = UserDefaults(suiteName: storeSuiteName)!
+    emergencyDefaults = UserDefaults(suiteName: emergencySuiteName)!
     store = SyncEngineStore(userRecordName: "user-1", defaults: storeDefaults)
     container = try TestModelContainer.create()
     context = container.mainContext
     sessionController = MockSessionController()
-    emergencyManager = EmergencyUnblockManager()
+    emergencyManager = EmergencyUnblockManager(defaults: emergencyDefaults)
     SyncConflictManager.shared.clearAll()
   }
 
@@ -36,6 +40,7 @@ final class SyncApplyServiceTests: XCTestCase {
     SyncConflictManager.shared.clearAll()
     UserDefaults().removePersistentDomain(forName: suiteName)
     UserDefaults().removePersistentDomain(forName: storeSuiteName)
+    UserDefaults().removePersistentDomain(forName: emergencySuiteName)
     for key in [
       "family_foqos_emergency_unblocks_remaining",
       "family_foqos_emergency_unblocks_reset_period_in_days",
@@ -192,7 +197,8 @@ final class SyncApplyServiceTests: XCTestCase {
     XCTAssertEqual(after?.name, "Focus", "local wins — incoming payload not applied")
     XCTAssertEqual(after?.syncVersion, 6, "conflict bump")
     XCTAssertTrue(service.pendingReenqueues.contains(record.recordID))
-    XCTAssertNotNil(SyncConflictManager.shared.conflictedProfiles[id])
+    XCTAssertTrue(SyncConflictManager.shared.shouldShowDivergenceBanner)
+    XCTAssertNotNil(SyncConflictManager.shared.divergenceProfiles[id])
   }
 
   // MARK: - S-31
@@ -320,7 +326,9 @@ final class SyncApplyServiceTests: XCTestCase {
       makeService().applyFetchedModification(
         remote.toCKRecord(in: zoneID), isPendingDeleteOrTombstoned: noPendingDelete),
       .applied)
-    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 7)
+    XCTAssertEqual(
+      emergencyManager.getRemainingEmergencyUnblocks(), 3,
+      "settings config no longer owns the derived count")
     XCTAssertEqual(emergencyManager.emergencySettingsVersion, nextVersion)
     XCTAssertNotNil(store.systemFields(for: SyncedEmergencySettings.recordName))
   }
@@ -339,7 +347,7 @@ final class SyncApplyServiceTests: XCTestCase {
       makeService().applyFetchedModification(
         stale.toCKRecord(in: zoneID), isPendingDeleteOrTombstoned: noPendingDelete),
       .applied)
-    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 1, "stale version ignored")
+    XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 3, "stale version ignored")
     XCTAssertNil(store.systemFields(for: SyncedEmergencySettings.recordName))
   }
 

--- a/FoqosTests/SyncConflictManagerDivergenceTests.swift
+++ b/FoqosTests/SyncConflictManagerDivergenceTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class SyncConflictManagerDivergenceTests: XCTestCase {
+
+  override func tearDown() async throws {
+    SyncConflictManager.shared.clearAll()
+    try await super.tearDown()
+  }
+
+  func testGivenDivergence_WhenAdded_ThenBannerShownWithDedicatedCopy() {
+    let manager = SyncConflictManager.shared
+    manager.clearAll()
+    manager.addDivergenceConflict(profileId: UUID(), profileName: "Homework")
+    XCTAssertTrue(manager.showConflictBanner)
+    XCTAssertTrue(manager.shouldShowDivergenceBanner)
+    XCTAssertTrue(manager.divergenceMessage.contains("Homework"))
+    XCTAssertFalse(
+      manager.divergenceMessage.lowercased().contains("older app version"),
+      "a same-version concurrent edit must NOT claim an app-version mismatch")
+  }
+
+  func testGivenDivergence_WhenCleared_ThenBannerHides() {
+    let manager = SyncConflictManager.shared
+    manager.clearAll()
+    let id = UUID()
+    manager.addDivergenceConflict(profileId: id, profileName: "Homework")
+    manager.clearConflict(profileId: id)
+    XCTAssertFalse(manager.showConflictBanner)
+  }
+}

--- a/FoqosTests/SyncConflictManagerDivergenceTests.swift
+++ b/FoqosTests/SyncConflictManagerDivergenceTests.swift
@@ -30,4 +30,30 @@ final class SyncConflictManagerDivergenceTests: XCTestCase {
     manager.clearConflict(profileId: id)
     XCTAssertFalse(manager.showConflictBanner)
   }
+
+  func testGivenDivergenceAndOlderConflict_WhenDismissingDivergence_ThenOlderConflictBannerRemains() {
+    let manager = SyncConflictManager.shared
+    manager.clearAll()
+
+    manager.addDivergenceConflict(profileId: UUID(), profileName: "Homework")
+    manager.addConflict(profileId: UUID(), profileName: "Chores")
+
+    manager.dismissDivergenceBanner()
+
+    XCTAssertFalse(manager.shouldShowDivergenceBanner)
+    XCTAssertTrue(manager.showConflictBanner)
+    XCTAssertTrue(manager.shouldShowOlderDeviceBanner)
+    XCTAssertTrue(manager.conflictMessage.contains("Chores"))
+  }
+
+  func testGivenOnlyDivergence_WhenDismissingDivergence_ThenBannerHides() {
+    let manager = SyncConflictManager.shared
+    manager.clearAll()
+
+    manager.addDivergenceConflict(profileId: UUID(), profileName: "Homework")
+    manager.dismissDivergenceBanner()
+
+    XCTAssertFalse(manager.shouldShowDivergenceBanner)
+    XCTAssertFalse(manager.showConflictBanner)
+  }
 }

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -14,6 +14,7 @@ final class SyncEngineControllerTests: XCTestCase {
   var driver: MockSyncEngineDriver!
   var apply: SyncApplyService!
   var provider: RecordProvider!
+  var emergencyManager: EmergencyUnblockManager!
   var sessionSync: MockSessionSyncFlushing!
   var sessionController: MockSessionController!
   var profileDeleteCommitScheduler: ManualProfileDeleteCommitScheduler!
@@ -33,13 +34,13 @@ final class SyncEngineControllerTests: XCTestCase {
     driver = MockSyncEngineDriver()
     sessionController = MockSessionController()
     profileDeleteCommitScheduler = ManualProfileDeleteCommitScheduler()
-    let emergency = EmergencyUnblockManager()
+    emergencyManager = EmergencyUnblockManager(defaults: defaults)
     apply = SyncApplyService(
       modelContext: context, store: store, sessionController: sessionController,
-      emergencyManager: emergency, deviceId: deviceId,
+      emergencyManager: emergencyManager, deviceId: deviceId,
       scheduleProfileDeleteCommit: profileDeleteCommitScheduler.schedule)
     provider = RecordProvider(
-      modelContext: context, store: store, emergencyManager: emergency, deviceId: deviceId)
+      modelContext: context, store: store, emergencyManager: emergencyManager, deviceId: deviceId)
     sessionSync = MockSessionSyncFlushing()
     SyncConflictManager.shared.clearAll()
   }
@@ -287,6 +288,18 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertTrue(saves.contains(SyncedEmergencySettings.recordName))
   }
 
+  func testRestorableRecordNames_IncludesEpochAndEvents() {
+    let now = Date()
+    emergencyManager.seedForTesting(allowance: 3, epoch: 4)
+    let event = emergencyManager.consumeUnblockEvent(now: now)
+    let controller = makeController()
+
+    let names = Set(controller.restorableRecordNames())
+
+    XCTAssertTrue(names.contains(SyncedEmergencyEpoch.recordName))
+    XCTAssertTrue(names.contains(event.recordName))
+  }
+
   func testGivenNewerSchemaProfile_WhenSeed_ThenNotIncludedInRestorableSet() throws {
     let p = BlockedProfiles(name: "A")
     p.profileSchemaVersion = BlockedProfiles.currentSchemaVersion + 1
@@ -502,7 +515,7 @@ final class SyncEngineControllerTests: XCTestCase {
     let batch = controller.nextRecordZoneChangeBatch(scope: nil) ?? []
     XCTAssertEqual(
       Set(batch.map { $0.recordID.recordName }),
-      Set([p.id.uuidString, SyncedEmergencySettings.recordName]))
+      Set([p.id.uuidString, SyncedEmergencySettings.recordName, SyncedEmergencyEpoch.recordName]))
 
     controller.handle(
       .sentRecordZoneChanges(
@@ -901,6 +914,7 @@ final class SyncEngineControllerTests: XCTestCase {
     controller.startupTask?.cancel()
 
     let remoteRecord = makeProfileRecord(id: id, version: 5, name: "Remote")
+    remoteRecord[SyncedProfile.FieldKey.updatedAt.rawValue] = local.updatedAt.addingTimeInterval(-10)
 
     controller.handle(
       .fetchedRecordZoneChanges(modifications: [remoteRecord], deletions: []))
@@ -909,8 +923,8 @@ final class SyncEngineControllerTests: XCTestCase {
       pendingSaveNames().contains(id.uuidString),
       "CRA-1: §5.1 equal-version-divergence reenqueue is drained and reaches the driver as .saveRecord")
     XCTAssertNotNil(
-      SyncConflictManager.shared.conflictedProfiles[id],
-      "equal-version divergence surfaces a conflict")
+      SyncConflictManager.shared.divergenceProfiles[id],
+      "equal-version divergence surfaces a dedicated divergence conflict")
   }
 
   // MARK: - T4 sentRecordZoneChanges routing (§5.3, S-10, S-11, S-17, S-23, S-29, CRA-1, CRA-3)
@@ -977,6 +991,7 @@ final class SyncEngineControllerTests: XCTestCase {
 
     let sent = makeProfileRecord(id: id, version: 5, name: "Local")
     let server = makeProfileRecord(id: id, version: 5, name: "ServerDiff")  // same version, differs
+    server[SyncedProfile.FieldKey.updatedAt.rawValue] = local.updatedAt.addingTimeInterval(-10)
     let error = makeCKError(
       .serverRecordChanged, userInfo: [CKRecordChangedErrorServerRecordKey: server])
 
@@ -989,7 +1004,45 @@ final class SyncEngineControllerTests: XCTestCase {
       pendingSaveNames().contains(id.uuidString),
       "CRA-1: branch E (§5.1 equal-version divergence) reenqueue drained to the driver")
     XCTAssertNotNil(
-      SyncConflictManager.shared.conflictedProfiles[id], "branch E surfaces a conflict")
+      SyncConflictManager.shared.divergenceProfiles[id], "branch E surfaces a divergence conflict")
+  }
+
+  func testGivenHigherLocalEpoch_WhenServerRecordLower_ThenLocalIsStrictlyNewer() {
+    emergencyManager.seedForTesting(allowance: 3, epoch: 5)
+    let controller = makeController()
+    let lowerServer = SyncedEmergencyEpoch(epoch: 3).toCKRecord(in: zoneID)
+    let equalServer = SyncedEmergencyEpoch(epoch: 5).toCKRecord(in: zoneID)
+
+    XCTAssertTrue(
+      controller.localIsStrictlyNewer(
+        SyncedEmergencyEpoch.recordType,
+        name: SyncedEmergencyEpoch.recordName,
+        server: lowerServer))
+    XCTAssertFalse(
+      controller.localIsStrictlyNewer(
+        SyncedEmergencyEpoch.recordType,
+        name: SyncedEmergencyEpoch.recordName,
+        server: equalServer))
+  }
+
+  func testGivenEpochSaveServerRecordChanged_WhenLocalHigher_ThenStoresTagAndReaddsEpoch() {
+    store.engineState = Data([0x01])
+    emergencyManager.seedForTesting(allowance: 3, epoch: 5)
+    let controller = makeController()
+    controller.start()
+    controller.startupTask?.cancel()
+    let sent = SyncedEmergencyEpoch(epoch: 5).toCKRecord(in: zoneID)
+    let server = SyncedEmergencyEpoch(epoch: 3).toCKRecord(in: zoneID)
+    let error = makeCKError(
+      .serverRecordChanged, userInfo: [CKRecordChangedErrorServerRecordKey: server])
+
+    controller.handle(
+      .sentRecordZoneChanges(
+        savedRecords: [], failedRecordSaves: [(record: sent, error: error)],
+        deletedRecordIDs: [], failedRecordDeletes: []))
+
+    XCTAssertNotNil(store.systemFields(for: SyncedEmergencyEpoch.recordName))
+    XCTAssertTrue(pendingSaveNames().contains(SyncedEmergencyEpoch.recordName))
   }
 
   func testGivenSentSave_WhenZoneNotFound_ThenBranchZSaveZoneSeedAndReAdd() {

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -290,7 +290,7 @@ final class SyncEngineControllerTests: XCTestCase {
 
   func testRestorableRecordNames_IncludesEpochAndEvents() {
     let now = Date()
-    emergencyManager.seedForTesting(allowance: 3, epoch: 4)
+    emergencyManager.seedForTesting(epoch: 4)
     let event = emergencyManager.consumeUnblockEvent(now: now)
     let controller = makeController()
 
@@ -1008,7 +1008,7 @@ final class SyncEngineControllerTests: XCTestCase {
   }
 
   func testGivenHigherLocalEpoch_WhenServerRecordLower_ThenLocalIsStrictlyNewer() {
-    emergencyManager.seedForTesting(allowance: 3, epoch: 5)
+    emergencyManager.seedForTesting(epoch: 5)
     let controller = makeController()
     let lowerServer = SyncedEmergencyEpoch(epoch: 3).toCKRecord(in: zoneID)
     let equalServer = SyncedEmergencyEpoch(epoch: 5).toCKRecord(in: zoneID)
@@ -1027,7 +1027,7 @@ final class SyncEngineControllerTests: XCTestCase {
 
   func testGivenEpochSaveServerRecordChanged_WhenLocalHigher_ThenStoresTagAndReaddsEpoch() {
     store.engineState = Data([0x01])
-    emergencyManager.seedForTesting(allowance: 3, epoch: 5)
+    emergencyManager.seedForTesting(epoch: 5)
     let controller = makeController()
     controller.start()
     controller.startupTask?.cancel()

--- a/FoqosTests/SyncEngineFacadeTests.swift
+++ b/FoqosTests/SyncEngineFacadeTests.swift
@@ -55,6 +55,9 @@ final class SyncEngineFacadeTests: XCTestCase {
 
   func testGivenController_WhenFacadeVerbsCalled_ThenTheyForward() throws {
     let id = UUID()
+    let now = Date()
+    let event = SyncedEmergencyUnblockEvent(
+      id: UUID(), deviceId: "device-A", consumedAt: now, resetEpoch: 1)
     manager.isSyncReady = true
 
     try manager.syncNow()
@@ -64,16 +67,22 @@ final class SyncEngineFacadeTests: XCTestCase {
     try manager.enqueueLocationSave(id)
     try manager.enqueueLocationDelete(id)
     try manager.enqueueEmergencySettingsSave()
+    try manager.enqueueEmergencyUnblockEvent(event)
+    try manager.enqueueEmergencyEpochSave()
+    try manager.enqueueEmergencyUnblockEventDelete(event.recordName)
 
     XCTAssertEqual(
-      mock.requestSyncCount, 6,
-      "syncNow (1) + five enqueue verbs each flush once when ready (5)")
+      mock.requestSyncCount, 9,
+      "syncNow (1) + eight enqueue verbs each flush once when ready (8)")
     XCTAssertEqual(mock.beginResetCalls, [true])
     XCTAssertEqual(mock.enqueuedProfileSaves, [id])
     XCTAssertEqual(mock.enqueuedProfileDeletes, [id])
     XCTAssertEqual(mock.enqueuedLocationSaves, [id])
     XCTAssertEqual(mock.enqueuedLocationDeletes, [id])
     XCTAssertEqual(mock.enqueuedEmergencySaves, 1)
+    XCTAssertEqual(mock.enqueuedEmergencyUnblockEvents, [event])
+    XCTAssertEqual(mock.enqueuedEmergencyEpochSaves, 1)
+    XCTAssertEqual(mock.enqueuedEmergencyUnblockEventDeletes, [event.recordName])
   }
 
   func testGivenReadyController_WhenEnqueueProfileSave_ThenRequestSyncIsScheduled() throws {
@@ -140,6 +149,67 @@ final class SyncEngineFacadeTests: XCTestCase {
     XCTAssertTrue(manager.hasNoDeferredMutations, "the deferred sets are cleared after draining")
   }
 
+  func testGivenNotAttached_WhenEnqueueEmergencyUnblockEvent_ThenEventIsDeferredAndReEnqueuedOnReady()
+    throws
+  {
+    let now = Date()
+    let event = SyncedEmergencyUnblockEvent(
+      id: UUID(), deviceId: "device-A", consumedAt: now, resetEpoch: 1)
+    manager.engineController = nil
+
+    XCTAssertThrowsError(try manager.enqueueEmergencyUnblockEvent(event)) { error in
+      XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+    }
+
+    let attached = MockSyncEngineControlling()
+    manager.engineController = attached
+    manager.markSyncReadyAndFlush()
+
+    XCTAssertEqual(attached.enqueuedEmergencyUnblockEvents, [event])
+    XCTAssertEqual(attached.requestSyncCount, 1, "exactly one flush covers all drained mutations")
+    XCTAssertTrue(manager.hasNoDeferredMutations, "the deferred sets are cleared after draining")
+  }
+
+  func testGivenNotAttached_WhenEnqueueEmergencyEpochSave_ThenSaveIsDeferredAndReEnqueuedOnReady()
+    throws
+  {
+    manager.engineController = nil
+
+    XCTAssertThrowsError(try manager.enqueueEmergencyEpochSave()) { error in
+      XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+    }
+
+    let attached = MockSyncEngineControlling()
+    manager.engineController = attached
+    manager.markSyncReadyAndFlush()
+
+    XCTAssertEqual(attached.enqueuedEmergencyEpochSaves, 1)
+    XCTAssertEqual(attached.requestSyncCount, 1, "exactly one flush covers all drained mutations")
+    XCTAssertTrue(manager.hasNoDeferredMutations, "the deferred sets are cleared after draining")
+  }
+
+  func testGivenNotAttached_WhenEnqueueEmergencyUnblockEventDelete_ThenDeleteIsReplayedOnReady()
+    throws
+  {
+    let recordName = SyncedEmergencyUnblockEvent.recordNamePrefix + UUID().uuidString
+    manager.engineController = nil
+
+    XCTAssertThrowsError(try manager.enqueueEmergencyUnblockEventDelete(recordName)) { error in
+      XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+    }
+
+    let attached = MockSyncEngineControlling()
+    manager.engineController = attached
+    manager.markSyncReadyAndFlush()
+
+    XCTAssertEqual(
+      attached.deferredDeletes,
+      [recordName],
+      "a GC delete dropped before attach is replayed through the existing deferred-delete path")
+    XCTAssertEqual(attached.requestSyncCount, 1)
+    XCTAssertTrue(manager.hasNoDeferredMutations)
+  }
+
   func testGivenNotAttached_WhenEnqueueProfileDelete_ThenTombstoneDeleteIsReplayedOnReady() throws {
     let id = UUID()
     manager.engineController = nil
@@ -197,18 +267,27 @@ final class SyncEngineFacadeTests: XCTestCase {
   func testGivenNotReady_WhenAnyFacadeEnqueueVerbRuns_ThenNoSendIsScheduled() throws {
     manager.isSyncReady = false
     let id = UUID()
+    let now = Date()
+    let event = SyncedEmergencyUnblockEvent(
+      id: UUID(), deviceId: "device-A", consumedAt: now, resetEpoch: 1)
 
     try manager.enqueueProfileSave(id)
     try manager.enqueueProfileDelete(id)
     try manager.enqueueLocationSave(id)
     try manager.enqueueLocationDelete(id)
     try manager.enqueueEmergencySettingsSave()
+    try manager.enqueueEmergencyUnblockEvent(event)
+    try manager.enqueueEmergencyEpochSave()
+    try manager.enqueueEmergencyUnblockEventDelete(event.recordName)
 
     XCTAssertEqual(mock.enqueuedProfileSaves, [id])
     XCTAssertEqual(mock.enqueuedProfileDeletes, [id])
     XCTAssertEqual(mock.enqueuedLocationSaves, [id])
     XCTAssertEqual(mock.enqueuedLocationDeletes, [id])
     XCTAssertEqual(mock.enqueuedEmergencySaves, 1)
+    XCTAssertEqual(mock.enqueuedEmergencyUnblockEvents, [event])
+    XCTAssertEqual(mock.enqueuedEmergencyEpochSaves, 1)
+    XCTAssertEqual(mock.enqueuedEmergencyUnblockEventDeletes, [event.recordName])
     XCTAssertEqual(
       mock.requestSyncCount, 0,
       "no facade enqueue verb may send before startup completes and T1 has stripped restored state")

--- a/FoqosTests/SyncedProfileDecodeBoundsTests.swift
+++ b/FoqosTests/SyncedProfileDecodeBoundsTests.swift
@@ -1,0 +1,50 @@
+import CloudKit
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class SyncedProfileDecodeBoundsTests: XCTestCase {
+
+  /// Builds a minimally-valid SyncedProfile CKRecord (all required fields present) so the
+  /// decode initializer reaches the optional-field assignments.
+  private func minimalProfileRecord(now: Date, reminder: Int?) -> CKRecord {
+    let zoneID = CKRecordZone.ID(
+      zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)
+    let record = CKRecord(
+      recordType: SyncedProfile.recordType,
+      recordID: CKRecord.ID(recordName: UUID().uuidString, zoneID: zoneID))
+    record["profileId"] = UUID().uuidString
+    record["name"] = "Focus"
+    record["createdAt"] = now
+    record["updatedAt"] = now
+    record["lastModified"] = now
+    record["originDeviceId"] = "device-A"
+    record["version"] = 1
+    if let reminder { record["reminderTimeInSeconds"] = reminder }
+    return record
+  }
+
+  func testGivenNegativeReminder_WhenDecoding_ThenDegradesToNilWithoutTrapping() {
+    let now = Date()
+    let record = minimalProfileRecord(now: now, reminder: -1)
+    let synced = SyncedProfile(from: record)
+    XCTAssertNotNil(synced, "an out-of-range reminder must not fail the whole decode")
+    XCTAssertNil(synced?.reminderTimeInSeconds, "negative reminder degrades to no-reminder")
+  }
+
+  func testGivenOverflowingReminder_WhenDecoding_ThenDegradesToNilWithoutTrapping() {
+    let now = Date()
+    let record = minimalProfileRecord(now: now, reminder: Int(UInt32.max) + 1)
+    let synced = SyncedProfile(from: record)
+    XCTAssertNotNil(synced)
+    XCTAssertNil(synced?.reminderTimeInSeconds, "overflowing reminder degrades to no-reminder")
+  }
+
+  func testGivenInRangeReminder_WhenDecoding_ThenPreservesValue() {
+    let now = Date()
+    let record = minimalProfileRecord(now: now, reminder: 3600)
+    let synced = SyncedProfile(from: record)
+    XCTAssertEqual(synced?.reminderTimeInSeconds, 3600)
+  }
+}


### PR DESCRIPTION
## Summary
- Fix #265 by range-checking inbound `reminderTimeInSeconds` with `UInt32(exactly:)`; poison records degrade to nil instead of trapping.
- Fix #222 by treating `serverRecordChanged` for deterministic `FamilyCommand` saves as idempotent success.
- Fix #218 by applying the settled deterministic tie-break (`updatedAt`, then `originDeviceId`) and surfacing same-version divergence with dedicated copy from the HomeView selection site.
- Fix #221 by replacing the LWW emergency-unblock scalar with immutable event records plus a dedicated monotonic-max reset epoch, mandatory stale-event pruning, and controller wiring for scope/CAS/restore.

## Maintainer Decisions Implemented
- #218 Option B: winner is newer `updatedAt`, then lexicographically lower `originDeviceId`. The same-version copy fix is separate from schema-version copy.
- #221 Option C: union of immutable usage-event records (G-Set), shared user/family-wide budget, reset epoch on its own unconditional `max()` channel, no per-device budget identity.
- #222: `serverRecordChanged` is success for already-pending deterministic commands. Rejected refetch/refresh because it adds a round trip without behavior gain.

## Plan Deviations Recorded
- Deviation #1: Task 4b was amended because the plan predated #296. The new event save, epoch save, and GC delete facade verbs now mirror the post-#296 contract: defer on `.notAttached`, drain via `drainDeferredMutations()` on ready, and `requestSync()` only when `isSyncReady` after successful enqueue. Safety argument: epoch drains are order-independent (`max()`), event saves are idempotent write-once unique recordNames, and GC deletes use the existing deferred-delete/tombstone path, so drain ordering needs no sequencing guarantee.
- Deviation #2: Task 3 wiring moved from `SyncConflictBanner` to `HomeView` because the actual selection site is `HomeView.swift:169`; evidence: true at base `4307654`, no intervening PR moved it. `SyncConflictBanner` remains generic.

## Verification
- `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -resultBundlePath /tmp/a3-review-full-20260710.xcresult 2>&1 | xcpretty` -> passed, 891/891.
- `./scripts/check-sync-guards.sh` -> passed.
- `swift-format lint --recursive .` -> passed.
- `git diff --check origin/main..HEAD` -> passed.
- Skeptic-pass tests are present and green:
  - `testGivenPeerPrunedBeforeEpochSeen_ThenNeverUnderCounts`
  - `testGivenEpochBumpArrivesWithoutEvents_ThenCountResetsAndOldEventsInert`
  - `testGivenEventsArriveBeforeEpoch_ThenCountedOnlyAfterEpochAdopted`

## Device Verification
| Scenario | Result | Evidence / Notes |
| --- | --- | --- |
| Two-device concurrent edit converges to the same winner on both devices | PASS | Device A showed `Sync Conflict`; Device B converged to A's winning title `A newer edit` after Sync Now. Logs: `docs/plans/FamilyFoqos-Logs-2026-07-10-222433.log`, `docs/plans/FamilyFoqos-Logs-2026-07-10-222446.log`. |
| Banner asymmetry during concurrent edit | PASS with explanation | A detected and resolved the equal-version divergence. B later adopted A's strictly-newer bumped winner without entering the divergence path. One banner on the detecting device is the shipped design. |
| Sync lifecycle `state=disabled` during requests | NOTED, out of scope | Pre-existing lifecycle anomaly now tracked as #307; maintainer evidence shows `state=disabled` appears 11x in the pre-A3′ #286 capture log. No diagnostics, lifecycle guards, or auto-recovery are included in this PR. |
| Emergency unblock consumed on both devices concurrently | PASS | Maintainer confirmed counts converge with no lost decrement. Logs: `docs/plans/FamilyFoqos-Logs-2026-07-10-222838.log`, `docs/plans/FamilyFoqos-Logs-2026-07-10-222847.log`. |
| Reset emergency allowance on one device | NOT RUN | Required parent/child device topology is unavailable in this verification pass; no result claimed for this row. |

Fixes #218
Fixes #221
Fixes #265
Fixes #222

## Summary by Sourcery

Revise emergency unblock allowance tracking and sync to use immutable event records with a shared reset epoch, strengthen profile sync conflict handling and messaging, and make CloudKit command saves idempotent on server-side collisions.

Bug Fixes:
- Prevent crashes when decoding out-of-range reminderTimeInSeconds values from CloudKit by safely degrading invalid data to no reminder.
- Treat serverRecordChanged errors for deterministic FamilyCommand saves as an idempotent success instead of a failure, avoiding unnecessary retries and user-visible errors.

Enhancements:
- Replace the scalar emergency-unblocks-remaining counter with an event ledger plus monotonic reset epoch, ensuring consistent cross-device counts and enabling garbage collection of stale events.
- Apply a deterministic tie-break for equal-version profile sync conflicts based on updatedAt and originDeviceId so concurrent edits converge on the same winner and surface a dedicated divergence banner in HomeView.
- Extend the sync engine, mutation funnel, and record provider to support syncing emergency unblock events and reset epochs, including restore behavior and scoped conflict handling.
- Improve sync conflict banner behavior and copy to distinguish same-version divergence from version-mismatch conflicts.

Tests:
- Add targeted unit tests for emergency unblock event ledger behavior, union apply semantics, reset and GC flows, and snapshot derivation of remaining allowance.
- Add tests covering the new profile tie-break logic, divergence conflict handling, FamilyCommand save outcome classification, and bounds-checked decoding of reminderTimeInSeconds.
- Update sync engine facade and controller tests to validate forwarding and replay of emergency unblock events and epochs, restorable record name coverage, and the new divergence conflict path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates several CloudKit sync conflict paths. The main changes are:

- Deterministic same-version profile conflict resolution.
- Idempotent handling for pending family commands.
- Event-ledger sync for emergency unblock usage.
- Monotonic reset epoch records and stale event pruning.
- Safer decoding for out-of-range reminder times.

<h3>Confidence Score: 4/5</h3>

The changed sync flow is mostly mergeable, but the conflict banner state needs a fix before merging.

- A divergence conflict can hide older-device or newer-version warnings.
- Dismissing the divergence banner can leave existing conflict data present but no longer visible.
- The emergency unblock event ledger has order-independent safeguards for the main count path.

Foqos/Views/HomeView.swift and Foqos/Models/SyncConflictManager.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Foqos/Utils/EmergencyUnblockManager.swift | Replaces the scalar emergency unblock count with current-epoch event counting and reset epoch updates. |
| Foqos/CloudKit/SyncEngine/SyncApplyService.swift | Adds event and epoch apply handling, plus deterministic same-version profile conflict resolution. |
| Foqos/Views/HomeView.swift | Adds the divergence conflict banner before existing sync conflict banners. |
| Foqos/CloudKit/CloudKitNetworkService+Commands.swift | Treats CloudKit `serverRecordChanged` for deterministic family commands as an already-pending command. |
| Foqos/CloudKit/SyncModels.swift | Adds emergency epoch and unblock-event sync models and bounds-checks reminder decode. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Existing older/newer conflict] --> D[HomeView banner selection]
  B[New divergence conflict] --> D
  D -->|divergence checked first| E[Divergence banner shown]
  E --> F[User dismisses]
  F --> G[dismissBanner sets showConflictBanner false]
  G --> H[Older/newer dictionaries remain populated]
  H --> I[Older/newer banners no longer render]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Existing older/newer conflict] --> D[HomeView banner selection]
  B[New divergence conflict] --> D
  D -->|divergence checked first| E[Divergence banner shown]
  E --> F[User dismisses]
  F --> G[dismissBanner sets showConflictBanner false]
  G --> H[Older/newer dictionaries remain populated]
  H --> I[Older/newer banners no longer render]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: implement A3 sync conflict semantic..."](https://github.com/mnbf9rca/family-foqos/commit/76e36f74b320dcd0244fd946c311a09f811bedd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43418169)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

