### PR TITLE
Fix durable tombstones for disabled-sync local deletes (#302)

### DIFF
--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -336,6 +336,18 @@ class ProfileSyncManager: ObservableObject {
     if isSyncReady { engineController.requestSync() }
   }
 
+  /// Records a disabled-sync delete after its local commit so I12 can replay it on re-enable.
+  /// Best-effort because the caller is already on a committed local-delete path.
+  func recordDisabledDeleteTombstone(recordName: String) {
+    guard let engineController else {
+      Log.warning(
+        "Disabled-delete tombstone dropped: engine not attached yet (\(recordName))",
+        category: .sync)
+      return
+    }
+    engineController.recordDisabledDeleteTombstone(recordName: recordName)
+  }
+
   /// Replay save-type mutations deferred while the engine was unattached (#294). Uses the
   /// controller-level enqueue verbs (which do not themselves send), so the single requestSync
   /// in `markSyncReadyAndFlush()` flushes them all at once.

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift
@@ -70,4 +70,11 @@ extension SyncEngineController: SyncEngineControlling {
   func enqueueDeferredDelete(recordName: String) {
     funnel?.enqueueTombstoneDelete(recordName: recordName)
   }
+
+  func recordDisabledDeleteTombstone(recordName: String) {
+    // Mirrors MutationFunnel.enqueueTombstoneDelete minus its driver.add.
+    store.setTombstone(
+      recordName: recordName,
+      changeTag: MutationFunnel.changeTag(fromSystemFields: store.systemFields(for: recordName)))
+  }
 }

--- a/Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift
@@ -18,6 +18,10 @@ protocol SyncEngineControlling: AnyObject {
   func enqueueEmergencyEpochSave() throws
   func enqueueEmergencyUnblockEventDelete(_ recordName: String) throws
   func enqueueDeferredDelete(recordName: String)
+  /// Durable delete-intent tombstone written on a local delete made while sync is disabled.
+  /// This store-only verb does not enqueue a driver change. Callers write only after the local
+  /// delete durably commits, so a rolled-back delete never leaves a tombstone for I12 to replay.
+  func recordDisabledDeleteTombstone(recordName: String)
 }
 
 /// Thrown by the `SyncEngineControlling` enqueue verbs (and by `ProfileSyncManager.syncNow()`/

--- a/Foqos/Views/BlockedProfileListView.swift
+++ b/Foqos/Views/BlockedProfileListView.swift
@@ -171,6 +171,7 @@ struct BlockedProfileListView: View {
 
     // Delete the profiles and reorder
     do {
+      var disabledDeletedRecordNames: [String] = []
       for index in offsets {
         let profile = profilesToDelete[index]
         let profileId = profile.id
@@ -194,8 +195,10 @@ struct BlockedProfileListView: View {
           }
         } else {
           // Sync disabled — the funnel would no-op (I2 is only reachable once the engine has
-          // started), so delete locally directly.
+          // started), so delete locally directly. Remember the id for a tombstone only after
+          // the shared reorder save durably commits.
           try BlockedProfiles.deleteProfile(profile, in: context)
+          disabledDeletedRecordNames.append(profileId.uuidString)
         }
       }
 
@@ -204,6 +207,11 @@ struct BlockedProfileListView: View {
           // Reorder remaining profiles to fix gaps in ordering after SwiftUI settles pending deletes.
           let remainingProfiles = try BlockedProfiles.fetchProfiles(in: context)
           try BlockedProfiles.reorderProfiles(remainingProfiles, in: context)
+          // The deletes are now durable. A failed save skips these writes, so a rolled-back
+          // delete cannot leave a tombstone that could later kill a live record.
+          for recordName in disabledDeletedRecordNames {
+            profileSyncManager.recordDisabledDeleteTombstone(recordName: recordName)
+          }
           // The `order` field is synced state — bump syncVersion + enqueue a save for each
           // surviving profile so the gap-fix reaches other devices (I2).
           for profile in remainingProfiles {

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -839,10 +839,13 @@ struct BlockedProfileView: View {
                     } else {
                       // Sync disabled — the funnel would no-op (I2 is only reachable once the
                       // engine has started), so delete locally directly.
+                      let deletedRecordName = profileId.uuidString
                       try BlockedProfiles.deleteProfile(profileToDelete, in: modelContext)
                       BlockedProfiles.scheduleProfileDeleteCommit {
                         do {
                           try modelContext.save()
+                          profileSyncManager.recordDisabledDeleteTombstone(
+                            recordName: deletedRecordName)
                         } catch {
                           showError(message: error.localizedDescription)
                         }

--- a/Foqos/Views/SavedLocationsView.swift
+++ b/Foqos/Views/SavedLocationsView.swift
@@ -217,8 +217,10 @@ struct SavedLocationsView: View {
       } else {
         // Sync disabled — the funnel would no-op (I2 is only reachable once the engine has
         // started), so delete locally directly.
+        let deletedRecordName = locationId.uuidString
         try BlockedProfiles.removeLocationReference(locationId, in: context)
         try SavedLocation.delete(location, in: context)
+        profileSyncManager.recordDisabledDeleteTombstone(recordName: deletedRecordName)
       }
     } catch {
       errorMessage = "Failed to delete location: \(error.localizedDescription)"

--- a/FoqosTests/Helpers/TestCKRecordSystemFields.swift
+++ b/FoqosTests/Helpers/TestCKRecordSystemFields.swift
@@ -1,0 +1,15 @@
+import CloudKit
+
+@testable import FamilyFoqos
+
+enum TestCKRecordSystemFields {
+  static func encodedProfile(recordName: String) -> Data {
+    let zoneID = CKRecordZone.ID(
+      zoneName: CloudKitConstants.syncZoneName,
+      ownerName: CKCurrentUserDefaultName
+    )
+    let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
+    let record = CKRecord(recordType: SyncedProfile.recordType, recordID: recordID)
+    return CKRecordSystemFieldsCodec.encode(record)
+  }
+}

--- a/FoqosTests/Mocks/MockSyncEngineControlling.swift
+++ b/FoqosTests/Mocks/MockSyncEngineControlling.swift
@@ -17,6 +17,7 @@ final class MockSyncEngineControlling: SyncEngineControlling {
   private(set) var enqueuedEmergencyEpochSaves = 0
   private(set) var enqueuedEmergencyUnblockEventDeletes: [String] = []
   private(set) var deferredDeletes: [String] = []
+  private(set) var recordedDisabledTombstones: [String] = []
 
   /// Set by a test to make every `enqueue*` verb below throw instead of recording — used to
   /// verify a genuine funnel throw propagates through the facade instead of being swallowed
@@ -66,5 +67,8 @@ final class MockSyncEngineControlling: SyncEngineControlling {
   }
   func enqueueDeferredDelete(recordName: String) {
     deferredDeletes.append(recordName)
+  }
+  func recordDisabledDeleteTombstone(recordName: String) {
+    recordedDisabledTombstones.append(recordName)
   }
 }

--- a/FoqosTests/MutationFunnelTests.swift
+++ b/FoqosTests/MutationFunnelTests.swift
@@ -53,14 +53,6 @@ final class MutationFunnelTests: XCTestCase {
     return profile
   }
 
-  private func encodedSystemFields(recordName: String) -> Data {
-    let record = CKRecord(recordType: SyncedProfile.recordType, recordID: recordID(recordName))
-    let archiver = NSKeyedArchiver(requiringSecureCoding: true)
-    record.encodeSystemFields(with: archiver)
-    archiver.finishEncoding()
-    return archiver.encodedData
-  }
-
   // MARK: - S-15 / S-16: save bumps in the same write, enqueues once
 
   func testGivenProfile_WhenEnqueueSave_ThenBumpsVersionInSameWriteAndEnqueuesOnce() throws {
@@ -388,7 +380,7 @@ final class MutationFunnelTests: XCTestCase {
     try insertProfile(in: userContext, id: profileId, name: "Focus", syncVersion: 2)
 
     let store = makeStore()
-    let systemFields = encodedSystemFields(recordName: recordName)
+    let systemFields = TestCKRecordSystemFields.encodedProfile(recordName: recordName)
     store.setSystemFields(systemFields, for: recordName)
 
     let syncContext = ModelContext(container)
@@ -525,7 +517,8 @@ final class MutationFunnelTests: XCTestCase {
     let syncContext = ModelContext(container)
 
     let store = makeStore()
-    store.setSystemFields(encodedSystemFields(recordName: recordName), for: recordName)
+    store.setSystemFields(
+      TestCKRecordSystemFields.encodedProfile(recordName: recordName), for: recordName)
 
     let driver = MockSyncEngineDriver()
     let funnel = MutationFunnel(
@@ -792,7 +785,8 @@ final class MutationFunnelTests: XCTestCase {
     let syncContext = ModelContext(container)
 
     let store = makeStore()
-    store.setSystemFields(encodedSystemFields(recordName: recordName), for: recordName)
+    store.setSystemFields(
+      TestCKRecordSystemFields.encodedProfile(recordName: recordName), for: recordName)
 
     let driver = MockSyncEngineDriver()
     let funnel = MutationFunnel(

--- a/FoqosTests/SyncEngineControllerCutoverTests.swift
+++ b/FoqosTests/SyncEngineControllerCutoverTests.swift
@@ -54,16 +54,6 @@ final class SyncEngineControllerCutoverTests: XCTestCase {
     return profile
   }
 
-  private func encodedSystemFields(recordName: String) -> Data {
-    let record = CKRecord(
-      recordType: SyncedProfile.recordType,
-      recordID: CKRecord.ID(recordName: recordName, zoneID: zoneID))
-    let archiver = NSKeyedArchiver(requiringSecureCoding: true)
-    record.encodeSystemFields(with: archiver)
-    archiver.finishEncoding()
-    return archiver.encodedData
-  }
-
   /// Drains fire-and-forget `Task { await ... }` work scheduled by a reset hook closure
   /// (e.g. `onFetchedResetCommand`, `onZoneChangeConfirmed`'s delete branch) so its
   /// async side effects are observable before assertions run.
@@ -112,7 +102,7 @@ final class SyncEngineControllerCutoverTests: XCTestCase {
 
   func testGivenControllerNotStarted_WhenRecordDisabledDeleteTombstone_ThenStoreOnlyWritePersists() {
     let recordName = UUID().uuidString
-    let systemFields = encodedSystemFields(recordName: recordName)
+    let systemFields = TestCKRecordSystemFields.encodedProfile(recordName: recordName)
     store.setSystemFields(systemFields, for: recordName)
     let expectedTag = MutationFunnel.changeTag(fromSystemFields: systemFields)
 

--- a/FoqosTests/SyncEngineControllerCutoverTests.swift
+++ b/FoqosTests/SyncEngineControllerCutoverTests.swift
@@ -1,4 +1,5 @@
 import CloudKit
+import Foundation
 import SwiftData
 import XCTest
 
@@ -53,6 +54,16 @@ final class SyncEngineControllerCutoverTests: XCTestCase {
     return profile
   }
 
+  private func encodedSystemFields(recordName: String) -> Data {
+    let record = CKRecord(
+      recordType: SyncedProfile.recordType,
+      recordID: CKRecord.ID(recordName: recordName, zoneID: zoneID))
+    let archiver = NSKeyedArchiver(requiringSecureCoding: true)
+    record.encodeSystemFields(with: archiver)
+    archiver.finishEncoding()
+    return archiver.encodedData
+  }
+
   /// Drains fire-and-forget `Task { await ... }` work scheduled by a reset hook closure
   /// (e.g. `onFetchedResetCommand`, `onZoneChangeConfirmed`'s delete branch) so its
   /// async side effects are observable before assertions run.
@@ -97,6 +108,22 @@ final class SyncEngineControllerCutoverTests: XCTestCase {
     XCTAssertEqual(after, before + 1)
     let refreshed = try XCTUnwrap(try BlockedProfiles.findProfile(byID: profile.id, in: context))
     XCTAssertGreaterThanOrEqual(refreshed.syncVersion, 1)  // funnel bumped in the same write
+  }
+
+  func testGivenControllerNotStarted_WhenRecordDisabledDeleteTombstone_ThenStoreOnlyWritePersists() {
+    let recordName = UUID().uuidString
+    let systemFields = encodedSystemFields(recordName: recordName)
+    store.setSystemFields(systemFields, for: recordName)
+    let expectedTag = MutationFunnel.changeTag(fromSystemFields: systemFields)
+
+    controller.recordDisabledDeleteTombstone(recordName: recordName)
+
+    let reloaded = SyncEngineStore(
+      userRecordName: "user-A", defaults: UserDefaults(suiteName: testSuiteName)!)
+    XCTAssertTrue(reloaded.deleteTombstones.keys.contains(recordName))
+    XCTAssertEqual(reloaded.deleteTombstones[recordName] ?? nil, expectedTag)
+    XCTAssertTrue(driver.pendingRecordZoneChanges.isEmpty)
+    XCTAssertTrue(driver.pendingDatabaseChanges.isEmpty)
   }
 
   // MARK: - Review fix: funnel-not-created-yet surfaces (findings #2–#6, #15)

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -602,6 +602,29 @@ final class SyncEngineControllerTests: XCTestCase {
       store.deleteTombstones[id.uuidString], "tombstone retained until delete confirmed")
   }
 
+  // #302 acceptance: a tombstone written while sync is disabled enters the existing I12
+  // recovered-intent path on re-enable. The adjacent different-tag and entity-present tests
+  // cover N5 keep-bias and the round-4/5 live-record guard respectively.
+  func testGivenDisabledDeleteTombstone_WhenReEnabledAndServerTagMatches_ThenDeleteEnqueued()
+    async
+  {
+    let id = UUID()
+    let recordName = id.uuidString
+    store.engineState = Data([0x01])
+    store.setTombstone(recordName: recordName, changeTag: "tag-before-disable")
+    let record = makeProfileRecord(id: id, version: 1)
+    driver.fetchRecordResults[recordName] = .found(record, changeTag: "tag-before-disable")
+
+    let controller = makeController()
+    controller.start()
+    await controller.startupTask?.value
+
+    XCTAssertTrue(pendingDeleteNames().contains(recordName))
+    XCTAssertTrue(
+      store.deleteTombstones.keys.contains(recordName),
+      "the intent remains durable until the server confirms deletion")
+  }
+
   func testGivenRecoveredTombstoneDifferentTag_WhenRecover_ThenClearedConflictSurfacedNoDelete()
     async
   {

--- a/FoqosTests/SyncEngineFacadeTests.swift
+++ b/FoqosTests/SyncEngineFacadeTests.swift
@@ -85,6 +85,22 @@ final class SyncEngineFacadeTests: XCTestCase {
     XCTAssertEqual(mock.enqueuedEmergencyUnblockEventDeletes, [event.recordName])
   }
 
+  func testGivenController_WhenRecordDisabledTombstone_ThenForwardedToController() {
+    manager.isEnabled = false
+
+    manager.recordDisabledDeleteTombstone(recordName: "p1")
+
+    XCTAssertEqual(mock.recordedDisabledTombstones, ["p1"])
+  }
+
+  func testGivenNoController_WhenRecordDisabledTombstone_ThenNoCrashNoForward() {
+    manager.engineController = nil
+
+    manager.recordDisabledDeleteTombstone(recordName: "p1")
+
+    XCTAssertEqual(mock.recordedDisabledTombstones, [])
+  }
+
   func testGivenReadyController_WhenEnqueueProfileSave_ThenRequestSyncIsScheduled() throws {
     manager.isSyncReady = true
     let id = UUID()

--- a/FoqosTests/SyncEngineStoreTombstoneTests.swift
+++ b/FoqosTests/SyncEngineStoreTombstoneTests.swift
@@ -1,4 +1,3 @@
-import CloudKit
 import FoqosShared
 import Foundation
 import XCTest
@@ -23,22 +22,9 @@ final class SyncEngineStoreTombstoneTests: XCTestCase {
     try await super.tearDown()
   }
 
-  private func encodedSystemFields(recordName: String) -> Data {
-    let record = CKRecord(
-      recordType: SyncedProfile.recordType,
-      recordID: CKRecord.ID(
-        recordName: recordName,
-        zoneID: CKRecordZone.ID(
-          zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)))
-    let archiver = NSKeyedArchiver(requiringSecureCoding: true)
-    record.encodeSystemFields(with: archiver)
-    archiver.finishEncoding()
-    return archiver.encodedData
-  }
-
   func testGivenCachedSystemFields_WhenDisabledTombstoneWritten_ThenTagMatchesDecoder() {
     let store = SyncEngineStore(userRecordName: "userA", defaults: defaults)
-    let systemFields = encodedSystemFields(recordName: "p1")
+    let systemFields = TestCKRecordSystemFields.encodedProfile(recordName: "p1")
     store.setSystemFields(systemFields, for: "p1")
 
     let expectedTag = MutationFunnel.changeTag(fromSystemFields: store.systemFields(for: "p1"))

--- a/FoqosTests/SyncEngineStoreTombstoneTests.swift
+++ b/FoqosTests/SyncEngineStoreTombstoneTests.swift
@@ -1,3 +1,4 @@
+import CloudKit
 import FoqosShared
 import Foundation
 import XCTest
@@ -20,6 +21,43 @@ final class SyncEngineStoreTombstoneTests: XCTestCase {
     UserDefaults().removePersistentDomain(forName: suiteName)
     UserDefaults().removePersistentDomain(forName: "\(suiteName!)-shared")
     try await super.tearDown()
+  }
+
+  private func encodedSystemFields(recordName: String) -> Data {
+    let record = CKRecord(
+      recordType: SyncedProfile.recordType,
+      recordID: CKRecord.ID(
+        recordName: recordName,
+        zoneID: CKRecordZone.ID(
+          zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)))
+    let archiver = NSKeyedArchiver(requiringSecureCoding: true)
+    record.encodeSystemFields(with: archiver)
+    archiver.finishEncoding()
+    return archiver.encodedData
+  }
+
+  func testGivenCachedSystemFields_WhenDisabledTombstoneWritten_ThenTagMatchesDecoder() {
+    let store = SyncEngineStore(userRecordName: "userA", defaults: defaults)
+    let systemFields = encodedSystemFields(recordName: "p1")
+    store.setSystemFields(systemFields, for: "p1")
+
+    let expectedTag = MutationFunnel.changeTag(fromSystemFields: store.systemFields(for: "p1"))
+    store.setTombstone(recordName: "p1", changeTag: expectedTag)
+
+    let reloaded = SyncEngineStore(userRecordName: "userA", defaults: defaults)
+    XCTAssertTrue(reloaded.deleteTombstones.keys.contains("p1"))
+    XCTAssertEqual(reloaded.deleteTombstones["p1"] ?? nil, expectedTag)
+  }
+
+  func testGivenNeverSyncedRecord_WhenDisabledTombstoneWritten_ThenNilTagKeyPresent() {
+    let store = SyncEngineStore(userRecordName: "userA", defaults: defaults)
+    store.setTombstone(
+      recordName: "p2",
+      changeTag: MutationFunnel.changeTag(fromSystemFields: store.systemFields(for: "p2")))
+
+    let map = SyncEngineStore(userRecordName: "userA", defaults: defaults).deleteTombstones
+    XCTAssertTrue(map.keys.contains("p2"))
+    XCTAssertNil(map["p2"] ?? nil)
   }
 
   func testGivenTombstones_WhenSetWithNilAndNonNilTags_ThenRoundTripAndClear() {


### PR DESCRIPTION
## Summary

- add a store-only `recordDisabledDeleteTombstone` verb behind `SyncEngineControlling`
- record disabled-sync profile and saved-location deletes only after their local commits succeed
- reuse I12 recovered-intent replay, including N5 keep-bias and live-entity abort behavior

## Root cause and safety

Disabled-sync delete branches committed local deletion without persisting the durable tombstone that survives sync toggle-off state reset. Re-enabling sync therefore had no delete intent to replay.

The new tombstone write occurs after the durable local commit. A failed or rolled-back delete never writes a tombstone, avoiding the family-wide kill-the-record hazard. The verb intentionally has no symmetric clear operation and never calls the sync driver. The adjacent enabled-but-`.notAttached` durability gap tracked by #305 remains out of scope.

Citation refresh was performed against `c17923d` after #306 and #308 merged. The store/funnel pair, deferred-commit boundary, and I12 semantics remain compatible with mini-plan A.

## Verification

- [x] Full test suite: 907 passed, 0 failed, 0 skipped on iPhone 17 simulator UUID `B9E4A679-BDF3-4541-A59F-DA4BE21F80ED`
- [x] `./scripts/check-sync-guards.sh`
- [x] `./scripts/check-c2-guards.sh`
- [x] `swift-format lint --recursive .`
- [x] Whole app simulator build
- [x] Independent read-only code review: no correctness findings; concrete controller coverage added from review feedback

## Device acceptance

Maintainer-assisted, debugger detached: completed July 11, 2026.

Evidence exports (local, intentionally gitignored):

- `docs/plans/FamilyFoqos-Logs-2026-07-11-110150.log` - device A export for scenario 1; records the recovered delete being sent and confirmed for profile `A57B7D24-FC2A-467B-81E6-F528B0DEE02A`.
- `docs/plans/FamilyFoqos-Logs-2026-07-11-110252.log` - device A export for scenario 2; the locally-created, never-synced profile remains absent after re-enable.

- [x] Sync ON with two devices in sync -> toggle sync OFF on device A -> delete a profile locally on A -> toggle sync ON -> profile stays gone on A and disappears on B.
- [x] Inverse regression: while sync is OFF, delete a profile that only ever existed locally and has no cloud copy -> local deletion succeeds and remains gone after sync is re-enabled.

Fixes #302

## Summary by Sourcery

Persist durable tombstones for profile and saved-location deletes performed while sync is disabled so delete intent is correctly replayed when sync is re-enabled.

New Features:
- Add a disabled-sync delete tombstone recording API on the sync engine controller and facade, and hook it into profile and saved-location delete flows when sync is off.

Bug Fixes:
- Ensure locally deleted profiles and saved locations while sync is disabled remain deleted and propagate to other devices after sync is re-enabled by persisting a store-only tombstone.
- Prevent tombstones from being written for deletes that fail or are rolled back by recording disabled-delete tombstones only after the associated local commits succeed.

Enhancements:
- Extend sync engine, controller, and facade tests to cover disabled-sync tombstone behavior, store-only writes, and recovered-intent replay paths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR records durable delete tombstones for local deletes made while sync is disabled. The main changes are:

- A new store-only tombstone verb on the sync controller interface.
- Disabled-sync profile and saved-location delete paths that record tombstones after local commits.
- Tests for store tombstone persistence, facade forwarding, and recovered delete replay.

<h3>Confidence Score: 4/5</h3>

The disabled-delete flow needs a fix for the missing-controller path before merging.

- The main post-save tombstone ordering looks correct for profile and saved-location deletes.
- A committed local delete can still lose its tombstone when the controller is not attached.
- That leaves recovery without a delete intent, so the remote record can remain on other devices.

Foqos/CloudKit/ProfileSyncManager.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Foqos/CloudKit/ProfileSyncManager.swift | Adds the manager API for disabled-delete tombstone recording, but drops the intent when no controller is attached. |
| Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift | Adds the store-only controller implementation that writes a tombstone without enqueueing an immediate driver change. |
| Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift | Extends the sync controller protocol with the new disabled-delete tombstone method. |
| Foqos/Views/BlockedProfileListView.swift | Records batch profile tombstones after the shared reorder save succeeds. |
| Foqos/Views/BlockedProfileView.swift | Records single-profile tombstones after the scheduled profile delete save succeeds. |
| Foqos/Views/SavedLocationsView.swift | Records saved-location tombstones after the local delete helper performs its save. |
| FoqosTests/Mocks/MockSyncEngineControlling.swift | Updates the mock controller to track calls to the new tombstone method. |
| FoqosTests/SyncEngineControllerCutoverTests.swift | Adds coverage for store-only tombstone writes with cached CloudKit system fields. |
| FoqosTests/SyncEngineControllerTests.swift | Adds recovery coverage for disabled-delete tombstones when the server tag matches. |
| FoqosTests/SyncEngineFacadeTests.swift | Adds facade coverage for forwarding tombstone writes and for the nil-controller no-op path. |
| FoqosTests/SyncEngineStoreTombstoneTests.swift | Adds tombstone storage tests for cached tags and never-synced nil-tag records. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant View as Disabled-sync delete view
  participant Manager as ProfileSyncManager
  participant Controller as SyncEngineController
  participant Store as SyncEngineStore
  participant Recovery as Sync re-enable recovery

  View->>View: Commit local delete
  View->>Manager: recordDisabledDeleteTombstone(recordName)
  alt controller attached
    Manager->>Controller: recordDisabledDeleteTombstone(recordName)
    Controller->>Store: setTombstone(recordName, cachedChangeTag)
    Recovery->>Store: read tombstone
    Recovery->>Recovery: replay delete intent
  else controller missing
    Manager-->>View: log and return
    Recovery->>Store: no tombstone found
    Recovery-->>Recovery: delete intent is not replayed
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant View as Disabled-sync delete view
  participant Manager as ProfileSyncManager
  participant Controller as SyncEngineController
  participant Store as SyncEngineStore
  participant Recovery as Sync re-enable recovery

  View->>View: Commit local delete
  View->>Manager: recordDisabledDeleteTombstone(recordName)
  alt controller attached
    Manager->>Controller: recordDisabledDeleteTombstone(recordName)
    Controller->>Store: setTombstone(recordName, cachedChangeTag)
    Recovery->>Store: read tombstone
    Recovery->>Recovery: replay delete intent
  else controller missing
    Manager-->>View: log and return
    Recovery->>Store: no tombstone found
    Recovery-->>Recovery: delete intent is not replayed
  end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(#302): cover concrete disabled tomb..."](https://github.com/mnbf9rca/family-foqos/commit/fcdf0178764089fd1fd8e13a04d3c9f4c68227b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43498408)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->