### PR TITLE
Fix D3+E2 start guards and carousel reset

### DIFF
--- a/Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift
+++ b/Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift
@@ -10,6 +10,7 @@ struct BlockedProfileCarousel: View {
   let activeSessionProfileId: UUID?
   let elapsedTime: TimeInterval
   let startingProfileId: UUID?
+  let onStartingProfileConsumed: () -> Void
 
   var onStartTapped: (BlockedProfiles) -> Void
   var onStopTapped: (BlockedProfiles) -> Void
@@ -43,6 +44,32 @@ struct BlockedProfileCarousel: View {
     profiles.valid
   }
 
+  nonisolated static func resolvedCurrentProfileId(
+    currentProfileId: UUID?,
+    validProfileIds: [UUID]
+  ) -> UUID? {
+    if let currentProfileId, validProfileIds.contains(currentProfileId) {
+      return currentProfileId
+    }
+
+    return validProfileIds.first
+  }
+
+  nonisolated static func shouldRunInitialSetupOnProfilesChange(
+    currentProfileId: UUID?,
+    startingProfileId: UUID?,
+    validProfileIds: [UUID]
+  ) -> Bool {
+    if let startingProfileId, validProfileIds.contains(startingProfileId) {
+      return true
+    }
+
+    return resolvedCurrentProfileId(
+      currentProfileId: currentProfileId,
+      validProfileIds: validProfileIds
+    ) != currentProfileId
+  }
+
   private var titleMessage: String {
     return isBlocking ? "Active Profile" : "Profile"
   }
@@ -68,6 +95,7 @@ struct BlockedProfileCarousel: View {
     activeSessionProfileId: UUID?,
     elapsedTime: TimeInterval,
     startingProfileId: UUID? = nil,
+    onStartingProfileConsumed: @escaping () -> Void = {},
     onStartTapped: @escaping (BlockedProfiles) -> Void,
     onStopTapped: @escaping (BlockedProfiles) -> Void,
     onEditTapped: @escaping (BlockedProfiles) -> Void,
@@ -89,6 +117,7 @@ struct BlockedProfileCarousel: View {
     self.activeSessionProfileId = activeSessionProfileId
     self.elapsedTime = elapsedTime
     self.startingProfileId = startingProfileId
+    self.onStartingProfileConsumed = onStartingProfileConsumed
     self.onStartTapped = onStartTapped
     self.onStopTapped = onStopTapped
     self.onEditTapped = onEditTapped
@@ -117,6 +146,7 @@ struct BlockedProfileCarousel: View {
       validProfiles.contains(where: { $0.id == startingId })
     {
       currentProfileId = startingId
+      onStartingProfileConsumed()
       return
     }
 
@@ -215,9 +245,16 @@ struct BlockedProfileCarousel: View {
       initialSetup()
     }
     .onChange(of: profiles) { _, _ in
-      initialSetup()
+      if Self.shouldRunInitialSetupOnProfilesChange(
+        currentProfileId: currentProfileId,
+        startingProfileId: startingProfileId,
+        validProfileIds: validProfiles.map(\.id)
+      ) {
+        initialSetup()
+      }
     }
-    .onChange(of: startingProfileId) { _, _ in
+    .onChange(of: startingProfileId) { _, newValue in
+      guard newValue != nil else { return }
       initialSetup()
     }
   }

--- a/Foqos/Intents/IntentError.swift
+++ b/Foqos/Intents/IntentError.swift
@@ -24,7 +24,7 @@ enum IntentError: Error, CustomLocalizedStringResourceConvertible {
     case .durationOutOfRange:
       "Duration must be between 15 minutes and 23 hours 59 minutes."
     case .needsAppSelection(let name):
-      "\(name) needs app selection on this device before it can start."
+      "Profile '\(name)' needs app selection on this device before it can start."
     case .noActiveSession(let name):
       "\(name) is not currently active."
     case .backgroundStopsDisabled(let name):

--- a/Foqos/Intents/IntentError.swift
+++ b/Foqos/Intents/IntentError.swift
@@ -11,6 +11,10 @@ enum IntentError: Error, CustomLocalizedStringResourceConvertible {
   case stopConditionsNotMet(reason: String)
   case unexpected(String)
 
+  static func needsAppSelectionMessage(profileName: String) -> String {
+    "Profile '\(profileName)' needs app selection on this device before it can start."
+  }
+
   var localizedStringResource: LocalizedStringResource {
     switch self {
     case .profileNotFound:

--- a/Foqos/Intents/IntentError.swift
+++ b/Foqos/Intents/IntentError.swift
@@ -4,6 +4,7 @@ enum IntentError: Error, CustomLocalizedStringResourceConvertible {
   case profileNotFound
   case sessionAlreadyActive
   case durationOutOfRange
+  case needsAppSelection(profileName: String)
   case noActiveSession(profileName: String)
   case backgroundStopsDisabled(profileName: String)
   case geofenceBlocked(reason: String)
@@ -18,6 +19,8 @@ enum IntentError: Error, CustomLocalizedStringResourceConvertible {
       "A session is already active."
     case .durationOutOfRange:
       "Duration must be between 15 minutes and 23 hours 59 minutes."
+    case .needsAppSelection(let name):
+      "\(name) needs app selection on this device before it can start."
     case .noActiveSession(let name):
       "\(name) is not currently active."
     case .backgroundStopsDisabled(let name):

--- a/Foqos/Utils/GeofenceEvaluator.swift
+++ b/Foqos/Utils/GeofenceEvaluator.swift
@@ -20,8 +20,10 @@ class GeofenceEvaluator: ObservableObject {
 
   @Published var isCheckingGeofence: Bool = false
   @Published var errorMessage: String?
+  private var geofenceCheckGeneration = 0
+  private var activeGeofenceCheckGeneration: Int?
   private var geofenceCheckStartedAt: Date?
-  private let staleGeofenceCheckInterval: TimeInterval = 60
+  private static let staleGeofenceCheckInterval: TimeInterval = 60
 
   // Geofence start warning state
   @AppStorage("family_foqos_warn_when_activating_away_from_location") private var warnWhenActivatingAwayFromLocation =
@@ -33,14 +35,37 @@ class GeofenceEvaluator: ObservableObject {
   // Stored completion for confirmGeofenceStart
   private var pendingStartCompletion: ((ModelContext, BlockedProfiles) -> Void)?
 
-  func beginGeofenceCheck(now: Date = Date()) {
+  @discardableResult
+  func beginGeofenceCheck(now: Date = Date()) -> Int {
+    geofenceCheckGeneration += 1
+    activeGeofenceCheckGeneration = geofenceCheckGeneration
     isCheckingGeofence = true
     geofenceCheckStartedAt = now
+    return geofenceCheckGeneration
   }
 
-  func endGeofenceCheck() {
+  func endGeofenceCheck(expectedGeneration: Int) {
+    guard isCurrentGeofenceCheck(expectedGeneration: expectedGeneration) else {
+      return
+    }
+
     isCheckingGeofence = false
+    activeGeofenceCheckGeneration = nil
     geofenceCheckStartedAt = nil
+  }
+
+  @discardableResult
+  func completeGeofenceCheck(
+    expectedGeneration: Int,
+    _ updates: () -> Void
+  ) -> Bool {
+    guard isCurrentGeofenceCheck(expectedGeneration: expectedGeneration) else {
+      return false
+    }
+
+    updates()
+    endGeofenceCheck(expectedGeneration: expectedGeneration)
+    return true
   }
 
   func recoverStaleGeofenceCheck(now: Date = Date()) -> Bool {
@@ -48,13 +73,20 @@ class GeofenceEvaluator: ObservableObject {
       return false
     }
 
-    guard now.timeIntervalSince(geofenceCheckStartedAt) >= staleGeofenceCheckInterval else {
+    guard now.timeIntervalSince(geofenceCheckStartedAt) >= Self.staleGeofenceCheckInterval else {
       return false
     }
 
-    endGeofenceCheck()
+    geofenceCheckGeneration += 1
+    activeGeofenceCheckGeneration = nil
+    isCheckingGeofence = false
+    self.geofenceCheckStartedAt = nil
     pendingStartCompletion = nil
     return true
+  }
+
+  func isCurrentGeofenceCheck(expectedGeneration: Int) -> Bool {
+    return activeGeofenceCheckGeneration == expectedGeneration
   }
 
   // MARK: - Evaluate (async, no UI side-effects)
@@ -114,12 +146,12 @@ class GeofenceEvaluator: ObservableObject {
       return
     }
 
-    beginGeofenceCheck()
+    let expectedGeneration = beginGeofenceCheck()
 
     // Capture Sendable snapshots before entering the Task to avoid capturing
     // non-Sendable SwiftData models (profile) across the concurrency boundary
     guard let geofenceRule = profile.geofenceRule else {
-      endGeofenceCheck()
+      endGeofenceCheck(expectedGeneration: expectedGeneration)
       onStop()
       return
     }
@@ -128,23 +160,23 @@ class GeofenceEvaluator: ObservableObject {
     do {
       savedLocationsSnapshot = try SavedLocation.fetchAll(in: context)
     } catch {
-      endGeofenceCheck()
+      endGeofenceCheck(expectedGeneration: expectedGeneration)
       self.errorMessage = "Unable to load saved locations. Please try again."
       return
     }
 
     Task { @MainActor in
-      defer { self.endGeofenceCheck() }
-
       let result = await self.locationManager.checkGeofenceRule(
         rule: ruleToCheck,
         savedLocations: savedLocationsSnapshot
       )
 
-      if result.isSatisfied {
-        onStop()
-      } else {
-        self.errorMessage = result.failureMessage ?? "Location restriction not met."
+      self.completeGeofenceCheck(expectedGeneration: expectedGeneration) {
+        if result.isSatisfied {
+          onStop()
+        } else {
+          self.errorMessage = result.failureMessage ?? "Location restriction not met."
+        }
       }
     }
   }
@@ -180,7 +212,7 @@ class GeofenceEvaluator: ObservableObject {
       return
     }
 
-    beginGeofenceCheck()
+    let expectedGeneration = beginGeofenceCheck()
 
     // Capture saved locations before entering the Task to avoid Sendable warnings
     let ruleToCheck = geofenceRule
@@ -188,7 +220,7 @@ class GeofenceEvaluator: ObservableObject {
     do {
       savedLocationsSnapshot = try SavedLocation.fetchAll(in: context)
     } catch {
-      endGeofenceCheck()
+      endGeofenceCheck(expectedGeneration: expectedGeneration)
       self.errorMessage = "Unable to load saved locations. Please try again."
       return
     }
@@ -197,25 +229,25 @@ class GeofenceEvaluator: ObservableObject {
     pendingStartCompletion = onStart
 
     Task { @MainActor in
-      defer { self.endGeofenceCheck() }
-
       let result = await locationManager.checkGeofenceRule(
         rule: ruleToCheck,
         savedLocations: savedLocationsSnapshot
       )
 
-      if result.isSatisfied {
-        // User is at location, proceed without warning
-        self.pendingStartCompletion = nil
-        onStart(context, profile)
-      } else {
-        // User is NOT at location, show warning
-        self.pendingStartProfile = profile
-        self.geofenceWarningMessage = self.buildStartWarningMessage(
-          rule: ruleToCheck,
-          savedLocations: savedLocationsSnapshot
-        )
-        self.showGeofenceStartWarning = true
+      self.completeGeofenceCheck(expectedGeneration: expectedGeneration) {
+        if result.isSatisfied {
+          // User is at location, proceed without warning
+          self.pendingStartCompletion = nil
+          onStart(context, profile)
+        } else {
+          // User is NOT at location, show warning
+          self.pendingStartProfile = profile
+          self.geofenceWarningMessage = self.buildStartWarningMessage(
+            rule: ruleToCheck,
+            savedLocations: savedLocationsSnapshot
+          )
+          self.showGeofenceStartWarning = true
+        }
       }
     }
   }
@@ -282,8 +314,8 @@ class GeofenceEvaluator: ObservableObject {
       throw .locationPermissionDenied
     }
 
-    beginGeofenceCheck()
-    defer { endGeofenceCheck() }
+    let expectedGeneration = beginGeofenceCheck()
+    defer { endGeofenceCheck(expectedGeneration: expectedGeneration) }
 
     let ruleToCheck = rule
     let savedLocationsSnapshot: [SavedLocation]
@@ -297,6 +329,10 @@ class GeofenceEvaluator: ObservableObject {
       rule: ruleToCheck,
       savedLocations: savedLocationsSnapshot
     )
+
+    guard isCurrentGeofenceCheck(expectedGeneration: expectedGeneration) else {
+      throw .geofenceBlocked("Location check expired. Try again.")
+    }
 
     if !result.isSatisfied {
       throw .geofenceBlocked(result.failureMessage ?? "Location restriction not met.")

--- a/Foqos/Utils/GeofenceEvaluator.swift
+++ b/Foqos/Utils/GeofenceEvaluator.swift
@@ -20,6 +20,8 @@ class GeofenceEvaluator: ObservableObject {
 
   @Published var isCheckingGeofence: Bool = false
   @Published var errorMessage: String?
+  private var geofenceCheckStartedAt: Date?
+  private let staleGeofenceCheckInterval: TimeInterval = 60
 
   // Geofence start warning state
   @AppStorage("family_foqos_warn_when_activating_away_from_location") private var warnWhenActivatingAwayFromLocation =
@@ -30,6 +32,30 @@ class GeofenceEvaluator: ObservableObject {
 
   // Stored completion for confirmGeofenceStart
   private var pendingStartCompletion: ((ModelContext, BlockedProfiles) -> Void)?
+
+  func beginGeofenceCheck(now: Date = Date()) {
+    isCheckingGeofence = true
+    geofenceCheckStartedAt = now
+  }
+
+  func endGeofenceCheck() {
+    isCheckingGeofence = false
+    geofenceCheckStartedAt = nil
+  }
+
+  func recoverStaleGeofenceCheck(now: Date = Date()) -> Bool {
+    guard isCheckingGeofence, let geofenceCheckStartedAt else {
+      return false
+    }
+
+    guard now.timeIntervalSince(geofenceCheckStartedAt) >= staleGeofenceCheckInterval else {
+      return false
+    }
+
+    endGeofenceCheck()
+    pendingStartCompletion = nil
+    return true
+  }
 
   // MARK: - Evaluate (async, no UI side-effects)
 
@@ -88,12 +114,12 @@ class GeofenceEvaluator: ObservableObject {
       return
     }
 
-    isCheckingGeofence = true
+    beginGeofenceCheck()
 
     // Capture Sendable snapshots before entering the Task to avoid capturing
     // non-Sendable SwiftData models (profile) across the concurrency boundary
     guard let geofenceRule = profile.geofenceRule else {
-      isCheckingGeofence = false
+      endGeofenceCheck()
       onStop()
       return
     }
@@ -102,18 +128,18 @@ class GeofenceEvaluator: ObservableObject {
     do {
       savedLocationsSnapshot = try SavedLocation.fetchAll(in: context)
     } catch {
-      self.isCheckingGeofence = false
+      endGeofenceCheck()
       self.errorMessage = "Unable to load saved locations. Please try again."
       return
     }
 
     Task { @MainActor in
+      defer { self.endGeofenceCheck() }
+
       let result = await self.locationManager.checkGeofenceRule(
         rule: ruleToCheck,
         savedLocations: savedLocationsSnapshot
       )
-
-      self.isCheckingGeofence = false
 
       if result.isSatisfied {
         onStop()
@@ -154,7 +180,7 @@ class GeofenceEvaluator: ObservableObject {
       return
     }
 
-    isCheckingGeofence = true
+    beginGeofenceCheck()
 
     // Capture saved locations before entering the Task to avoid Sendable warnings
     let ruleToCheck = geofenceRule
@@ -162,7 +188,7 @@ class GeofenceEvaluator: ObservableObject {
     do {
       savedLocationsSnapshot = try SavedLocation.fetchAll(in: context)
     } catch {
-      self.isCheckingGeofence = false
+      endGeofenceCheck()
       self.errorMessage = "Unable to load saved locations. Please try again."
       return
     }
@@ -171,12 +197,12 @@ class GeofenceEvaluator: ObservableObject {
     pendingStartCompletion = onStart
 
     Task { @MainActor in
+      defer { self.endGeofenceCheck() }
+
       let result = await locationManager.checkGeofenceRule(
         rule: ruleToCheck,
         savedLocations: savedLocationsSnapshot
       )
-
-      self.isCheckingGeofence = false
 
       if result.isSatisfied {
         // User is at location, proceed without warning
@@ -256,8 +282,8 @@ class GeofenceEvaluator: ObservableObject {
       throw .locationPermissionDenied
     }
 
-    isCheckingGeofence = true
-    defer { isCheckingGeofence = false }
+    beginGeofenceCheck()
+    defer { endGeofenceCheck() }
 
     let ruleToCheck = rule
     let savedLocationsSnapshot: [SavedLocation]

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -148,6 +148,11 @@ class StrategyManager: ObservableObject {
 
       stopBlocking(context: context, bypassStrategy: true)
     } else {
+      guard !geofenceEvaluator.isCheckingGeofence else {
+        Log.info("Start tap ignored: geofence check already in flight", category: .strategy)
+        return
+      }
+
       geofenceEvaluator.checkGeofenceAndStart(context: context, activeProfile: activeProfile) {
         ctx, profile in
         self.startBlocking(context: ctx, activeProfile: profile, bypassStrategy: true)
@@ -439,6 +444,10 @@ class StrategyManager: ObservableObject {
               "\(profile.name) is not configured to start via written NFC or printed QR"
             return
           }
+          guard !profile.needsAppSelection else {
+            self.errorMessage = needsAppSelectionMessage(for: profile)
+            return
+          }
         }
 
         let stopResult = StartStopActionResolver.canStop(
@@ -504,6 +513,10 @@ class StrategyManager: ObservableObject {
             "\(profile.name) is not configured to start via written NFC or printed QR"
           return
         }
+        guard !profile.needsAppSelection else {
+          self.errorMessage = needsAppSelectionMessage(for: profile)
+          return
+        }
 
         _ = manualStrategy.startBlocking(
           context: context,
@@ -538,6 +551,13 @@ class StrategyManager: ObservableObject {
           category: .strategy)
         self.errorMessage = "A session is already active."
         throw IntentError.sessionAlreadyActive
+      }
+
+      if profile.needsAppSelection {
+        let message = needsAppSelectionMessage(for: profile)
+        Log.info("Refusing background start: \(message)", category: .strategy)
+        self.errorMessage = message
+        throw IntentError.needsAppSelection(profileName: profile.name)
       }
 
       if let duration = durationInMinutes {
@@ -1143,6 +1163,12 @@ class StrategyManager: ObservableObject {
       return
     }
 
+    if let rejection = rejectionForStart(definedProfile, context: context) {
+      errorMessage = rejection
+      Log.info("Refusing manual start: \(rejection)", category: .strategy)
+      return
+    }
+
     // When bypassStrategy is true, the V2 trigger system has already routed
     // the start action. Use ManualBlockingStrategy to create the session
     // directly, avoiding redundant NFC/QR scans from legacy strategies.
@@ -1256,6 +1282,12 @@ class StrategyManager: ObservableObject {
 
   /// Start blocking with a pre-scanned tag (internal helper)
   private func startWithTag(context: ModelContext, profile: BlockedProfiles, tag: String) {
+    if let rejection = rejectionForStart(profile, context: context) {
+      errorMessage = rejection
+      Log.info("Refusing tag start: \(rejection)", category: .strategy)
+      return
+    }
+
     AppBlockerUtil().activateRestrictions(for: BlockedProfiles.getSnapshot(for: profile))
 
     let session = BlockedProfileSession.createSession(
@@ -1268,6 +1300,22 @@ class StrategyManager: ObservableObject {
     activateSession(session, context: context)
 
     Log.info("Started session for profile '\(profile.name)' with tag", category: .strategy)
+  }
+
+  private func rejectionForStart(_ profile: BlockedProfiles, context: ModelContext) -> String? {
+    if (try? getActiveSession(context: context)) != nil {
+      return "A session is already active. Stop it before starting another."
+    }
+
+    if profile.needsAppSelection {
+      return needsAppSelectionMessage(for: profile)
+    }
+
+    return nil
+  }
+
+  private func needsAppSelectionMessage(for profile: BlockedProfiles) -> String {
+    "Profile '\(profile.name)' needs app selection on this device before it can start."
   }
 
   /// Stop the active blocking session.

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -148,7 +148,10 @@ class StrategyManager: ObservableObject {
 
       stopBlocking(context: context, bypassStrategy: true)
     } else {
-      guard !geofenceEvaluator.isCheckingGeofence else {
+      if geofenceEvaluator.isCheckingGeofence,
+        !geofenceEvaluator.recoverStaleGeofenceCheck()
+      {
+        errorMessage = "Still checking your location. Try again in a moment."
         Log.info("Start tap ignored: geofence check already in flight", category: .strategy)
         return
       }
@@ -1303,8 +1306,24 @@ class StrategyManager: ObservableObject {
   }
 
   private func rejectionForStart(_ profile: BlockedProfiles, context: ModelContext) -> String? {
-    if (try? getActiveSession(context: context)) != nil {
-      return "A session is already active. Stop it before starting another."
+    rejectionForStart(profile) {
+      try getActiveSession(context: context)
+    }
+  }
+
+  func rejectionForStart(
+    _ profile: BlockedProfiles,
+    activeSessionProvider: () throws -> BlockedProfileSession?
+  ) -> String? {
+    do {
+      if try activeSessionProvider() != nil {
+        return "A session is already active. Stop it before starting another."
+      }
+    } catch {
+      Log.error(
+        "Failed to verify active session before start: \(error.localizedDescription)",
+        category: .strategy)
+      return "Couldn't verify whether a session is already active. Try again."
     }
 
     if profile.needsAppSelection {
@@ -1315,7 +1334,7 @@ class StrategyManager: ObservableObject {
   }
 
   private func needsAppSelectionMessage(for profile: BlockedProfiles) -> String {
-    "Profile '\(profile.name)' needs app selection on this device before it can start."
+    IntentError.needsAppSelectionMessage(profileName: profile.name)
   }
 
   /// Stop the active blocking session.

--- a/Foqos/Views/HomeView.swift
+++ b/Foqos/Views/HomeView.swift
@@ -195,6 +195,9 @@ struct HomeView: View {
             activeSessionProfileId: activeSessionProfileId,
             elapsedTime: strategyManager.elapsedTime,
             startingProfileId: navigateToProfileId,
+            onStartingProfileConsumed: {
+              navigateToProfileId = nil
+            },
             onStartTapped: { profile in
               strategyButtonPress(profile)
             },

--- a/FoqosTests/BlockedProfileCarouselTests.swift
+++ b/FoqosTests/BlockedProfileCarouselTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class BlockedProfileCarouselTests: XCTestCase {
+  func testGivenCurrentPageStillPresent_WhenProfilesChange_ThenCurrentPageKept() {
+    let currentId = UUID()
+    let nextId = UUID()
+
+    let resolved = BlockedProfileCarousel.resolvedCurrentProfileId(
+      currentProfileId: currentId,
+      validProfileIds: [currentId, nextId]
+    )
+
+    XCTAssertEqual(resolved, currentId)
+  }
+
+  func testGivenCurrentPageRemoved_WhenProfilesChange_ThenFallsBackToFirst() {
+    let removedId = UUID()
+    let firstRemainingId = UUID()
+    let secondRemainingId = UUID()
+
+    let resolved = BlockedProfileCarousel.resolvedCurrentProfileId(
+      currentProfileId: removedId,
+      validProfileIds: [firstRemainingId, secondRemainingId]
+    )
+
+    XCTAssertEqual(resolved, firstRemainingId)
+  }
+
+  func testGivenPendingStartingPageAppears_WhenProfilesChange_ThenInitialSetupRuns() {
+    let currentId = UUID()
+    let startingId = UUID()
+
+    let shouldRunInitialSetup = BlockedProfileCarousel.shouldRunInitialSetupOnProfilesChange(
+      currentProfileId: currentId,
+      startingProfileId: startingId,
+      validProfileIds: [currentId, startingId]
+    )
+
+    XCTAssertTrue(shouldRunInitialSetup)
+  }
+}

--- a/FoqosTests/StrategyManagerBackgroundTests.swift
+++ b/FoqosTests/StrategyManagerBackgroundTests.swift
@@ -59,6 +59,28 @@ final class StrategyManagerBackgroundTests: XCTestCase {
     }
   }
 
+  func testGivenProfileNeedsAppSelection_WhenStartSessionFromBackground_ThenThrowsAndNoSession()
+    throws
+  {
+    let profile = BlockedProfiles(name: "Needs Apps")
+    profile.needsAppSelection = true
+    context.insert(profile)
+    try context.save()
+
+    XCTAssertThrowsError(
+      try manager.startSessionFromBackground(profile.id, context: context)
+    ) { error in
+      if case IntentError.needsAppSelection = error {
+      } else {
+        XCTFail("Expected needsAppSelection, got \(error)")
+      }
+    }
+
+    let sessions = try context.fetch(FetchDescriptor<BlockedProfileSession>())
+    XCTAssertTrue(sessions.isEmpty)
+    XCTAssertNotNil(manager.errorMessage)
+  }
+
   func testGivenDurationTooShort_WhenStartingFromBackground_ThenThrowsDurationOutOfRange() throws {
     let profile = BlockedProfiles(name: "Test")
     context.insert(profile)

--- a/FoqosTests/StrategyManagerStartTests.swift
+++ b/FoqosTests/StrategyManagerStartTests.swift
@@ -1,11 +1,38 @@
 // FoqosTests/StrategyManagerStartTests.swift
 import FoqosShared
+import SwiftData
 import XCTest
 
 @testable import FamilyFoqos
 
 @MainActor
 final class StrategyManagerStartTests: XCTestCase {
+  private var container: ModelContainer!
+  private var context: ModelContext!
+  private var manager: StrategyManager!
+  private var suiteName: String!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "StrategyManagerStartTests-\(UUID().uuidString)"
+    SharedData.configure(suite: UserDefaults(suiteName: suiteName)!)
+    container = try TestModelContainer.create()
+    context = container.mainContext
+    manager = StrategyManager()
+  }
+
+  override func tearDown() async throws {
+    manager.stopTimer()
+    UserDefaults().removePersistentDomain(forName: suiteName)
+    try await super.tearDown()
+  }
+
+  private func activeSessions() throws -> [BlockedProfileSession] {
+    try context.fetch(
+      FetchDescriptor<BlockedProfileSession>(
+        predicate: #Predicate { $0.endTime == nil }
+      ))
+  }
 
   func testGivenManualTriggerOnly_WhenDeterminingStartAction_ThenReturnsStartImmediately() {
     var start = ProfileStartTriggers()
@@ -118,5 +145,142 @@ final class StrategyManagerStartTests: XCTestCase {
     let action = StartStopActionResolver.determineStartAction(for: start, stopConditions: stop)
 
     XCTAssertEqual(action, .startImmediately)
+  }
+
+  func testGivenActiveSession_WhenStartWithNFCTag_ThenNoSecondSessionAndErrorSurfaced() throws {
+    let activeProfile = BlockedProfiles(name: "Active")
+    let scannedProfile = BlockedProfiles(name: "Scanned")
+    context.insert(activeProfile)
+    context.insert(scannedProfile)
+    _ = BlockedProfileSession.createSession(
+      in: context, withTag: "existing", withProfile: activeProfile)
+    try context.save()
+
+    manager.startWithNFCTag(context: context, profile: scannedProfile, tagId: "tag-1")
+
+    XCTAssertEqual(try activeSessions().count, 1)
+    XCTAssertNotNil(manager.errorMessage)
+  }
+
+  func testGivenProfileNeedsAppSelection_WhenStartWithQRCode_ThenNoSessionAndErrorSurfaced()
+    throws
+  {
+    let profile = BlockedProfiles(name: "Needs Apps")
+    profile.needsAppSelection = true
+    context.insert(profile)
+    try context.save()
+
+    manager.startWithQRCode(context: context, profile: profile, codeValue: "qr-1")
+
+    XCTAssertNil(manager.activeSession)
+    XCTAssertTrue(try activeSessions().isEmpty)
+    XCTAssertNotNil(manager.errorMessage)
+  }
+
+  func testGivenActiveSession_WhenToggleBlockingStart_ThenNoSecondSessionAndErrorSurfaced()
+    throws
+  {
+    let activeProfile = BlockedProfiles(name: "Active")
+    let nextProfile = BlockedProfiles(name: "Next")
+    nextProfile.blockingStrategyId = ManualBlockingStrategy.id
+    context.insert(activeProfile)
+    context.insert(nextProfile)
+    _ = BlockedProfileSession.createSession(
+      in: context, withTag: "existing", withProfile: activeProfile)
+    try context.save()
+
+    manager.toggleBlocking(context: context, activeProfile: nextProfile)
+
+    XCTAssertEqual(try activeSessions().count, 1)
+    XCTAssertNotNil(manager.errorMessage)
+  }
+
+  func testGivenProfileNeedsAppSelection_WhenToggleBlockingStart_ThenNoSessionAndErrorSurfaced()
+    throws
+  {
+    let profile = BlockedProfiles(name: "Needs Apps")
+    profile.needsAppSelection = true
+    profile.blockingStrategyId = ManualBlockingStrategy.id
+    context.insert(profile)
+    try context.save()
+
+    manager.toggleBlocking(context: context, activeProfile: profile)
+
+    XCTAssertNil(manager.activeSession)
+    XCTAssertTrue(try activeSessions().isEmpty)
+    XCTAssertNotNil(manager.errorMessage)
+  }
+
+  func testGivenNoActiveSessionAndAppsSelected_WhenStartWithNFCTag_ThenSessionStarts() throws {
+    let profile = BlockedProfiles(name: "Ready")
+    context.insert(profile)
+    try context.save()
+
+    manager.startWithNFCTag(context: context, profile: profile, tagId: "tag-1")
+
+    XCTAssertEqual(manager.activeSession?.blockedProfile.id, profile.id)
+    XCTAssertNotNil(manager.timerTask)
+  }
+
+  func testGivenProfileNeedsAppSelection_WhenToggleSessionFromDeeplink_ThenNoSessionAndErrorSurfaced()
+    async throws
+  {
+    let profile = BlockedProfiles(name: "Needs Apps")
+    profile.needsAppSelection = true
+    profile.startTriggers = ProfileStartTriggers(deepLink: true)
+    context.insert(profile)
+    try context.save()
+
+    await manager.toggleSessionFromDeeplink(
+      profile.id.uuidString,
+      url: URL(string: "familyfoqos://profile/\(profile.id.uuidString)")!,
+      context: context
+    )
+
+    XCTAssertNil(manager.activeSession)
+    XCTAssertTrue(try activeSessions().isEmpty)
+    XCTAssertNotNil(manager.errorMessage)
+  }
+
+  func testGivenProfileNeedsAppSelection_WhenToggleSessionFromDeeplinkSwitching_ThenCurrentSessionRemainsAndErrorSurfaced()
+    async throws
+  {
+    let activeProfile = BlockedProfiles(name: "Active")
+    activeProfile.stopConditions = ProfileStopConditions(deepLink: true)
+    let nextProfile = BlockedProfiles(name: "Needs Apps")
+    nextProfile.needsAppSelection = true
+    nextProfile.startTriggers = ProfileStartTriggers(deepLink: true)
+    context.insert(activeProfile)
+    context.insert(nextProfile)
+    let activeSession = BlockedProfileSession.createSession(
+      in: context, withTag: "active", withProfile: activeProfile)
+    try context.save()
+
+    await manager.toggleSessionFromDeeplink(
+      nextProfile.id.uuidString,
+      url: URL(string: "familyfoqos://profile/\(nextProfile.id.uuidString)")!,
+      context: context
+    )
+
+    XCTAssertNil(activeSession.endTime)
+    XCTAssertEqual(try activeSessions().count, 1)
+    XCTAssertNotNil(manager.errorMessage)
+  }
+
+  func testGivenGeofenceCheckInFlight_WhenToggleBlockingCalledAgain_ThenSecondCallIsIgnored()
+    throws
+  {
+    let geofenceEvaluator = GeofenceEvaluator()
+    geofenceEvaluator.isCheckingGeofence = true
+    manager = StrategyManager(geofenceEvaluator: geofenceEvaluator)
+    let profile = BlockedProfiles(name: "Manual")
+    profile.blockingStrategyId = ManualBlockingStrategy.id
+    context.insert(profile)
+    try context.save()
+
+    manager.toggleBlocking(context: context, activeProfile: profile)
+
+    XCTAssertNil(manager.activeSession)
+    XCTAssertTrue(try activeSessions().isEmpty)
   }
 }

--- a/FoqosTests/StrategyManagerStartTests.swift
+++ b/FoqosTests/StrategyManagerStartTests.swift
@@ -271,7 +271,7 @@ final class StrategyManagerStartTests: XCTestCase {
     throws
   {
     let geofenceEvaluator = GeofenceEvaluator()
-    geofenceEvaluator.isCheckingGeofence = true
+    geofenceEvaluator.beginGeofenceCheck()
     manager = StrategyManager(geofenceEvaluator: geofenceEvaluator)
     let profile = BlockedProfiles(name: "Manual")
     profile.blockingStrategyId = ManualBlockingStrategy.id
@@ -282,5 +282,35 @@ final class StrategyManagerStartTests: XCTestCase {
 
     XCTAssertNil(manager.activeSession)
     XCTAssertTrue(try activeSessions().isEmpty)
+    XCTAssertNotNil(manager.errorMessage)
+  }
+
+  func testGivenStaleGeofenceCheckInFlight_WhenToggleBlockingCalledAgain_ThenStartCanProceed()
+    throws
+  {
+    let geofenceEvaluator = GeofenceEvaluator()
+    geofenceEvaluator.beginGeofenceCheck(now: Date().addingTimeInterval(-120))
+    manager = StrategyManager(geofenceEvaluator: geofenceEvaluator)
+    let profile = BlockedProfiles(name: "Manual")
+    profile.blockingStrategyId = ManualBlockingStrategy.id
+    context.insert(profile)
+    try context.save()
+
+    manager.toggleBlocking(context: context, activeProfile: profile)
+
+    XCTAssertEqual(manager.activeSession?.blockedProfile.id, profile.id)
+    XCTAssertFalse(geofenceEvaluator.isCheckingGeofence)
+  }
+
+  func testGivenActiveSessionFetchFails_WhenRejectionForStart_ThenFailsClosed() throws {
+    let profile = BlockedProfiles(name: "Manual")
+    context.insert(profile)
+    try context.save()
+
+    let rejection = manager.rejectionForStart(profile) {
+      throw CocoaError(.fileReadUnknown)
+    }
+
+    XCTAssertEqual(rejection, "Couldn't verify whether a session is already active. Try again.")
   }
 }

--- a/FoqosTests/StrategyManagerStartTests.swift
+++ b/FoqosTests/StrategyManagerStartTests.swift
@@ -302,6 +302,59 @@ final class StrategyManagerStartTests: XCTestCase {
     XCTAssertFalse(geofenceEvaluator.isCheckingGeofence)
   }
 
+  func testGivenRecoveredStaleGeofenceCheck_WhenOldGenerationCompletes_ThenCurrentStateIsNotMutated()
+    throws
+  {
+    let now = Date()
+    let geofenceEvaluator = GeofenceEvaluator()
+    let staleGeneration = geofenceEvaluator.beginGeofenceCheck(
+      now: now.addingTimeInterval(-120))
+    XCTAssertTrue(geofenceEvaluator.recoverStaleGeofenceCheck(now: now))
+    let currentGeneration = geofenceEvaluator.beginGeofenceCheck(now: now)
+
+    let didCompleteStaleGeneration = geofenceEvaluator.completeGeofenceCheck(
+      expectedGeneration: staleGeneration
+    ) {
+      geofenceEvaluator.errorMessage = "stale completion mutated state"
+      geofenceEvaluator.geofenceWarningMessage = "stale warning"
+      geofenceEvaluator.showGeofenceStartWarning = true
+    }
+
+    XCTAssertFalse(didCompleteStaleGeneration)
+    XCTAssertTrue(geofenceEvaluator.isCheckingGeofence)
+    XCTAssertNil(geofenceEvaluator.errorMessage)
+    XCTAssertEqual(geofenceEvaluator.geofenceWarningMessage, "")
+    XCTAssertFalse(geofenceEvaluator.showGeofenceStartWarning)
+
+    let didCompleteCurrentGeneration = geofenceEvaluator.completeGeofenceCheck(
+      expectedGeneration: currentGeneration
+    ) {
+      geofenceEvaluator.errorMessage = "current completion"
+    }
+
+    XCTAssertTrue(didCompleteCurrentGeneration)
+    XCTAssertFalse(geofenceEvaluator.isCheckingGeofence)
+    XCTAssertEqual(geofenceEvaluator.errorMessage, "current completion")
+  }
+
+  func testGivenRecoveredStaleGeofenceCheck_WhenEmergencyGenerationCompletes_ThenOldGenerationIsRejected()
+    throws
+  {
+    let now = Date()
+    let geofenceEvaluator = GeofenceEvaluator()
+    let staleGeneration = geofenceEvaluator.beginGeofenceCheck(
+      now: now.addingTimeInterval(-120))
+    XCTAssertTrue(geofenceEvaluator.recoverStaleGeofenceCheck(now: now))
+    let currentGeneration = geofenceEvaluator.beginGeofenceCheck(now: now)
+
+    XCTAssertFalse(
+      geofenceEvaluator.isCurrentGeofenceCheck(expectedGeneration: staleGeneration)
+    )
+    XCTAssertTrue(
+      geofenceEvaluator.isCurrentGeofenceCheck(expectedGeneration: currentGeneration)
+    )
+  }
+
   func testGivenActiveSessionFetchFails_WhenRejectionForStart_ThenFailsClosed() throws {
     let profile = BlockedProfiles(name: "Manual")
     context.insert(profile)

--- a/docs/plans/2026-07-12-pr-318-review-r2.md
+++ b/docs/plans/2026-07-12-pr-318-review-r2.md
@@ -1,0 +1,75 @@
+# Address PR #318 Review Comments (Round 2)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Address accepted and partially accepted review comments from PR #318 after the ready-for-review rerun.
+
+**Architecture:** Keep D3+E2 scope intact. The geofence stale-check fix should use the same identity-gate vocabulary and shape used elsewhere in this codebase: in-flight work records an expected identity/generation, invalidation advances that identity, and stale completions must not mutate shared state.
+
+**Tech Stack:** Swift, SwiftUI, SwiftData, AppIntents, XCTest.
+
+---
+
+### Task 1: Add geofence stale-task identity gate (comment #1)
+
+**Review comment:** Greptile reported that `recoverStaleGeofenceCheck()` clears shared state, but the old async geofence task can resume later and mutate pending geofence state that now belongs to a newer check.
+
+**Category:** Accept.
+
+**Required fix:**
+
+1. Add an identity gate to `GeofenceEvaluator` for geofence checks.
+2. Match the house pattern vocabulary and shape used by `expectedSessionId`, `namespaceGeneration`, and the #315 watermark:
+   - A begin operation records and returns the expected identity.
+   - A stale recovery invalidates existing in-flight work by advancing/clearing the identity.
+   - Async completion checks the expected identity before mutating shared state.
+3. Do not add CoreLocation cancellation semantics.
+4. Guard all shared geofence state mutations that can run from stale async completions:
+   - `endGeofenceCheck`
+   - `pendingStartCompletion`
+   - `pendingStartProfile`
+   - `geofenceWarningMessage`
+   - `showGeofenceStartWarning`
+   - start/stop callbacks from stale checks
+   - error updates from stale checks
+5. Add a regression test for the resumed-stale-task case specifically:
+   - Start old check and capture its expected identity.
+   - Recover it as stale.
+   - Start a newer check or otherwise establish a newer/current identity.
+   - Simulate old task completion with the old identity.
+   - Assert no shared state mutates from the old completion.
+
+**Evidence anchors:**
+
+- `Foqos/Utils/GeofenceEvaluator.swift`: existing `beginGeofenceCheck`, `endGeofenceCheck`, `recoverStaleGeofenceCheck`, `checkGeofenceAndStop`, and `checkGeofenceAndStart`.
+- `FoqosTests/StrategyManagerStartTests.swift`: existing geofence in-flight/stale tests.
+
+**Verification:**
+
+- Red-first focused test showing stale old completion mutates state before the fix.
+- Focused `StrategyManagerStartTests` after the fix.
+
+---
+
+### Task 2: Minor review cleanups (comments #2, #3)
+
+**Review comments:**
+
+- Sourcery noted the stale geofence interval is a hardcoded `60`.
+- Sourcery noted that `IntentError.needsAppSelectionMessage` and `.needsAppSelection`'s `LocalizedStringResource` literal use slightly different copy.
+
+**Category:** Partially accept both.
+
+**Required fix:**
+
+1. Convert the geofence stale interval to a private static constant in `GeofenceEvaluator`.
+2. Do not make the interval injectable.
+3. Align only the AppIntent `.needsAppSelection` literal to the existing plain `String` helper copy:
+   - `Profile '\(name)' needs app selection on this device before it can start.`
+4. Do not centralize across `LocalizedStringResource` and `String`.
+5. Do not touch the remote-start distinct copy.
+
+**Verification:**
+
+- Existing focused tests remain green.
+- `swift-format lint --recursive .` after all changes.


### PR DESCRIPTION
| #225 synced needs-app-selection profile: deep-link and NFC/QR scan-start | Pass | Human device test passed; log `docs/plans/FamilyFoqos-Logs-2026-07-12-135818.log`. This row is specifically for a synced profile whose device-local FamilyControls tokens are missing (`needsAppSelection == true`), not a locally-created zero-selection profile. |
| #246 sync-driven carousel membership change while Home stays visible | Pass | Human device test passed; with Device A on card 3 of 3, Device B deleted profile 2, and Device A stayed on profile 3. Separate fallback observed: when Device B deleted the currently visible profile 3, Device A fell back to profile 1; that fallback is accepted behavior. Log `docs/plans/FamilyFoqos-Logs-2026-07-12-135705.log`. |## Summary

- Add shared local start preflight guards for active sessions and `needsAppSelection` before NFC/QR scan starts and manual/toggle starts.
- Mirror the remote `needsAppSelection` rejection on App Intent/background and deep-link local start paths, including the deep-link switching branch before stopping the current session.
- Preserve carousel scroll position across profile membership changes and clear HomeView's navigation target only after carousel consumption.

Fixes #224
Fixes #225
Fixes #246

## Bring-forward diff audit

Plan source: `docs/superpowers/plans/2026-07-07-d3-e2-start-guards-carousel-scroll.md` from PR #290. The plan was grounded at `4307654`; this branch is based on current `origin/main` `3a5eee2`.

Current anchors re-derived by symbol before device/build work:

- `StrategyManager.toggleBlocking` still had no `geofenceEvaluator.isCheckingGeofence` start gate; fixed at the start branch.
- `StrategyManager.startBlocking` and `startWithTag` still reached strategy/session creation without active-session or `needsAppSelection` preflight; both now use `rejectionForStart(_:context:)`, which calls `getActiveSession(context:)` so scheduled snapshots are reconciled before rejecting.
- `startSessionFromBackground` already had the active-session guard but no `needsAppSelection` guard; now throws `IntentError.needsAppSelection` and sets the same clear message.
- `toggleSessionFromDeeplink` had unguarded no-active and switching starts; both now reject `needsAppSelection`, and switching rejects before stopping the current session.
- `startRemoteSession` remains the reference remote `needsAppSelection` guard.
- Carousel/card semantic drift since #300/#314 was accounted for: `BlockedProfileCarousel` still builds `profile.cardData(...)` inside `SafeModelView`; this PR does not reintroduce live model reads into `BlockedProfileCard` or `ProfileScheduleRow`.

## HomeView navigation clear point

I chose a carousel-consumption callback, not immediate clearing in `HomeView.onChange` or `onAppear`.

Reason: `HomeView` sets local `navigateToProfileId`, passes it as `startingProfileId`, and `BlockedProfileCarousel` consumes that value in its own `onChange(of: startingProfileId)` / `initialSetup()` path. Clearing in Home immediately would race the carousel consumer. The callback fires only after `initialSetup()` assigns `currentProfileId = startingId`; the carousel also ignores `startingProfileId == nil` changes so the clear does not snap back to the first card. A review catch also added coverage for a pending target that appears later via profile membership change.

## Verification

TDD red-first evidence:

- Initial focused red run failed on missing carousel helper, then missing `IntentError.needsAppSelection`, then behavior failures for active-session guard, needs-app-selection local starts, geofence in-flight tap, and deep-link guard.
- Additional red pass for `startBlocking` and deep-link switching temporarily removed the corresponding guards; `StrategyManagerStartTests` failed on those new regressions, then passed after restoring the implementation.
- Review fix red pass: `BlockedProfileCarouselTests` failed on missing `shouldRunInitialSetupOnProfilesChange`, then passed after implementing the pending-starting-profile membership-change fix.

Automated verification on iPhone 17 simulator UUID `B9E4A679-BDF3-4541-A59F-DA4BE21F80ED`:

- `swift-format lint --recursive .` ✅
- `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -only-testing:FoqosTests/StrategyManagerStartTests -only-testing:FoqosTests/StrategyManagerBackgroundTests -only-testing:FoqosTests/StrategyManagerRemoteSessionTests -only-testing:FoqosTests/StrategyManagerReconcileTests -only-testing:FoqosTests/StrategyManagerStopTests -only-testing:FoqosTests/ConcurrentSessionTests -only-testing:FoqosTests/BlockedProfileCarouselTests | xcpretty` ✅
- `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' | xcpretty` ✅
- Commit hook guard output: `I5`, `I2`, and `C2 guards passed` ✅
- Review-fix focused suite, broader related suite, `swift-format lint --recursive .`, and full suite rerun after commit `5505588` ✅

Read-only code review: subagent found one Important carousel edge case (pending `startingProfileId` appears via membership change); fixed with a red/green regression.

PR review processing: accepted fail-closed active-session fetch handling, accepted geofence stuck-flag evidence/fix, and partially accepted local/background `needsAppSelection` string cleanup. Geofence evidence: `GeofenceEvaluator.checkGeofenceAndStart` set `isCheckingGeofence` before awaiting `LocationManager.checkGeofenceRule`; `LocationManager.getCurrentLocation()` waits on a CoreLocation continuation with no timeout, so the flag could outlive the underlying check if the callback never resumes. Fix: `beginGeofenceCheck`/`endGeofenceCheck` with `defer` cleanup on completion plus stale-check recovery before ignoring a hold-to-start.

Device rows, debugger detached:

| Row | Status | Notes |
| --- | --- | --- |
| #225 synced needs-app-selection profile: deep-link and NFC/QR scan-start | Pass | Human device test passed; log `docs/plans/FamilyFoqos-Logs-2026-07-12-135818.log`. This row is specifically for a synced profile whose device-local FamilyControls tokens are missing (`needsAppSelection == true`), not a locally-created zero-selection profile. |
| #246 sync-driven carousel membership change while Home stays visible | Pass | Human device test passed; with Device A on card 3 of 3, Device B deleted profile 2, and Device A stayed on profile 3. Separate fallback observed: when Device B deleted the currently visible profile 3, Device A fell back to profile 1; that fallback is accepted behavior. Log `docs/plans/FamilyFoqos-Logs-2026-07-12-135705.log`. |
| #224 hold-to-start/geofence in-flight observation | Not run by this agent | Unit-territory per plan; if manually probing, use hold-to-start and verify an in-flight geofence start check does not create a duplicate active session. |

## Notes

- No CloudKit, CKSyncEngine, MutationFunnel, sync transport, or card data snapshot files were changed.
- Out of scope device finding: a locally-created all-empty profile can be saved and started with no warning. This is not `needsAppSelection`; it should be tracked as a separate product/configuration-validation issue.
- Commits `7076d91` and `5505588` are SSH-signed and show as Verified on GitHub.

## Summary by Sourcery

Add stricter session start guards for active sessions and profiles needing app selection, and improve carousel navigation handling so Home keeps its selected profile across membership changes.

Bug Fixes:
- Prevent starting new sessions via NFC, QR, manual toggle, deep-link, and background paths when a session is already active or the profile still needs local app selection.
- Avoid duplicate or stuck geofence-driven starts by tracking in-flight geofence checks and recovering stale checks before allowing new starts.
- Preserve the currently visible profile in the blocked profile carousel across sync-driven profile list changes while correctly honoring pending navigation targets from Home.

Enhancements:
- Surface clearer user-facing error messages when session starts are rejected due to configuration or state issues.
- Delay clearing HomeView’s navigation target until the carousel has consumed it, avoiding unintended jumps back to the first profile.

Tests:
- Add unit tests covering start rejection conditions, geofence in-flight and stale recovery behavior, and blocked profile carousel selection and initial setup logic.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens local session starts and keeps the profile carousel stable. The main changes are:

- Shared start guards for active sessions and profiles that need app selection.
- Matching rejections for NFC, QR, manual, background, and deep-link starts.
- Geofence in-flight handling with stale-check recovery.
- Carousel state preservation across profile membership changes.

<h3>Confidence Score: 4/5</h3>

This is close, but the geofence recovery path should be fixed before merging.

- Start guards now fail closed across the changed start paths.
- Carousel navigation handling looks stable for the changed membership cases.
- A recovered geofence check does not stop the old async check from later mutating shared pending state.

Foqos/Utils/GeofenceEvaluator.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Foqos/Utils/GeofenceEvaluator.swift | Adds timestamped geofence check recovery, but old async checks can still update shared pending state after recovery. |
| Foqos/Utils/StrategyManager.swift | Adds fail-closed start guards across local, tag, deep-link, and background start paths. |
| Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift | Preserves the current carousel card and consumes pending navigation after setup. |
| Foqos/Views/HomeView.swift | Clears the pending carousel navigation target after the carousel consumes it. |

<sub>Reviews (2): Last reviewed commit: ["Address D3 E2 review feedback"](https://github.com/mnbf9rca/family-foqos/commit/550558861fc6fadc8fbffe6db3eb0134b85fcdc5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43608978)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->