### PR TITLE
Fix #301 synced schedule registration

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -311,6 +311,7 @@
 				801B20922CB363A10073E9E2 /* Frameworks */,
 				801B20932CB363A10073E9E2 /* Resources */,
 				80DBF61D2CB776D100EEA8A6 /* Embed Foundation Extensions */,
+				D4F301012F5A000100000001 /* Stamp Build Metadata */,
 			);
 			buildRules = (
 			);
@@ -564,6 +565,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "cd \"${SRCROOT}\"\nif [ ! -d .git ] && ! git rev-parse --git-dir >/dev/null 2>&1; then\n    exit 0\nfi\nCURRENT=$(git config --get core.hooksPath 2>/dev/null || true)\nif [ -z \"$CURRENT\" ]; then\n    git config core.hooksPath .githooks\nelif [ \"$CURRENT\" != \".githooks\" ]; then\n    echo \"error: core.hooksPath is set to '$CURRENT' — expected '.githooks'. Run: git config core.hooksPath .githooks\"\n    exit 1\nfi\n";
+		};
+		D4F301012F5A000100000001 /* Stamp Build Metadata */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Stamp Build Metadata";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cd \"${SRCROOT}\"\nSHA=\"unknown\"\nDIRTY=\"NO\"\nif git rev-parse --is-inside-work-tree >/dev/null 2>&1; then\n    SHA=$(git rev-parse --short=7 HEAD 2>/dev/null || echo unknown)\n    if ! git diff --quiet -- . || ! git diff --cached --quiet -- .; then\n        DIRTY=\"YES\"\n    fi\nfi\nBUILD_INFO=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/BuildInfo.plist\"\nmkdir -p \"$(dirname \"$BUILD_INFO\")\"\ncat > \"$BUILD_INFO\" <<EOF\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n    <key>GitCommitSHA</key>\n    <string>$SHA</string>\n    <key>GitHasUncommittedChanges</key>\n    <string>$DIRTY</string>\n</dict>\n</plist>\nEOF\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -29,6 +29,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   private let sessionSync: SessionSyncFlushing
   private let deviceId: String
   private let scheduleProfileDeleteCommit: (@escaping @MainActor () -> Void) -> Void
+  private let scheduleReconciler: (ModelContext) -> Void
 
   private let zoneID = CKRecordZone.ID(
     zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)
@@ -83,7 +84,9 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     sessionSync: SessionSyncFlushing,
     deviceId: String,
     scheduleProfileDeleteCommit: @escaping (@escaping @MainActor () -> Void) -> Void =
-      BlockedProfiles.scheduleProfileDeleteCommit
+      BlockedProfiles.scheduleProfileDeleteCommit,
+    scheduleReconciler: @escaping (ModelContext) -> Void =
+      { PreActivationReminderScheduler.reconcileScheduleRegistrations(context: $0) }
   ) {
     self.modelContext = modelContext
     self.store = store
@@ -93,6 +96,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     self.sessionSync = sessionSync
     self.deviceId = deviceId
     self.scheduleProfileDeleteCommit = scheduleProfileDeleteCommit
+    self.scheduleReconciler = scheduleReconciler
     self.apply.profileDeleteCommitObserver = { [weak self] recordName in
       guard let self else { return }
       let recordID = CKRecord.ID(recordName: recordName, zoneID: self.zoneID)
@@ -648,6 +652,10 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     fetchCycleSweepTask = Task { [weak self] in
       await self?.retryFailedApplies(generation: generation)
     }
+    // #301: a fetch cycle may have applied profiles whose schedule/trigger config changed;
+    // register their DeviceActivity schedules once, coalesced across the whole cycle (not
+    // per-record). Idempotent + self-gating; respects cleanUpGhostSchedules (adds only).
+    scheduleReconciler(modelContext)
   }
 
   // MARK: - §5.4 nextRecordZoneChangeBatch materialization (S-14, S-29)

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -650,12 +650,14 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     if state == .bootstrapping { state = .steady }  // T2
     let generation = namespaceGeneration
     fetchCycleSweepTask = Task { [weak self] in
-      await self?.retryFailedApplies(generation: generation)
+      guard let self else { return }
+      await self.retryFailedApplies(generation: generation)
+      guard generation == self.namespaceGeneration else { return }
+      // #301: a fetch cycle may have applied profiles whose schedule/trigger config changed;
+      // register their DeviceActivity schedules once, coalesced across the whole cycle (not
+      // per-record). Run after §5.6 retry applies so repaired profile schedules are included.
+      self.scheduleReconciler(self.modelContext)
     }
-    // #301: a fetch cycle may have applied profiles whose schedule/trigger config changed;
-    // register their DeviceActivity schedules once, coalesced across the whole cycle (not
-    // per-record). Idempotent + self-gating; respects cleanUpGhostSchedules (adds only).
-    scheduleReconciler(modelContext)
   }
 
   // MARK: - §5.4 nextRecordZoneChangeBatch materialization (S-14, S-29)

--- a/Foqos/Components/BlockedProfileCards/BlockedProfileCardData.swift
+++ b/Foqos/Components/BlockedProfileCards/BlockedProfileCardData.swift
@@ -48,6 +48,10 @@ extension BlockedProfiles {
   /// passing the zombie test. Verified by `testGivenModelMutated_WhenCardDataRebuilt_ThenReflectsChange`
   /// and the device-gate edit step.
   var cardData: BlockedProfileCardData {
+    cardData(scheduleIsOutOfSync: scheduleIsOutOfSync)
+  }
+
+  func cardData(scheduleIsOutOfSync: Bool) -> BlockedProfileCardData {
     BlockedProfileCardData(
       id: id,
       name: name,

--- a/Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift
+++ b/Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift
@@ -26,6 +26,7 @@ struct BlockedProfileCarousel: View {
   var onOneMoreMinuteTapped: (BlockedProfiles) -> Void
 
   @State private var currentProfileId: UUID?
+  @State private var scheduleOutOfSyncCards = ScheduleOutOfSyncCardState()
 
   // Constants for the carousel
   private let cardSpacing: CGFloat = 12
@@ -146,7 +147,8 @@ struct BlockedProfileCarousel: View {
                   // Built only on a valid model, inside this observation-tracked body. These
                   // tracked reads register dependencies so legitimate edits rebuild the snapshot
                   // in place. Do not hoist or memoize this call; see the `cardData` tripwire.
-                  data: profile.cardData,
+                  data: profile.cardData(
+                    scheduleIsOutOfSync: scheduleOutOfSyncCards.isOutOfSync(for: profile)),
                   isActive: profile.id == activeSessionProfileId,
                   isBreakAvailable: isBreakAvailable,
                   isBreakActive: isBreakActive,
@@ -202,6 +204,12 @@ struct BlockedProfileCarousel: View {
     }
     .onAppear {
       initialSetup()
+      refreshScheduleOutOfSyncCards()
+    }
+    .onReceive(
+      NotificationCenter.default.publisher(for: .scheduleRegistrationsDidReconcile)
+    ) { _ in
+      scheduleOutOfSyncCards.refreshAfterScheduleReconcile(profiles: validProfiles)
     }
     .onChange(of: activeSessionProfileId) { _, _ in
       initialSetup()
@@ -212,6 +220,10 @@ struct BlockedProfileCarousel: View {
     .onChange(of: startingProfileId) { _, _ in
       initialSetup()
     }
+  }
+
+  private func refreshScheduleOutOfSyncCards() {
+    scheduleOutOfSyncCards.refresh(profiles: validProfiles)
   }
 
 }

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -158,7 +158,8 @@ struct FoqosApp: App {
             if hasPerformedInitialSetup {
               PreActivationReminderScheduler.mergeExtensionScheduleSuppression(
                 context: container.mainContext)
-              PreActivationReminderScheduler.rescheduleAllReminders(context: container.mainContext)
+              PreActivationReminderScheduler.reconcileScheduleRegistrations(
+                context: container.mainContext)
               PreActivationReminderScheduler.catchUpMissedScheduleStarts(context: container.mainContext)
             }
           }
@@ -257,7 +258,7 @@ struct FoqosApp: App {
           }
           // Reschedule pre-activation reminders for today
           PreActivationReminderScheduler.mergeExtensionScheduleSuppression(context: container.mainContext)
-          PreActivationReminderScheduler.rescheduleAllReminders(context: container.mainContext)
+          PreActivationReminderScheduler.reconcileScheduleRegistrations(context: container.mainContext)
           // Catch up any missed schedule starts
           PreActivationReminderScheduler.catchUpMissedScheduleStarts(context: container.mainContext)
           hasPerformedInitialSetup = true

--- a/Foqos/Utils/AppBuildInfo.swift
+++ b/Foqos/Utils/AppBuildInfo.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct AppBuildInfo {
+  private let infoDictionary: [String: Any]
+
+  init(infoDictionary: [String: Any] = Self.bundleInfoDictionary()) {
+    self.infoDictionary = infoDictionary
+  }
+
+  private static func bundleInfoDictionary(bundle: Bundle = .main) -> [String: Any] {
+    var info = bundle.infoDictionary ?? [:]
+    guard let url = bundle.url(forResource: "BuildInfo", withExtension: "plist"),
+      let data = try? Data(contentsOf: url),
+      let buildInfo = try? PropertyListSerialization.propertyList(from: data, format: nil)
+        as? [String: Any]
+    else {
+      return info
+    }
+    info.merge(buildInfo) { _, buildValue in buildValue }
+    return info
+  }
+
+  var version: String {
+    infoDictionary["CFBundleShortVersionString"] as? String ?? "Unknown"
+  }
+
+  var build: String {
+    infoDictionary["CFBundleVersion"] as? String ?? "Unknown"
+  }
+
+  var commitDisplay: String {
+    guard let sha = infoDictionary["GitCommitSHA"] as? String,
+      !sha.isEmpty,
+      sha != "unknown"
+    else {
+      return "unknown"
+    }
+
+    let dirty = (infoDictionary["GitHasUncommittedChanges"] as? String) == "YES"
+    return dirty ? "\(sha)+wip" : sha
+  }
+}

--- a/Foqos/Utils/LogExportManager.swift
+++ b/Foqos/Utils/LogExportManager.swift
@@ -64,6 +64,7 @@ final class LogExportManager {
   private func generateDeviceInfo() -> String {
     let device = UIDevice.current
     let bundle = Bundle.main
+    let buildInfo = AppBuildInfo()
 
     let info = """
       Family Foqos Log Export
@@ -71,8 +72,9 @@ final class LogExportManager {
       Generated: \(ISO8601DateFormatter().string(from: Date()))
 
       App Info:
-      - Version: \(bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown")
-      - Build: \(bundle.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown")
+      - Version: \(buildInfo.version)
+      - Build: \(buildInfo.build)
+      - Commit: \(buildInfo.commitDisplay)
       - Bundle ID: \(bundle.bundleIdentifier ?? "Unknown")
 
       Device Info:

--- a/Foqos/Utils/PreActivationReminderScheduler.swift
+++ b/Foqos/Utils/PreActivationReminderScheduler.swift
@@ -2,6 +2,11 @@ import FoqosShared
 import Foundation
 import SwiftData
 
+extension Notification.Name {
+  static let scheduleRegistrationsDidReconcile = Notification.Name(
+    "scheduleRegistrationsDidReconcile")
+}
+
 /// Schedules pre-activation reminders for all profiles with active schedules.
 /// Call this on app launch and when returning to foreground to ensure
 /// daily notifications are scheduled.
@@ -44,6 +49,7 @@ enum PreActivationReminderScheduler {
   /// Old reminder-gated name `rescheduleAllReminders` caused #301 by hiding registration.
   static func reconcileScheduleRegistrations(
     context: ModelContext,
+    notificationCenter: NotificationCenter = .default,
     register: (BlockedProfiles) -> Void = { DeviceActivityCenterUtil.scheduleTimerActivity(for: $0) }
   ) {
     do {
@@ -54,6 +60,7 @@ enum PreActivationReminderScheduler {
       }
 
       Log.debug("Reconciled DeviceActivity schedule registrations", category: .timer)
+      notificationCenter.post(name: .scheduleRegistrationsDidReconcile, object: nil)
     } catch {
       Log.error(
         "Failed to reconcile schedule registrations: \(error.localizedDescription)",

--- a/Foqos/Utils/PreActivationReminderScheduler.swift
+++ b/Foqos/Utils/PreActivationReminderScheduler.swift
@@ -61,7 +61,7 @@ enum PreActivationReminderScheduler {
       }
 
       Log.debug("Reconciled DeviceActivity schedule registrations", category: .timer)
-      notificationCenter.post(name: .scheduleRegistrationsDidReconcile, object: nil)
+      ScheduleRegistrationRefreshNotifier.post(notificationCenter: notificationCenter)
     } catch {
       Log.error(
         "Failed to reconcile schedule registrations: \(error.localizedDescription)",

--- a/Foqos/Utils/PreActivationReminderScheduler.swift
+++ b/Foqos/Utils/PreActivationReminderScheduler.swift
@@ -47,6 +47,7 @@ enum PreActivationReminderScheduler {
   /// #301: register DeviceActivity schedules for eligible profiles independent of whether
   /// pre-activation reminders are enabled.
   /// Old reminder-gated name `rescheduleAllReminders` caused #301 by hiding registration.
+  @MainActor
   static func reconcileScheduleRegistrations(
     context: ModelContext,
     notificationCenter: NotificationCenter = .default,

--- a/Foqos/Utils/PreActivationReminderScheduler.swift
+++ b/Foqos/Utils/PreActivationReminderScheduler.swift
@@ -28,28 +28,35 @@ enum PreActivationReminderScheduler {
     }
   }
 
-  /// Reschedule all pre-activation reminders for profiles with active schedules.
-  /// This should be called on app launch to ensure today's reminders are set.
-  static func rescheduleAllReminders(context: ModelContext) {
+  /// #301: a profile is eligible for automatic DeviceActivity schedule registration iff it has
+  /// an active start/legacy schedule AND its apps are selected on THIS device. The
+  /// needsAppSelection gate is the semantic default: FamilyControls tokens are device-local,
+  /// so a freshly-synced profile registers only after its apps are selected on this device.
+  static func isEligibleForScheduleReconcile(_ profile: BlockedProfiles) -> Bool {
+    let hasActiveSchedule =
+      (profile.startTriggers.schedule && profile.startSchedule?.isActive == true)
+      || profile.schedule?.isActive == true
+    return hasActiveSchedule && !profile.needsAppSelection
+  }
+
+  /// #301: register DeviceActivity schedules for eligible profiles independent of whether
+  /// pre-activation reminders are enabled.
+  /// Old reminder-gated name `rescheduleAllReminders` caused #301 by hiding registration.
+  static func reconcileScheduleRegistrations(
+    context: ModelContext,
+    register: (BlockedProfiles) -> Void = { DeviceActivityCenterUtil.scheduleTimerActivity(for: $0) }
+  ) {
     do {
       let profiles = try BlockedProfiles.fetchProfiles(in: context)
 
-      for profile in profiles {
-        let hasActiveSchedule =
-          (profile.startTriggers.schedule && profile.startSchedule?.isActive == true)
-          || profile.schedule?.isActive == true
-        guard profile.preActivationReminderEnabled, hasActiveSchedule else {
-          continue
-        }
-
-        // Reschedule via DeviceActivityCenterUtil which handles the notification
-        DeviceActivityCenterUtil.scheduleTimerActivity(for: profile)
+      for profile in profiles where isEligibleForScheduleReconcile(profile) {
+        register(profile)
       }
 
-      Log.debug("Rescheduled pre-activation reminders for all eligible profiles", category: .timer)
+      Log.debug("Reconciled DeviceActivity schedule registrations", category: .timer)
     } catch {
       Log.error(
-        "Failed to reschedule pre-activation reminders: \(error.localizedDescription)",
+        "Failed to reconcile schedule registrations: \(error.localizedDescription)",
         category: .timer
       )
     }

--- a/Foqos/Utils/ScheduleOutOfSyncBannerState.swift
+++ b/Foqos/Utils/ScheduleOutOfSyncBannerState.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct ScheduleOutOfSyncBannerState {
+  var isVisible: Bool = false
+
+  mutating func refresh(
+    profile: BlockedProfiles?,
+    isOutOfSync: (BlockedProfiles) -> Bool = { $0.scheduleIsOutOfSync }
+  ) {
+    isVisible = Self.shouldShow(profile: profile, isOutOfSync: isOutOfSync)
+  }
+
+  mutating func refreshAfterScheduleReconcile(
+    profile: BlockedProfiles?,
+    isOutOfSync: (BlockedProfiles) -> Bool = { $0.scheduleIsOutOfSync }
+  ) {
+    refresh(profile: profile, isOutOfSync: isOutOfSync)
+  }
+
+  static func shouldShow(
+    profile: BlockedProfiles?,
+    isOutOfSync: (BlockedProfiles) -> Bool = { $0.scheduleIsOutOfSync }
+  ) -> Bool {
+    guard let profile else { return false }
+    return isOutOfSync(profile)
+  }
+}

--- a/Foqos/Utils/ScheduleOutOfSyncBannerState.swift
+++ b/Foqos/Utils/ScheduleOutOfSyncBannerState.swift
@@ -25,3 +25,29 @@ struct ScheduleOutOfSyncBannerState {
     return isOutOfSync(profile)
   }
 }
+
+struct ScheduleOutOfSyncCardState {
+  var visibilityByProfileId: [UUID: Bool] = [:]
+
+  mutating func refresh(
+    profiles: [BlockedProfiles],
+    isOutOfSync: (BlockedProfiles) -> Bool = { $0.scheduleIsOutOfSync }
+  ) {
+    visibilityByProfileId = Dictionary(
+      uniqueKeysWithValues: profiles.map { ($0.id, isOutOfSync($0)) })
+  }
+
+  mutating func refreshAfterScheduleReconcile(
+    profiles: [BlockedProfiles],
+    isOutOfSync: (BlockedProfiles) -> Bool = { $0.scheduleIsOutOfSync }
+  ) {
+    refresh(profiles: profiles, isOutOfSync: isOutOfSync)
+  }
+
+  func isOutOfSync(
+    for profile: BlockedProfiles,
+    fallback: (BlockedProfiles) -> Bool = { $0.scheduleIsOutOfSync }
+  ) -> Bool {
+    visibilityByProfileId[profile.id] ?? fallback(profile)
+  }
+}

--- a/Foqos/Utils/ScheduleOutOfSyncBannerState.swift
+++ b/Foqos/Utils/ScheduleOutOfSyncBannerState.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+enum ScheduleRegistrationRefreshNotifier {
+  @MainActor
+  static func post(notificationCenter: NotificationCenter = .default) {
+    notificationCenter.post(name: .scheduleRegistrationsDidReconcile, object: nil)
+  }
+}
+
 struct ScheduleOutOfSyncBannerState {
   var isVisible: Bool = false
 

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -88,6 +88,7 @@ struct BlockedProfileView: View {
   @State private var isManaged: Bool = false
   @State private var showingLockCodeEntry = false
   @State private var pendingAction: PendingAction?
+  @State private var scheduleRegistrationRefreshTick = 0
 
   /// Pending actions that require code verification
   private enum PendingAction {
@@ -589,6 +590,11 @@ struct BlockedProfileView: View {
           if let existingProfile = profile {
             triggerConfig.loadFromProfile(existingProfile)
           }
+        }
+        .onReceive(
+          NotificationCenter.default.publisher(for: .scheduleRegistrationsDidReconcile)
+        ) { _ in
+          scheduleRegistrationRefreshTick += 1
         }
         .navigationTitle(isEditing ? "Profile Details" : "New Profile")
         .toolbar {

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -88,7 +88,7 @@ struct BlockedProfileView: View {
   @State private var isManaged: Bool = false
   @State private var showingLockCodeEntry = false
   @State private var pendingAction: PendingAction?
-  @State private var scheduleRegistrationRefreshTick = 0
+  @State private var scheduleOutOfSyncBanner = ScheduleOutOfSyncBannerState()
 
   /// Pending actions that require code verification
   private enum PendingAction {
@@ -282,7 +282,7 @@ struct BlockedProfileView: View {
             }
           }
 
-          if profile?.scheduleIsOutOfSync == true {
+          if scheduleOutOfSyncBanner.isVisible {
             Section {
               ScheduleWarningPrompt(onApply: { saveProfile() }, disabled: isBlocking)
             }
@@ -590,11 +590,12 @@ struct BlockedProfileView: View {
           if let existingProfile = profile {
             triggerConfig.loadFromProfile(existingProfile)
           }
+          refreshScheduleOutOfSyncBanner()
         }
         .onReceive(
           NotificationCenter.default.publisher(for: .scheduleRegistrationsDidReconcile)
         ) { _ in
-          scheduleRegistrationRefreshTick += 1
+          scheduleOutOfSyncBanner.refreshAfterScheduleReconcile(profile: profile)
         }
         .navigationTitle(isEditing ? "Profile Details" : "New Profile")
         .toolbar {
@@ -873,6 +874,10 @@ struct BlockedProfileView: View {
         }
       }  // else (non-newer-schema profile)
     }
+  }
+
+  private func refreshScheduleOutOfSyncBanner() {
+    scheduleOutOfSyncBanner.refresh(profile: profile)
   }
 
   /// Largest minutes value whose seconds representation fits in UInt32.

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -939,6 +939,7 @@ struct BlockedProfileView: View {
         "Failed to save trigger config: \(error.localizedDescription)", category: .ui)
     }
     DeviceActivityCenterUtil.scheduleTimerActivity(for: profile)
+    ScheduleRegistrationRefreshNotifier.post()
     do {
       try profileSyncManager.enqueueProfileSave(profile.id)
     } catch SyncEngineControllingError.notAttached {

--- a/Foqos/Views/DebugView.swift
+++ b/Foqos/Views/DebugView.swift
@@ -17,6 +17,10 @@ struct DebugView: View {
     DeviceActivityCenterUtil.getDeviceActivities()
   }
 
+  private var buildInfo: AppBuildInfo {
+    AppBuildInfo()
+  }
+
   var body: some View {
     NavigationStack {
       ScrollView {
@@ -83,6 +87,12 @@ struct DebugView: View {
           }
 
           // Diagnostics section - always visible
+          DebugSection(title: "App Build") {
+            DebugRow(label: "Version", value: buildInfo.version)
+            DebugRow(label: "Build", value: buildInfo.build)
+            DebugRow(label: "Commit", value: buildInfo.commitDisplay)
+          }
+
           DebugSection(title: "Diagnostics") {
             Button {
               showingLogExport = true

--- a/FoqosTests/AppBuildInfoTests.swift
+++ b/FoqosTests/AppBuildInfoTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class AppBuildInfoTests: XCTestCase {
+  func testGivenGitShaAndCleanBuild_WhenDisplayCommit_ThenShowsShaOnly() {
+    let info = AppBuildInfo(
+      infoDictionary: [
+        "GitCommitSHA": "f4fca03",
+        "GitHasUncommittedChanges": "NO",
+      ])
+
+    XCTAssertEqual(info.commitDisplay, "f4fca03")
+  }
+
+  func testGivenGitShaAndDirtyBuild_WhenDisplayCommit_ThenShowsWipSuffix() {
+    let info = AppBuildInfo(
+      infoDictionary: [
+        "GitCommitSHA": "f4fca03",
+        "GitHasUncommittedChanges": "YES",
+      ])
+
+    XCTAssertEqual(info.commitDisplay, "f4fca03+wip")
+  }
+
+  func testGivenMissingGitSha_WhenDisplayCommit_ThenShowsUnknown() {
+    let info = AppBuildInfo(infoDictionary: [:])
+
+    XCTAssertEqual(info.commitDisplay, "unknown")
+  }
+}

--- a/FoqosTests/PreActivationReminderSchedulerTests.swift
+++ b/FoqosTests/PreActivationReminderSchedulerTests.swift
@@ -86,4 +86,24 @@ final class PreActivationReminderSchedulerTests: XCTestCase {
 
     XCTAssertEqual(registeredIds, [])
   }
+
+  func testGivenReconcileCompletes_WhenReconciling_ThenPostsRefreshNotification() throws {
+    let notificationCenter = NotificationCenter()
+    let posted = expectation(description: "schedule reconcile notification posted")
+    let observer = notificationCenter.addObserver(
+      forName: .scheduleRegistrationsDidReconcile,
+      object: nil,
+      queue: nil
+    ) { _ in
+      posted.fulfill()
+    }
+    defer { notificationCenter.removeObserver(observer) }
+
+    PreActivationReminderScheduler.reconcileScheduleRegistrations(
+      context: context,
+      notificationCenter: notificationCenter,
+      register: { _ in })
+
+    wait(for: [posted], timeout: 0.1)
+  }
 }

--- a/FoqosTests/PreActivationReminderSchedulerTests.swift
+++ b/FoqosTests/PreActivationReminderSchedulerTests.swift
@@ -1,0 +1,89 @@
+import FoqosShared
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class PreActivationReminderSchedulerTests: XCTestCase {
+  private var container: ModelContainer!
+  private var context: ModelContext!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    container = try TestModelContainer.create()
+    context = container.mainContext
+  }
+
+  func testGivenScheduledAppSelectedProfileNoReminders_WhenEligibility_ThenTrue() throws {
+    let now = Date()
+    let profile = BlockedProfiles(name: "Synced")
+    profile.startTriggers.schedule = true
+    profile.startSchedule = ProfileScheduleTime(
+      days: [.monday, .tuesday],
+      hour: 9,
+      minute: 0,
+      updatedAt: now)
+    profile.needsAppSelection = false
+    context.insert(profile)
+
+    XCTAssertTrue(PreActivationReminderScheduler.isEligibleForScheduleReconcile(profile))
+  }
+
+  func testGivenScheduledButNeedsAppSelection_WhenEligibility_ThenFalse() throws {
+    let now = Date()
+    let profile = BlockedProfiles(name: "Unselected")
+    profile.startTriggers.schedule = true
+    profile.startSchedule = ProfileScheduleTime(
+      days: [.monday],
+      hour: 8,
+      minute: 30,
+      updatedAt: now)
+    profile.needsAppSelection = true
+    context.insert(profile)
+
+    XCTAssertFalse(PreActivationReminderScheduler.isEligibleForScheduleReconcile(profile))
+  }
+
+  func testGivenScheduledAppSelectedProfileNoReminders_WhenReconciling_ThenRegisters() throws {
+    let now = Date()
+    let profile = BlockedProfiles(name: "Synced")
+    profile.startTriggers.schedule = true
+    profile.startSchedule = ProfileScheduleTime(
+      days: [.monday],
+      hour: 9,
+      minute: 0,
+      updatedAt: now)
+    profile.needsAppSelection = false
+    context.insert(profile)
+    try context.save()
+    var registeredIds: [UUID] = []
+
+    PreActivationReminderScheduler.reconcileScheduleRegistrations(
+      context: context,
+      register: { registeredIds.append($0.id) })
+
+    XCTAssertEqual(registeredIds, [profile.id])
+  }
+
+  func testGivenScheduledButNeedsAppSelection_WhenReconciling_ThenSkipsRegistration() throws {
+    let now = Date()
+    let profile = BlockedProfiles(name: "Unselected")
+    profile.startTriggers.schedule = true
+    profile.startSchedule = ProfileScheduleTime(
+      days: [.monday],
+      hour: 8,
+      minute: 30,
+      updatedAt: now)
+    profile.needsAppSelection = true
+    context.insert(profile)
+    try context.save()
+    var registeredIds: [UUID] = []
+
+    PreActivationReminderScheduler.reconcileScheduleRegistrations(
+      context: context,
+      register: { registeredIds.append($0.id) })
+
+    XCTAssertEqual(registeredIds, [])
+  }
+}

--- a/FoqosTests/ScheduleOutOfSyncBannerStateTests.swift
+++ b/FoqosTests/ScheduleOutOfSyncBannerStateTests.swift
@@ -12,4 +12,14 @@ final class ScheduleOutOfSyncBannerStateTests: XCTestCase {
 
     XCTAssertFalse(state.isVisible)
   }
+
+  func testGivenHomeCardWarningVisible_WhenReconcileRefreshSeesActivityPresent_ThenCardWarningClears() {
+    let profile = BlockedProfiles(name: "Scheduled")
+    var state = ScheduleOutOfSyncCardState(visibilityByProfileId: [profile.id: true])
+
+    state.refreshAfterScheduleReconcile(profiles: [profile], isOutOfSync: { _ in false })
+    let data = profile.cardData(scheduleIsOutOfSync: state.isOutOfSync(for: profile))
+
+    XCTAssertFalse(data.scheduleIsOutOfSync)
+  }
 }

--- a/FoqosTests/ScheduleOutOfSyncBannerStateTests.swift
+++ b/FoqosTests/ScheduleOutOfSyncBannerStateTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class ScheduleOutOfSyncBannerStateTests: XCTestCase {
+  func testGivenWarningVisible_WhenReconcileNotificationRefreshSeesActivityPresent_ThenWarningClears() {
+    let profile = BlockedProfiles(name: "Scheduled")
+    var state = ScheduleOutOfSyncBannerState(isVisible: true)
+
+    state.refreshAfterScheduleReconcile(profile: profile, isOutOfSync: { _ in false })
+
+    XCTAssertFalse(state.isVisible)
+  }
+}

--- a/FoqosTests/ScheduleOutOfSyncBannerStateTests.swift
+++ b/FoqosTests/ScheduleOutOfSyncBannerStateTests.swift
@@ -22,4 +22,21 @@ final class ScheduleOutOfSyncBannerStateTests: XCTestCase {
 
     XCTAssertFalse(data.scheduleIsOutOfSync)
   }
+
+  func testGivenLocalScheduleRegistration_WhenPostingRefreshSignal_ThenReconcileNotificationEmitted() {
+    let notificationCenter = NotificationCenter()
+    let posted = expectation(description: "schedule registration refresh notification posted")
+    let observer = notificationCenter.addObserver(
+      forName: .scheduleRegistrationsDidReconcile,
+      object: nil,
+      queue: nil
+    ) { _ in
+      posted.fulfill()
+    }
+    defer { notificationCenter.removeObserver(observer) }
+
+    ScheduleRegistrationRefreshNotifier.post(notificationCenter: notificationCenter)
+
+    wait(for: [posted], timeout: 0.1)
+  }
 }

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -813,6 +813,31 @@ final class SyncEngineControllerTests: XCTestCase {
     await controller.fetchCycleSweepTask?.value
   }
 
+  func testGivenFetchCycle_WhenDidFetchChanges_ThenSchedulesReconciledOnceWithApplyContext()
+    async
+  {
+    store.engineState = Data([0x01])
+    var reconciledContexts: [ModelContext] = []
+    let controller = SyncEngineController(
+      modelContext: context,
+      store: store,
+      driverFactory: { [driver] _ in driver! },
+      apply: apply,
+      provider: provider,
+      sessionSync: sessionSync,
+      deviceId: deviceId,
+      scheduleReconciler: { reconciledContexts.append($0) })
+    controller.start()
+    await controller.startupTask?.value
+
+    controller.handle(.willFetchChanges)
+    controller.handle(.didFetchChanges)
+
+    XCTAssertEqual(reconciledContexts.count, 1)
+    XCTAssertTrue(reconciledContexts.first === context)
+    await controller.fetchCycleSweepTask?.value
+  }
+
   func testGivenFailedApplyPending_WhenDidFetchChanges_ThenPostCycleSweepRetriesIt() async {
     store.engineState = Data([0x01])
     let controller = makeController()

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -833,9 +833,10 @@ final class SyncEngineControllerTests: XCTestCase {
     controller.handle(.willFetchChanges)
     controller.handle(.didFetchChanges)
 
+    XCTAssertEqual(reconciledContexts.count, 0, "reconcile waits for post-cycle retry sweep")
+    await controller.fetchCycleSweepTask?.value
     XCTAssertEqual(reconciledContexts.count, 1)
     XCTAssertTrue(reconciledContexts.first === context)
-    await controller.fetchCycleSweepTask?.value
   }
 
   func testGivenFailedApplyPending_WhenDidFetchChanges_ThenPostCycleSweepRetriesIt() async {


### PR DESCRIPTION
Fixes #301.

Supersedes #313; this branch is the same FU-B work replayed onto a fresh branch with signed commits after the local sandbox blocked signing for the follow-up commit.

## What changed

- Renamed `rescheduleAllReminders` to `reconcileScheduleRegistrations` and kept the one-line comment noting the old reminder-gated name caused #301.
- Implemented mini-plan B / MD-B1 Option C: schedule registration reconcile is called from both foreground sites and once per sync fetch cycle, coalesced, never per record.
- Removed the reminder preference gate from registration eligibility while keeping `!needsAppSelection` as the default shipping gate.
- Registration paths only add/update schedules; deletion and ghost cleanup remain untouched and are not keyed off registration state.
- Added an always-visible Debug page App Build section showing version, build, and commit SHA.
- Stamped build metadata into `BuildInfo.plist`; dirty tracked/index state appends `+wip`, clean builds do not.
- Added a schedule registration refresh notification so already-open UI can refresh after sync-triggered or local-save-triggered registration.
- Replaced the prior detail-screen `scheduleRegistrationRefreshTick` invalidation attempt with one local `ScheduleOutOfSyncBannerState` source of truth. The detail banner refreshes only on appear and on the registration refresh notification; there are no delays and no retry polling.
- Added matching Home/card observation state so `BlockedProfileCardData` is rebuilt with refreshed schedule-warning visibility after the same notification. This keeps the card value-snapshot / zombie-safety pattern from #297 intact.
- Addressed review round 1:
  - Fetch-cycle schedule reconciliation now runs after the §5.6 failed-apply retry sweep completes, so repaired schedule fields are included before DeviceActivity registration.
  - Local profile saves now publish the same schedule-registration refresh signal after local registration succeeds.

## B0 citation refresh

- Branch replayed from current `origin/main` at `4a8fadf128fe9b5106d11520461e1e9f7247bd53`.
- A4′ prerequisite is present via PR #308 (`c17923d`).
- PR #312/#302 is present at `4a8fadf` and touched cited sync files.
- Refreshed cited symbols before implementation: `SyncApplyService.zoneID`, `SyncEngineController.handleDidFetchChanges`, A4′ drain sites, and the foreground reconcile sites in `FoqosApp`.

## Probe / deviation notes

- Throwaway probe on real devices showed `DeviceActivityCenter.activities` reads back synchronously after `startMonitoring`: `presentImmediately=true` for the just-registered activity.
- Therefore the stale “Schedule Out of Sync” banner is treated as a SwiftUI observation/read-site issue, not DeviceActivity registration lag.
- The probe was removed before commit; no throwaway diagnostics are shipped.

## Validation

- Red-first regression: `ScheduleOutOfSyncBannerStateTests/testGivenWarningVisible_WhenReconcileNotificationRefreshSeesActivityPresent_ThenWarningClears` first failed because `ScheduleOutOfSyncBannerState` did not exist.
- Red-first Home/card regression: `ScheduleOutOfSyncBannerStateTests/testGivenHomeCardWarningVisible_WhenReconcileRefreshSeesActivityPresent_ThenCardWarningClears` first failed because `ScheduleOutOfSyncCardState` / card-data override did not exist.
- Red-first review regression: `SyncEngineControllerTests/testGivenFetchCycle_WhenDidFetchChanges_ThenSchedulesReconciledOnceWithApplyContext` first failed when changed to require reconcile after the retry sweep.
- Red-first review regression: `ScheduleOutOfSyncBannerStateTests/testGivenLocalScheduleRegistration_WhenPostingRefreshSignal_ThenReconcileNotificationEmitted` first failed because `ScheduleRegistrationRefreshNotifier` did not exist.
- Focused review tests: controller ordering regression + schedule warning state tests ✅
- Focused Home-card tests: `ScheduleOutOfSyncBannerStateTests` + `BlockedProfileCardDataTests` + `ProfileScheduleRowDataTests` ✅
- `scripts/check-sync-guards.sh` ✅
- `scripts/check-c2-guards.sh` ✅
- `swift-format lint --recursive .` ✅
- Full suite before review round 1: `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -resultBundlePath /tmp/family-foqos-home-card-full-tests.xcresult | xcpretty` ✅ — 918 passed, 0 failed, 0 skipped
- Full suite after review round 1: `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -resultBundlePath /tmp/family-foqos-pr314-review-r1-full-tests.xcresult | xcpretty` ✅ — 919 passed, 0 failed, 0 skipped
- Physical-device build metadata before acceptance: `GitCommitSHA = e697feb`, `GitHasUncommittedChanges = NO` ✅

## Device acceptance

- Original #301 registration rows stand: user device logs showed the remote schedule update applied on device B and `DeviceActivityCenter` registration succeeded without manual “Fix Schedule”.
- Follow-up probe showed the just-registered activity is present immediately in `DeviceActivityCenter.activities`.
- Detail-screen acceptance passed: opening the profile detail screen no longer shows the warning after reconcile.
- Home-card acceptance passed on clean `e697feb`: exact failing sequence from `150629.log` retested — scheduled v3 arrived on B, registration fired, and Home card “Schedule Out of Sync” cleared without opening/force-closing the app.
- Review round 1 automated coverage now covers the retry-sweep ordering case and local-save refresh case. The local-save refresh is user-visible; a quick device smoke is reasonable before ready-for-review if desired.
- The §D empty-selection probe still needs maintainer confirmation; the `!needsAppSelection` gate remains regardless of probe outcome.