### PR TITLE
plans the fix for #226, #227, #242, #245, #266, #311, #305, #315 (epic #263 Wave 3)

### DIFF
--- a/docs/superpowers/plans/2026-07-12-263-d4-311-305-315.md
+++ b/docs/superpowers/plans/2026-07-12-263-d4-311-305-315.md
@@ -1,0 +1,1615 @@
+# Epic #263 Wave 3 — D4 / #311 / #305 / #315 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix four independent epic-#263 defect groups — session-lifecycle hygiene (D4), active-anywhere edit/delete locks (#311), durable pre-attach deferred deletes (#305), and stale-echo delete resurrection (#315) — as **four separate mini-plans committed on one branch / one PR** (the established F+I bundle pattern).
+
+**Architecture:** Each mini-plan is a focused, TDD-first change on `main` at base commit `3a5eee2`. D4 is five small mechanical fixes in the session/notification/DeviceActivity layer. #311 widens two existing local-session locks to consult already-synced session state (no new sync data). #305 and #315 both harden CloudKit delete durability behind the `ProfileSyncManager` / `SyncEngineController` seam — #305 persists pre-attach delete intents, #315 gates the record-create path with a durable version watermark. The four are code-independent across distinct subsystems, so they may be implemented in any order; commit each mini-plan's tasks under its own `(#N)` scope.
+
+**Tech Stack:** Swift 6, SwiftUI, SwiftData, CloudKit (custom `CKSyncEngine` transport — SwiftData auto-CloudKit is disabled), DeviceActivity, UNUserNotificationCenter, `FoqosShared` app-group `SharedData`.
+
+## Global Constraints
+
+- **Base commit:** `3a5eee2` (current `main`). Re-run the citation-refresh step (Task 0 of each mini-plan) before writing code — ~20 PRs landed since the D4 handovers (2026-07-02) and line numbers drift.
+- **No live users** — prefer structural fixes; no migration/back-compat constraints.
+- **NEVER force-push or amend.** New commits only; `git revert` to undo. Request code review before merging (AGENTS.md).
+- **NO parallel builds/tests** on this machine — one implementation stream at a time. Branch off `main` after the previous PR merges.
+- **`@SafeQuery` never raw `@Query`** in views; non-query model arrays use `.valid`.
+- **Lock checks use `appModeManager.currentMode == .child`** — never `!= .parent`.
+- **`Log.<level>(_, category:)`** not `print()`; never log lock codes / personal identifiers.
+- **swift-format** enforced by pre-commit hook (2-space indent, ~100–120 col).
+- **Tests:** name `testGivenX_WhenY_ThenZ()`; pin time — one `let now = Date()` per test, injected via `now:`. Run against a booted simulator **by UUID**, never device name.
+- **No new SwiftData schema** in any mini-plan (#305/#315/#311 durable state is `UserDefaults`). Do not add `@Attribute`/`@Relationship`.
+- **PR title:** "plans the fix for #226, #227, #242, #245, #266, #311, #305, #315 (epic #263 Wave 3)" — **"plans the fix for"**, never "fixes".
+
+## Implementation order (epic #263 Wave 3)
+
+Per the epic: **D4 and #311 after D3+E2**; **#305/#315 wherever the sync lane reaches them**. #315 is the higher-severity sync fix (high) — prefer it before #305 (medium) if the lane is contended. Within this bundle the four are independent; a reviewer may accept/reject any one without blocking the others.
+
+**Maintainer decisions: none.** Each design was forced by the grounded code or settled by the issue's stated rule: #305's non-namespaced pre-attach buffer is a forced consequence of the store's user-namespacing; #315's version-gate seed was argued **correct** (version-keyed beats a time window — no escalation needed, per the issue's "escalate only if the seed is wrong"); #311's rule ("active anywhere ⇒ locked everywhere") is the spec and the reduced scope satisfies it. The one thing the maintainer should *know* (not decide) is surfaced on #311: its "locations have no protection" premise is stale — protection exists and is merely local-session-scoped; this plan widens it rather than rebuilding.
+
+---
+
+# Mini-plan D4 — session-lifecycle hygiene (#226, #227, #242, #245, #266)
+
+**Re-triage result (2026-07-12, base `3a5eee2`):** all five **STILL-PRESENT** (grounded, file:line evidence posted to each issue). None obsoleted by C2/D1/D2/#289/#301/A3′/A4′.
+
+**Scope:** five independent fixes. #226 (CAS identity guard), #227 (targeted notification cancellation), #242 (remove duplicate reminder), #245 (delete-profile cleanup), #266 (re-snapshot after migration). #242 and #227 both touch the reminder path — implement #227 first (it introduces stable reminder identifiers that make #242's fix robust), but each is independently testable.
+
+### Task D4.0: Citation refresh
+
+- [ ] **Step 1: Re-confirm the five call sites still match.** Run and eyeball:
+
+```bash
+grep -n "currentSession.startTime != remoteStartTime" Foqos/Utils/StrategyManager.swift   # #226 scheduled reconcile (~1073)
+grep -n "func cancelAllNotifications\|removeAllPendingNotificationRequests" Foqos/Utils/TimersUtil.swift  # #227 (~279/281)
+grep -n "self.scheduleReminder(profile: sess.blockedProfile)" Foqos/Utils/StrategyManager.swift  # #242 (~722)
+grep -n "func deleteProfile" Foqos/Models/BlockedProfiles.swift   # #245 (~497)
+grep -n "migrateToV2IfNeeded\|migrateToV2IfEligible" Foqos/Utils/ProfileMigrationUtil.swift Foqos/Utils/StrategyManager.swift  # #266
+```
+
+Expected: `syncScheduleSessions` reconcile block still lacks a profile-identity condition; `cancelAllNotifications` still calls `removeAllPendingNotificationRequests()`; the emergency-unblock closure still calls `scheduleReminder`; `deleteProfile` still calls only `removeScheduleTimerActivities`; migration paths still omit `updateSnapshot`. If any moved, update the line references in the tasks below before proceeding.
+
+---
+
+### Task D4.1 (#226): profile-identity guard on scheduled-session CAS reconciliation
+
+**Files:**
+- Modify: `Foqos/Utils/StrategyManager.swift` (the `.alreadyActive` block in `syncScheduleSessions`, ~lines 1071-1074)
+- Test: `FoqosTests/StrategyManagerScheduledReconcileTests.swift` (new)
+
+**Interfaces:**
+- Consumes: `SharedData.SessionSnapshot.blockedProfileId: UUID` (already used at `:1058`); `BlockedProfileSession.blockedProfile.id: UUID`.
+- Produces: nothing new (behavioral fix only).
+
+**Context:** The non-scheduled path `syncSessionStart` already guards `currentSession.id == session.id` (`:751`). The scheduled path has no local session object to compare ids against (it upserts from a snapshot), so guard on **profile identity** instead: the active session must belong to the scheduled profile before its `startTime` is reconciled.
+
+- [ ] **Step 1: Write the failing test.** The reconcile logic is inside a private async CAS closure, so test the extracted decision. Add a small pure helper and test it.
+
+Add to `StrategyManager.swift` (near `syncScheduleSessions`):
+
+```swift
+/// #226: a scheduled-session `.alreadyActive` reconcile may only overwrite the local
+/// session's startTime when the local active session actually belongs to the scheduled
+/// profile — otherwise a late CAS result for profile A would corrupt a since-started
+/// profile B. Pure so it is unit-testable without a live CAS round trip.
+static func shouldReconcileScheduledStartTime(
+  activeProfileId: UUID?,
+  scheduledProfileId: UUID,
+  localStartTime: Date?,
+  remoteStartTime: Date?
+) -> Bool {
+  guard let activeProfileId, activeProfileId == scheduledProfileId else { return false }
+  guard let remoteStartTime, let localStartTime else { return false }
+  return localStartTime != remoteStartTime
+}
+```
+
+Test file `FoqosTests/StrategyManagerScheduledReconcileTests.swift`:
+
+```swift
+import XCTest
+@testable import FamilyFoqos
+
+final class StrategyManagerScheduledReconcileTests: XCTestCase {
+  func testGivenActiveSessionForDifferentProfile_WhenScheduledCASResolves_ThenDoesNotReconcile() {
+    let now = Date()
+    let profileA = UUID()
+    let profileB = UUID()
+    let result = StrategyManager.shouldReconcileScheduledStartTime(
+      activeProfileId: profileB,          // user switched to B while A's CAS was in flight
+      scheduledProfileId: profileA,       // CAS result is for A
+      localStartTime: now,
+      remoteStartTime: now.addingTimeInterval(-3600))  // A's earlier start
+    XCTAssertFalse(result, "A late CAS result for A must not overwrite B's startTime")
+  }
+
+  func testGivenActiveSessionForSameProfileWithDrift_WhenScheduledCASResolves_ThenReconciles() {
+    let now = Date()
+    let profileA = UUID()
+    let result = StrategyManager.shouldReconcileScheduledStartTime(
+      activeProfileId: profileA,
+      scheduledProfileId: profileA,
+      localStartTime: now,
+      remoteStartTime: now.addingTimeInterval(-60))
+    XCTAssertTrue(result, "Same-profile startTime drift must still reconcile")
+  }
+
+  func testGivenMatchingStartTimes_WhenScheduledCASResolves_ThenNoReconcile() {
+    let now = Date()
+    let profileA = UUID()
+    XCTAssertFalse(
+      StrategyManager.shouldReconcileScheduledStartTime(
+        activeProfileId: profileA, scheduledProfileId: profileA,
+        localStartTime: now, remoteStartTime: now))
+  }
+}
+```
+
+- [ ] **Step 2: Run the test — expect FAIL** (`shouldReconcileScheduledStartTime` not defined):
+
+`xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=<UUID>' -only-testing:FoqosTests/StrategyManagerScheduledReconcileTests | xcpretty`
+
+- [ ] **Step 3: Add the helper (Step 1 code) and wire it into `syncScheduleSessions`.** Replace the reconcile guard (~lines 1071-1074):
+
+```swift
+          case .alreadyActive(let existing):
+            Log.info(
+              "Scheduled session joined existing from \(existing.sessionOriginDevice ?? "unknown")",
+              category: .strategy
+            )
+            // #226: only reconcile when the local active session belongs to THIS scheduled
+            // profile — a late CAS result for another profile must not overwrite its startTime.
+            if let currentSession = self.activeSession,
+              Self.shouldReconcileScheduledStartTime(
+                activeProfileId: currentSession.blockedProfile.id,
+                scheduledProfileId: activeScheduledSession.blockedProfileId,
+                localStartTime: currentSession.startTime,
+                remoteStartTime: existing.startTime),
+              let remoteStartTime = existing.startTime
+            {
+              currentSession.startTime = remoteStartTime
+              do {
+                try context.save()
+              } catch {
+                Log.error(
+                  "Failed to save reconciled scheduled session startTime: \(error.localizedDescription)",
+                  category: .strategy)
+              }
+              Log.info(
+                "Reconciled scheduled session startTime to \(remoteStartTime)", category: .strategy)
+            }
+```
+
+- [ ] **Step 4: Run the test — expect PASS.** Same command as Step 2.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/Utils/StrategyManager.swift FoqosTests/StrategyManagerScheduledReconcileTests.swift
+git commit -m "fix(#226): guard scheduled-session CAS reconcile on profile identity"
+```
+
+---
+
+### Task D4.2 (#227): targeted notification cancellation (stop wiping other profiles' reminders)
+
+**Files:**
+- Modify: `Foqos/Utils/TimersUtil.swift` (add stable identifiers for session/break reminders; retarget `cancelAllNotifications`)
+- Modify: `Foqos/Utils/StrategyManager.swift` (`scheduleReminder` ~1306, `scheduleBreakReminder` ~1321 pass stable identifiers)
+- Test: `FoqosTests/TimersUtilTargetedCancelTests.swift` (new)
+
+**Interfaces:**
+- Consumes: existing `TimersUtil.preActivationReminderPrefix`, `cancelAllPreActivationReminders(for:)`.
+- Produces: `TimersUtil.sessionReminderIdentifier(for profileId: UUID) -> String`, `TimersUtil.breakReminderIdentifier(for profileId: UUID) -> String`, `TimersUtil.sessionReminderPrefix`, `TimersUtil.breakReminderPrefix`; a retargeted `cancelAllNotifications()` that removes only session + break reminders (not other profiles' pending pre-activation reminders). #242 (Task D4.3) relies on `sessionReminderIdentifier` making a re-schedule idempotent.
+
+**Context:** `cancelAllNotifications()` (`TimersUtil.swift:279-294`) calls `removeAllPendingNotificationRequests()` — a system-wide wipe. Session/break reminders currently use random UUID identifiers (`scheduleNotification` `:220`), so they can't be targeted; the blanket wipe was the author's workaround, and it also deletes OTHER profiles' pending pre-activation reminders (which only re-schedule on app foreground). Fix: give session and break reminders **stable, prefixed** identifiers, then cancel only those two families plus (via the callers that already do so) the current profile's pre-activation reminders.
+
+- [ ] **Step 1: Write the failing test.** Test the pure identifier + the set of identifiers the targeted cancel computes.
+
+Add to `TimersUtil.swift` (near the existing pre-activation identifier helpers ~line 32-53):
+
+```swift
+  /// #227: stable identifier prefixes so session/break reminders can be cancelled by scope
+  /// instead of a system-wide `removeAllPendingNotificationRequests()` that also wipes other
+  /// profiles' pending pre-activation reminders.
+  static let sessionReminderPrefix = "session-reminder-"
+  static let breakReminderPrefix = "break-reminder-"
+
+  static func sessionReminderIdentifier(for profileId: UUID) -> String {
+    return "\(sessionReminderPrefix)\(profileId.uuidString)"
+  }
+
+  static func breakReminderIdentifier(for profileId: UUID) -> String {
+    return "\(breakReminderPrefix)\(profileId.uuidString)"
+  }
+
+  /// True iff `identifier` is a session or break reminder (the notifications the session
+  /// lifecycle owns and may cancel), NOT a pre-activation reminder (owned per-profile,
+  /// re-scheduled only on foreground — must survive a session start/stop of another profile).
+  static func isSessionOrBreakReminder(_ identifier: String) -> Bool {
+    return identifier.hasPrefix(sessionReminderPrefix) || identifier.hasPrefix(breakReminderPrefix)
+  }
+```
+
+Test file `FoqosTests/TimersUtilTargetedCancelTests.swift`:
+
+```swift
+import XCTest
+@testable import FamilyFoqos
+
+final class TimersUtilTargetedCancelTests: XCTestCase {
+  func testGivenReminderIdentifiers_WhenClassifying_ThenOnlySessionAndBreakAreOwned() {
+    let profileId = UUID()
+    XCTAssertTrue(
+      TimersUtil.isSessionOrBreakReminder(TimersUtil.sessionReminderIdentifier(for: profileId)))
+    XCTAssertTrue(
+      TimersUtil.isSessionOrBreakReminder(TimersUtil.breakReminderIdentifier(for: profileId)))
+    XCTAssertFalse(
+      TimersUtil.isSessionOrBreakReminder(
+        TimersUtil.preActivationReminderIdentifier(for: profileId, minutes: 5)),
+      "A pre-activation reminder must NOT be swept by a session start/stop")
+  }
+
+  func testGivenSameProfile_WhenBuildingSessionReminderId_ThenStableAcrossCalls() {
+    let profileId = UUID()
+    XCTAssertEqual(
+      TimersUtil.sessionReminderIdentifier(for: profileId),
+      TimersUtil.sessionReminderIdentifier(for: profileId),
+      "Stable id lets a re-schedule replace rather than duplicate (see #242)")
+  }
+}
+```
+
+- [ ] **Step 2: Run the test — expect FAIL** (identifiers not defined). Command as before, `-only-testing:FoqosTests/TimersUtilTargetedCancelTests`.
+
+- [ ] **Step 3: Add the identifier helpers (Step 1) and retarget `cancelAllNotifications`.** Replace `cancelAllNotifications()` (`TimersUtil.swift:279-294`):
+
+```swift
+  /// #227: cancel ONLY the session/break reminders this app schedules — never the blanket
+  /// `removeAllPendingNotificationRequests()`, which also deletes other profiles' pending
+  /// pre-activation reminders (they only re-schedule on app foreground). Pre-activation
+  /// reminders are cancelled per-profile by `cancelAllPreActivationReminders(for:)` at the
+  /// call sites that actually start/delete that profile.
+  func cancelAllNotifications() {
+    let center = UNUserNotificationCenter.current()
+    center.getPendingNotificationRequests { requests in
+      let ids = requests.map(\.request.identifier).filter(Self.isSessionOrBreakReminder)
+      if !ids.isEmpty {
+        center.removePendingNotificationRequests(withIdentifiers: ids)
+      }
+    }
+    // Also clear any DELIVERED session/break/pre-activation reminders (unchanged intent:
+    // a stale delivered reminder for an ended session should not linger).
+    center.getDeliveredNotifications { notifications in
+      let ids =
+        notifications
+        .map(\.request.identifier)
+        .filter {
+          Self.isSessionOrBreakReminder($0) || $0.hasPrefix(Self.preActivationReminderPrefix)
+        }
+      if !ids.isEmpty {
+        center.removeDeliveredNotifications(withIdentifiers: ids)
+      }
+    }
+  }
+```
+
+> NOTE: `getPendingNotificationRequests` is async (completion-based). The existing callers (`activateSession`, `stopBreak`, `.ended`) do not await cancellation — behavior is unchanged in that respect. The DELIVERED-side filter keeps the current behavior of clearing delivered pre-activation reminders.
+
+- [ ] **Step 4: Pass stable identifiers from the schedulers.** In `StrategyManager.swift`, `scheduleReminder` (~1313) — pass the profile-scoped identifier:
+
+```swift
+    timersUtil
+      .scheduleNotification(
+        title: profileName + " time!",
+        message: message,
+        seconds: TimeInterval(reminderTimeInSeconds),
+        identifier: TimersUtil.sessionReminderIdentifier(for: profile.id)
+      )
+```
+
+And `scheduleBreakReminder` (~1328):
+
+```swift
+    timersUtil.scheduleNotification(
+      title: "Break almost over!",
+      message: "Hope you enjoyed your break, starting " + profileName + " in 1 minute.",
+      seconds: TimeInterval(breakNotificationTimeInSeconds),
+      identifier: TimersUtil.breakReminderIdentifier(for: profile.id)
+    )
+```
+
+- [ ] **Step 5: Run the test — expect PASS.** Also run the full `TimersUtil`/`StrategyManager` suites to confirm no regression in existing cancellation tests.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add Foqos/Utils/TimersUtil.swift Foqos/Utils/StrategyManager.swift FoqosTests/TimersUtilTargetedCancelTests.swift
+git commit -m "fix(#227): cancel only session/break reminders, not all pending notifications"
+```
+
+---
+
+### Task D4.3 (#242): drop the duplicate post-session reminder in emergency unblock
+
+**Files:**
+- Modify: `Foqos/Utils/StrategyManager.swift` (`emergencyUnblock` closure, ~lines 717-724)
+- Test: `FoqosTests/EmergencyUnblockReminderTests.swift` (new)
+
+**Interfaces:**
+- Consumes: `ManualBlockingStrategy.stopBlocking` fires `.ended`, whose callback (`StrategyManager.swift:868-876`) already calls `endSessionActivity`, `scheduleReminder(profile:)`, and `stopTimer()`.
+- Produces: nothing new.
+
+**Context:** The `emergencyUnblock` closure (`:717-724`) calls `manualStrategy.stopBlocking` — which synchronously fires `.ended` (doing `endSessionActivity` + `scheduleReminder` + `stopTimer`) — and then **redundantly** calls `endSessionActivity`, `scheduleReminder`, and `stopTimer` again. With #227's stable identifier the second `scheduleReminder` now *replaces* the first rather than duplicating; but the redundant calls are still dead work and mask intent. Remove them (the issue's directed fix).
+
+- [ ] **Step 1: Write the failing test.** Assert the closure body after `stopBlocking` performs no extra reminder scheduling. Since the closure isn't directly reachable, assert the invariant structurally via a spy: inject a `TimersUtil` spy that counts `scheduleNotification(identifier:)` calls with the session-reminder prefix during an emergency unblock.
+
+> If a `TimersUtil` seam does not already exist for injection, use the existing `timersUtil` stored property on `StrategyManager` (it is settable in tests via the shared instance's initializer). Add the spy in the test target:
+
+```swift
+import XCTest
+@testable import FamilyFoqos
+
+final class EmergencyUnblockReminderTests: XCTestCase {
+  /// Verifies the emergency-unblock closure does not schedule the post-session reminder a
+  /// second time on top of the `.ended` callback. With #227's stable session-reminder id a
+  /// duplicate would collapse to one, but the redundant calls must still be gone (#242).
+  func testGivenReminderSet_WhenEmergencyUnblock_ThenSessionReminderScheduledExactlyOnce() throws {
+    // Arrange a profile with a reminder time, a manual active session, and a counting spy.
+    // (Use the existing in-memory ModelContainer test helper `makeInMemoryContext()`.)
+    let ctx = try makeInMemoryContext()
+    let profile = BlockedProfiles(name: "Focus")
+    profile.reminderTimeInSeconds = 1800
+    ctx.insert(profile)
+    let spy = CountingTimersUtil()
+    let manager = StrategyManager(timersUtil: spy)  // DI seam
+    _ = manager.startManualSessionForTest(profile: profile, context: ctx)
+
+    // Act
+    try awaitEmergencyUnblock(manager, context: ctx)  // helper awaits the async throwing call
+
+    // Assert
+    XCTAssertEqual(
+      spy.scheduleCount(prefix: TimersUtil.sessionReminderPrefix), 1,
+      "Emergency unblock must schedule the post-session reminder exactly once")
+  }
+}
+```
+
+> `CountingTimersUtil`, `makeInMemoryContext()`, `startManualSessionForTest`, and `awaitEmergencyUnblock` are test-support seams. If `StrategyManager` has no `init(timersUtil:)` or `startManualSessionForTest`, add minimal `internal` test hooks (a settable `timersUtil` and a thin start wrapper) rather than exposing production internals broadly. Keep the spy in `FoqosTests/Support/`.
+
+- [ ] **Step 2: Run the test — expect FAIL** (reminder scheduled twice ⇒ count 2, or, post-#227, the redundant call still runs). Command `-only-testing:FoqosTests/EmergencyUnblockReminderTests`.
+
+- [ ] **Step 3: Remove the redundant closure calls.** Replace the `emergencyUnblock` closure (`:717-724`):
+
+```swift
+    ) { [weak self] ctx, sess in
+      guard let self else { return }
+      let manualStrategy = self.getStrategy(id: ManualBlockingStrategy.id)
+      // `.ended` (wired by getStrategy) already runs endSessionActivity + scheduleReminder +
+      // stopTimer for this profile (#242) — do NOT repeat them here or the reminder double-fires.
+      _ = manualStrategy.stopBlocking(context: ctx, session: sess)
+    }
+```
+
+- [ ] **Step 4: Run the test — expect PASS.**
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/Utils/StrategyManager.swift FoqosTests/EmergencyUnblockReminderTests.swift FoqosTests/Support/CountingTimersUtil.swift
+git commit -m "fix(#242): stop emergency unblock scheduling the post-session reminder twice"
+```
+
+---
+
+### Task D4.4 (#245): clear pre-activation reminders + stop-only DeviceActivity on profile delete
+
+**Files:**
+- Modify: `Foqos/Models/BlockedProfiles.swift` (`deleteProfile`, ~lines 497-522)
+- Test: `FoqosTests/DeleteProfileCleanupTests.swift` (new)
+
+**Interfaces:**
+- Consumes: `TimersUtil.cancelAllPreActivationReminders(for: UUID)` (static, `TimersUtil.swift:67`), `DeviceActivityCenterUtil.removeStopScheduleActivity(for: BlockedProfiles)` (`:148`).
+- Produces: nothing new. `deleteProfile` is the single delete path for all six call sites (incl. remote-apply `SyncApplyService.swift:136` and funnel `MutationFunnel.swift:133`), so the fix lands once and applies uniformly regardless of delete origin.
+
+**Context:** `deleteProfile` calls only `removeScheduleTimerActivities(for:)` (the start-schedule), leaving (a) pending pre-activation reminder notifications that still fire for the deleted profile, and (b) the stop-only `StopScheduleTimerActivity` registered as a ghost. Add the two missing cleanups.
+
+- [ ] **Step 1: Write the failing test.** Because notification/DeviceActivity centers aren't unit-testable directly, assert against a small extractable side-effect list. Introduce a testable seam: extract the cleanup into a pure helper enumerating the cleanup actions, and assert it includes both.
+
+Add to `BlockedProfiles.swift`:
+
+```swift
+  /// #245: the side-effects `deleteProfile` must perform beyond model deletion. Enumerated so
+  /// the set is unit-testable (the concrete centers are not).
+  enum DeleteCleanupAction: Equatable {
+    case removeStartSchedule
+    case removeStopSchedule
+    case cancelPreActivationReminders
+  }
+
+  static func deleteCleanupActions() -> [DeleteCleanupAction] {
+    [.removeStartSchedule, .removeStopSchedule, .cancelPreActivationReminders]
+  }
+```
+
+Test `FoqosTests/DeleteProfileCleanupTests.swift`:
+
+```swift
+import XCTest
+@testable import FamilyFoqos
+
+final class DeleteProfileCleanupTests: XCTestCase {
+  func testGivenProfileDelete_WhenEnumeratingCleanup_ThenIncludesStopScheduleAndReminders() {
+    let actions = BlockedProfiles.deleteCleanupActions()
+    XCTAssertTrue(actions.contains(.removeStopSchedule),
+      "#245: stop-only DeviceActivity must be removed on delete")
+    XCTAssertTrue(actions.contains(.cancelPreActivationReminders),
+      "#245: pending pre-activation reminders must be cancelled on delete")
+    XCTAssertTrue(actions.contains(.removeStartSchedule))
+  }
+}
+```
+
+- [ ] **Step 2: Run the test — expect FAIL** (`deleteCleanupActions` not defined). `-only-testing:FoqosTests/DeleteProfileCleanupTests`.
+
+- [ ] **Step 3: Add the enum/helper (Step 1) and the two calls into `deleteProfile`.** Replace lines ~516-521:
+
+```swift
+    // Remove the schedule restrictions (start schedule)
+    DeviceActivityCenterUtil.removeScheduleTimerActivities(for: profile)
+    // #245: also remove the stop-only DeviceActivity (separate name, not covered above) and
+    // cancel any pending pre-activation reminders so a deleted profile fires neither.
+    DeviceActivityCenterUtil.removeStopScheduleActivity(for: profile)
+    TimersUtil.cancelAllPreActivationReminders(for: profile.id)
+
+    // Then delete the profile
+    context.delete(profile)
+    // Defer context saving as the reference to the profile might be used
+```
+
+- [ ] **Step 4: Run the test — expect PASS.**
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/Models/BlockedProfiles.swift FoqosTests/DeleteProfileCleanupTests.swift
+git commit -m "fix(#245): cancel pre-activation reminders and stop-only schedule on profile delete"
+```
+
+---
+
+### Task D4.5 (#266): re-snapshot the app group after V1→V2 migration
+
+**Files:**
+- Modify: `Foqos/Utils/ProfileMigrationUtil.swift` (`migrateProfilesIfNeeded`, ~lines 32-34)
+- Modify: `Foqos/Utils/StrategyManager.swift` (session-end deferred migration, ~lines 892-905)
+- Test: `FoqosTests/MigrationSnapshotTests.swift` (new), mirroring `ProfileSaveSnapshotTests`
+
+**Interfaces:**
+- Consumes: `BlockedProfiles.updateSnapshot(for: BlockedProfiles)` (`BlockedProfiles.swift:578`) — the same helper the save path and `cloneProfile` use.
+- Produces: nothing new.
+
+**Context:** After migration + `context.save()`, both migration paths reschedule DeviceActivity but never refresh the app-group `ProfileSnapshot`, so the `FoqosDeviceMonitor` extension reads a pre-migration shape until the profile is next edited. The masking legacy fallback (extension `ScheduleTimerActivity`) is slated for removal in #59 — coordinate so the fallback is NOT removed before this ships.
+
+- [ ] **Step 1: Write the failing test.** Migrate a V1 profile, assert the written snapshot reflects the migrated trigger config.
+
+```swift
+import XCTest
+@testable import FamilyFoqos
+
+final class MigrationSnapshotTests: XCTestCase {
+  func testGivenV1Profile_WhenMigrated_ThenAppGroupSnapshotReflectsV2Config() throws {
+    let now = Date()
+    let ctx = try makeInMemoryContext()
+    let profile = makeLegacyV1Profile(now: now)  // helper: sets blockingStrategyId, no triggers
+    ctx.insert(profile)
+    try ctx.save()
+
+    ProfileMigrationUtil.migrateProfilesIfNeeded(context: ctx)
+
+    XCTAssertFalse(profile.needsMigration, "profile should have migrated")
+    let snapshot = BlockedProfiles.getSnapshot(for: profile)
+    XCTAssertEqual(snapshot.id, profile.id)
+    // Assert the snapshot carries the migrated (V2) trigger/schedule shape, not the V1 default.
+    XCTAssertEqual(
+      snapshot.profileSchemaVersion, profile.profileSchemaVersion,
+      "#266: snapshot must be re-written with the migrated schema version")
+  }
+}
+```
+
+> `makeLegacyV1Profile(now:)` builds a profile with `needsMigration == true` (V1 `blockingStrategyId` set, V2 triggers absent). If a helper already exists in the migration tests, reuse it. `getSnapshot(for:)` reads the same struct `updateSnapshot(for:)` writes, so asserting on it verifies the write path.
+
+- [ ] **Step 2: Run the test — expect FAIL** (snapshot still pre-migration). `-only-testing:FoqosTests/MigrationSnapshotTests`.
+
+- [ ] **Step 3a: Add the re-snapshot in `ProfileMigrationUtil`.** In the `if migratedCount > 0` block (~32-34):
+
+```swift
+      if migratedCount > 0 {
+        try context.save()
+        Log.info("Migrated \(migratedCount) profiles to schema V2", category: .app)
+        // Register schedules and refresh the app-group snapshot for migrated profiles (#266):
+        // the extension must read the migrated V2 shape, not the pre-migration snapshot.
+        for profile in migratedProfiles {
+          DeviceActivityCenterUtil.scheduleTimerActivity(for: profile)
+          BlockedProfiles.updateSnapshot(for: profile)
+        }
+      }
+```
+
+- [ ] **Step 3b: Add the re-snapshot in the session-end migration.** In `StrategyManager.swift` (~904, after the successful save + reschedule):
+
+```swift
+            Log.info(
+              "Migrated deferred profile '\(endedProfile.name)' on session end", category: .app)
+            DeviceActivityCenterUtil.scheduleTimerActivity(for: endedProfile)
+            BlockedProfiles.updateSnapshot(for: endedProfile)  // #266: refresh app-group snapshot
+```
+
+- [ ] **Step 4: Run the test — expect PASS.**
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/Utils/ProfileMigrationUtil.swift Foqos/Utils/StrategyManager.swift FoqosTests/MigrationSnapshotTests.swift
+git commit -m "fix(#266): refresh app-group snapshot after V1 to V2 migration"
+```
+
+---
+
+### D4 skeptic pass
+
+**Verdict: SOUND-WITH-FIXES.** All five production fixes are correct against current main (#226 helper wiring compiles — `activeScheduledSession.blockedProfileId` is in closure scope; #245's `deleteProfile` is confirmed the single delete path for all 6 sites with idempotent helpers; #242's dead `.ended`-duplicate chain confirmed; #266's `updateSnapshot`/`scheduleTimerActivity` exist). One production correction and three test corrections:
+
+- **[MAJOR — production] #227's new `cancelAllNotifications` async query races the immediate reschedule.** Replacing the synchronous blanket wipe with `center.getPendingNotificationRequests { … removePendingNotificationRequests(session/break ids) }` makes cancellation async; on the `.ended` path `cancelAll()` is immediately followed by `scheduleReminder(endedProfile)` (a stable-id add, itself 2 async hops). The two now race — if the pending snapshot is captured *after* the new reminder lands, the filter matches it and deletes the just-scheduled reminder. **Amend Task D4.2** to cancel owned reminders **synchronously via a tracked identifier set**, never an async query:
+
+  ```swift
+  // TimersUtil — tracked so owned reminders cancel synchronously (no async snapshot race, #227).
+  private var ownedReminderIdentifiers: Set<String> = []
+
+  // In scheduleNotification, at CALL time (before the async auth/add), when the id is owned:
+  if let identifier, Self.isSessionOrBreakReminder(identifier) {
+    ownedReminderIdentifiers.insert(identifier)
+  }
+
+  func cancelAllNotifications() {
+    let ids = Array(ownedReminderIdentifiers)
+    ownedReminderIdentifiers.removeAll()
+    let center = UNUserNotificationCenter.current()
+    center.removePendingNotificationRequests(withIdentifiers: ids)  // synchronous enqueue
+    center.removeDeliveredNotifications(withIdentifiers: ids)
+    // Delivered pre-activation cleanup (async, harmless — those already fired):
+    center.getDeliveredNotifications { notifications in
+      let pa = notifications.map(\.request.identifier)
+        .filter { $0.hasPrefix(Self.preActivationReminderPrefix) }
+      if !pa.isEmpty { center.removeDeliveredNotifications(withIdentifiers: pa) }
+    }
+  }
+  ```
+
+  `removePendingNotificationRequests(oldId)` then `add(newId)` (same profile stable id) are enqueued in program order on the center's serial queue, so the reschedule wins deterministically. Update the Task D4.2 NOTE: the ordering change is now handled by synchronous tracked-set cancellation, not by hoping the old 1-hop-vs-2-hop timing holds.
+
+- **[MAJOR — test seam] #242's spy test references non-existent injection.** `StrategyManager.timersUtil` is `private let timersUtil = TimersUtil()` (`:30`) with an 8-param init (no `timersUtil:`), and `TimersUtil` is `final` with no protocol — so `StrategyManager(timersUtil: spy)` and `CountingTimersUtil` cannot compile. **Amend Task D4.2/D4.3** to add a minimal seam: introduce `protocol TimersUtilScheduling` (the methods `StrategyManager` calls — `scheduleNotification(...)`, `cancelAll()`, `cancelAllNotifications()`, `cancelAllBackgroundTasks()`), conform `TimersUtil` to it, and change the stored property to `private let timersUtil: TimersUtilScheduling` with a 9th init param `timersUtil: TimersUtilScheduling = TimersUtil()`. Then `CountingTimersUtil` conforms to the protocol and the #242 spy test compiles. (This seam also makes #227 unit-testable.)
+
+- **[MAJOR — test seam] #266's test can't compile or fail as written.** `SharedData.ProfileSnapshot` has **no** `profileSchemaVersion` field, and `BlockedProfiles.getSnapshot(for:)` **recomputes** from the live (already-migrated) profile rather than reading persisted storage — so it reflects the migrated shape regardless of whether `updateSnapshot` ran (Step 2 can't FAIL). **Amend Task D4.5 Step 1** to mirror `ProfileSaveSnapshotTests`: `SharedData.configure(suite: UserDefaults(suiteName: …)!)` in `setUp`; build the context via `TestModelContainer.create().mainContext`; after `migrateProfilesIfNeeded`, assert on the **persisted** read `SharedData.snapshot(for: profile.id.uuidString)?.<field migration changes>` (a schedule/trigger field the snapshot actually carries, e.g. the migrated schedule), **not** `getSnapshot(...)` and **not** `profileSchemaVersion`.
+
+- **[MINOR — test helper] `makeInMemoryContext()` does not exist** (used in D4.3/D4.5 and reused in #311/#305 tests). Replace with `let ctx = try TestModelContainer.create().mainContext`, or add one shared helper wrapping it. Apply everywhere the plan wrote `makeInMemoryContext()`.
+
+- **[MINOR — test strength] #245's `deleteCleanupActions()` test is enumeration-only** — it asserts a literal contains its own cases and never invokes `deleteProfile`, so it wouldn't catch a regression that removes the two new calls. Either keep it as an intent-documentation test **and** add a behavioral test that injects spies for the DeviceActivity/notification centers to observe `deleteProfile`'s actual side-effects, or state explicitly that the enumeration test is documentation-only. The production fix itself is correct.
+
+---
+
+# Mini-plan #311 — active-anywhere edit/delete locks (reduced scope)
+
+**Re-triage result (2026-07-12, base `3a5eee2`): PARTIAL — one premise is stale; scope is reduced, not a rebuild.**
+
+**What already works (grounded, contradicts the issue's hints):**
+- **Locations already have in-use protection.** `SavedLocationsView.locationsInUseByActiveProfiles` (`:26-41`) computes which locations a running profile's geofence stop rule depends on, and `SavedLocationCard` disables the card (`.disabled(isDisabled)`, `SavedLocationCard.swift:11,68`) + shows "In use by …". The issue's "locations have no protection at all" is no longer true.
+- **Remote sessions already mirror across devices** for profiles that have apps selected here: `SyncApplyService.applySessionState` (`:619`) → `StrategyManager.startRemoteSession` (`:1415`) creates a real local active `BlockedProfileSession`, which flips both `isBlocking` (profiles) and `locationsInUseByActiveProfiles` (locations). So active-anywhere already holds for app-selected profiles.
+
+**The precise remaining gap (this is the whole scope):** `startRemoteSession` **early-returns without creating a local session** when `profile.needsAppSelection == true` (`StrategyManager.swift:1433-1438`). On a device that never selected apps for the profile — exactly the issue's device B — a profile active elsewhere is **not mirrored locally**, so both locks read "not active" and the profile is editable / its stop-rule location deletable. Both locks key off the local mirror, never the authoritative synced record.
+
+**Design (satisfies the maintainer's rule "active anywhere ⇒ locked everywhere"):** maintain an observable set of profile ids the *synced session records* report active, populated directly in `applySessionState` **regardless of whether the local mirror materializes**. This surfaces already-synced state — **no new sync data, no new SwiftData schema**. The set is persisted to a fixed `UserDefaults` key so it survives relaunch (the skeptic pass corrected an earlier "in-memory suffices" assumption — the `CKSyncEngine` change token is durable, so an unchanged active session record is *not* re-delivered on relaunch and an in-memory set would silently empty). Then OR that set into both locks and add a hard guard to the location delete (today the block is UI-only). The accepted offline-device limitation (a device that never heard the start can still delete) is unchanged; a device that *did* hear it now keeps the lock across restarts, over-locking safely until it fetches the stop.
+
+**Explicitly out of scope (per issue):** blocking the running profile from *stopping* when its location disappears — rejected by the maintainer. This plan does not add it.
+
+### Task 311.0: Citation refresh
+
+- [ ] **Step 1:** Confirm the gap is unchanged:
+
+```bash
+grep -n "needsAppSelection" Foqos/Utils/StrategyManager.swift            # startRemoteSession early-return (~1433)
+grep -n "private var isBlocking" Foqos/Views/BlockedProfileView.swift    # ~115
+grep -n "locationsInUseByActiveProfiles\|profile.sessions.valid.contains" Foqos/Views/SavedLocationsView.swift  # ~26-41
+grep -n "protocol SessionController" Foqos/CloudKit/SessionController.swift
+grep -n "func applySessionState" Foqos/CloudKit/SyncEngine/SyncApplyService.swift  # ~619
+```
+
+Expected: all present and local-session-based; `applySessionState` still calls only `startRemoteSession`/`stopRemoteSession`. Confirm no stop-condition type other than `geofenceRule` references `SavedLocation` (`grep -rn "locationReferences\|savedLocationId" Foqos/Models`).
+
+---
+
+### Task 311.1: observable `remotelyActiveProfileIds` maintained from synced session state
+
+**Files:**
+- Modify: `Foqos/CloudKit/SessionController.swift` (add protocol method)
+- Modify: `Foqos/Utils/StrategyManager.swift` (add `@Published` set + implement)
+- Modify: `Foqos/CloudKit/SyncEngine/SyncApplyService.swift` (`applySessionState` maintains it)
+- Test: `FoqosTests/RemotelyActiveProfilesTests.swift` (new)
+
+**Interfaces:**
+- Consumes: `ProfileSessionRecord.isActive`, `.profileId`, `.lastModifiedBy`; `SessionController` injected into `SyncApplyService`.
+- Produces: `SessionController.setRemoteSessionActive(_ isActive: Bool, profileId: UUID)`; `StrategyManager.remotelyActiveProfileIds: Set<UUID>` (`@Published private(set)`). Tasks 311.2/311.3 read `StrategyManager.shared.remotelyActiveProfileIds`.
+
+- [ ] **Step 1: Write the failing test.** Drive `applySessionState` through a `SyncApplyService` with a stub `SessionController` and assert the set tracks the synced record (independent of mirror success). Since `applySessionState` is private, test through the public `applyFetchedModification` with a `ProfileSessionRecord` CKRecord, OR expose an `internal` seam. Prefer a focused test on `StrategyManager`'s set maintenance:
+
+```swift
+import XCTest
+@testable import FamilyFoqos
+
+@MainActor
+final class RemotelyActiveProfilesTests: XCTestCase {
+  func testGivenRemoteActiveRecord_WhenApplied_ThenProfileMarkedRemotelyActive() {
+    let manager = StrategyManager.shared
+    manager.resetRemotelyActiveForTest()  // internal test hook
+    let profileId = UUID()
+
+    manager.setRemoteSessionActive(true, profileId: profileId)
+    XCTAssertTrue(manager.remotelyActiveProfileIds.contains(profileId))
+
+    manager.setRemoteSessionActive(false, profileId: profileId)
+    XCTAssertFalse(manager.remotelyActiveProfileIds.contains(profileId))
+  }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`setRemoteSessionActive` / `remotelyActiveProfileIds` undefined). `-only-testing:FoqosTests/RemotelyActiveProfilesTests`.
+
+- [ ] **Step 3a: Extend the protocol.** `SessionController.swift`:
+
+```swift
+@MainActor
+protocol SessionController: AnyObject {
+  var activeSession: BlockedProfileSession? { get }
+  func startRemoteSession(context: ModelContext, profileId: UUID, sessionId: UUID, startTime: Date)
+  func stopRemoteSession(context: ModelContext, profileId: UUID)
+  /// #311: record the synced session record's active state for a profile, independent of
+  /// whether a local session could be materialized (a device without app selection cannot
+  /// mirror the session but must still treat the profile as active-anywhere for edit/delete locks).
+  func setRemoteSessionActive(_ isActive: Bool, profileId: UUID)
+}
+```
+
+- [ ] **Step 3b: Implement on `StrategyManager`.** Add near `activeSession` (`:23`):
+
+```swift
+  /// #311: profile ids reported active by a SYNCED session record originating on another
+  /// device — even when this device cannot mirror the session (no app selection). OR'd into
+  /// the profile edit/delete lock and the location in-use check so "active anywhere ⇒ locked
+  /// everywhere". In-memory only: the bootstrap fetch re-applies active session records on
+  /// relaunch and re-populates this; an offline device that hasn't fetched is the accepted
+  /// limitation documented on #311.
+  @Published private(set) var remotelyActiveProfileIds: Set<UUID> = []
+
+  func setRemoteSessionActive(_ isActive: Bool, profileId: UUID) {
+    if isActive {
+      remotelyActiveProfileIds.insert(profileId)
+    } else {
+      remotelyActiveProfileIds.remove(profileId)
+    }
+  }
+
+  #if DEBUG
+  func resetRemotelyActiveForTest() { remotelyActiveProfileIds = [] }
+  #endif
+```
+
+- [ ] **Step 3c: Maintain it in `applySessionState`.** After the own-origin filter (`SyncApplyService.swift:621-624`), before the `localActive` computation:
+
+```swift
+  private func applySessionState(_ session: ProfileSessionRecord) {
+    let profileId = session.profileId
+    if session.lastModifiedBy == deviceId {
+      SyncDiagnostics.sessionApply(profileId: profileId, branch: "own_origin_noop")
+      return
+    }
+    // #311: record the synced active state BEFORE attempting to mirror — startRemoteSession
+    // early-returns for a profile without local app selection, but the lock must still apply.
+    sessionController.setRemoteSessionActive(session.isActive, profileId: profileId)
+    let localActive = sessionController.activeSession?.blockedProfile.id == profileId
+    if session.isActive && !localActive {
+      // ... unchanged startRemoteSession call ...
+```
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/CloudKit/SessionController.swift Foqos/Utils/StrategyManager.swift Foqos/CloudKit/SyncEngine/SyncApplyService.swift FoqosTests/RemotelyActiveProfilesTests.swift
+git commit -m "feat(#311): track synced active-session state for active-anywhere locks"
+```
+
+---
+
+### Task 311.2: widen the profile edit/delete lock
+
+**Files:**
+- Modify: `Foqos/Views/BlockedProfileView.swift` (`isBlocking`, ~115-117)
+- Test: covered by 311.1 unit + a `ProfileEditGate`-level assertion (below)
+
+**Context:** `isBlocking` (`:115-117`) gates both the editing form (via `editingDisabled`) and the delete/NFC menu (`if !isBlocking`, `:611`). Widening it to include remote-active profiles closes the profile half in one move — the delete confirmation (`:809-865`) is unreachable without the menu, so no separate guard is needed there.
+
+- [ ] **Step 1: Write the failing test** (`ProfileEditGate` already pure — assert remote-active disables editing). Extend `FoqosTests` `ProfileEditGateTests` (or add one):
+
+```swift
+func testGivenRemoteActiveProfile_WhenComputingIsBlocking_ThenEditingDisabled() {
+  // isBlocking is (local active) OR (remotely active). Simulate the OR result = true.
+  XCTAssertTrue(
+    ProfileEditGate.editingDisabled(
+      isBlocking: true, isManaged: false, isUnlocked: true, mode: .individual, lockActive: false),
+    "A profile active on another device must disable editing")
+}
+```
+
+- [ ] **Step 2: Run — expect PASS already** (the gate is correct; the bug is the `isBlocking` input). This documents intent; the behavioral fix is Step 3.
+
+- [ ] **Step 3: Widen `isBlocking`.** Replace `BlockedProfileView.swift:115-117`:
+
+```swift
+  private var isBlocking: Bool {
+    if strategyManager.activeSession?.isActive == true { return true }
+    // #311: also locked when a SYNCED session reports this profile active on another device.
+    if let id = profile?.id, strategyManager.remotelyActiveProfileIds.contains(id) { return true }
+    return false
+  }
+```
+
+- [ ] **Step 4: Manual/preview verification note.** `isBlocking` now also hides the delete/NFC menu and disables the form when the profile is active on another device. Confirm by code inspection that `editingDisabled` (`:131`) and the `if !isBlocking` menu guard (`:611`) both consume this property (they do).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/Views/BlockedProfileView.swift FoqosTests/ProfileEditGateTests.swift
+git commit -m "fix(#311): lock profile edit/delete when active on any device"
+```
+
+---
+
+### Task 311.3: widen the location in-use lock + hard delete guard + cross-device message
+
+**Files:**
+- Modify: `Foqos/Views/SavedLocationsView.swift` (`locationsInUseByActiveProfiles` ~26-41; `deleteLocation` ~194)
+- Modify: `Foqos/Components/Settings/SavedLocationCard.swift` (message wording — optional)
+- Test: `FoqosTests/LocationInUseTests.swift` (new)
+
+**Context:** `locationsInUseByActiveProfiles` currently only checks `profile.sessions.valid.contains { $0.isActive }` (local). Widen to also treat a profile as active when it is in `remotelyActiveProfileIds`. The card `.disabled` is UI-only, so also add a **hard guard** inside `deleteLocation` (defense-in-depth) and surface the cross-device message.
+
+- [ ] **Step 1: Write the failing test.** Assert the in-use computation includes locations of a remotely-active profile. Extract the predicate to a pure helper so it is testable without SwiftUI:
+
+Add to `SavedLocationsView.swift` (or a small `LocationInUseResolver` type):
+
+```swift
+  /// #311: a profile counts as "active" for location-locking if it has a local active session
+  /// OR a synced session reports it active on another device. Pure for unit testing.
+  static func locationsInUse(
+    profiles: [BlockedProfiles],
+    hasLocalActiveSession: (BlockedProfiles) -> Bool,
+    remotelyActiveProfileIds: Set<UUID>
+  ) -> [UUID: String] {
+    var result: [UUID: String] = [:]
+    for profile in profiles {
+      let active = hasLocalActiveSession(profile) || remotelyActiveProfileIds.contains(profile.id)
+      guard active, let rule = profile.geofenceRule else { continue }
+      for ref in rule.locationReferences {
+        result[ref.savedLocationId] = profile.name
+      }
+    }
+    return result
+  }
+```
+
+Test `FoqosTests/LocationInUseTests.swift`:
+
+```swift
+import XCTest
+@testable import FamilyFoqos
+
+@MainActor
+final class LocationInUseTests: XCTestCase {
+  func testGivenRemotelyActiveProfileWithGeofence_WhenComputingInUse_ThenLocationLocked() throws {
+    let ctx = try makeInMemoryContext()
+    let locationId = UUID()
+    let profile = makeProfileWithGeofence(locationId: locationId, in: ctx)  // helper
+    let inUse = SavedLocationsView.locationsInUse(
+      profiles: [profile],
+      hasLocalActiveSession: { _ in false },       // NOT locally active (device B)
+      remotelyActiveProfileIds: [profile.id])       // active on another device
+    XCTAssertEqual(inUse[locationId], profile.name,
+      "#311: a location used by a profile running on another device must be locked here")
+  }
+
+  func testGivenInactiveProfile_WhenComputingInUse_ThenLocationFree() throws {
+    let ctx = try makeInMemoryContext()
+    let locationId = UUID()
+    let profile = makeProfileWithGeofence(locationId: locationId, in: ctx)
+    let inUse = SavedLocationsView.locationsInUse(
+      profiles: [profile], hasLocalActiveSession: { _ in false }, remotelyActiveProfileIds: [])
+    XCTAssertNil(inUse[locationId])
+  }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`locationsInUse` undefined). `-only-testing:FoqosTests/LocationInUseTests`.
+
+- [ ] **Step 3a: Add the helper (Step 1) and route the computed property through it.** Replace `locationsInUseByActiveProfiles` (`:26-41`):
+
+```swift
+  private var locationsInUseByActiveProfiles: [UUID: String] {
+    Self.locationsInUse(
+      profiles: profiles,
+      hasLocalActiveSession: { $0.sessions.valid.contains { $0.isActive } },
+      remotelyActiveProfileIds: strategyManager.remotelyActiveProfileIds)
+  }
+```
+
+> Add `@ObservedObject private var strategyManager = StrategyManager.shared` to the view (it is a shared `ObservableObject`; adding it makes the list re-render when `remotelyActiveProfileIds` changes).
+
+- [ ] **Step 3b: Hard guard in `deleteLocation`** (defense-in-depth beyond the card `.disabled`). At the top of `deleteLocation(_:)` (`:194`):
+
+```swift
+  private func deleteLocation(_ location: SavedLocation) {
+    let locationId = location.id
+    // #311: never delete a location an active profile's stop rule depends on — even if the
+    // UI disable was bypassed. Surface the cross-device reason.
+    if let profileName = locationsInUseByActiveProfiles[locationId] {
+      errorMessage =
+        "\"\(location.name)\" is in use by \"\(profileName)\", which is currently running "
+        + "on this or another device. Stop that profile before deleting the location."
+      return
+    }
+    do {
+      // ... unchanged existing body ...
+```
+
+- [ ] **Step 3c (optional): distinguish the card message.** If desired, pass a bool to `SavedLocationCard` to say "on another device" when the profile is only remotely active. Minimal version keeps the existing "In use by …" label; the hard-guard message above already conveys the cross-device reason on the delete attempt.
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/Views/SavedLocationsView.swift Foqos/Components/Settings/SavedLocationCard.swift FoqosTests/LocationInUseTests.swift
+git commit -m "fix(#311): lock stop-rule locations when their profile runs on any device"
+```
+
+### #311 skeptic pass
+
+**Verdict: SOUND-WITH-FIXES.** The reduced-scope diagnosis holds. Apply these amendments:
+
+- **[BLOCKER] Second `SessionController` conformer.** `MockSessionController` (`FoqosTests/Mocks/MockSessionController.swift`) hand-implements every protocol method and is used by ≥5 test files (`SyncApplyServiceTests`, `SyncEngineControllerTests`, …). Adding `setRemoteSessionActive` to the protocol breaks their compile. **Amend Task 311.1 Files** to include `FoqosTests/Mocks/MockSessionController.swift`, and in Step 3a implement it there:
+
+  ```swift
+  var setRemoteSessionActiveCalls: [(Bool, UUID)] = []
+  func setRemoteSessionActive(_ isActive: Bool, profileId: UUID) {
+    setRemoteSessionActiveCalls.append((isActive, profileId))
+  }
+  ```
+
+- **[MAJOR — design correction] The in-memory set does NOT survive relaunch.** My claim "the bootstrap fetch re-applies active session records on relaunch and re-populates this" is **false**: the `CKSyncEngine` change token is durably persisted (`SyncEngineStore.engineState`, restored via `driverFactory` at `SyncEngineController.swift:113`), so an *unchanged* active session record is **not** re-delivered after a normal relaunch → the set would be empty and the lock would silently open. **Amend Task 311.1** to make `remotelyActiveProfileIds` **durable**: back it with a fixed-key `UserDefaults` array (non-namespaced, mirroring `PreAttachDeleteBuffer`'s approach), written in `setRemoteSessionActive`, and load it into the `@Published` set at `StrategyManager` init. Over-locking briefly after relaunch (if the remote session stopped while this device was offline) is the safe direction — it self-heals when the stop record is next fetched (`applySessionState(!isActive)` clears it). Revised property + method:
+
+  ```swift
+  @Published private(set) var remotelyActiveProfileIds: Set<UUID> = RemotelyActiveStore.load()
+
+  func setRemoteSessionActive(_ isActive: Bool, profileId: UUID) {
+    if isActive { remotelyActiveProfileIds.insert(profileId) }
+    else { remotelyActiveProfileIds.remove(profileId) }
+    RemotelyActiveStore.save(remotelyActiveProfileIds)  // durable across relaunch
+  }
+  ```
+
+  where `RemotelyActiveStore` is a tiny fixed-key (`family_foqos_remotely_active_profiles`) UserDefaults `[String]` load/save helper (add it as Task 311.1 Step 3b-bis with its own test).
+
+- **[MINOR] Clear the set on the session-record deletion path too.** `setRemoteSessionActive` is wired only into `applySessionState` (modification path). The §5.2 deletion path — `applyFetchedDeletion` → `stopSessionForDeletedRecord` (`SyncApplyService.swift:229`) — must also clear it. **Amend Task 311.1 Step 3c** to call `sessionController.setRemoteSessionActive(false, profileId:)` for the parsed profile id there, keeping the modification and deletion paths symmetric.
+
+- **[RESOLVED] Own-active session double-count.** Own-origin session records are filtered in `applySessionState` (`lastModifiedBy == deviceId` → no-op return) before `setRemoteSessionActive`, so a device's own active session never enters the set; the local `activeSession` branch of `isBlocking` covers it. The new-profile (`profile?.id == nil`) case correctly returns not-blocking. No change needed.
+
+---
+
+# Mini-plan #305 — durable pre-attach deferred deletes
+
+**Re-triage result (2026-07-12, base `3a5eee2`): STILL-PRESENT** — the follow-up gap PR #312 deliberately left open. Two pre-attach loss variants both reproduce:
+- **Variant A (enabled sync):** the delete verbs park record names in the **in-memory** `deferredDeleteRecordNames: Set<String>` (`ProfileSyncManager.swift:51`; inserts at `:250,256,275,281,327,333`) on `.notAttached`, drained via `enqueueDeferredDelete` (`:361`) at attach — an app kill before attach loses the set.
+- **Variant B (disabled sync, the #312 pre-controller window):** `recordDisabledDeleteTombstone` (`:341-349`) drops the intent with a `Log.warning + return` when `engineController` is nil — not even buffered.
+
+**Design (converges both variants on #302's tombstone mechanism):**
+
+The only durable delete-intent home is the store tombstone (`store.setTombstone`, replayed by I12 recovery). But `SyncEngineStore` is **user-namespaced** (`family_foqos_syncengine_<field>_<userRecordName>`, `SyncEngineStore.swift:39`) and constructed only inside `attachEngine` (`:169`) after the CloudKit user id resolves — so it cannot exist in the pre-attach window. **Therefore a non-user-namespaced durable buffer is required as the pre-attach medium**, drained into store tombstones at attach.
+
+> **Design note (not a maintainer decision — a forced consequence of the store namespacing).** The issue's fix direction ("persist … the same store tombstone #302 writes") describes the *destination*; the store can't be reached pre-attach (confirmed: `userRecordName` is unresolved). So this plan introduces `PreAttachDeleteBuffer` — a fixed-key `UserDefaults` buffer — as the durable pre-attach medium, then drains it into store tombstones inside `attachEngine`, at which point I12 recovery (`recoverDeleteIntents`) replays them verbatim as **recovered intents** (verify-before-delete, keep-biased). No new I12 logic; the buffer only has to exist and be drained before `start()`.
+
+**Round-4/5 tombstone-lifecycle conformance:**
+- Variant B writes are **after** the local commit (the call site is inside `scheduleProfileDeleteCommit`'s success block, e.g. `BlockedProfileView.swift:854`) — strict write-after-commit, so a rolled-back delete never buffers.
+- Variant A writes occur in the facade's `.notAttached` branch, at the **same point** the existing in-memory `deferredDeleteRecordNames` insert already happens (before the caller's local commit) — behavior identical to today's in-memory path. The keep-biased safety net is I12 recovery's **entity-still-present ⇒ abort (clear tombstone, enqueue nothing)** branch (`design.md:275-277`): a buffered name whose entity is still present after attach is cleared without deleting. So an unmatched buffer entry can never destroy a live record.
+- Idempotency: the buffer is drained-and-cleared once at attach; the resulting store tombstone becomes the durable intent (survives further kills via I12). The in-memory set remains as the same-process fast path; both converge on `setTombstone`/`.deleteRecord`, which are set-keyed and idempotent, so double-drain is harmless.
+
+### Task 305.0: Citation refresh
+
+- [ ] **Step 1:** Confirm both variants unchanged:
+
+```bash
+grep -n "deferredDeleteRecordNames" Foqos/CloudKit/ProfileSyncManager.swift          # in-memory Set + inserts
+grep -n "func recordDisabledDeleteTombstone" Foqos/CloudKit/ProfileSyncManager.swift # nil-controller drop (~341)
+grep -n "func attachEngine\|SyncEngineStore(userRecordName\|controller.start()" Foqos/CloudKit/ProfileSyncManager.swift  # ~156/169/192
+grep -n "func recoverDeleteIntents\|await recoverDeleteIntents" Foqos/CloudKit/SyncEngine/SyncEngineController.swift  # ~730/857
+```
+
+Expected: `deferredDeleteRecordNames` still in-memory; `recordDisabledDeleteTombstone` still returns on nil controller; `attachEngine` builds the store at `:169` and calls `start()` at `:192`; `recoverDeleteIntents` runs inside `runStartupSequence`.
+
+---
+
+### Task 305.1: `PreAttachDeleteBuffer` — durable non-namespaced buffer
+
+**Files:**
+- Create: `Foqos/CloudKit/SyncEngine/PreAttachDeleteBuffer.swift`
+- Test: `FoqosTests/PreAttachDeleteBufferTests.swift` (new)
+
+**Interfaces:**
+- Produces: `PreAttachDeleteBuffer.add(_ recordName: String, defaults:)`, `PreAttachDeleteBuffer.drainAll(defaults:) -> [String]`, `PreAttachDeleteBuffer.defaultsKey`. Consumed by Task 305.2 (facade writes) and 305.3 (attach drain).
+
+- [ ] **Step 1: Write the failing test.**
+
+```swift
+import XCTest
+@testable import FamilyFoqos
+
+@MainActor
+final class PreAttachDeleteBufferTests: XCTestCase {
+  private func makeDefaults() -> UserDefaults {
+    let d = UserDefaults(suiteName: "preattach-test-\(UUID().uuidString)")!
+    return d
+  }
+
+  func testGivenBufferedDeletes_WhenDrained_ThenReturnsAllAndClears() {
+    let d = makeDefaults()
+    PreAttachDeleteBuffer.add("A", defaults: d)
+    PreAttachDeleteBuffer.add("B", defaults: d)
+    PreAttachDeleteBuffer.add("A", defaults: d)  // dedup
+
+    let drained = Set(PreAttachDeleteBuffer.drainAll(defaults: d))
+    XCTAssertEqual(drained, ["A", "B"])
+    XCTAssertTrue(PreAttachDeleteBuffer.drainAll(defaults: d).isEmpty, "drain must clear durably")
+  }
+
+  func testGivenNoBuffer_WhenDrained_ThenEmpty() {
+    XCTAssertTrue(PreAttachDeleteBuffer.drainAll(defaults: makeDefaults()).isEmpty)
+  }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (type undefined). `-only-testing:FoqosTests/PreAttachDeleteBufferTests`.
+
+- [ ] **Step 3: Create the buffer.** `Foqos/CloudKit/SyncEngine/PreAttachDeleteBuffer.swift`:
+
+```swift
+import Foundation
+
+/// #305: durable, NON-user-namespaced buffer for delete-intent record names formed in the
+/// pre-attach window — before the user-namespaced `SyncEngineStore` (and thus the only durable
+/// tombstone) exists. Drained into store tombstones inside `attachEngine`, where I12 recovery
+/// replays them (converges on #302's `recordDisabledDeleteTombstone` mechanism). The in-memory
+/// `deferredDeleteRecordNames` remains the same-process fast path; this is the cross-kill
+/// durability backstop. All access is `@MainActor` (facade + attach), so no additional lock.
+@MainActor
+enum PreAttachDeleteBuffer {
+  static let defaultsKey = "family_foqos_pending_preattach_deletes"
+
+  static func add(_ recordName: String, defaults: UserDefaults = .standard) {
+    var names = Set(defaults.stringArray(forKey: defaultsKey) ?? [])
+    names.insert(recordName)
+    defaults.set(Array(names), forKey: defaultsKey)
+  }
+
+  /// Returns all buffered record names and clears the buffer durably.
+  static func drainAll(defaults: UserDefaults = .standard) -> [String] {
+    let names = defaults.stringArray(forKey: defaultsKey) ?? []
+    defaults.removeObject(forKey: defaultsKey)
+    return names
+  }
+}
+```
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/CloudKit/SyncEngine/PreAttachDeleteBuffer.swift FoqosTests/PreAttachDeleteBufferTests.swift
+git commit -m "feat(#305): durable non-namespaced pre-attach delete buffer"
+```
+
+---
+
+### Task 305.2: write both delete variants to the buffer
+
+**Files:**
+- Modify: `Foqos/CloudKit/ProfileSyncManager.swift` (the three `.notAttached` delete branches + `recordDisabledDeleteTombstone` nil-controller branch)
+- Test: `FoqosTests/ProfileSyncManagerDeferredDeleteTests.swift` (extend existing if present)
+
+**Interfaces:**
+- Consumes: `PreAttachDeleteBuffer.add` (Task 305.1).
+- Produces: nothing new; makes deferred deletes durable.
+
+- [ ] **Step 1: Write the failing test.** Drive the facade with a nil controller and assert the record name is buffered durably.
+
+```swift
+import XCTest
+@testable import FamilyFoqos
+
+@MainActor
+final class ProfileSyncManagerDeferredDeleteTests: XCTestCase {
+  func testGivenNoController_WhenProfileDeleteDeferred_ThenBufferedDurably() {
+    let d = UserDefaults(suiteName: "deferred-del-\(UUID().uuidString)")!
+    let manager = ProfileSyncManager.makeForTest(engineController: nil, buffer: d)  // test seam
+    let id = UUID()
+
+    XCTAssertThrowsError(try manager.enqueueProfileDelete(id)) { error in
+      XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+    }
+    XCTAssertTrue(PreAttachDeleteBuffer.drainAll(defaults: d).contains(id.uuidString))
+  }
+
+  func testGivenNoController_WhenDisabledDeleteTombstone_ThenBufferedNotDropped() {
+    let d = UserDefaults(suiteName: "disabled-del-\(UUID().uuidString)")!
+    let manager = ProfileSyncManager.makeForTest(engineController: nil, buffer: d)
+    manager.recordDisabledDeleteTombstone(recordName: "loc-1")
+    XCTAssertTrue(PreAttachDeleteBuffer.drainAll(defaults: d).contains("loc-1"),
+      "#305 variant B: the intent must be buffered, not dropped")
+  }
+}
+```
+
+> `ProfileSyncManager.makeForTest(engineController:buffer:)` is a test seam: it constructs the manager with a nil (or injected) controller and routes `PreAttachDeleteBuffer` writes at the injected `UserDefaults`. If the manager can't easily inject the buffer's defaults, thread a `bufferDefaults: UserDefaults = .standard` parameter into the buffer-write helper (Step 3) and expose it for tests. Keep production default `.standard`.
+
+- [ ] **Step 2: Run — expect FAIL** (variant B drops; variant A only in-memory). `-only-testing:FoqosTests/ProfileSyncManagerDeferredDeleteTests`.
+
+- [ ] **Step 3a: Buffer the disabled-delete (variant B).** Replace `recordDisabledDeleteTombstone` (`ProfileSyncManager.swift:341-349`):
+
+```swift
+  /// Records a disabled-sync delete after its local commit so I12 can replay it on re-enable.
+  /// Best-effort because the caller is already on a committed local-delete path. #305: when the
+  /// controller isn't attached yet (pre-controller window), buffer the intent durably instead of
+  /// dropping it — `attachEngine` drains the buffer into a store tombstone.
+  func recordDisabledDeleteTombstone(recordName: String) {
+    guard let engineController else {
+      PreAttachDeleteBuffer.add(recordName)
+      Log.info(
+        "Disabled-delete tombstone buffered pre-attach (\(recordName))", category: .sync)
+      return
+    }
+    engineController.recordDisabledDeleteTombstone(recordName: recordName)
+  }
+```
+
+- [ ] **Step 3b: Buffer the enabled `.notAttached` deletes (variant A).** In each of the three delete verbs, add a `PreAttachDeleteBuffer.add` next to the existing `deferredDeleteRecordNames.insert`. For `enqueueProfileDelete` (`:248-259`):
+
+```swift
+  func enqueueProfileDelete(_ id: UUID) throws {
+    guard let engineController else {
+      deferredDeleteRecordNames.insert(id.uuidString)
+      PreAttachDeleteBuffer.add(id.uuidString)  // #305: durable across kill
+      throw SyncEngineControllingError.notAttached
+    }
+    do {
+      try engineController.enqueueProfileDelete(id, requestSyncAfterPendingDelete: isSyncReady)
+    } catch SyncEngineControllingError.notAttached {
+      deferredDeleteRecordNames.insert(id.uuidString)
+      PreAttachDeleteBuffer.add(id.uuidString)  // #305
+      throw SyncEngineControllingError.notAttached
+    }
+  }
+```
+
+Apply the identical `PreAttachDeleteBuffer.add(...)` addition to both `.notAttached` sites in `enqueueLocationDelete` (`:273-284`, arg `id.uuidString`) and `enqueueEmergencyUnblockEventDelete` (`:325-336`, arg `recordName`).
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/CloudKit/ProfileSyncManager.swift FoqosTests/ProfileSyncManagerDeferredDeleteTests.swift
+git commit -m "fix(#305): buffer pre-attach delete intents durably (both variants)"
+```
+
+---
+
+### Task 305.3: drain the buffer into store tombstones at attach
+
+**Files:**
+- Modify: `Foqos/CloudKit/ProfileSyncManager.swift` (`attachEngine`, between store construction and `start()`)
+- Test: `FoqosTests/AttachDrainTombstoneTests.swift` (new)
+
+**Interfaces:**
+- Consumes: `PreAttachDeleteBuffer.drainAll`; `SyncEngineControlling.recordDisabledDeleteTombstone` (writes `store.setTombstone`).
+- Produces: at attach, every buffered name becomes a durable store tombstone **before** `start()` runs I12 recovery.
+
+- [ ] **Step 1: Write the failing test.** Pre-seed the buffer, attach with a spy controller (or a real store), assert the buffer is drained and a tombstone exists (and the buffer is cleared).
+
+```swift
+@MainActor
+final class AttachDrainTombstoneTests: XCTestCase {
+  func testGivenBufferedDelete_WhenAttach_ThenTombstoneWrittenAndBufferCleared() async throws {
+    let d = UserDefaults(suiteName: "attach-drain-\(UUID().uuidString)")!
+    PreAttachDeleteBuffer.add("p-123", defaults: d)
+    let (manager, store) = try makeAttachableManager(bufferDefaults: d)  // test seam
+    await manager.attachEngine(
+      modelContext: store.context, emergencyManager: .init(),
+      userRecordNameProvider: { "test-user" }, driverFactory: { _ in NoopDriver() })
+
+    XCTAssertTrue(PreAttachDeleteBuffer.drainAll(defaults: d).isEmpty, "buffer drained at attach")
+    XCTAssertNotNil(store.engineStore.tombstoneChangeTag(for: "p-123"),
+      "#305: buffered delete became a durable store tombstone at attach")
+  }
+}
+```
+
+> `makeAttachableManager(bufferDefaults:)`, `NoopDriver`, and `tombstoneChangeTag(for:)` are test seams — reuse the `SyncEngineAttachTests` scaffolding if present (it already drives `attachEngine` with a `driverFactory`). `tombstoneChangeTag(for:)` reads the store's `deleteTombstones` map.
+
+- [ ] **Step 2: Run — expect FAIL** (buffer never drained; no tombstone). `-only-testing:FoqosTests/AttachDrainTombstoneTests`.
+
+- [ ] **Step 3: Drain in `attachEngine`.** Insert immediately after `engineController = controller` (`:190`), before `if isEnabled { controller.start() … }`:
+
+```swift
+    pendingController = controller
+    ownedEngineController = controller
+    engineController = controller
+    // #305: replay pre-attach delete intents buffered durably before the store existed. Write
+    // them as store tombstones NOW (the controller/store exist) so `start()`'s I12 recovery
+    // treats them as recovered intents and verify-before-deletes them — same mechanism as #302.
+    // Drain-and-clear once: the tombstone becomes the durable intent (survives further kills).
+    for recordName in PreAttachDeleteBuffer.drainAll() {
+      controller.recordDisabledDeleteTombstone(recordName: recordName)
+    }
+    if isEnabled {
+      controller.start()
+      await controller.startupTask?.value
+      markSyncReadyAndFlushIfStillEnabled(for: controller)
+    }
+```
+
+> Ordering rationale: the drain runs **before** `start()`, so the tombstones are present when `runStartupSequence → recoverDeleteIntents` scans them. If sync is disabled at attach, `start()` isn't called and the tombstones simply persist durably in the store until a later enable triggers recovery (matching #302's disabled→enabled flow).
+
+- [ ] **Step 4: Run — expect PASS.** Also run the existing `SyncEngineAttachTests` / `ProfileSyncManager` suites to confirm attach idempotency and no regression.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/CloudKit/ProfileSyncManager.swift FoqosTests/AttachDrainTombstoneTests.swift
+git commit -m "fix(#305): drain pre-attach delete buffer into store tombstones at attach"
+```
+
+### #305 skeptic pass
+
+**Verdict: SOUND-WITH-FIXES.** The ordering (drain before `start()` ⇒ before `recoverDeleteIntents`) is confirmed correct, and the controller's `recordDisabledDeleteTombstone` writes `store.setTombstone` without needing the funnel. Apply these amendments:
+
+- **[MAJOR] Injectable buffer defaults — production `.standard` vs test-injected suite mismatch.** The production snippets call `PreAttachDeleteBuffer.add/drainAll` with default `.standard`, but every test injects a private suite and asserts against it — so the tests would pass while production writes to (and leaks into) the real `.standard` domain. **Amend Task 305.1/305.2/305.3**: add a stored `private let bufferDefaults: UserDefaults = .standard` on `ProfileSyncManager` and thread it into **every** `PreAttachDeleteBuffer.add(...)` (the three delete verbs + `recordDisabledDeleteTombstone`) and the `drainAll()` call in `attachEngine`. Tests inject a suite via the manager's test seam.
+
+- **[MAJOR] Update the existing facade test.** `SyncEngineFacadeTests.swift:100-105` (`testGivenNoController_WhenRecordDisabledTombstone_ThenNoOp` or similar) sets `engineController = nil` then calls `recordDisabledDeleteTombstone` — after Step 3a it now **buffers** instead of no-op'ing, so that test's assertion is stale and (with `.standard` defaults) would leak `"p1"`. **Amend Task 305.2** to update this existing test to assert the new buffering behavior against the injected suite, and add `tearDown` cleanup of the buffer key.
+
+- **[MINOR] Test seam is invented — pick the real pattern.** `ProfileSyncManager` is a `static let shared` singleton with `private init()`; `makeForTest(engineController:buffer:)` / `makeAttachableManager` don't exist. **Amend the 305 tests** to follow the established `SyncEngineFacadeTests` pattern: use `ProfileSyncManager.shared`, set `manager.engineController = nil/mock`, `SharedData.configure(suite:)`, and inject `bufferDefaults` via a settable internal property (add one if needed). Specify this concretely rather than inventing a factory.
+
+- **[MINOR] Tighten the idempotency claim.** The "unmatched buffer entry can never destroy a live record / double-drain harmless" statement is fully true only for the **cross-kill** case (in-memory set already lost, only the buffer→tombstone path runs, gated by I12 verify-before-delete). In the **same-process** case the retained in-memory `deferredDeleteRecordNames` drains after startup via `enqueueTombstoneDelete`, which re-writes the tombstone unconditionally. Reword the design note to "in the cross-kill case (in-memory set already lost)"; optionally route the in-memory deferred-delete drain through the same verify-before-delete gate for full symmetry (not required — the enqueue is idempotent at the CKSyncEngine state level).
+
+---
+
+# Mini-plan #315 — version-carrying delete watermark (stale-echo resurrection)
+
+**Re-triage result (2026-07-12, base `3a5eee2`): STILL-PRESENT.** After a confirmed delete, the in-memory echo guard (`recentlyConfirmedDeletes`) drains one cycle later (`SyncEngineController.swift:635-643`); a stale ≤-version modification arriving after the drain passes the skip check (`SyncApplyService.swift:67`) and hits the **unconditional create branch** (`applyDecodedProfile` `:280-292`) → resurrection. A3′ hardened only the existing-profile branch, not the locally-absent create. Locations share the identical version-blind create (`:524-539`). No durable version ledger exists (the I12 tombstone is cleared at confirmation, `:438`, and carries a change-tag, not a version).
+
+**Design — durable version-carrying delete watermark:**
+
+Record the record's **version at the moment of delete** in a durable per-user map that **survives confirmation** (unlike the echo guard and the I12 tombstone). Gate the create branch: a fetched modification for a locally-absent record whose version is **≤ the watermark** is a stale echo of our own confirmed delete → drop; a **higher** version is a genuine delete-vs-edit recreation → apply (the designed keep-bias: edit wins). The echo guard/tombstone stay for the transient in-cycle window (N12); the watermark closes the permanent post-drain window.
+
+**Why version-keyed, not time-keyed (answers the issue's "explicit bound with rationale"):** the discriminator is the record version, so **CloudKit's delivery latency is irrelevant** — a stale echo carries the deleted record's own last version (≤ watermark) whenever it arrives (one cycle late, ten cycles late; #219's demonstrated latitude does not matter); a genuine recreation always carries a **bumped** version (> watermark, because a concurrent edit incremented it). No retention *window* is needed for correctness. The only bound is storage GC — capped FIFO — justified because CloudKit cannot redeliver a stale entry past change-token expiry (N10), and profiles/locations are few.
+
+**Equal-version rule (`<=`, delete wins the tie):** the gate uses `synced.version <= watermark`, so at *exactly* the deleted version the delete wins. This is required — the stale echo carries the same version as the deleted record. The only case it bites is a diverged-by-one race: a device exactly one version behind the deleter concurrently edits and republishes at the same version the deleter deleted; that edit is dropped in favor of the delete. This is a rare, keep-of-delete-biased outcome consistent with N5's keep-bias asymmetry, and is the deliberate cost of gating by version rather than by a fragile time window.
+
+**Conformance vs N12 / AB-3 / round-4/5 tombstone-lifecycle:**
+- **N12(b)** calls the post-delete recreation race "transient, healed by any later edit." The #315 repro proves it is **not** transient when the echo is a *stale ≤-version re-publish with no later edit* — there is nothing to heal it. This plan closes that residual; it does not contradict N12, it completes it.
+- **AB-3** (cycle-delimited echo-guard drain) is unchanged — the watermark is an independent durable gate, not a change to the drain timing.
+- **Round-4/5 lingering-tombstone hazard is avoided** because the watermark is **not** the delete-intent tombstone (which must clear at confirmation to avoid killing a live recreation). The watermark only gates the **create** branch (absent entity); while the entity is present the create branch is never taken, so a stale watermark is inert. It is cleared on delete-failure/rollback (symmetric with `clearTombstone`), on a genuine higher-version recreation, and by FIFO cap.
+- **Own-echo no-op (§5.1 branch 0):** unaffected — an own echo of a *present* record still takes the existing-entity branch.
+
+**Scope:** the watermark is written on the **enabled-sync funnel delete path** (`MutationFunnel.enqueueDelete`), which reads the entity before deleting — the exact path of the #315 repro. Disabled/pre-attach deletes (the entity is already gone when their tombstone is written, so no version is available) are out of scope here; their propagation is #305/#302 territory and their stale-echo window is not the reported repro. This is stated as a deliberate boundary, not an omission.
+
+### Task 315.0: Citation refresh
+
+- [ ] **Step 1:** Confirm the create paths are still version-blind and the funnel still reads the entity:
+
+```bash
+grep -n "createLocalProfile(from: synced)" Foqos/CloudKit/SyncEngine/SyncApplyService.swift   # ~283 create branch
+grep -n "syncVersion: 1" Foqos/CloudKit/SyncEngine/SyncApplyService.swift                     # ~532 location create
+grep -n "func enqueueDelete" Foqos/CloudKit/SyncEngine/MutationFunnel.swift                   # profile ~122 / location ~181
+grep -n "clearTombstone(recordName: name)  // I12 confirmed" Foqos/CloudKit/SyncEngine/SyncEngineController.swift  # ~438
+grep -rn "deleteWatermark\|deletedVersion" Foqos/CloudKit                                     # expect: none yet
+```
+
+Expected: create branches unconditional; funnel finds the entity (`findProfile`/`SavedLocation.find`) before deleting; no watermark exists yet.
+
+---
+
+### Task 315.1: durable delete watermark in `SyncEngineStore`
+
+**Files:**
+- Modify: `Foqos/CloudKit/SyncEngine/SyncEngineStore.swift` (add the watermark map + GC cap)
+- Test: `FoqosTests/DeleteWatermarkStoreTests.swift` (new)
+
+**Interfaces:**
+- Produces: `SyncEngineStore.setDeleteWatermark(recordName:value: Double)`, `SyncEngineStore.deleteWatermark(for:) -> Double?`, `SyncEngineStore.clearDeleteWatermark(recordName:)`, `SyncEngineStore.maxDeleteWatermarkEntries`. The `Double` is the record's version at delete: `Double(syncVersion)` for profiles, `updatedAt.timeIntervalSinceReferenceDate` for locations (recordName spaces are disjoint UUIDs, so one map is safe).
+
+- [ ] **Step 1: Write the failing test.**
+
+```swift
+import XCTest
+@testable import FamilyFoqos
+
+@MainActor
+final class DeleteWatermarkStoreTests: XCTestCase {
+  private func makeStore() -> SyncEngineStore {
+    SyncEngineStore(userRecordName: "u-\(UUID().uuidString)",
+      defaults: UserDefaults(suiteName: "wm-\(UUID().uuidString)")!)
+  }
+
+  func testGivenWatermarkSet_WhenRead_ThenReturnsValueUntilCleared() {
+    let s = makeStore()
+    s.setDeleteWatermark(recordName: "p1", value: 5)
+    XCTAssertEqual(s.deleteWatermark(for: "p1"), 5)
+    s.clearDeleteWatermark(recordName: "p1")
+    XCTAssertNil(s.deleteWatermark(for: "p1"))
+  }
+
+  func testGivenWatermarkReset_WhenSetAgain_ThenOverwrites() {
+    let s = makeStore()
+    s.setDeleteWatermark(recordName: "p1", value: 5)
+    s.setDeleteWatermark(recordName: "p1", value: 7)
+    XCTAssertEqual(s.deleteWatermark(for: "p1"), 7)
+  }
+
+  func testGivenMoreThanCap_WhenSet_ThenOldestEvicted() {
+    let s = makeStore()
+    let cap = SyncEngineStore.maxDeleteWatermarkEntries
+    for i in 0...cap { s.setDeleteWatermark(recordName: "r\(i)", value: Double(i)) }
+    XCTAssertNil(s.deleteWatermark(for: "r0"), "oldest evicted past the FIFO cap")
+    XCTAssertEqual(s.deleteWatermark(for: "r\(cap)"), Double(cap))
+  }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (methods undefined). `-only-testing:FoqosTests/DeleteWatermarkStoreTests`.
+
+- [ ] **Step 3: Add the watermark to `SyncEngineStore`.** After the tombstone section (`:176`), mirroring the `tombstoneEntries` Codable-array pattern:
+
+```swift
+  // MARK: - Delete version watermark (#315)
+
+  /// Guard value captured at delete time: `Double(syncVersion)` for profiles,
+  /// `updatedAt.timeIntervalSinceReferenceDate` for locations. Unlike the I12 tombstone this
+  /// is NOT cleared at confirmation — it survives to gate the locally-absent create branch so
+  /// a stale ≤-version echo of a confirmed delete cannot resurrect the record. Cleared on
+  /// delete rollback, on a genuine higher-version recreation, and by FIFO cap.
+  static let maxDeleteWatermarkEntries = 512
+
+  private struct DeleteWatermarkEntry: Codable {
+    var recordName: String
+    var value: Double
+  }
+
+  private var deleteWatermarkEntries: [DeleteWatermarkEntry] {
+    decoded([DeleteWatermarkEntry].self, "delete_watermarks") ?? []
+  }
+
+  func deleteWatermark(for recordName: String) -> Double? {
+    deleteWatermarkEntries.first { $0.recordName == recordName }?.value
+  }
+
+  func setDeleteWatermark(recordName: String, value: Double) {
+    locked {
+      var all = self.deleteWatermarkEntries.filter { $0.recordName != recordName }
+      all.append(DeleteWatermarkEntry(recordName: recordName, value: value))
+      // GC: bound growth (N10 — CloudKit cannot redeliver a stale entry past token expiry).
+      if all.count > Self.maxDeleteWatermarkEntries {
+        all = Array(all.suffix(Self.maxDeleteWatermarkEntries))
+      }
+      self.encodeStore(all, "delete_watermarks")
+    }
+  }
+
+  func clearDeleteWatermark(recordName: String) {
+    locked {
+      let all = self.deleteWatermarkEntries.filter { $0.recordName != recordName }
+      self.encodeStore(all, "delete_watermarks")
+    }
+  }
+```
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/CloudKit/SyncEngine/SyncEngineStore.swift FoqosTests/DeleteWatermarkStoreTests.swift
+git commit -m "feat(#315): durable delete-version watermark in SyncEngineStore"
+```
+
+---
+
+### Task 315.2: capture the watermark at funnel-delete; clear on rollback
+
+**Files:**
+- Modify: `Foqos/CloudKit/SyncEngine/MutationFunnel.swift` (`enqueueDelete(profileId:)` ~122, `enqueueDelete(locationId:)` ~181)
+- Test: `FoqosTests/FunnelDeleteWatermarkTests.swift` (new)
+
+**Interfaces:**
+- Consumes: `SyncEngineStore.setDeleteWatermark`, `.clearDeleteWatermark` (Task 315.1).
+- Produces: after a funnel delete enqueues, the store holds the deleted record's version watermark; a failed/rolled-back delete leaves no watermark.
+
+- [ ] **Step 1: Write the failing test.** Delete a profile at a known `syncVersion` through the funnel; assert the watermark equals that version.
+
+```swift
+@MainActor
+final class FunnelDeleteWatermarkTests: XCTestCase {
+  func testGivenProfileAtVersion_WhenFunnelDelete_ThenWatermarkRecorded() throws {
+    let (funnel, store, ctx) = try makeFunnel()  // test seam mirroring existing MutationFunnel tests
+    let profile = BlockedProfiles(name: "P")
+    profile.syncVersion = 4
+    ctx.insert(profile)
+    try ctx.save()
+
+    try funnel.enqueueDelete(profileId: profile.id)
+    // Deferred commit runs on the next main-actor turn (scheduleProfileDeleteCommit).
+    try awaitMainActorTurn()
+
+    XCTAssertEqual(store.deleteWatermark(for: profile.id.uuidString), 4.0,
+      "#315: watermark must capture the version the record had when deleted")
+  }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (no watermark written). `-only-testing:FoqosTests/FunnelDeleteWatermarkTests`.
+
+- [ ] **Step 3a: Capture in the profile delete.** In `enqueueDelete(profileId:)`, right after the entity is found (`:130-132`):
+
+```swift
+      guard let profile = try BlockedProfiles.findProfile(byID: profileId, in: modelContext) else {
+        throw MutationFunnelError.entityNotFound
+      }
+      // #315: record the version at delete time so a stale ≤-version echo of this confirmed
+      // delete cannot resurrect the profile after the in-memory echo guard drains.
+      store.setDeleteWatermark(recordName: recordName, value: Double(profile.syncVersion))
+      try BlockedProfiles.deleteProfile(profile, in: modelContext)
+```
+
+Then add `store.clearDeleteWatermark(recordName: recordName)` next to **each** `store.clearTombstone(recordName: recordName)` on the failure paths (`:151`, `:163`, `:173`) — symmetric lifecycle so a rolled-back delete leaves no watermark. Example at `:173`:
+
+```swift
+    } catch {
+      store.clearTombstone(recordName: recordName)
+      store.clearDeleteWatermark(recordName: recordName)  // #315: no watermark for a rolled-back delete
+      modelContext.rollback()
+      throw error
+    }
+```
+
+- [ ] **Step 3b: Capture in the location delete.** In `enqueueDelete(locationId:)`, after the entity is found (`:187-189`):
+
+```swift
+      guard let location = try SavedLocation.find(byID: locationId, in: modelContext) else {
+        throw MutationFunnelError.entityNotFound
+      }
+      // #315: locations order by client clock (N6), so the watermark is the deleted record's
+      // updatedAt as a reference-timestamp; a stale echo with an equal/older lastModified is dropped.
+      store.setDeleteWatermark(
+        recordName: recordName, value: location.updatedAt.timeIntervalSinceReferenceDate)
+```
+
+And add `store.clearDeleteWatermark(recordName: recordName)` next to the location delete's `store.clearTombstone(recordName: recordName)` failure path (`:193`).
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/CloudKit/SyncEngine/MutationFunnel.swift FoqosTests/FunnelDeleteWatermarkTests.swift
+git commit -m "fix(#315): capture delete-version watermark in the funnel delete path"
+```
+
+---
+
+### Task 315.3: gate the profile create branch with the watermark
+
+**Files:**
+- Modify: `Foqos/CloudKit/SyncEngine/SyncApplyService.swift` (`applyDecodedProfile` create branch ~280-292)
+- Modify: `Foqos/CloudKit/SyncEngine/SyncApplyService.swift` (add a `.skippedStaleDelete` `ApplyOutcome` case if not reusing `.skippedPendingDelete`)
+- Test: `FoqosTests/StaleDeleteEchoTests.swift` (new)
+
+**Interfaces:**
+- Consumes: `store.deleteWatermark(for:)`, `store.clearDeleteWatermark(recordName:)`.
+- Produces: create branch drops stale ≤-version echoes; a genuine higher-version create applies and clears the watermark (GC).
+
+- [ ] **Step 1: Write the failing test.** Set a watermark for a deleted profile, then apply a modification at ≤ and at > that version; assert skip vs create.
+
+```swift
+@MainActor
+final class StaleDeleteEchoTests: XCTestCase {
+  func testGivenConfirmedDeleteAtV3_WhenStaleEchoV3Fetched_ThenNotResurrected() throws {
+    let (apply, store, ctx) = try makeApplyService()  // seam mirroring existing SyncApplyService tests
+    let profileId = UUID()
+    store.setDeleteWatermark(recordName: profileId.uuidString, value: 3)   // deleted at v3
+    let staleEcho = makeSyncedProfileRecord(id: profileId, version: 3)      // re-published stale copy
+
+    let outcome = apply.applyFetchedModification(staleEcho, isPendingDeleteOrTombstoned: { _ in false })
+
+    XCTAssertNil(try BlockedProfiles.findProfile(byID: profileId, in: ctx),
+      "#315: a stale ≤-version echo must NOT recreate the deleted profile")
+    XCTAssertEqual(outcome, .skippedStaleDelete)
+  }
+
+  func testGivenConfirmedDeleteAtV3_WhenGenuineRecreationV4Fetched_ThenApplied() throws {
+    let (apply, store, ctx) = try makeApplyService()
+    let profileId = UUID()
+    store.setDeleteWatermark(recordName: profileId.uuidString, value: 3)
+    let recreation = makeSyncedProfileRecord(id: profileId, version: 4)     // concurrent edit bumped it
+
+    _ = apply.applyFetchedModification(recreation, isPendingDeleteOrTombstoned: { _ in false })
+
+    XCTAssertNotNil(try BlockedProfiles.findProfile(byID: profileId, in: ctx),
+      "#315: a higher-version recreation IS a genuine delete-vs-edit and must apply (keep-bias)")
+    XCTAssertNil(store.deleteWatermark(for: profileId.uuidString),
+      "watermark cleared once superseded by a genuine recreation")
+  }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (stale echo resurrects; `.skippedStaleDelete` undefined). `-only-testing:FoqosTests/StaleDeleteEchoTests`.
+
+- [ ] **Step 3a: Add the outcome case.** In the `ApplyOutcome` enum (find its definition; it already has `.applied`, `.skippedPendingDelete`, `.ignored`, `.failed`):
+
+```swift
+    case skippedStaleDelete   // #315: dropped a stale ≤-watermark echo of a confirmed delete
+```
+
+- [ ] **Step 3b: Gate the profile create branch.** Replace the create branch in `applyDecodedProfile` (`:280-292`):
+
+```swift
+    guard
+      let existing = try BlockedProfiles.findProfile(byID: synced.profileId, in: modelContext)
+    else {
+      // #315: a modification for a locally-absent record at or below the version we deleted it
+      // at is a STALE echo of our own confirmed delete — drop it (keep the delete). A HIGHER
+      // version is a genuine delete-vs-edit recreation → create (keep-bias, edit wins).
+      let recordName = record.recordID.recordName
+      if let watermark = store.deleteWatermark(for: recordName), Double(synced.version) <= watermark {
+        SyncDiagnostics.profileApply(
+          profileId: synced.profileId, branch: "stale_delete_echo_skipped",
+          remoteVersion: synced.version, localVersion: nil,
+          remoteSchema: synced.profileSchemaVersion, localSchema: nil,
+          remoteGeofenceRefCount: synced.geofenceRule?.locationReferences.count,
+          localGeofenceRefCount: nil)
+        return .skippedStaleDelete
+      }
+      createLocalProfile(from: synced)
+      try commit()
+      storeSystemFields(record)
+      store.clearDeleteWatermark(recordName: recordName)  // #315: genuine recreation supersedes
+      SyncDiagnostics.profileApply(
+        profileId: synced.profileId, branch: "created", remoteVersion: synced.version,
+        localVersion: nil, remoteSchema: synced.profileSchemaVersion, localSchema: nil,
+        remoteGeofenceRefCount: synced.geofenceRule?.locationReferences.count,
+        localGeofenceRefCount: nil)
+      return .applied
+    }
+```
+
+> The caller `applyFetchedModification` (`:63`) already returns the branch outcome; `.skippedStaleDelete` propagates like `.skippedPendingDelete`. Confirm no exhaustive `switch` on `ApplyOutcome` elsewhere breaks — if one exists, add the new case (treat it like `.skippedPendingDelete`).
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/CloudKit/SyncEngine/SyncApplyService.swift FoqosTests/StaleDeleteEchoTests.swift
+git commit -m "fix(#315): gate profile create branch with delete-version watermark"
+```
+
+---
+
+### Task 315.4: gate the location create branch with the watermark
+
+**Files:**
+- Modify: `Foqos/CloudKit/SyncEngine/SyncApplyService.swift` (location create branch ~524-539)
+- Test: `FoqosTests/StaleDeleteEchoTests.swift` (extend)
+
+**Interfaces:**
+- Consumes: `store.deleteWatermark(for:)`, `store.clearDeleteWatermark`; `SyncedLocation.lastModified: Date`.
+
+- [ ] **Step 1: Write the failing test.** Extend `StaleDeleteEchoTests`:
+
+```swift
+  func testGivenDeletedLocation_WhenStaleEchoNotNewer_ThenNotRecreated() throws {
+    let now = Date()
+    let (apply, store, ctx) = try makeApplyService()
+    let locationId = UUID()
+    store.setDeleteWatermark(
+      recordName: locationId.uuidString, value: now.timeIntervalSinceReferenceDate)
+    // Stale echo with lastModified == deletion time (not newer).
+    let staleEcho = makeSyncedLocationRecord(id: locationId, lastModified: now)
+
+    let outcome = apply.applyFetchedModification(staleEcho, isPendingDeleteOrTombstoned: { _ in false })
+
+    XCTAssertNil(try SavedLocation.find(byID: locationId, in: ctx),
+      "#315: a stale location echo not newer than the deletion must not recreate it")
+    XCTAssertEqual(outcome, .skippedStaleDelete)
+  }
+```
+
+- [ ] **Step 2: Run — expect FAIL.** `-only-testing:FoqosTests/StaleDeleteEchoTests/testGivenDeletedLocation_WhenStaleEchoNotNewer_ThenNotRecreated`.
+
+- [ ] **Step 3: Gate the location create branch.** Replace the `else` create branch (`:524-539`):
+
+```swift
+      } else {
+        // #315: drop a stale location echo whose lastModified is not strictly newer than the
+        // deletion watermark; a newer lastModified is a genuine recreation (N6 client clock).
+        if let watermark = store.deleteWatermark(for: recordName),
+          synced.lastModified.timeIntervalSinceReferenceDate <= watermark
+        {
+          SyncDiagnostics.locationApply(
+            locationId: synced.locationId, branch: "stale_delete_echo_skipped",
+            localVersion: nil, newLocalVersion: nil)
+          store.removeFailedApply(recordName: recordName)
+          return .skippedStaleDelete
+        }
+        let location = SavedLocation(
+          id: synced.locationId,
+          name: synced.name,
+          latitude: synced.latitude,
+          longitude: synced.longitude,
+          defaultRadiusMeters: synced.defaultRadiusMeters,
+          isLocked: synced.isLocked,
+          syncVersion: 1
+        )
+        modelContext.insert(location)
+        try commit()
+        store.clearDeleteWatermark(recordName: recordName)  // #315: genuine recreation supersedes
+        SyncDiagnostics.locationApply(
+          locationId: synced.locationId, branch: "created", localVersion: nil,
+          newLocalVersion: location.syncVersion)
+      }
+```
+
+> Confirm the `SyncDiagnostics.locationApply(...:localVersion:newLocalVersion:)` signature accepts `nil` for both (it does at the existing `created` call); if `branch` values are an enum, add `stale_delete_echo_skipped`.
+
+- [ ] **Step 4: Run — expect PASS.** Run the full `SyncApplyService` suite to confirm no regression in the existing create/modify branches.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Foqos/CloudKit/SyncEngine/SyncApplyService.swift FoqosTests/StaleDeleteEchoTests.swift
+git commit -m "fix(#315): gate location create branch with delete-version watermark"
+```
+
+### #315 skeptic pass
+
+**Verdict: SOUND-WITH-FIXES.** The version-watermark design holds; grounding confirmed the create paths are version-blind, `SyncedProfile.version: Int` is non-optional (SyncModels.swift:71) and decoded via a `guard` (SyncModels.swift:186) — so **an absent-version record fails decode upstream and never reaches the create branch; the "nil version" edge does not exist.** Apply these amendments when implementing:
+
+- **[BLOCKER] Exhaustive `ApplyOutcome` switch — Task 315.3 must be concrete, not conditional.** `ApplyOutcome` (SyncApplyService.swift:10) is switched **exhaustively (no `default`)** in `SyncEngineController.swift:1277-1282` (`outcomeLabel`). Adding `.skippedStaleDelete` breaks that compile. Amend Task 315.3: add `Foqos/CloudKit/SyncEngine/SyncEngineController.swift` to the Files list and the Step 5 `git add`, and in Step 3a add the case to the switch:
+
+  ```swift
+  case .skippedStaleDelete: return "skipped_stale_delete"
+  ```
+
+  Check for a second switch nearby (`:1286`) and add the case there too if it is also exhaustive over `ApplyOutcome`.
+
+- **[MAJOR] Foreign-delete paths are unwatermarked — a second device can still resurrect its own record.** The watermark is written only on the delete-originating funnel path. A device applying a **foreign** delete goes through `deleteLocalProfile` (SyncApplyService.swift:121) / `deleteLocalLocation`, which write no watermark; if that device had previously published a save of the record, a later stale echo of its own save reaches the ungated create. **Amend Task 315.2** to also write the watermark on the foreign-delete apply paths, before the local delete:
+  - In `deleteLocalProfile` (before `BlockedProfiles.deleteProfile`, when the profile is still found ~:124): `store.setDeleteWatermark(recordName: recordName, value: Double(profile.syncVersion))`.
+  - In `deleteLocalLocation` (before the local delete, when the location is still found): `store.setDeleteWatermark(recordName: recordName, value: location.updatedAt.timeIntervalSinceReferenceDate)`.
+  This closes the gate on every device that removes the record, not only the originator. (Add a test mirroring `StaleDeleteEchoTests` but seeding the delete via the fetched-deletion path.)
+
+- **[MINOR] Kill between watermark-write and deferred commit.** The profile watermark is written synchronously (funnel `:132`) before `scheduleProfileDeleteCommit`. A kill in that window leaves the delete uncommitted (entity present) and the watermark durable; I12 `recoverDeleteIntents` clears the *tombstone* on its entity-present abort (`:863/:876/:881`) but not the watermark. This is **inert** (the entity is present ⇒ the create branch is never taken), but for symmetry, amend I12 recovery's entity-present abort to also call `store.clearDeleteWatermark(recordName:)` for the name it clears the tombstone for. Document either way.
+
+- **[MINOR — resolved, keep `<=`] Equal-version keep-bias.** `Double(synced.version) <= watermark` makes the **delete win at equal version**. This is required for the repro (the stale echo carries the same version as the deleted record). The only case it bites: a device exactly one version behind concurrently edits and republishes at the same version the deleter deleted — a diverged-by-one edit is then dropped in favor of the delete. Accepted and **stated in the design section** (a rare race, keep-biased toward the delete, self-consistent with N5). Do not change to `<`.
+
+- **[MINOR — accepted] FIFO cap 512 shared across profiles+locations.** A device deleting >512 records inside one change-token window could evict an old watermark; justified because by then its token has advanced far past those records (N10). UserDefaults cost is trivial — an implementer may raise the cap or split per-type; not required.
+
+---
+
+# Self-review
+
+Run after all four mini-plans are drafted (this is a checklist, not a subagent dispatch):
+
+1. **Spec coverage:** every issue in D4 (#226/#227/#242/#245/#266), plus #311, #305, #315, has ≥1 task. ✓
+2. **Placeholder scan:** no "TBD"/"add error handling"/"similar to Task N" — each step shows real code. Re-scan before finalizing.
+3. **Type consistency:** `remotelyActiveProfileIds: Set<UUID>` (311), `PreAttachDeleteBuffer.add/drainAll` (305), `SyncEngineStore.setDeleteWatermark/deleteWatermark/clearDeleteWatermark` + `ApplyOutcome.skippedStaleDelete` (315), `TimersUtil.sessionReminderIdentifier`/`isSessionOrBreakReminder` (227) — names identical across the tasks that produce and consume them.
+4. **No new SwiftData schema** — confirmed (305/315/311 durable state is `UserDefaults`; no `@Model` changes).


### PR DESCRIPTION
Plan-only (no code changes). Four mini-plans on one branch (the established F+I bundle), doc: \`docs/superpowers/plans/2026-07-12-263-d4-311-305-315.md\`.

## Mini-plans
- **D4 — session-lifecycle hygiene** (#226 scheduled-CAS identity guard, #227 targeted notification cancellation, #242 duplicate-reminder removal, #245 delete-profile cleanup, #266 re-snapshot after migration)
- **#311 — active-anywhere edit/delete locks** (reduced scope — see below)
- **#305 — durable pre-attach deferred deletes** (converges both variants on #302’s tombstone)
- **#315 — version-carrying delete watermark** (stops stale-echo resurrection)

## Re-triage (against current main \`3a5eee2\`)
All 8 re-grounded with file:line evidence (per-issue triage comments posted). All **STILL-PRESENT** except **#311 = PARTIAL**: location in-use protection already exists (\`locationsInUseByActiveProfiles\` + \`SavedLocationCard.disabled\`) and remote sessions already mirror for app-selected profiles — the real gap is the device with no app selection (\`startRemoteSession\` early-returns, no mirror). The plan widens the existing locks to consult synced session state rather than rebuilding.

## Skeptic pass
One adversarial skeptic per mini-plan, folded as amendment blocks. Caught: two compile blockers (a second \`SessionController\` conformer \`MockSessionController\`; an exhaustive \`ApplyOutcome\` switch) and three design corrections (#227 async cancel racing the reschedule → synchronous tracked-set; #311 in-memory set doesn’t survive relaunch since the change-token is durable → persist it; #315 foreign-delete paths unwatermarked → also watermark \`deleteLocalProfile\`/\`deleteLocalLocation\`).

## Notes
- No genuine maintainer decisions — designs forced by grounded code / the issue’s stated rule.
- Slots into epic #263 Wave 3: D4 and #311 after D3+E2; #305/#315 wherever the sync lane reaches them.
- Implementation is a separate session per mini-plan (house process).