### PR TITLE
Fix #301 synced schedule registration

### DIFF
--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -29,6 +29,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   private let sessionSync: SessionSyncFlushing
   private let deviceId: String
   private let scheduleProfileDeleteCommit: (@escaping @MainActor () -> Void) -> Void
+  private let scheduleReconciler: (ModelContext) -> Void
 
   private let zoneID = CKRecordZone.ID(
     zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)
@@ -83,7 +84,9 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     sessionSync: SessionSyncFlushing,
     deviceId: String,
     scheduleProfileDeleteCommit: @escaping (@escaping @MainActor () -> Void) -> Void =
-      BlockedProfiles.scheduleProfileDeleteCommit
+      BlockedProfiles.scheduleProfileDeleteCommit,
+    scheduleReconciler: @escaping (ModelContext) -> Void =
+      { PreActivationReminderScheduler.reconcileScheduleRegistrations(context: $0) }
   ) {
     self.modelContext = modelContext
     self.store = store
@@ -93,6 +96,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     self.sessionSync = sessionSync
     self.deviceId = deviceId
     self.scheduleProfileDeleteCommit = scheduleProfileDeleteCommit
+    self.scheduleReconciler = scheduleReconciler
     self.apply.profileDeleteCommitObserver = { [weak self] recordName in
       guard let self else { return }
       let recordID = CKRecord.ID(recordName: recordName, zoneID: self.zoneID)
@@ -648,6 +652,10 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     fetchCycleSweepTask = Task { [weak self] in
       await self?.retryFailedApplies(generation: generation)
     }
+    // #301: a fetch cycle may have applied profiles whose schedule/trigger config changed;
+    // register their DeviceActivity schedules once, coalesced across the whole cycle (not
+    // per-record). Idempotent + self-gating; respects cleanUpGhostSchedules (adds only).
+    scheduleReconciler(modelContext)
   }
 
   // MARK: - §5.4 nextRecordZoneChangeBatch materialization (S-14, S-29)

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -158,7 +158,8 @@ struct FoqosApp: App {
             if hasPerformedInitialSetup {
               PreActivationReminderScheduler.mergeExtensionScheduleSuppression(
                 context: container.mainContext)
-              PreActivationReminderScheduler.rescheduleAllReminders(context: container.mainContext)
+              PreActivationReminderScheduler.reconcileScheduleRegistrations(
+                context: container.mainContext)
               PreActivationReminderScheduler.catchUpMissedScheduleStarts(context: container.mainContext)
             }
           }
@@ -257,7 +258,7 @@ struct FoqosApp: App {
           }
           // Reschedule pre-activation reminders for today
           PreActivationReminderScheduler.mergeExtensionScheduleSuppression(context: container.mainContext)
-          PreActivationReminderScheduler.rescheduleAllReminders(context: container.mainContext)
+          PreActivationReminderScheduler.reconcileScheduleRegistrations(context: container.mainContext)
           // Catch up any missed schedule starts
           PreActivationReminderScheduler.catchUpMissedScheduleStarts(context: container.mainContext)
           hasPerformedInitialSetup = true

--- a/Foqos/Utils/PreActivationReminderScheduler.swift
+++ b/Foqos/Utils/PreActivationReminderScheduler.swift
@@ -28,28 +28,35 @@ enum PreActivationReminderScheduler {
     }
   }
 
-  /// Reschedule all pre-activation reminders for profiles with active schedules.
-  /// This should be called on app launch to ensure today's reminders are set.
-  static func rescheduleAllReminders(context: ModelContext) {
+  /// #301: a profile is eligible for automatic DeviceActivity schedule registration iff it has
+  /// an active start/legacy schedule AND its apps are selected on THIS device. The
+  /// needsAppSelection gate is the semantic default: FamilyControls tokens are device-local,
+  /// so a freshly-synced profile registers only after its apps are selected on this device.
+  static func isEligibleForScheduleReconcile(_ profile: BlockedProfiles) -> Bool {
+    let hasActiveSchedule =
+      (profile.startTriggers.schedule && profile.startSchedule?.isActive == true)
+      || profile.schedule?.isActive == true
+    return hasActiveSchedule && !profile.needsAppSelection
+  }
+
+  /// #301: register DeviceActivity schedules for eligible profiles independent of whether
+  /// pre-activation reminders are enabled.
+  /// Old reminder-gated name `rescheduleAllReminders` caused #301 by hiding registration.
+  static func reconcileScheduleRegistrations(
+    context: ModelContext,
+    register: (BlockedProfiles) -> Void = { DeviceActivityCenterUtil.scheduleTimerActivity(for: $0) }
+  ) {
     do {
       let profiles = try BlockedProfiles.fetchProfiles(in: context)
 
-      for profile in profiles {
-        let hasActiveSchedule =
-          (profile.startTriggers.schedule && profile.startSchedule?.isActive == true)
-          || profile.schedule?.isActive == true
-        guard profile.preActivationReminderEnabled, hasActiveSchedule else {
-          continue
-        }
-
-        // Reschedule via DeviceActivityCenterUtil which handles the notification
-        DeviceActivityCenterUtil.scheduleTimerActivity(for: profile)
+      for profile in profiles where isEligibleForScheduleReconcile(profile) {
+        register(profile)
       }
 
-      Log.debug("Rescheduled pre-activation reminders for all eligible profiles", category: .timer)
+      Log.debug("Reconciled DeviceActivity schedule registrations", category: .timer)
     } catch {
       Log.error(
-        "Failed to reschedule pre-activation reminders: \(error.localizedDescription)",
+        "Failed to reconcile schedule registrations: \(error.localizedDescription)",
         category: .timer
       )
     }

--- a/FoqosTests/PreActivationReminderSchedulerTests.swift
+++ b/FoqosTests/PreActivationReminderSchedulerTests.swift
@@ -1,0 +1,89 @@
+import FoqosShared
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class PreActivationReminderSchedulerTests: XCTestCase {
+  private var container: ModelContainer!
+  private var context: ModelContext!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    container = try TestModelContainer.create()
+    context = container.mainContext
+  }
+
+  func testGivenScheduledAppSelectedProfileNoReminders_WhenEligibility_ThenTrue() throws {
+    let now = Date()
+    let profile = BlockedProfiles(name: "Synced")
+    profile.startTriggers.schedule = true
+    profile.startSchedule = ProfileScheduleTime(
+      days: [.monday, .tuesday],
+      hour: 9,
+      minute: 0,
+      updatedAt: now)
+    profile.needsAppSelection = false
+    context.insert(profile)
+
+    XCTAssertTrue(PreActivationReminderScheduler.isEligibleForScheduleReconcile(profile))
+  }
+
+  func testGivenScheduledButNeedsAppSelection_WhenEligibility_ThenFalse() throws {
+    let now = Date()
+    let profile = BlockedProfiles(name: "Unselected")
+    profile.startTriggers.schedule = true
+    profile.startSchedule = ProfileScheduleTime(
+      days: [.monday],
+      hour: 8,
+      minute: 30,
+      updatedAt: now)
+    profile.needsAppSelection = true
+    context.insert(profile)
+
+    XCTAssertFalse(PreActivationReminderScheduler.isEligibleForScheduleReconcile(profile))
+  }
+
+  func testGivenScheduledAppSelectedProfileNoReminders_WhenReconciling_ThenRegisters() throws {
+    let now = Date()
+    let profile = BlockedProfiles(name: "Synced")
+    profile.startTriggers.schedule = true
+    profile.startSchedule = ProfileScheduleTime(
+      days: [.monday],
+      hour: 9,
+      minute: 0,
+      updatedAt: now)
+    profile.needsAppSelection = false
+    context.insert(profile)
+    try context.save()
+    var registeredIds: [UUID] = []
+
+    PreActivationReminderScheduler.reconcileScheduleRegistrations(
+      context: context,
+      register: { registeredIds.append($0.id) })
+
+    XCTAssertEqual(registeredIds, [profile.id])
+  }
+
+  func testGivenScheduledButNeedsAppSelection_WhenReconciling_ThenSkipsRegistration() throws {
+    let now = Date()
+    let profile = BlockedProfiles(name: "Unselected")
+    profile.startTriggers.schedule = true
+    profile.startSchedule = ProfileScheduleTime(
+      days: [.monday],
+      hour: 8,
+      minute: 30,
+      updatedAt: now)
+    profile.needsAppSelection = true
+    context.insert(profile)
+    try context.save()
+    var registeredIds: [UUID] = []
+
+    PreActivationReminderScheduler.reconcileScheduleRegistrations(
+      context: context,
+      register: { registeredIds.append($0.id) })
+
+    XCTAssertEqual(registeredIds, [])
+  }
+}

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -813,6 +813,31 @@ final class SyncEngineControllerTests: XCTestCase {
     await controller.fetchCycleSweepTask?.value
   }
 
+  func testGivenFetchCycle_WhenDidFetchChanges_ThenSchedulesReconciledOnceWithApplyContext()
+    async
+  {
+    store.engineState = Data([0x01])
+    var reconciledContexts: [ModelContext] = []
+    let controller = SyncEngineController(
+      modelContext: context,
+      store: store,
+      driverFactory: { [driver] _ in driver! },
+      apply: apply,
+      provider: provider,
+      sessionSync: sessionSync,
+      deviceId: deviceId,
+      scheduleReconciler: { reconciledContexts.append($0) })
+    controller.start()
+    await controller.startupTask?.value
+
+    controller.handle(.willFetchChanges)
+    controller.handle(.didFetchChanges)
+
+    XCTAssertEqual(reconciledContexts.count, 1)
+    XCTAssertTrue(reconciledContexts.first === context)
+    await controller.fetchCycleSweepTask?.value
+  }
+
   func testGivenFailedApplyPending_WhenDidFetchChanges_ThenPostCycleSweepRetriesIt() async {
     store.engineState = Data([0x01])
     let controller = makeController()


### PR DESCRIPTION
## Summary

Fixes #301 as FU-B from epic #263.

This implements mini-plan B / MD-B1 Option C from `docs/superpowers/plans/2026-07-10-263-followups-302-301-298.md`:

- Renames the foreground reconciler from `rescheduleAllReminders` to `reconcileScheduleRegistrations`.
- Decouples DeviceActivity schedule registration from `preActivationReminderEnabled` so schedules register even when reminders are off.
- Keeps the settled `!needsAppSelection` default gate because FamilyControls selection tokens are device-local.
- Calls the reconciler from both foreground sites and exactly once per sync fetch cycle at `SyncEngineController.handleDidFetchChanges`.
- Leaves deletion/ghost cleanup semantics untouched; registration only adds/synchronizes live schedules and remains disjoint from `cleanUpGhostSchedules`.

## Root cause

The old foreground path only registered existing schedules through `PreActivationReminderScheduler.rescheduleAllReminders`, whose eligibility guard required `profile.preActivationReminderEnabled`. A synced scheduled profile with no reminder times therefore never called `DeviceActivityCenterUtil.scheduleTimerActivity`, leaving the receiver with a persisted schedule but no OS-level DeviceActivity registration.

## B0 citation refresh

Verified against `origin/main` at `4a8fadf128fe9b5106d11520461e1e9f7247bd53` after PR #308 and PR #312:

- PR #308 / A4′ is present at `c17923d`.
- PR #312 / #302 is present at `4a8fadf`.
- `SyncApplyService.private var zoneID` exists at line 19.
- `SyncEngineController.handleDidFetchChanges` is the fetch-cycle delimiter at line 645 before this PR.
- A4′ drain calls are present in `SyncEngineController` at lines 369, 384, 524, 758, and 787 before this PR.
- Foreground call sites were `FoqosApp.swift:161` and `FoqosApp.swift:260` before the rename.

## Validation

- TDD red-first:
  - `PreActivationReminderSchedulerTests` first failed on missing `isEligibleForScheduleReconcile` / `reconcileScheduleRegistrations`.
  - `SyncEngineControllerTests/testGivenFetchCycle_WhenDidFetchChanges_ThenSchedulesReconciledOnceWithApplyContext` first failed on missing `scheduleReconciler` injection.
- `scripts/check-sync-guards.sh` — passed.
- `scripts/check-c2-guards.sh` — passed.
- `swift-format lint --recursive .` — passed.
- B1/B2 slices — passed.
- Full suite: `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -resultBundlePath /tmp/family-foqos-full-tests.xcresult | xcpretty` — passed.
  - xcresult summary: 912 passed, 0 failed, 0 skipped.

## Device gates

Pending maintainer-assisted physical-device verification. Current workspace device discovery had only one online iOS device (`Rob’s iPhone`); the other candidate iPads were offline, so the required two-device flows could not be completed from this session.

Required before marking ready:

- [ ] §D throwaway build probe with the `!needsAppSelection` gate removed; record whether empty selection is (a) harmless no-op, (b) spurious notification, or (c) invalid restriction activation. The shipping code keeps the gate regardless.
- [ ] Device A creates scheduled profile with reminders off; device B completes app selection; schedule fires on B without manual “Fix Schedule”.
- [ ] Foreground pass on B clears stale warning for an already-selected scheduled profile.

## Review notes

Requesting code review before merge per `AGENTS.md`. This PR intentionally does not change cleanup/deletion semantics and does not call DeviceActivity from `SyncApplyService` per the plan’s disjointness and layering constraints.