### PR TITLE
A4′ location sync integrity

### DIFF
--- a/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
+++ b/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
@@ -53,10 +53,7 @@ final class MutationFunnel {
     }
     // Never enqueue newer-schema profiles (I2; the newer device is authoritative — §5.4).
     guard !profile.isNewerSchemaVersion else {
-      Log.info(
-        "MutationFunnel skipping save for newer-schema profile '\(profile.name)'",
-        category: .sync
-      )
+      SyncDiagnostics.localProfileSaveSkippedNewerSchema(profileId: profile.id)
       return
     }
     profile.syncVersion += 1
@@ -68,6 +65,7 @@ final class MutationFunnel {
     }
     let recordID = CKRecord.ID(recordName: profileId.uuidString, zoneID: zoneID)
     driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+    SyncDiagnostics.localProfileSaveEnqueued(profileId: profileId, syncVersion: profile.syncVersion)
   }
 
   /// Re-read the location on the sync context, advance `updatedAt` in the same persisted write
@@ -85,6 +83,7 @@ final class MutationFunnel {
     }
     let recordID = CKRecord.ID(recordName: locationId.uuidString, zoneID: zoneID)
     driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+    SyncDiagnostics.localLocationSaveEnqueued(locationId: locationId)
   }
 
   /// Bump the emergency-settings version and enqueue the single fixed-name record (I2, §2).
@@ -94,6 +93,7 @@ final class MutationFunnel {
     EmergencyUnblockManager.shared.incrementEmergencySettingsVersionForSync()
     let recordID = CKRecord.ID(recordName: SyncedEmergencySettings.recordName, zoneID: zoneID)
     driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+    SyncDiagnostics.localEmergencySettingsSaveEnqueued(recordName: SyncedEmergencySettings.recordName)
   }
 
   /// Enqueue a write-once emergency-unblock event (I2, #221). The event is already persisted by
@@ -101,6 +101,7 @@ final class MutationFunnel {
   func enqueueEmergencyUnblockEvent(_ event: SyncedEmergencyUnblockEvent) {
     let recordID = CKRecord.ID(recordName: event.recordName, zoneID: zoneID)
     driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+    SyncDiagnostics.localEmergencyUnblockEventSaveEnqueued(recordName: event.recordName)
   }
 
   /// Enqueue the fixed-name reset-epoch record. There is no version bump: the epoch value itself
@@ -108,6 +109,7 @@ final class MutationFunnel {
   func enqueueEmergencyEpochSave() {
     let recordID = CKRecord.ID(recordName: SyncedEmergencyEpoch.recordName, zoneID: zoneID)
     driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+    SyncDiagnostics.localEmergencyEpochSaveEnqueued(recordName: SyncedEmergencyEpoch.recordName)
   }
 
   // MARK: - Delete paths
@@ -155,6 +157,7 @@ final class MutationFunnel {
           }
           let recordID = CKRecord.ID(recordName: recordName, zoneID: deleteZoneID)
           driver.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
+          SyncDiagnostics.localProfileDeleteEnqueued(profileId: profileId)
           onPendingDeleteEnqueued()
         } catch {
           store.clearTombstone(recordName: recordName)
@@ -193,6 +196,7 @@ final class MutationFunnel {
     }
     let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
     driver.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
+    SyncDiagnostics.localLocationDeleteEnqueued(locationId: locationId, repairedProfileIds: repaired)
     for profileId in repaired {
       do {
         try enqueueSave(profileId: profileId)
@@ -213,6 +217,7 @@ final class MutationFunnel {
     store.setTombstone(recordName: recordName, changeTag: changeTag)
     let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
     driver.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
+    SyncDiagnostics.localTombstoneDeleteEnqueued(recordName: recordName)
   }
 
   /// Delete a write-once emergency-unblock event through the explicit delete path (#221 GC).

--- a/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
+++ b/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
@@ -179,10 +179,12 @@ final class MutationFunnel {
     let recordName = locationId.uuidString
     let changeTag = Self.changeTag(fromSystemFields: store.systemFields(for: recordName))
     store.setTombstone(recordName: recordName, changeTag: changeTag)
+    let repaired: [UUID]
     do {
       guard let location = try SavedLocation.find(byID: locationId, in: modelContext) else {
         throw MutationFunnelError.entityNotFound
       }
+      repaired = try BlockedProfiles.removeLocationReference(locationId, in: modelContext)
       try SavedLocation.delete(location, in: modelContext)
     } catch {
       store.clearTombstone(recordName: recordName)
@@ -191,6 +193,16 @@ final class MutationFunnel {
     }
     let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
     driver.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
+    for profileId in repaired {
+      do {
+        try enqueueSave(profileId: profileId)
+      } catch {
+        Log.warning(
+          "Location-delete profile repair re-push failed for \(profileId): "
+            + error.localizedDescription,
+          category: .sync)
+      }
+    }
   }
 
   /// Enqueue a delete for a record whose model is already gone locally (a delete that fell

--- a/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
@@ -65,9 +65,8 @@ final class SyncApplyService {
     // Pending-delete-wins (§5.1): a modification shadowed by a pending delete, a live
     // tombstone, or the in-memory confirmed-delete echo guard is skipped.
     if isPendingDeleteOrTombstoned(recordName) || recentlyConfirmedDeletes.contains(recordName) {
-      Log.info(
-        "Skipping fetched modification for pending-delete/echo-guarded id \(recordName)",
-        category: .sync)
+      SyncDiagnostics.modificationSkippedPendingDelete(
+        recordType: record.recordType, recordName: recordName)
       return .skippedPendingDelete
     }
     switch record.recordType {
@@ -124,11 +123,14 @@ final class SyncApplyService {
     do {
       guard let profile = try BlockedProfiles.findProfile(byID: id, in: modelContext) else {
         clearDeletionBookkeeping(recordName: recordName)  // intent already satisfied
+        SyncDiagnostics.profileDeletionApplied(
+          profileId: id, existed: false, stoppedActiveSession: false, outcome: .notPresent)
         return .notPresent
       }
       // §5.2 / #203: if the deleted profile owns the active session, stop it first so
       // restrictions are deactivated and the manager does not retain a deleted model.
-      if sessionController.activeSession?.blockedProfile.id == id {
+      let stoppedActiveSession = sessionController.activeSession?.blockedProfile.id == id
+      if stoppedActiveSession {
         sessionController.stopRemoteSession(context: modelContext, profileId: id)
       }
       try BlockedProfiles.deleteProfile(profile, in: modelContext)  // defers save
@@ -170,6 +172,9 @@ final class SyncApplyService {
             category: .sync)
         }
       }
+      SyncDiagnostics.profileDeletionApplied(
+        profileId: id, existed: true, stoppedActiveSession: stoppedActiveSession,
+        outcome: .deleted)
       return .deleted
     } catch {
       modelContext.rollback()
@@ -205,7 +210,10 @@ final class SyncApplyService {
       }
 
       clearDeletionBookkeeping(recordName: recordName)
-      return (location == nil && repaired.isEmpty) ? .notPresent : .deleted
+      let outcome: DeletionOutcome = (location == nil && repaired.isEmpty) ? .notPresent : .deleted
+      SyncDiagnostics.locationDeletionApplied(
+        locationId: id, existed: location != nil, repairedProfileIds: repaired, outcome: outcome)
+      return outcome
     } catch {
       modelContext.rollback()
       store.addFailedApply(
@@ -275,8 +283,18 @@ final class SyncApplyService {
       createLocalProfile(from: synced)
       try commit()
       storeSystemFields(record)
+      SyncDiagnostics.profileApply(
+        profileId: synced.profileId, branch: "created", remoteVersion: synced.version,
+        localVersion: nil, remoteSchema: synced.profileSchemaVersion, localSchema: nil,
+        remoteGeofenceRefCount: synced.geofenceRule?.locationReferences.count,
+        localGeofenceRefCount: nil)
       return .applied
     }
+
+    let localVersion = existing.syncVersion
+    let localSchema = existing.profileSchemaVersion
+    let localGeofenceRefCount = existing.geofenceRule?.locationReferences.count
+    let remoteGeofenceRefCount = synced.geofenceRule?.locationReferences.count
 
     // I9 schema-version gate (verbatim from SyncCoordinator.swift:126-166, own-origin skip removed).
     if synced.profileSchemaVersion < existing.profileSchemaVersion {
@@ -286,6 +304,12 @@ final class SyncApplyService {
       existing.syncVersion += 1
       try commit()
       pendingReenqueues.append(record.recordID)
+      SyncDiagnostics.profileApply(
+        profileId: existing.id, branch: "local_schema_newer_reenqueue",
+        remoteVersion: synced.version, localVersion: localVersion,
+        remoteSchema: synced.profileSchemaVersion, localSchema: localSchema,
+        remoteGeofenceRefCount: remoteGeofenceRefCount,
+        localGeofenceRefCount: localGeofenceRefCount)
       return .applied
     } else if synced.profileSchemaVersion > BlockedProfiles.currentSchemaVersion {
       SyncConflictManager.shared.addNewerVersionConflict(
@@ -293,17 +317,35 @@ final class SyncApplyService {
       existing.profileSchemaVersion = synced.profileSchemaVersion
       existing.syncVersion = synced.version
       try commit()
+      SyncDiagnostics.profileApply(
+        profileId: existing.id, branch: "remote_schema_newer_marker",
+        remoteVersion: synced.version, localVersion: localVersion,
+        remoteSchema: synced.profileSchemaVersion, localSchema: localSchema,
+        remoteGeofenceRefCount: remoteGeofenceRefCount,
+        localGeofenceRefCount: localGeofenceRefCount)
       return .applied
     } else if synced.version > existing.syncVersion {
       updateLocalProfile(existing, from: synced)
       try commit()
       SyncConflictManager.shared.clearConflict(profileId: existing.id)
       storeSystemFields(record)
+      SyncDiagnostics.profileApply(
+        profileId: existing.id, branch: "remote_newer_applied",
+        remoteVersion: synced.version, localVersion: localVersion,
+        remoteSchema: synced.profileSchemaVersion, localSchema: localSchema,
+        remoteGeofenceRefCount: remoteGeofenceRefCount,
+        localGeofenceRefCount: localGeofenceRefCount)
       return .applied
     } else if synced.version == existing.syncVersion {
       // Equal-version divergence (§5.1): payload-differing => deterministic tie-break (#218).
       let localSynced = SyncedProfile(from: existing, originDeviceId: deviceId)
       if SyncPayloadEquality.profilesPayloadEqual(synced, localSynced) {
+        SyncDiagnostics.profileApply(
+          profileId: existing.id, branch: "equal_payload_noop",
+          remoteVersion: synced.version, localVersion: localVersion,
+          remoteSchema: synced.profileSchemaVersion, localSchema: localSchema,
+          remoteGeofenceRefCount: remoteGeofenceRefCount,
+          localGeofenceRefCount: localGeofenceRefCount)
         return .applied  // payload-equal echo ⇒ no-op
       }
       if Self.remoteWinsProfileTie(remote: synced, local: localSynced) {
@@ -313,6 +355,12 @@ final class SyncApplyService {
         storeSystemFields(record)
         SyncConflictManager.shared.addDivergenceConflict(
           profileId: existing.id, profileName: existing.name)
+        SyncDiagnostics.profileApply(
+          profileId: existing.id, branch: "equal_divergence_remote_wins",
+          remoteVersion: synced.version, localVersion: localVersion,
+          remoteSchema: synced.profileSchemaVersion, localSchema: localSchema,
+          remoteGeofenceRefCount: remoteGeofenceRefCount,
+          localGeofenceRefCount: localGeofenceRefCount)
         return .applied
       } else {
         // Local wins: bump above the tie and re-enqueue through the existing I2 exception.
@@ -321,10 +369,21 @@ final class SyncApplyService {
         pendingReenqueues.append(record.recordID)
         SyncConflictManager.shared.addDivergenceConflict(
           profileId: existing.id, profileName: existing.name)
+        SyncDiagnostics.profileApply(
+          profileId: existing.id, branch: "equal_divergence_local_wins_reenqueue",
+          remoteVersion: synced.version, localVersion: localVersion,
+          remoteSchema: synced.profileSchemaVersion, localSchema: localSchema,
+          remoteGeofenceRefCount: remoteGeofenceRefCount,
+          localGeofenceRefCount: localGeofenceRefCount)
         return .applied
       }
     } else {
       // Older incoming version ⇒ no-op.
+      SyncDiagnostics.profileApply(
+        profileId: existing.id, branch: "older_remote_noop", remoteVersion: synced.version,
+        localVersion: localVersion, remoteSchema: synced.profileSchemaVersion,
+        localSchema: localSchema, remoteGeofenceRefCount: remoteGeofenceRefCount,
+        localGeofenceRefCount: localGeofenceRefCount)
       return .applied
     }
   }
@@ -440,6 +499,7 @@ final class SyncApplyService {
       if let existing = try SavedLocation.find(byID: synced.locationId, in: modelContext) {
         // N6 client-clock merge (verbatim from SyncCoordinator.swift:438-455).
         if synced.lastModified > existing.updatedAt {
+          let localVersion = existing.syncVersion
           existing.syncVersion = max(existing.syncVersion, 1) + 1
           _ = try SavedLocation.update(
             existing,
@@ -450,9 +510,16 @@ final class SyncApplyService {
             defaultRadiusMeters: synced.defaultRadiusMeters,
             isLocked: synced.isLocked
           )
+          SyncDiagnostics.locationApply(
+            locationId: synced.locationId, branch: "remote_newer_applied",
+            localVersion: localVersion, newLocalVersion: existing.syncVersion)
         } else {
+          let localVersion = existing.syncVersion
           existing.syncVersion = max(existing.syncVersion, 1)
           try commit()
+          SyncDiagnostics.locationApply(
+            locationId: synced.locationId, branch: "local_newer_or_equal_noop",
+            localVersion: localVersion, newLocalVersion: existing.syncVersion)
         }
       } else {
         let location = SavedLocation(
@@ -466,6 +533,9 @@ final class SyncApplyService {
         )
         modelContext.insert(location)
         try commit()
+        SyncDiagnostics.locationApply(
+          locationId: synced.locationId, branch: "created", localVersion: nil,
+          newLocalVersion: location.syncVersion)
       }
       store.removeFailedApply(recordName: recordName)  // supersession (§5.6)
       storeSystemFields(record)
@@ -491,12 +561,15 @@ final class SyncApplyService {
     }
     // Last-write-wins version gate (verbatim from SyncCoordinator.swift:514-524).
     guard remote.version > emergencyManager.emergencySettingsVersion else {
-      Log.info(
-        "Ignoring emergency settings v\(remote.version) "
-          + "(local v\(emergencyManager.emergencySettingsVersion))", category: .sync)
+      SyncDiagnostics.emergencySettingsApply(
+        branch: "local_newer_or_equal_noop", remoteVersion: remote.version,
+        localVersion: emergencyManager.emergencySettingsVersion)
       return .applied
     }
+    let localVersion = emergencyManager.emergencySettingsVersion
     emergencyManager.applyRemoteEmergencySettings(remote)
+    SyncDiagnostics.emergencySettingsApply(
+      branch: "remote_newer_applied", remoteVersion: remote.version, localVersion: localVersion)
     store.removeFailedApply(recordName: record.recordID.recordName)  // supersession (§5.6)
     storeSystemFields(record)
     return .applied
@@ -510,6 +583,7 @@ final class SyncApplyService {
       return .ignored
     }
     emergencyManager.mergeRemoteUnblockEvent(event)
+    SyncDiagnostics.emergencyUnblockEventApply(recordName: event.recordName)
     store.removeFailedApply(recordName: record.recordID.recordName)
     storeSystemFields(record)
     return .applied
@@ -523,6 +597,7 @@ final class SyncApplyService {
     // #221 monotonic-max channel: no version gate. max() is order-independent, so a deferred
     // local epoch drain and a fetched remote epoch converge regardless of arrival order.
     emergencyManager.adoptRemoteEpoch(remote.epoch)
+    SyncDiagnostics.emergencyEpochApply(epoch: remote.epoch)
     store.removeFailedApply(recordName: record.recordID.recordName)
     storeSystemFields(record)
     return .applied
@@ -544,7 +619,7 @@ final class SyncApplyService {
   private func applySessionState(_ session: ProfileSessionRecord) {
     let profileId = session.profileId
     if session.lastModifiedBy == deviceId {
-      Log.info("Ignoring our own session update for \(profileId)", category: .sync)
+      SyncDiagnostics.sessionApply(profileId: profileId, branch: "own_origin_noop")
       return
     }
     let localActive = sessionController.activeSession?.blockedProfile.id == profileId
@@ -552,9 +627,13 @@ final class SyncApplyService {
       if let startTime = session.startTime {
         sessionController.startRemoteSession(
           context: modelContext, profileId: profileId, sessionId: UUID(), startTime: startTime)
+        SyncDiagnostics.sessionApply(profileId: profileId, branch: "remote_start_applied")
       }
     } else if !session.isActive && localActive {
       sessionController.stopRemoteSession(context: modelContext, profileId: profileId)
+      SyncDiagnostics.sessionApply(profileId: profileId, branch: "remote_stop_applied")
+    } else {
+      SyncDiagnostics.sessionApply(profileId: profileId, branch: "state_already_matching_noop")
     }
   }
 

--- a/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
@@ -16,6 +16,9 @@ final class SyncApplyService {
   private let emergencyManager: EmergencyUnblockManager
   private let deviceId: String
   private let scheduleProfileDeleteCommit: (@escaping @MainActor () -> Void) -> Void
+  private var zoneID: CKRecordZone.ID {
+    CKRecordZone.ID(zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)
+  }
 
   /// In-memory confirmed-delete echo guard (§5.1). Populated by the controller on §5.3 confirmation.
   var recentlyConfirmedDeletes: Set<String> = []
@@ -183,13 +186,26 @@ final class SyncApplyService {
   private func deleteLocalLocation(recordName: String) -> DeletionOutcome {
     guard let id = UUID(uuidString: recordName) else { return .ignored }
     do {
-      guard let location = try SavedLocation.find(byID: id, in: modelContext) else {
-        clearDeletionBookkeeping(recordName: recordName)
-        return .notPresent
+      let location = try SavedLocation.find(byID: id, in: modelContext)
+      if let location {
+        try SavedLocation.delete(location, in: modelContext)  // saves internally
       }
-      try SavedLocation.delete(location, in: modelContext)  // saves internally
+
+      let repaired = try BlockedProfiles.removeLocationReference(id, in: modelContext)
+      for profileId in repaired {
+        guard let profile = try BlockedProfiles.findProfile(byID: profileId, in: modelContext)
+        else {
+          continue
+        }
+        profile.syncVersion += 1
+        pendingReenqueues.append(CKRecord.ID(recordName: profileId.uuidString, zoneID: zoneID))
+      }
+      if !repaired.isEmpty {
+        try commit()
+      }
+
       clearDeletionBookkeeping(recordName: recordName)
-      return .deleted
+      return (location == nil && repaired.isEmpty) ? .notPresent : .deleted
     } catch {
       modelContext.rollback()
       store.addFailedApply(

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -343,10 +343,12 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     modifications: [CKRecord],
     deletions: [(recordID: CKRecord.ID, recordType: CKRecord.RecordType)]
   ) {
+    SyncDiagnostics.fetchedBatch(modifications: modifications, deletions: deletions)
     let legacyRecords = modifications.filter { $0.recordType == LegacySyncedSession.recordType }
     if !legacyRecords.isEmpty {
       legacyCleanup?.identify(modifications: legacyRecords)  // §11 — never applied
     }
+    var modificationOutcomes: [String] = []
     for record in modifications {
       if record.recordType == SyncResetRequest.recordType {
         onFetchedResetCommand?(record)  // §8.3 — never applied via applyFetchedModification
@@ -357,20 +359,31 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       }
       let outcome = apply.applyFetchedModification(
         record, isPendingDeleteOrTombstoned: blockedPredicate())
+      SyncDiagnostics.fetchedModification(record: record, outcome: outcome)
+      modificationOutcomes.append(SyncDiagnostics.outcomeLabel(outcome))
       if outcome == .applied {
         store.removeFailedApply(recordName: record.recordID.recordName)  // supersession (§5.6)
       }
     }
-    for recordID in apply.drainReenqueues() {  // CRA-1
+    SyncDiagnostics.fetchedModificationSummary(outcomes: modificationOutcomes)
+    let modificationReenqueues = apply.drainReenqueues()
+    SyncDiagnostics.repairReenqueue(source: "fetched_modifications", recordIDs: modificationReenqueues)
+    for recordID in modificationReenqueues {  // CRA-1
       driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
     }
+    var deletionOutcomes: [String] = []
     for (recordID, recordType) in deletions {
       let outcome = apply.applyFetchedDeletion(recordID: recordID, recordType: recordType)
+      SyncDiagnostics.fetchedDeletion(recordID: recordID, recordType: recordType, outcome: outcome)
+      deletionOutcomes.append(SyncDiagnostics.outcomeLabel(outcome))
       guard !(recordType == SyncedProfile.recordType && outcome == .deleted) else { continue }
       applyDeletionSideEffects(recordID: recordID)
       store.removeFailedApply(recordName: recordID.recordName)  // supersession
     }
-    for recordID in apply.drainReenqueues() {
+    SyncDiagnostics.fetchedDeletionSummary(outcomes: deletionOutcomes)
+    let deletionReenqueues = apply.drainReenqueues()
+    SyncDiagnostics.repairReenqueue(source: "fetched_deletions", recordIDs: deletionReenqueues)
+    for recordID in deletionReenqueues {
       driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
     }
   }
@@ -396,12 +409,16 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     deletedRecordIDs: [CKRecord.ID],
     failedRecordDeletes: [(recordID: CKRecord.ID, error: CKError)]
   ) {
+    SyncDiagnostics.sentBatch(
+      savedRecords: savedRecords, failedRecordSaves: failedRecordSaves,
+      deletedRecordIDs: deletedRecordIDs, failedRecordDeletes: failedRecordDeletes)
     var savedCommandRecords: [CKRecord] = []
     store.transaction { s in
       for record in savedRecords {
         let name = record.recordID.recordName
         if record.recordType == SyncResetRequest.recordType {
           savedCommandRecords.append(record)  // CRA-3: command record, no systemFields
+          SyncDiagnostics.sentSaveConfirmed(record: record)
           continue
         }
         if Self.scopedTypes.contains(record.recordType) {
@@ -409,12 +426,14 @@ final class SyncEngineController: SyncEngineDriverDelegate {
         }
         self.clearLegacyId(name, in: s)
         self.resolveSeedName(name)  // I11 observable-clear (Fix 5): save confirmed sent
+        SyncDiagnostics.sentSaveConfirmed(record: record)
       }
       for id in deletedRecordIDs {
         let name = id.recordName
         s.setSystemFields(nil, for: name)
         s.clearTombstone(recordName: name)  // I12 confirmed
         self.clearLegacyId(name, in: s)
+        SyncDiagnostics.sentDeleteConfirmed(recordID: id)
       }
     }
     // Fired outside `store.transaction` (non-reentrant `SharedData.withLock`): a hook
@@ -426,8 +445,14 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       apply.recentlyConfirmedDeletes.insert(id.recordName)  // echo guard (§5.1)
       confirmDeleteCycle[id.recordName] = currentCycle  // AB-3 drain writer (Task 68 reader)
     }
-    for (record, error) in failedRecordSaves { handleFailedSave(record: record, error: error) }
-    for (id, error) in failedRecordDeletes { handleFailedDelete(recordID: id, error: error) }
+    for (record, error) in failedRecordSaves {
+      SyncDiagnostics.sentSaveFailed(record: record, error: error)
+      handleFailedSave(record: record, error: error)
+    }
+    for (id, error) in failedRecordDeletes {
+      SyncDiagnostics.sentDeleteFailed(recordID: id, error: error)
+      handleFailedDelete(recordID: id, error: error)
+    }
   }
 
   // MARK: - T4b sentDatabaseChanges routing (§5.5)
@@ -606,6 +631,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   private func handleWillFetchChanges() {
     currentCycle += 1
     let drained = confirmDeleteCycle.filter { $0.value < currentCycle }.map { $0.key }
+    SyncDiagnostics.echoGuardDrained(currentCycle: currentCycle, recordNames: drained)
     for name in drained {
       apply.recentlyConfirmedDeletes.remove(name)
       confirmDeleteCycle.removeValue(forKey: name)
@@ -682,6 +708,8 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       }
     }
     if !deletesToRemove.isEmpty { driver.remove(pendingRecordZoneChanges: deletesToRemove) }
+    SyncDiagnostics.materializedSendBatch(
+      records: records, removedSaves: savesToRemove.count, removedDeletes: deletesToRemove.count)
     return records.isEmpty ? nil : records
   }
 
@@ -974,6 +1002,312 @@ final class SyncEngineController: SyncEngineDriverDelegate {
 
   private func recordID(_ name: String) -> CKRecord.ID {
     CKRecord.ID(recordName: name, zoneID: zoneID)
+  }
+}
+
+enum SyncDiagnostics {
+  static func fetchedBatch(
+    modifications: [CKRecord],
+    deletions: [(recordID: CKRecord.ID, recordType: CKRecord.RecordType)]
+  ) {
+    Log.debug(
+      "sync.event=fetched_batch modifications=\(modifications.count) "
+        + "modification_types=\(typeSummary(modifications.map(\.recordType))) "
+        + "deletions=\(deletions.count) "
+        + "deletion_types=\(typeSummary(deletions.map { $0.recordType }))",
+      category: .sync)
+  }
+
+  static func fetchedModification(record: CKRecord, outcome: SyncApplyService.ApplyOutcome) {
+    Log.debug(
+      "sync.event=fetched_modification type=\(record.recordType) "
+        + "record=\(record.recordID.recordName) outcome=\(outcomeLabel(outcome))",
+      category: .sync)
+  }
+
+  static func fetchedModificationSummary(outcomes: [String]) {
+    guard !outcomes.isEmpty else { return }
+    Log.debug(
+      "sync.event=fetched_modification_summary outcomes=\(bucketSummary(outcomes))",
+      category: .sync)
+  }
+
+  static func fetchedDeletion(
+    recordID: CKRecord.ID,
+    recordType: CKRecord.RecordType,
+    outcome: SyncApplyService.DeletionOutcome
+  ) {
+    Log.debug(
+      "sync.event=fetched_deletion type=\(recordType) record=\(recordID.recordName) "
+        + "outcome=\(outcomeLabel(outcome))",
+      category: .sync)
+  }
+
+  static func fetchedDeletionSummary(outcomes: [String]) {
+    guard !outcomes.isEmpty else { return }
+    Log.debug(
+      "sync.event=fetched_deletion_summary outcomes=\(bucketSummary(outcomes))",
+      category: .sync)
+  }
+
+  static func repairReenqueue(source: String, recordIDs: [CKRecord.ID]) {
+    guard !recordIDs.isEmpty else { return }
+    Log.debug(
+      "sync.event=repair_reenqueue source=\(source) count=\(recordIDs.count) "
+        + "records=\(recordNames(recordIDs))",
+      category: .sync)
+  }
+
+  static func sentBatch(
+    savedRecords: [CKRecord],
+    failedRecordSaves: [(record: CKRecord, error: CKError)],
+    deletedRecordIDs: [CKRecord.ID],
+    failedRecordDeletes: [(recordID: CKRecord.ID, error: CKError)]
+  ) {
+    Log.debug(
+      "sync.event=sent_batch saved=\(savedRecords.count) "
+        + "save_types=\(typeSummary(savedRecords.map(\.recordType))) "
+        + "failed_saves=\(failedRecordSaves.count) deleted=\(deletedRecordIDs.count) "
+        + "failed_deletes=\(failedRecordDeletes.count)",
+      category: .sync)
+  }
+
+  static func sentSaveConfirmed(record: CKRecord) {
+    Log.debug(
+      "sync.event=sent_save_confirmed type=\(record.recordType) "
+        + "record=\(record.recordID.recordName)",
+      category: .sync)
+  }
+
+  static func sentDeleteConfirmed(recordID: CKRecord.ID) {
+    Log.debug(
+      "sync.event=sent_delete_confirmed record=\(recordID.recordName)",
+      category: .sync)
+  }
+
+  static func sentSaveFailed(record: CKRecord, error: CKError) {
+    Log.warning(
+      "sync.event=sent_save_failed type=\(record.recordType) "
+        + "record=\(record.recordID.recordName) ck_error=\(error.code.rawValue)",
+      category: .sync)
+  }
+
+  static func sentDeleteFailed(recordID: CKRecord.ID, error: CKError) {
+    Log.warning(
+      "sync.event=sent_delete_failed record=\(recordID.recordName) "
+        + "ck_error=\(error.code.rawValue)",
+      category: .sync)
+  }
+
+  static func echoGuardDrained(currentCycle: Int, recordNames: [String]) {
+    guard !recordNames.isEmpty else { return }
+    Log.debug(
+      "sync.event=echo_guard_drained cycle=\(currentCycle) count=\(recordNames.count) "
+        + "records=\(stringList(recordNames))",
+      category: .sync)
+  }
+
+  static func materializedSendBatch(
+    records: [CKRecord],
+    removedSaves: Int,
+    removedDeletes: Int
+  ) {
+    Log.debug(
+      "sync.event=materialized_send_batch records=\(records.count) "
+        + "types=\(typeSummary(records.map(\.recordType))) "
+        + "removed_saves=\(removedSaves) removed_deletes=\(removedDeletes)",
+      category: .sync)
+  }
+
+  static func modificationSkippedPendingDelete(recordType: CKRecord.RecordType, recordName: String) {
+    Log.info(
+      "sync.event=modification_skipped_pending_delete type=\(recordType) record=\(recordName)",
+      category: .sync)
+  }
+
+  static func profileApply(
+    profileId: UUID,
+    branch: String,
+    remoteVersion: Int,
+    localVersion: Int?,
+    remoteSchema: Int,
+    localSchema: Int?,
+    remoteGeofenceRefCount: Int?,
+    localGeofenceRefCount: Int?
+  ) {
+    Log.debug(
+      "sync.event=profile_apply profile=\(profileId.uuidString) branch=\(branch) "
+        + "remote_version=\(remoteVersion) local_version=\(optionalInt(localVersion)) "
+        + "remote_schema=\(remoteSchema) local_schema=\(optionalInt(localSchema)) "
+        + "remote_geofence_refs=\(optionalInt(remoteGeofenceRefCount)) "
+        + "local_geofence_refs=\(optionalInt(localGeofenceRefCount))",
+      category: .sync)
+  }
+
+  static func profileDeletionApplied(
+    profileId: UUID,
+    existed: Bool,
+    stoppedActiveSession: Bool,
+    outcome: SyncApplyService.DeletionOutcome
+  ) {
+    Log.debug(
+      "sync.event=profile_deletion_apply profile=\(profileId.uuidString) existed=\(existed) "
+        + "stopped_active_session=\(stoppedActiveSession) outcome=\(outcomeLabel(outcome))",
+      category: .sync)
+  }
+
+  static func locationApply(
+    locationId: UUID,
+    branch: String,
+    localVersion: Int?,
+    newLocalVersion: Int
+  ) {
+    Log.debug(
+      "sync.event=location_apply location=\(locationId.uuidString) branch=\(branch) "
+        + "local_version=\(optionalInt(localVersion)) new_local_version=\(newLocalVersion)",
+      category: .sync)
+  }
+
+  static func locationDeletionApplied(
+    locationId: UUID,
+    existed: Bool,
+    repairedProfileIds: [UUID],
+    outcome: SyncApplyService.DeletionOutcome
+  ) {
+    Log.debug(
+      "sync.event=location_deletion_apply location=\(locationId.uuidString) existed=\(existed) "
+        + "repaired_profiles=\(repairedProfileIds.count) "
+        + "profile_ids=\(uuidList(repairedProfileIds)) outcome=\(outcomeLabel(outcome))",
+      category: .sync)
+  }
+
+  static func emergencySettingsApply(branch: String, remoteVersion: Int, localVersion: Int) {
+    Log.debug(
+      "sync.event=emergency_settings_apply branch=\(branch) "
+        + "remote_version=\(remoteVersion) local_version=\(localVersion)",
+      category: .sync)
+  }
+
+  static func emergencyUnblockEventApply(recordName: String) {
+    Log.debug(
+      "sync.event=emergency_unblock_event_apply record=\(recordName)",
+      category: .sync)
+  }
+
+  static func emergencyEpochApply(epoch: Int) {
+    Log.debug(
+      "sync.event=emergency_epoch_apply epoch=\(epoch)",
+      category: .sync)
+  }
+
+  static func sessionApply(profileId: UUID, branch: String) {
+    Log.debug(
+      "sync.event=session_apply profile=\(profileId.uuidString) branch=\(branch)",
+      category: .sync)
+  }
+
+  static func localProfileSaveSkippedNewerSchema(profileId: UUID) {
+    Log.info(
+      "sync.event=local_profile_save_skipped_newer_schema profile=\(profileId.uuidString)",
+      category: .sync)
+  }
+
+  static func localProfileSaveEnqueued(profileId: UUID, syncVersion: Int) {
+    Log.debug(
+      "sync.event=local_profile_save_enqueued profile=\(profileId.uuidString) "
+        + "sync_version=\(syncVersion)",
+      category: .sync)
+  }
+
+  static func localLocationSaveEnqueued(locationId: UUID) {
+    Log.debug(
+      "sync.event=local_location_save_enqueued location=\(locationId.uuidString)",
+      category: .sync)
+  }
+
+  static func localProfileDeleteEnqueued(profileId: UUID) {
+    Log.debug(
+      "sync.event=local_profile_delete_enqueued profile=\(profileId.uuidString)",
+      category: .sync)
+  }
+
+  static func localLocationDeleteEnqueued(locationId: UUID, repairedProfileIds: [UUID]) {
+    Log.debug(
+      "sync.event=local_location_delete_enqueued location=\(locationId.uuidString) "
+        + "repaired_profiles=\(repairedProfileIds.count) "
+        + "profile_ids=\(uuidList(repairedProfileIds))",
+      category: .sync)
+  }
+
+  static func localEmergencySettingsSaveEnqueued(recordName: String) {
+    Log.debug(
+      "sync.event=local_emergency_settings_save_enqueued record=\(recordName)",
+      category: .sync)
+  }
+
+  static func localEmergencyUnblockEventSaveEnqueued(recordName: String) {
+    Log.debug(
+      "sync.event=local_emergency_unblock_event_save_enqueued record=\(recordName)",
+      category: .sync)
+  }
+
+  static func localEmergencyEpochSaveEnqueued(recordName: String) {
+    Log.debug(
+      "sync.event=local_emergency_epoch_save_enqueued record=\(recordName)",
+      category: .sync)
+  }
+
+  static func localTombstoneDeleteEnqueued(recordName: String) {
+    Log.debug(
+      "sync.event=local_tombstone_delete_enqueued record=\(recordName)",
+      category: .sync)
+  }
+
+  static func outcomeLabel(_ outcome: SyncApplyService.ApplyOutcome) -> String {
+    switch outcome {
+    case .applied: return "applied"
+    case .skippedPendingDelete: return "skipped_pending_delete"
+    case .ignored: return "ignored"
+    case .failed: return "failed"
+    }
+  }
+
+  static func outcomeLabel(_ outcome: SyncApplyService.DeletionOutcome) -> String {
+    switch outcome {
+    case .deleted: return "deleted"
+    case .notPresent: return "not_present"
+    case .ignored: return "ignored"
+    }
+  }
+
+  static func typeSummary(_ types: [CKRecord.RecordType]) -> String {
+    bucketSummary(types.map { String($0) })
+  }
+
+  static func bucketSummary(_ values: [String]) -> String {
+    guard !values.isEmpty else { return "none" }
+    let counts = Dictionary(grouping: values, by: { $0 }).mapValues(\.count)
+    return counts.keys.sorted().map { "\($0):\(counts[$0] ?? 0)" }.joined(separator: ",")
+  }
+
+  static func recordNames(_ recordIDs: [CKRecord.ID]) -> String {
+    let names = recordIDs.map { $0.recordName }.sorted()
+    return names.isEmpty ? "none" : names.joined(separator: ",")
+  }
+
+  static func uuidList(_ ids: [UUID]) -> String {
+    let names = ids.map { $0.uuidString }.sorted()
+    return names.isEmpty ? "none" : names.joined(separator: ",")
+  }
+
+  static func stringList(_ values: [String]) -> String {
+    let sorted = values.sorted()
+    return sorted.isEmpty ? "none" : sorted.joined(separator: ",")
+  }
+
+  private static func optionalInt(_ value: Int?) -> String {
+    guard let value else { return "nil" }
+    return String(value)
   }
 }
 

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -370,6 +370,9 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       applyDeletionSideEffects(recordID: recordID)
       store.removeFailedApply(recordName: recordID.recordName)  // supersession
     }
+    for recordID in apply.drainReenqueues() {
+      driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+    }
   }
 
   // MARK: - T4 sentRecordZoneChanges routing (§5.3, S-10, S-11, S-17, S-23, S-29)
@@ -752,6 +755,9 @@ final class SyncEngineController: SyncEngineDriverDelegate {
           break  // retry next cycle
         }
       }
+    }
+    for recordID in apply.drainReenqueues() {
+      driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
     }
   }
 

--- a/Foqos/Models/BlockedProfiles.swift
+++ b/Foqos/Models/BlockedProfiles.swift
@@ -312,6 +312,26 @@ class BlockedProfiles {
     return try context.fetch(descriptor)
   }
 
+  @discardableResult
+  static func removeLocationReference(_ locationId: UUID, in context: ModelContext) throws
+    -> [UUID]
+  {
+    let profiles = try fetchProfiles(in: context)
+    var changed: [UUID] = []
+    for profile in profiles {
+      guard var rule = profile.geofenceRule,
+        rule.locationReferences.contains(where: { $0.savedLocationId == locationId })
+      else {
+        continue
+      }
+
+      rule.locationReferences.removeAll { $0.savedLocationId == locationId }
+      profile.geofenceRule = rule.locationReferences.isEmpty ? nil : rule
+      changed.append(profile.id)
+    }
+    return changed
+  }
+
   static func findProfile(byID id: UUID, in context: ModelContext) throws
     -> BlockedProfiles?
   {

--- a/Foqos/Utils/LocationManager.swift
+++ b/Foqos/Utils/LocationManager.swift
@@ -107,6 +107,14 @@ class LocationManager: NSObject, ObservableObject {
       return .satisfied()
     }
 
+    let resolvableIds = Set(savedLocations.map { $0.id })
+    let hasResolvableReference = rule.locationReferences.contains {
+      resolvableIds.contains($0.savedLocationId)
+    }
+    guard hasResolvableReference else {
+      return .satisfied()
+    }
+
     // Get current location
     let currentLocation: CLLocation
     do {
@@ -157,7 +165,8 @@ class LocationManager: NSObject, ObservableObject {
 
     case .outside:
       // User must be outside ALL locations
-      if unsatisfiedLocations.count == rule.locationReferences.count {
+      let resolvableCount = satisfiedLocations.count + unsatisfiedLocations.count
+      if unsatisfiedLocations.count == resolvableCount {
         return .satisfied()
       } else {
         let locationNames = satisfiedLocations.prefix(2).joined(separator: " and ")

--- a/Foqos/Views/DebugView.swift
+++ b/Foqos/Views/DebugView.swift
@@ -99,6 +99,12 @@ struct DebugView: View {
               .cornerRadius(10)
             }
             .buttonStyle(.plain)
+
+            #if DEBUG
+              Button("DEBUG reset emergency") {
+                EmergencyUnblockManager.shared.resetEmergencyUnblocks()
+              }
+            #endif
           }
         }
         .padding()

--- a/Foqos/Views/SavedLocationsView.swift
+++ b/Foqos/Views/SavedLocationsView.swift
@@ -195,9 +195,6 @@ struct SavedLocationsView: View {
     let locationId = location.id
 
     do {
-      // Remove references from profiles that use this location
-      removeLocationFromProfiles(locationId)
-
       if profileSyncManager.isEnabled {
         // Route the delete entirely through the funnel (I2): it re-reads the location
         // itself, writes the delete-intent tombstone, performs the persisted delete, and
@@ -214,34 +211,17 @@ struct SavedLocationsView: View {
           // the funnel can't own this delete, so delete locally now instead of silently
           // leaving the location behind (review finding #4). It will propagate once the
           // engine attaches / on the next sync.
+          try BlockedProfiles.removeLocationReference(locationId, in: context)
           try SavedLocation.delete(location, in: context)
         }
       } else {
         // Sync disabled — the funnel would no-op (I2 is only reachable once the engine has
         // started), so delete locally directly.
+        try BlockedProfiles.removeLocationReference(locationId, in: context)
         try SavedLocation.delete(location, in: context)
       }
     } catch {
       errorMessage = "Failed to delete location: \(error.localizedDescription)"
-    }
-  }
-
-  private func removeLocationFromProfiles(_ locationId: UUID) {
-    do {
-      let profiles = try BlockedProfiles.fetchProfiles(in: context)
-      for profile in profiles {
-        if var rule = profile.geofenceRule {
-          rule.locationReferences.removeAll { $0.savedLocationId == locationId }
-          if rule.locationReferences.isEmpty {
-            profile.geofenceRule = nil
-          } else {
-            profile.geofenceRule = rule
-          }
-        }
-      }
-      try context.save()
-    } catch {
-      Log.error("Failed to update profiles after location deletion: \(error)", category: .location)
     }
   }
 }

--- a/FoqosTests/GeofenceDanglingReferenceTests.swift
+++ b/FoqosTests/GeofenceDanglingReferenceTests.swift
@@ -1,0 +1,28 @@
+import FoqosShared
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class GeofenceDanglingReferenceTests: XCTestCase {
+
+  private func rule(_ type: GeofenceRuleType, refs: [UUID]) -> ProfileGeofenceRule {
+    ProfileGeofenceRule(
+      ruleType: type,
+      locationReferences: refs.map { ProfileLocationReference(savedLocationId: $0) },
+      allowEmergencyOverride: true)
+  }
+
+  func testGivenOutsideRuleWithOnlyDanglingRef_WhenEvaluated_ThenSatisfied() async {
+    // No SavedLocation matches the reference => the rule has no live constraint => stoppable.
+    let result = await LocationManager.shared.checkGeofenceRule(
+      rule: rule(.outside, refs: [UUID()]), savedLocations: [])
+    XCTAssertTrue(result.isSatisfied, "an all-dangling .outside rule must not be unsatisfiable")
+  }
+
+  func testGivenWithinRuleWithOnlyDanglingRef_WhenEvaluated_ThenSatisfied() async {
+    let result = await LocationManager.shared.checkGeofenceRule(
+      rule: rule(.within, refs: [UUID()]), savedLocations: [])
+    XCTAssertTrue(result.isSatisfied, "an all-dangling .within rule must not fail forever")
+  }
+}

--- a/FoqosTests/MutationFunnelTests.swift
+++ b/FoqosTests/MutationFunnelTests.swift
@@ -741,6 +741,43 @@ final class MutationFunnelTests: XCTestCase {
     _ = now
   }
 
+  func testGivenLocationReferencedByProfile_WhenEnqueueDelete_ThenRepairsAndPushesProfile()
+    throws
+  {
+    let locationId = UUID()
+    let profileId = UUID()
+    let container = try TestModelContainer.create()
+    let context = ModelContext(container)
+
+    let location = SavedLocation(id: locationId, name: "Library", latitude: 1, longitude: 2)
+    context.insert(location)
+    let profile = BlockedProfiles(id: profileId, name: "Homework", syncVersion: 4)
+    profile.geofenceRule = ProfileGeofenceRule(
+      ruleType: .outside,
+      locationReferences: [ProfileLocationReference(savedLocationId: locationId)],
+      allowEmergencyOverride: true)
+    context.insert(profile)
+    try context.save()
+
+    let store = makeStore()
+    let driver = MockSyncEngineDriver()
+    let funnel = MutationFunnel(
+      modelContext: context,
+      store: store,
+      driver: driver,
+      deviceId: "device-A"
+    )
+
+    try funnel.enqueueDelete(locationId: locationId)
+
+    XCTAssertNil(try SavedLocation.find(byID: locationId, in: context))
+    let reread = try XCTUnwrap(BlockedProfiles.findProfile(byID: profileId, in: context))
+    XCTAssertNil(reread.geofenceRule, "dangling rule is cleaned up")
+    XCTAssertEqual(reread.syncVersion, 5, "repaired profile bumps for replication")
+    XCTAssertTrue(driver.pendingRecordZoneChanges.contains(.deleteRecord(recordID(locationId.uuidString))))
+    XCTAssertTrue(driver.pendingRecordZoneChanges.contains(.saveRecord(recordID(profileId.uuidString))))
+  }
+
   // MARK: - Location delete failure: tombstone removed, rollback, nothing enqueued
 
   func testGivenAbsentLocation_WhenEnqueueDelete_ThenTombstoneRemovedRollbackAndNothingEnqueued()

--- a/FoqosTests/RemoveLocationReferenceTests.swift
+++ b/FoqosTests/RemoveLocationReferenceTests.swift
@@ -1,0 +1,70 @@
+import FoqosShared
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class RemoveLocationReferenceTests: XCTestCase {
+
+  private func profile(
+    _ context: ModelContext,
+    name: String,
+    rule: ProfileGeofenceRule?
+  ) throws -> BlockedProfiles {
+    let profile = BlockedProfiles(id: UUID(), name: name)
+    profile.geofenceRule = rule
+    context.insert(profile)
+    try context.save()
+    return profile
+  }
+
+  func testGivenProfilesReferencingLocation_WhenRemoved_ThenStrippedAndChangedIdsReturned() throws {
+    let container = try TestModelContainer.create()
+    let context = ModelContext(container)
+    let locId = UUID()
+    let ruleWith = ProfileGeofenceRule(
+      ruleType: .outside,
+      locationReferences: [ProfileLocationReference(savedLocationId: locId)],
+      allowEmergencyOverride: true)
+    let referencing = try profile(context, name: "Ref", rule: ruleWith)
+    _ = try profile(context, name: "Unrelated", rule: nil)
+
+    let changed = try BlockedProfiles.removeLocationReference(locId, in: context)
+    try context.save()
+
+    XCTAssertEqual(changed, [referencing.id])
+    let reread = try XCTUnwrap(BlockedProfiles.findProfile(byID: referencing.id, in: context))
+    XCTAssertNil(reread.geofenceRule, "rule with only that reference is nulled when it empties")
+  }
+
+  func testGivenMultiRefRule_WhenOneRemoved_ThenOthersKept() throws {
+    let container = try TestModelContainer.create()
+    let context = ModelContext(container)
+    let locId = UUID()
+    let keepId = UUID()
+    let rule = ProfileGeofenceRule(
+      ruleType: .within,
+      locationReferences: [
+        ProfileLocationReference(savedLocationId: locId),
+        ProfileLocationReference(savedLocationId: keepId),
+      ],
+      allowEmergencyOverride: true)
+    let profile = try profile(context, name: "Multi", rule: rule)
+
+    let changed = try BlockedProfiles.removeLocationReference(locId, in: context)
+    try context.save()
+
+    XCTAssertEqual(changed, [profile.id])
+    let reread = try XCTUnwrap(BlockedProfiles.findProfile(byID: profile.id, in: context))
+    XCTAssertEqual(reread.geofenceRule?.locationReferences.map { $0.savedLocationId }, [keepId])
+  }
+
+  func testGivenNoReferences_WhenRemoved_ThenNoChange() throws {
+    let container = try TestModelContainer.create()
+    let context = ModelContext(container)
+    _ = try profile(context, name: "None", rule: nil)
+    let changed = try BlockedProfiles.removeLocationReference(UUID(), in: context)
+    XCTAssertTrue(changed.isEmpty)
+  }
+}

--- a/FoqosTests/SyncApplyServiceTests.swift
+++ b/FoqosTests/SyncApplyServiceTests.swift
@@ -1,4 +1,5 @@
 import CloudKit
+import FoqosShared
 import SwiftData
 import XCTest
 
@@ -457,6 +458,63 @@ final class SyncApplyServiceTests: XCTestCase {
         recordType: SyncedLocation.recordType),
       .deleted)
     XCTAssertNil(try SavedLocation.find(byID: id, in: context))
+  }
+
+  func testGivenReferencingProfile_WhenLocationDeletionApplied_ThenRepairedAndReenqueued()
+    throws
+  {
+    let apply = makeService()
+    let locId = UUID()
+    let profileId = UUID()
+    let location = SavedLocation(id: locId, name: "Library", latitude: 1, longitude: 2)
+    context.insert(location)
+    let profile = BlockedProfiles(id: profileId, name: "Homework", syncVersion: 4)
+    profile.geofenceRule = ProfileGeofenceRule(
+      ruleType: .outside,
+      locationReferences: [ProfileLocationReference(savedLocationId: locId)],
+      allowEmergencyOverride: true)
+    context.insert(profile)
+    try context.save()
+
+    let outcome = apply.applyFetchedDeletion(
+      recordID: CKRecord.ID(recordName: locId.uuidString, zoneID: zoneID),
+      recordType: SyncedLocation.recordType)
+
+    XCTAssertEqual(outcome, .deleted)
+    XCTAssertNil(try SavedLocation.find(byID: locId, in: context))
+    let reread = try XCTUnwrap(BlockedProfiles.findProfile(byID: profileId, in: context))
+    XCTAssertNil(reread.geofenceRule, "dangling rule repaired on the peer")
+    XCTAssertEqual(reread.syncVersion, 5, "bumped so the peer accepts the repaired payload")
+    XCTAssertEqual(
+      apply.drainReenqueues(),
+      [CKRecord.ID(recordName: profileId.uuidString, zoneID: zoneID)],
+      "repaired profile queued for re-push via the I2 exception")
+  }
+
+  func testGivenDanglingProfileButLocationAlreadyAbsent_WhenDeletionApplied_ThenStillRepairs()
+    throws
+  {
+    let apply = makeService()
+    let locId = UUID()
+    let profileId = UUID()
+    let profile = BlockedProfiles(id: profileId, name: "Homework", syncVersion: 4)
+    profile.geofenceRule = ProfileGeofenceRule(
+      ruleType: .outside,
+      locationReferences: [ProfileLocationReference(savedLocationId: locId)],
+      allowEmergencyOverride: true)
+    context.insert(profile)
+    try context.save()
+
+    let outcome = apply.applyFetchedDeletion(
+      recordID: CKRecord.ID(recordName: locId.uuidString, zoneID: zoneID),
+      recordType: SyncedLocation.recordType)
+
+    XCTAssertEqual(outcome, .deleted, "repaired a dangling ref means this is not a no-op")
+    let reread = try XCTUnwrap(BlockedProfiles.findProfile(byID: profileId, in: context))
+    XCTAssertNil(reread.geofenceRule, "dangling ref repaired even though the row was already gone")
+    XCTAssertEqual(reread.syncVersion, 5)
+    XCTAssertEqual(
+      apply.drainReenqueues(), [CKRecord.ID(recordName: profileId.uuidString, zoneID: zoneID)])
   }
 
   func testGivenDeletionForAbsentProfile_WhenApplied_ThenNotPresentNoMutation() throws {

--- a/FoqosTests/SyncApplyServiceTests.swift
+++ b/FoqosTests/SyncApplyServiceTests.swift
@@ -315,6 +315,59 @@ final class SyncApplyServiceTests: XCTestCase {
     XCTAssertEqual(try SavedLocation.find(byID: id, in: context)?.name, "Cafe")
   }
 
+  func testGivenNewerRemoteLocation_WhenApplied_ThenNothingReenqueued() throws {
+    let now = Date()
+    let apply = makeService()
+    let locId = UUID()
+    let location = SavedLocation(
+      id: locId,
+      name: "Home",
+      latitude: 1,
+      longitude: 2,
+      updatedAt: now.addingTimeInterval(-3600)
+    )
+    context.insert(location)
+    try context.save()
+
+    let synced = SyncedLocation(
+      locationId: locId,
+      name: "Renamed",
+      latitude: 1,
+      longitude: 2,
+      defaultRadiusMeters: 500,
+      isLocked: false,
+      lastModified: now
+    )
+    _ = apply.applyFetchedModification(
+      synced.toCKRecord(in: zoneID), isPendingDeleteOrTombstoned: noPendingDelete)
+
+    XCTAssertTrue(apply.drainReenqueues().isEmpty, "applying a location must never trigger a push")
+  }
+
+  func testGivenOlderRemoteLocation_WhenApplied_ThenNoOpAndNothingReenqueued() throws {
+    let now = Date()
+    let apply = makeService()
+    let locId = UUID()
+    let location = SavedLocation(
+      id: locId, name: "Home", latitude: 1, longitude: 2, updatedAt: now)
+    context.insert(location)
+    try context.save()
+
+    let synced = SyncedLocation(
+      locationId: locId,
+      name: "Stale",
+      latitude: 9,
+      longitude: 9,
+      defaultRadiusMeters: 500,
+      isLocked: false,
+      lastModified: now.addingTimeInterval(-3600)
+    )
+    _ = apply.applyFetchedModification(
+      synced.toCKRecord(in: zoneID), isPendingDeleteOrTombstoned: noPendingDelete)
+
+    XCTAssertTrue(apply.drainReenqueues().isEmpty, "the N6 no-op branch must not push either")
+  }
+
   // MARK: - Emergency versioned apply
 
   func testGivenNewerEmergencySettings_WhenApplied_ThenAppliedAndSystemFieldsStored() {


### PR DESCRIPTION
## Summary

Implements A4′ from #263:

- #215: geofence evaluation now ignores dangling saved-location references when deciding whether a profile is stoppable.
- #216: saved-location deletion repairs profile geofence references on both explicit deletion seams:
  - local deletes through `MutationFunnel.enqueueDelete(locationId:)`, with repaired profiles re-pushed through `enqueueSave(profileId:)`;
  - inbound deletes through `SyncApplyService.deleteLocalLocation`, with repaired profiles re-pushed via `pendingReenqueues -> drainReenqueues`.
- #220: adds characterization guards showing inbound location apply never enqueues a push under S0.
- Adds privacy-safe sync diagnostics across local enqueue, fetched apply, deletion repair, sent confirmation/failure, and send-batch materialization paths.
- Adds a temporary DEBUG-only emergency unblock reset button for maintainer device verification.

Fixes #215
Fixes #216
Closes #220

## S0 / Scope Notes

- Cleanup rides explicit location deletion events only: no orphan inference, no absence scans.
- Locally-originated synced mutations still route through `MutationFunnel`.
- Inbound apply still does not push directly; repaired profiles are drained through the existing `pendingReenqueues` exception.
- #301 schedule-registration work was not touched.
- Sync diagnostics log only record types/names, UUIDs, counts, versions, booleans, outcomes, and CK error codes; they do not log profile names, saved-location names, coordinates, addresses, or user-entered strings.

## #220 Evidence

The new guard tests `testGivenNewerRemoteLocation_WhenApplied_ThenNothingReenqueued` and `testGivenOlderRemoteLocation_WhenApplied_ThenNoOpAndNothingReenqueued` pass, matching the #220 re-triage comment that the ping-pong is obsolete under S0 because inbound location apply never re-enqueues a push.

## Verification

- Citation refresh: re-verified the cited A4′ seams by symbol against `origin/main` at `e7ac000` (A3′ #306); no semantic drift found.
- Red/green TDD:
  - `GeofenceDanglingReferenceTests` failed before the evaluator fix, then passed.
  - `RemoveLocationReferenceTests` failed to compile before the helper, then passed.
  - `MutationFunnelTests/testGivenLocationReferencedByProfile_WhenEnqueueDelete_ThenRepairsAndPushesProfile` failed before the local seam fix, then passed.
  - `SyncApplyServiceTests` remote deletion repair tests failed before the remote seam fix, then passed.
  - #220 guard tests passed immediately with no production change.
- After diagnostics commit `c1f10d1`:
  - `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -parallel-testing-enabled NO -only-testing:FoqosTests/SyncApplyServiceTests -only-testing:FoqosTests/SyncEngineControllerTests -only-testing:FoqosTests/MutationFunnelTests | xcpretty`
    - 123 tests, 0 failures.
- After DEBUG reset button commit `2460700`:
  - `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -parallel-testing-enabled NO | xcpretty`
    - 901 tests, 0 failures.
  - `./scripts/check-sync-guards.sh`
    - passed.
  - `./scripts/check-c2-guards.sh`
    - passed.
  - `swift-format lint --recursive .`
    - passed.
  - `git diff --check`
    - passed.

## Device Verification Rows

| Row | Scenario | Result |
| --- | --- | --- |
| 1 | Device A profile has a geofence stop rule referencing a saved location; delete that location on Device B; confirm Device A cleans the geofence refs and the profile remains stoppable. | Passed on 2026-07-11 maintainer two-device pass. Path A: created profile on A, assigned apps on B, deleted location on B; A removed the location reference and the profile could start/stop normally. Path B: created profile on A, did not assign apps on B, started on A, deleted location on B while profile was running on A; stop succeeded on A. Logs: `docs/plans/FamilyFoqos-Logs-2026-07-11-092251.log`. |
| 2 | Normal saved-location create/edit/delete propagation still syncs prompts and location records. | Passed on 2026-07-11 maintainer pass. |

## Deviations

- A related follow-up was logged as #311: deleting a location on B is currently allowed when the referencing profile is running remotely on A but cannot start locally on B because apps are unassigned. This is not an A4′ failure because the tested cleanup and stop behavior passed.
- Local `gh auth status` output was sandbox-affected during this session; branch push used git/SSH and PR creation used the GitHub connector.

## Summary by Sourcery

Strengthen sync integrity around saved-location references and geofence rules, repair profiles when locations are deleted, and add privacy-conscious diagnostics and a DEBUG emergency reset hook while expanding test coverage for the new behavior.

New Features:
- Ensure geofence stop rules remain satisfiable by ignoring saved-location references that no longer resolve to existing locations.
- Automatically repair profiles that reference a deleted saved location and re-enqueue them for sync on both local and remote deletion paths.
- Add a DEBUG-only emergency reset control in the debug view to clear emergency unblock state on maintainer devices.

Enhancements:
- Introduce centralized sync diagnostics that log key events and outcomes across fetched changes, local mutations, repair reenqueues, emergency flows, and send-batch materialization without exposing user-identifying content.
- Route more sync-related outcomes through structured labels and summaries to improve observability of apply decisions and error conditions.

Tests:
- Add unit tests covering geofence evaluation with dangling location references to ensure profiles remain stoppable.
- Add tests for location-reference removal and profile repair behavior on both local deletion and remote deletion apply seams.
- Add tests asserting that inbound location modifications never trigger reenqueued pushes under the current sync model.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps saved-location deletion and profile geofence sync in step. The main changes are:

- Geofence checks now ignore dangling saved-location references.
- Local and inbound location deletes repair affected profile rules.
- Repaired profiles are re-enqueued through the sync engine.
- Sync diagnostics were added across apply, enqueue, send, and repair paths.
- A DEBUG-only emergency reset button was added for device verification.

<h3>Confidence Score: 4/5</h3>

The local saved-location delete path needs a sync repair fix before merging.

- Inbound deletion repair looks consistent with the existing re-enqueue drain.
- Geofence evaluation now handles all-dangling and mixed dangling references correctly.
- Local deletion can still propagate the location delete without propagating the repaired profile.

Foqos/CloudKit/SyncEngine/MutationFunnel.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Foqos/CloudKit/SyncEngine/MutationFunnel.swift | Adds local saved-location delete repair, but repaired profile re-pushes are best-effort after the delete is already queued. |
| Foqos/CloudKit/SyncEngine/SyncApplyService.swift | Adds inbound location deletion repair, profile version bumps, repair re-enqueues, and sync diagnostics. |
| Foqos/CloudKit/SyncEngine/SyncEngineController.swift | Adds sync diagnostics and drains repaired-profile re-enqueues after fetched deletions. |
| Foqos/Models/BlockedProfiles.swift | Adds a helper to remove saved-location references from profile geofence rules. |
| Foqos/Utils/LocationManager.swift | Updates geofence evaluation so dangling saved-location references do not make rules permanently fail. |
| Foqos/Views/SavedLocationsView.swift | Routes direct local deletion fallbacks through the shared profile-reference repair helper. |
| Foqos/Views/DebugView.swift | Adds a DEBUG-only emergency reset button. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Local saved-location delete] --> B[Remove location refs from profiles]
  B --> C[SavedLocation.delete saves context]
  C --> D[Queue CloudKit location delete]
  D --> E{Re-push repaired profiles}
  E -->|save enqueued| F[Peers receive repaired profile]
  E -->|save fails or skips| G[Peers receive only location delete]
  G --> H[Remote profiles keep dangling refs]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Local saved-location delete] --> B[Remove location refs from profiles]
  B --> C[SavedLocation.delete saves context]
  C --> D[Queue CloudKit location delete]
  D --> E{Re-push repaired profiles}
  E -->|save enqueued| F[Peers receive repaired profile]
  E -->|save fails or skips| G[Peers receive only location delete]
  G --> H[Remote profiles keep dangling refs]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore: add debug emergency reset button"](https://github.com/mnbf9rca/family-foqos/commit/24607000a0d51a38944fbb5eed30c204eced34a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43488279)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->