### PR TITLE
Fix B2 family command and heartbeat plumbing

### DIFF
--- a/Foqos/CloudKit/CloudKitNetworkService+Sharing.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Sharing.swift
@@ -5,6 +5,20 @@ extension CloudKitNetworkService {
 
   // MARK: - Family Sharing
 
+  /// Decide which existing FamilyMembers to remove after a share-participant sync.
+  ///
+  /// FAIL-SAFE (#241): when any accepted participant has an unresolved userRecordID,
+  /// `acceptedParticipantRecordNames` is incomplete, so a still-enrolled member could look
+  /// departed. In that case remove nothing and let a later fully resolved sync clean up.
+  nonisolated static func familyMembersToRemove(
+    from existing: [FamilyMember],
+    acceptedParticipantRecordNames: Set<String>,
+    hasUnresolvedAcceptedParticipant: Bool
+  ) -> [FamilyMember] {
+    guard !hasUnresolvedAcceptedParticipant else { return [] }
+    return existing.filter { !acceptedParticipantRecordNames.contains($0.userRecordName) }
+  }
+
   func getOrCreateFamilyShare() async throws -> CKShare {
     if let existingShare = self.activeZoneShare {
       return existingShare
@@ -222,20 +236,31 @@ extension CloudKitNetworkService {
         "\(pending.count) accepted participants pending self-registration", category: .cloudKit)
     }
 
-    // Remove FamilyMembers who are no longer accepted participants
-    for member in familyMembers {
-      let userRecordName = member.userRecordName
-
-      if !currentParticipantRecordNames.contains(userRecordName) {
-        do {
-          let recordID = CKRecord.ID(recordName: member.id.uuidString, zoneID: policyZoneID)
-          try await privateDatabase.deleteRecord(withID: recordID)
-          familyMembers.removeAll { $0.id == member.id }
-          Log.info(
-            "Removed FamilyMember who left share: \(member.displayName)", category: .cloudKit)
-        } catch {
-          Log.error("Failed to remove stale FamilyMember: \(error)", category: .cloudKit)
-        }
+    // Remove FamilyMembers who are no longer accepted participants.
+    // FAIL-SAFE (#241): skip removals when any accepted participant is unresolved, so a
+    // transient nil userRecordID cannot delete a still-enrolled child.
+    let hasUnresolvedAcceptedParticipant = acceptedParticipants.contains {
+      $0.userIdentity.userRecordID == nil
+    }
+    if hasUnresolvedAcceptedParticipant {
+      Log.info(
+        "Skipping FamilyMember cleanup: an accepted participant has an unresolved identity",
+        category: .cloudKit)
+    }
+    let membersToRemove = Self.familyMembersToRemove(
+      from: familyMembers,
+      acceptedParticipantRecordNames: currentParticipantRecordNames,
+      hasUnresolvedAcceptedParticipant: hasUnresolvedAcceptedParticipant
+    )
+    for member in membersToRemove {
+      do {
+        let recordID = CKRecord.ID(recordName: member.id.uuidString, zoneID: policyZoneID)
+        try await privateDatabase.deleteRecord(withID: recordID)
+        familyMembers.removeAll { $0.id == member.id }
+        Log.info(
+          "Removed FamilyMember who left share: \(member.displayName)", category: .cloudKit)
+      } catch {
+        Log.error("Failed to remove stale FamilyMember: \(error)", category: .cloudKit)
       }
     }
 

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -142,6 +142,9 @@ struct FoqosApp: App {
               await CloudKitManager.shared.verifySelfFamilyMemberRecord()
               // Verify child authorization when app becomes active
               verifyChildAuthorizationIfNeeded()
+              if AppModeManager.shared.currentMode == .child {
+                await LockCodeManager.shared.processPendingCommands()
+              }
             }
             // #201: re-drive persisted session-stop retries so a remote device doesn't see a
             // stopped session as perpetually active

--- a/Foqos/Models/MonitoredDevice.swift
+++ b/Foqos/Models/MonitoredDevice.swift
@@ -11,11 +11,24 @@ struct MonitoredDevice: Codable, Identifiable {
   var isSuppressed: Bool
   var notificationIdentifier: String?
   var authorizationStatus: String?
+  /// Timestamp when the parent was alerted about this device's current authorization revocation.
+  var authRevokedNotifiedAt: Date?
 
   static let stalenessThreshold: TimeInterval = 24 * 3600  // 24 hours
 
   var isAuthRevoked: Bool {
     authorizationStatus == "denied"
+  }
+
+  func shouldScheduleAuthRevokedAlert() -> Bool {
+    isAuthRevoked && authRevokedNotifiedAt == nil
+  }
+
+  nonisolated static func carriedAuthRevokedNotifiedAt(
+    previous: Date?,
+    newStatus: String?
+  ) -> Date? {
+    newStatus == "denied" ? previous : nil
   }
 
   func isStale(now: Date = Date()) -> Bool {

--- a/Foqos/Utils/AuthorizationRequesting.swift
+++ b/Foqos/Utils/AuthorizationRequesting.swift
@@ -1,9 +1,34 @@
+import Combine
 @preconcurrency import FamilyControls
 
 /// Seam over AuthorizationCenter's async request so RequestAuthorizer can await the real outcome.
 @MainActor
 protocol AuthorizationRequesting {
+  var authorizationStatus: AuthorizationStatus { get }
+  var authorizationStatusPublisher: AnyPublisher<AuthorizationStatus, Never> { get }
+
   func requestAuthorization(for member: FamilyControlsMember) async throws
 }
 
-extension AuthorizationCenter: AuthorizationRequesting {}
+@MainActor
+final class AuthorizationCenterRequester: AuthorizationRequesting {
+  static let shared = AuthorizationCenterRequester()
+
+  private let authorizationCenter: AuthorizationCenter
+
+  init(authorizationCenter: AuthorizationCenter = .shared) {
+    self.authorizationCenter = authorizationCenter
+  }
+
+  var authorizationStatus: AuthorizationStatus {
+    authorizationCenter.authorizationStatus
+  }
+
+  var authorizationStatusPublisher: AnyPublisher<AuthorizationStatus, Never> {
+    authorizationCenter.$authorizationStatus.eraseToAnyPublisher()
+  }
+
+  func requestAuthorization(for member: FamilyControlsMember) async throws {
+    try await authorizationCenter.requestAuthorization(for: member)
+  }
+}

--- a/Foqos/Utils/AuthorizationRequesting.swift
+++ b/Foqos/Utils/AuthorizationRequesting.swift
@@ -1,0 +1,9 @@
+@preconcurrency import FamilyControls
+
+/// Seam over AuthorizationCenter's async request so RequestAuthorizer can await the real outcome.
+@MainActor
+protocol AuthorizationRequesting {
+  func requestAuthorization(for member: FamilyControlsMember) async throws
+}
+
+extension AuthorizationCenter: AuthorizationRequesting {}

--- a/Foqos/Utils/HeartbeatManager.swift
+++ b/Foqos/Utils/HeartbeatManager.swift
@@ -129,21 +129,26 @@ class HeartbeatManager: ObservableObject {
   }
 
   private func scheduleNotification(for device: MonitoredDevice) {
-    cancelNotification(for: device)
-
     let notificationId = "heartbeat-\(device.id)"
     let content = UNMutableNotificationContent()
     content.sound = .default
 
     let triggerDate: Date
+    let now = Date()
+    var markAuthRevokedNotified = false
 
     if device.isAuthRevoked {
-      // Auth revoked — fire near-immediately
+      guard device.shouldScheduleAuthRevokedAlert() else { return }
+      cancelNotification(for: device)
+
       content.title = "Screen Time Permissions Lost"
       content.body =
         "\(device.deviceName) has lost Screen Time permissions. Tap to review."
-      triggerDate = Date().addingTimeInterval(1)
+      triggerDate = now.addingTimeInterval(1)
+      markAuthRevokedNotified = true
     } else {
+      cancelNotification(for: device)
+
       // Normal staleness countdown
       content.title = "Device Check-In"
       content.body =
@@ -152,24 +157,24 @@ class HeartbeatManager: ObservableObject {
     }
 
     // Don't schedule if trigger is in the past (device already stale — banner handles it)
-    guard triggerDate > Date() else { return }
+    guard triggerDate > now else { return }
 
     let interval = triggerDate.timeIntervalSinceNow
     let trigger = UNTimeIntervalNotificationTrigger(timeInterval: max(interval, 1), repeats: false)
     let request = UNNotificationRequest(identifier: notificationId, content: content, trigger: trigger)
 
+    if let index = monitoredDevices.firstIndex(where: { $0.id == device.id }) {
+      monitoredDevices[index].notificationIdentifier = notificationId
+      if markAuthRevokedNotified {
+        monitoredDevices[index].authRevokedNotifiedAt = now
+      }
+      saveDevices()
+    }
+
     UNUserNotificationCenter.current().add(request) { error in
       if let error {
         Log.warning("Failed to schedule heartbeat notification: \(error)", category: .cloudKit)
       }
-    }
-
-    // Update device with notification ID
-    if let index = monitoredDevices.firstIndex(where: {
-      $0.id == device.id
-    }) {
-      monitoredDevices[index].notificationIdentifier = notificationId
-      saveDevices()
     }
   }
 
@@ -188,6 +193,9 @@ class HeartbeatManager: ObservableObject {
     }) {
       monitoredDevices[index].lastSeenAt = heartbeat.lastHeartbeatAt
       monitoredDevices[index].deviceName = heartbeat.deviceName
+      monitoredDevices[index].authRevokedNotifiedAt = MonitoredDevice.carriedAuthRevokedNotifiedAt(
+        previous: monitoredDevices[index].authRevokedNotifiedAt,
+        newStatus: heartbeat.authorizationStatus)
       monitoredDevices[index].authorizationStatus = heartbeat.authorizationStatus
     } else {
       let device = MonitoredDevice(

--- a/Foqos/Utils/HeartbeatManager.swift
+++ b/Foqos/Utils/HeartbeatManager.swift
@@ -3,6 +3,56 @@ import Foundation
 import UIKit
 @preconcurrency import UserNotifications
 
+@MainActor
+protocol HeartbeatNotificationScheduling {
+  func requestAuthorization(
+    options: UNAuthorizationOptions,
+    completionHandler: @MainActor @Sendable @escaping (Bool, Error?) -> Void
+  )
+  func add(
+    _ request: UNNotificationRequest,
+    completionHandler: @MainActor @Sendable @escaping (Error?) -> Void
+  )
+  func removePendingNotificationRequests(withIdentifiers identifiers: [String])
+}
+
+@MainActor
+final class UserNotificationCenterScheduler: HeartbeatNotificationScheduling {
+  private let notificationCenter: UNUserNotificationCenter
+
+  init(notificationCenter: UNUserNotificationCenter = .current()) {
+    self.notificationCenter = notificationCenter
+  }
+
+  func requestAuthorization(
+    options: UNAuthorizationOptions,
+    completionHandler: @MainActor @Sendable @escaping (Bool, Error?) -> Void
+  ) {
+    notificationCenter.requestAuthorization(options: options) { granted, error in
+      let callbackError = error as NSError?
+      Task { @MainActor in
+        completionHandler(granted, callbackError)
+      }
+    }
+  }
+
+  func add(
+    _ request: UNNotificationRequest,
+    completionHandler: @MainActor @Sendable @escaping (Error?) -> Void
+  ) {
+    notificationCenter.add(request) { error in
+      let callbackError = error as NSError?
+      Task { @MainActor in
+        completionHandler(callbackError)
+      }
+    }
+  }
+
+  func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+    notificationCenter.removePendingNotificationRequests(withIdentifiers: identifiers)
+  }
+}
+
 /// Manages device heartbeat lifecycle for both child and parent modes.
 @MainActor
 class HeartbeatManager: ObservableObject {
@@ -11,15 +61,17 @@ class HeartbeatManager: ObservableObject {
   private static let userDefaultsKey = "family_foqos_monitored_devices"
   private static let notificationEnabledKey = "family_foqos_heartbeat_notifications_enabled"
 
+  private let defaults: UserDefaults
+  private let notificationScheduler: HeartbeatNotificationScheduling
+  private var authRevokedNotificationDeviceIdsInFlight = Set<String>()
+
   @Published var monitoredDevices: [MonitoredDevice] = []
 
   @Published var heartbeatNotificationsEnabled: Bool {
     didSet {
-      UserDefaults.standard.set(heartbeatNotificationsEnabled, forKey: Self.notificationEnabledKey)
+      defaults.set(heartbeatNotificationsEnabled, forKey: Self.notificationEnabledKey)
       if heartbeatNotificationsEnabled {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) {
-          _, _ in
-        }
+        notificationScheduler.requestAuthorization(options: [.alert, .sound]) { _, _ in }
         scheduleNotifications()
       } else {
         cancelAllNotifications()
@@ -27,10 +79,14 @@ class HeartbeatManager: ObservableObject {
     }
   }
 
-  private init() {
-    self.heartbeatNotificationsEnabled = UserDefaults.standard.bool(
-      forKey: Self.notificationEnabledKey)
-    self.monitoredDevices = Self.loadDevices()
+  init(
+    defaults: UserDefaults = .standard,
+    notificationScheduler: HeartbeatNotificationScheduling = UserNotificationCenterScheduler()
+  ) {
+    self.defaults = defaults
+    self.notificationScheduler = notificationScheduler
+    self.heartbeatNotificationsEnabled = defaults.bool(forKey: Self.notificationEnabledKey)
+    self.monitoredDevices = Self.loadDevices(defaults: defaults)
   }
 
   // MARK: - Child Side
@@ -40,7 +96,7 @@ class HeartbeatManager: ObservableObject {
     let authStatus = AuthorizationCenter.shared.authorizationStatus
     let statusString: String
     switch authStatus {
-    case .approved: statusString = "approved"
+    case .approved, .approvedWithDataAccess: statusString = "approved"
     case .denied: statusString = "denied"
     case .notDetermined: statusString = "notDetermined"
     @unknown default: statusString = "unknown"
@@ -125,7 +181,7 @@ class HeartbeatManager: ObservableObject {
 
   func cancelAllNotifications() {
     let ids = monitoredDevices.compactMap { $0.notificationIdentifier }
-    UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ids)
+    notificationScheduler.removePendingNotificationRequests(withIdentifiers: ids)
   }
 
   private func scheduleNotification(for device: MonitoredDevice) {
@@ -139,6 +195,8 @@ class HeartbeatManager: ObservableObject {
 
     if device.isAuthRevoked {
       guard device.shouldScheduleAuthRevokedAlert() else { return }
+      guard !authRevokedNotificationDeviceIdsInFlight.contains(device.id) else { return }
+      authRevokedNotificationDeviceIdsInFlight.insert(device.id)
       cancelNotification(for: device)
 
       content.title = "Screen Time Permissions Lost"
@@ -157,30 +215,40 @@ class HeartbeatManager: ObservableObject {
     }
 
     // Don't schedule if trigger is in the past (device already stale — banner handles it)
-    guard triggerDate > now else { return }
+    guard triggerDate > now else {
+      if markAuthRevokedNotified {
+        authRevokedNotificationDeviceIdsInFlight.remove(device.id)
+      }
+      return
+    }
 
     let interval = triggerDate.timeIntervalSinceNow
     let trigger = UNTimeIntervalNotificationTrigger(timeInterval: max(interval, 1), repeats: false)
     let request = UNNotificationRequest(identifier: notificationId, content: content, trigger: trigger)
 
-    if let index = monitoredDevices.firstIndex(where: { $0.id == device.id }) {
-      monitoredDevices[index].notificationIdentifier = notificationId
+    notificationScheduler.add(request) { [weak self] error in
+      guard let self else { return }
       if markAuthRevokedNotified {
-        monitoredDevices[index].authRevokedNotifiedAt = now
+        self.authRevokedNotificationDeviceIdsInFlight.remove(device.id)
       }
-      saveDevices()
-    }
-
-    UNUserNotificationCenter.current().add(request) { error in
       if let error {
         Log.warning("Failed to schedule heartbeat notification: \(error)", category: .cloudKit)
+        return
+      }
+
+      if let index = self.monitoredDevices.firstIndex(where: { $0.id == device.id }) {
+        self.monitoredDevices[index].notificationIdentifier = notificationId
+        if markAuthRevokedNotified {
+          self.monitoredDevices[index].authRevokedNotifiedAt = now
+        }
+        self.saveDevices()
       }
     }
   }
 
   private func cancelNotification(for device: MonitoredDevice) {
     if let id = device.notificationIdentifier {
-      UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [id])
+      notificationScheduler.removePendingNotificationRequests(withIdentifiers: [id])
     }
   }
 
@@ -213,12 +281,12 @@ class HeartbeatManager: ObservableObject {
 
   private func saveDevices() {
     if let data = try? JSONEncoder().encode(monitoredDevices) {
-      UserDefaults.standard.set(data, forKey: Self.userDefaultsKey)
+      defaults.set(data, forKey: Self.userDefaultsKey)
     }
   }
 
-  private static func loadDevices() -> [MonitoredDevice] {
-    guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+  private static func loadDevices(defaults: UserDefaults) -> [MonitoredDevice] {
+    guard let data = defaults.data(forKey: userDefaultsKey),
       let devices = try? JSONDecoder().decode([MonitoredDevice].self, from: data)
     else {
       return []

--- a/Foqos/Utils/LockCodeManager.swift
+++ b/Foqos/Utils/LockCodeManager.swift
@@ -301,15 +301,17 @@ class LockCodeManager: ObservableObject {
 
   // MARK: - Command Processing (Child Mode)
 
-  /// Check for and process any pending commands from parent
-  /// Called automatically during fetchSharedLockCodes
-  private func processPendingCommands() async {
+  /// Check for and process any pending commands from parent.
+  /// Called from child lock-code refresh, the PIN-dialog poll, and child foreground.
+  func processPendingCommands(cleanupStale: Bool = true) async {
     guard appModeManager.currentMode == .child else {
       return
     }
 
-    // Clean up any stale commands (from any user, not just this child)
-    await cloudKitManager.cleanupStaleCommands()
+    if cleanupStale {
+      // Clean up any stale commands (from any user, not just this child)
+      await cloudKitManager.cleanupStaleCommands()
+    }
 
     do {
       let commands = try await cloudKitManager.fetchPendingCommands()
@@ -322,9 +324,10 @@ class LockCodeManager: ObservableObject {
     }
   }
 
-  private func processCommand(_ command: FamilyCommand) async {
-    Log.info("Processing command: \(command.commandType.rawValue)", category: .cloudKit)
-
+  /// Apply a parent command's local side effect.
+  /// Replication of a parent-authorized operation (#230); not re-gated on the child.
+  func applyCommand(_ command: FamilyCommand) {
+    Log.info("Applying command: \(command.commandType.rawValue)", category: .cloudKit)
     switch command.commandType {
     case .resetEmergencyCount:
       EmergencyUnblockManager.shared.resetEmergencyUnblocks()
@@ -333,6 +336,10 @@ class LockCodeManager: ObservableObject {
       resetThrottle()
       Log.info("Lock code throttle reset by parent", category: .cloudKit)
     }
+  }
+
+  private func processCommand(_ command: FamilyCommand) async {
+    applyCommand(command)
 
     // Delete the command after processing
     do {

--- a/Foqos/Utils/LockCodeManager.swift
+++ b/Foqos/Utils/LockCodeManager.swift
@@ -27,6 +27,13 @@ class LockCodeManager: ObservableObject {
 
   private var cancellables = Set<AnyCancellable>()
 
+  private static let maxProcessedCommandEntries = 50
+
+  private struct ProcessedCommandEntry: Codable {
+    let id: UUID
+    let processedAt: Date
+  }
+
   private init(
     cloudKitManager: CloudKitManager = .shared,
     appModeManager: AppModeManager = .shared
@@ -338,8 +345,29 @@ class LockCodeManager: ObservableObject {
     }
   }
 
-  private func processCommand(_ command: FamilyCommand) async {
+  /// Apply a parent command once per persisted command ID.
+  /// Commands that remain in CloudKit after a delete failure may be fetched again after relaunch;
+  /// the persisted ledger prevents replaying non-idempotent local side effects.
+  func applyCommandIfNeeded(_ command: FamilyCommand, now: Date = Date()) -> Bool {
+    let entries = loadProcessedCommandEntries()
+    if entries.contains(where: { $0.id == command.id }) {
+      persistProcessedCommandEntries(entries)
+      return false
+    }
+
     applyCommand(command)
+
+    let updatedEntries =
+      [ProcessedCommandEntry(id: command.id, processedAt: now)] + entries
+    persistProcessedCommandEntries(updatedEntries)
+    return true
+  }
+
+  private func processCommand(_ command: FamilyCommand) async {
+    let didApply = applyCommandIfNeeded(command)
+    if !didApply {
+      Log.info("Skipping already processed command: \(command.commandType.rawValue)", category: .cloudKit)
+    }
 
     // Delete the command after processing
     do {
@@ -400,6 +428,10 @@ class LockCodeManager: ObservableObject {
     static let childLockCodes = "family_foqos_child_lock_codes"
   }
 
+  private enum CommandLedgerKey {
+    static let processedCommands = "family_foqos_processed_family_commands"
+  }
+
   /// Throttle schedule: failed attempts -> lockout duration in seconds
   private static let throttleSchedule: [(threshold: Int, duration: TimeInterval)] = [
     (3, 30),  // 30 seconds after 3 failures
@@ -452,6 +484,7 @@ class LockCodeManager: ObservableObject {
     throttleDefaults = defaults ?? .standard
     loadThrottleState()
     cachedLockCodes = loadPersistedLockCodes()
+    persistProcessedCommandEntries(loadProcessedCommandEntries())
   }
 
   /// Load throttle state from UserDefaults
@@ -492,6 +525,33 @@ class LockCodeManager: ObservableObject {
     if let data = try? JSONEncoder().encode(codes) {
       throttleDefaults.set(data, forKey: CacheKey.childLockCodes)
     }
+  }
+
+  private func loadProcessedCommandEntries() -> [ProcessedCommandEntry] {
+    guard let data = throttleDefaults.data(forKey: CommandLedgerKey.processedCommands),
+      let entries = try? JSONDecoder().decode([ProcessedCommandEntry].self, from: data)
+    else {
+      return []
+    }
+
+    return Self.prunedProcessedCommandEntries(entries)
+  }
+
+  private func persistProcessedCommandEntries(_ entries: [ProcessedCommandEntry]) {
+    let prunedEntries = Self.prunedProcessedCommandEntries(entries)
+    if let data = try? JSONEncoder().encode(prunedEntries) {
+      throttleDefaults.set(data, forKey: CommandLedgerKey.processedCommands)
+    }
+  }
+
+  private static func prunedProcessedCommandEntries(
+    _ entries: [ProcessedCommandEntry]
+  ) -> [ProcessedCommandEntry] {
+    Array(
+      entries
+        .sorted { $0.processedAt > $1.processedAt }
+        .prefix(maxProcessedCommandEntries)
+    )
   }
 }
 

--- a/Foqos/Utils/RequestAuthorizer.swift
+++ b/Foqos/Utils/RequestAuthorizer.swift
@@ -13,21 +13,20 @@ class RequestAuthorizer: ObservableObject {
   private var cancellable: AnyCancellable?
   private let authorizationCenter: AuthorizationRequesting
 
-  init(authorizationCenter: AuthorizationRequesting = AuthorizationCenter.shared) {
+  init(authorizationCenter: AuthorizationRequesting = AuthorizationCenterRequester.shared) {
     self.authorizationCenter = authorizationCenter
-    let status = AuthorizationCenter.shared.authorizationStatus
-    let approved = status == .approved
+    let status = authorizationCenter.authorizationStatus
+    let approved = Self.isApproved(status)
     self.isAuthorized = approved
     self.authorizationStatus = status
     Log.info(
       "RequestAuthorizer init: authorizationStatus=\(status), isAuthorized=\(approved)",
       category: .authorization)
 
-    cancellable = AuthorizationCenter.shared.$authorizationStatus
-      .receive(on: DispatchQueue.main)
+    cancellable = authorizationCenter.authorizationStatusPublisher
       .sink { [weak self] newStatus in
         guard let self else { return }
-        let approved = newStatus == .approved
+        let approved = Self.isApproved(newStatus)
         if self.authorizationStatus != newStatus {
           Log.info(
             "AuthorizationCenter status changed: \(self.authorizationStatus) → \(newStatus)",
@@ -36,6 +35,17 @@ class RequestAuthorizer: ObservableObject {
         self.authorizationStatus = newStatus
         self.isAuthorized = approved
       }
+  }
+
+  private static func isApproved(_ status: AuthorizationStatus) -> Bool {
+    switch status {
+    case .approved, .approvedWithDataAccess:
+      return true
+    case .denied, .notDetermined:
+      return false
+    @unknown default:
+      return false
+    }
   }
 
   /// Request authorization for the current app mode

--- a/Foqos/Utils/RequestAuthorizer.swift
+++ b/Foqos/Utils/RequestAuthorizer.swift
@@ -11,8 +11,10 @@ class RequestAuthorizer: ObservableObject {
   @Published var authorizationError: String?
 
   private var cancellable: AnyCancellable?
+  private let authorizationCenter: AuthorizationRequesting
 
-  init() {
+  init(authorizationCenter: AuthorizationRequesting = AuthorizationCenter.shared) {
+    self.authorizationCenter = authorizationCenter
     let status = AuthorizationCenter.shared.authorizationStatus
     let approved = status == .approved
     self.isAuthorized = approved
@@ -37,36 +39,28 @@ class RequestAuthorizer: ObservableObject {
   }
 
   /// Request authorization for the current app mode
-  func requestAuthorization() {
-    requestAuthorization(for: AppModeManager.shared.currentMode)
+  @discardableResult
+  func requestAuthorization() async -> Bool {
+    await requestAuthorization(for: AppModeManager.shared.currentMode)
   }
 
   /// Request authorization for a specific app mode
   /// - Parameter mode: The app mode to request authorization for
-  func requestAuthorization(for mode: AppMode) {
-    Task {
-      do {
-        switch mode {
-        case .individual, .parent:
-          // Individual and parent modes use .individual authorization
-          // Parent still controls their own device, just creates policies for others
-          try await AuthorizationCenter.shared.requestAuthorization(for: .individual)
-          Log.info("Individual authorization successful for mode: \(mode)", category: .authorization)
+  @discardableResult
+  func requestAuthorization(for mode: AppMode) async -> Bool {
+    let member: FamilyControlsMember = mode == .child ? .child : .individual
 
-        case .child:
-          // Child mode uses .child authorization
-          // This requires parent approval via Screen Time Family Sharing
-          try await AuthorizationCenter.shared.requestAuthorization(for: .child)
-          Log.info("Child authorization successful", category: .authorization)
-        }
-
-        self.isAuthorized = true
-        self.authorizationError = nil
-      } catch {
-        Log.info("Error requesting authorization: \(error)", category: .authorization)
-        self.isAuthorized = false
-        self.authorizationError = self.describeAuthorizationError(error, for: mode)
-      }
+    do {
+      try await authorizationCenter.requestAuthorization(for: member)
+      Log.info("Authorization successful for mode: \(mode)", category: .authorization)
+      self.isAuthorized = true
+      self.authorizationError = nil
+      return true
+    } catch {
+      Log.info("Error requesting authorization: \(error)", category: .authorization)
+      self.isAuthorized = false
+      self.authorizationError = self.describeAuthorizationError(error, for: mode)
+      return false
     }
   }
 

--- a/Foqos/Views/Components/LockCodeEntryView.swift
+++ b/Foqos/Views/Components/LockCodeEntryView.swift
@@ -15,6 +15,7 @@ struct LockCodeEntryView: View {
   @State private var showError: Bool = false
   @State private var isVerifying: Bool = false
   @State private var lockoutSecondsRemaining: Int = 0
+  @State private var pollTick: Int = 0
 
   private let codeLength = 4
 
@@ -125,10 +126,20 @@ struct LockCodeEntryView: View {
       }
       .onAppear {
         updateLockoutRemaining()
+        if lockoutSecondsRemaining > 0 {
+          processPendingResetCommands()
+        }
       }
       .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in
-        guard lockoutSecondsRemaining > 0 else { return }
+        guard lockoutSecondsRemaining > 0 else {
+          pollTick = 0
+          return
+        }
         updateLockoutRemaining()
+        pollTick += 1
+        if pollTick % 5 == 0 {
+          processPendingResetCommands()
+        }
       }
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
@@ -190,6 +201,14 @@ struct LockCodeEntryView: View {
   private func updateLockoutRemaining() {
     let remaining = lockCodeManager.lockoutRemaining()
     lockoutSecondsRemaining = remaining > 0 ? Int(ceil(remaining)) : 0
+  }
+
+  private func processPendingResetCommands() {
+    guard AppModeManager.shared.currentMode == .child else { return }
+    Task { @MainActor in
+      await lockCodeManager.processPendingCommands(cleanupStale: false)
+      updateLockoutRemaining()
+    }
   }
 }
 

--- a/Foqos/Views/EmergencyView.swift
+++ b/Foqos/Views/EmergencyView.swift
@@ -33,6 +33,9 @@ struct EmergencyView: View {
     }
     .onAppear {
       emergencyManager.checkAndResetEmergencyUnblocks()
+      if appModeManager.currentMode == .child {
+        Task { await lockCodeManager.processPendingCommands() }
+      }
     }
     .sheet(isPresented: $showingLockCodeEntry) {
       LockCodeEntryView(

--- a/Foqos/Views/HomeView.swift
+++ b/Foqos/Views/HomeView.swift
@@ -148,7 +148,7 @@ struct HomeView: View {
         AuthorizationCallout(
           authorizationStatus: requestAuthorizer.authorizationStatus,
           onAuthorizationHandler: {
-            requestAuthorizer.requestAuthorization()
+            Task { await requestAuthorizer.requestAuthorization() }
           }
         )
         .padding(.horizontal, 16)

--- a/Foqos/Views/ModeSelectionView.swift
+++ b/Foqos/Views/ModeSelectionView.swift
@@ -117,12 +117,9 @@ struct ModeSelectionView: View {
   private func continueWithSelectedMode() {
     isAuthorizing = true
 
-    // Request authorization for the selected mode
-    requestAuthorizer.requestAuthorization(for: selectedMode)
-
-    // Wait a moment for authorization to complete
-    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-      if requestAuthorizer.isAuthorized {
+    Task {
+      let authorized = await requestAuthorizer.requestAuthorization(for: selectedMode)
+      if authorized {
         appModeManager.selectMode(selectedMode)
         onModeSelected(selectedMode)
       } else if let error = requestAuthorizer.authorizationError {

--- a/FoqosTests/FamilyCommandApplyTests.swift
+++ b/FoqosTests/FamilyCommandApplyTests.swift
@@ -4,6 +4,14 @@ import XCTest
 
 @MainActor
 final class FamilyCommandApplyTests: XCTestCase {
+  private static let emergencyDefaultsKeys = [
+    "family_foqos_emergency_unblocks_reset_period_in_days",
+    "family_foqos_last_emergency_unblocks_reset_date",
+    "family_foqos_emergency_settings_locked",
+    "family_foqos_emergency_settings_version",
+    "family_foqos_emergency_unblock_events",
+    "family_foqos_emergency_reset_epoch",
+  ]
 
   override func setUp() {
     super.setUp()
@@ -12,6 +20,7 @@ final class FamilyCommandApplyTests: XCTestCase {
       defaults.removePersistentDomain(forName: "FamilyCommandApplyTests")
       LockCodeManager.shared.overrideDefaults(defaults)
       LockCodeManager.shared.resetThrottle()
+      EmergencyUnblockManager.shared.seedForTesting(epoch: 0)
     }
   }
 
@@ -19,6 +28,9 @@ final class FamilyCommandApplyTests: XCTestCase {
     MainActor.assumeIsolated {
       LockCodeManager.shared.resetThrottle()
       LockCodeManager.shared.overrideDefaults(nil)
+      for key in Self.emergencyDefaultsKeys {
+        UserDefaults.standard.removeObject(forKey: key)
+      }
     }
     super.tearDown()
   }
@@ -39,5 +51,23 @@ final class FamilyCommandApplyTests: XCTestCase {
 
     XCTAssertEqual(LockCodeManager.shared.failedAttempts, 0)
     XCTAssertFalse(LockCodeManager.shared.isLockedOut(now: now))
+  }
+
+  func testGivenEmergencyResetCommandAlreadyProcessed_WhenDeliveredAfterFreshLoad_ThenEpochAdvancesOnce() {
+    let command = FamilyCommand(
+      id: UUID(uuidString: "00000000-0000-0000-0000-000000000230")!,
+      commandType: .resetEmergencyCount,
+      targetChildId: "child-rec-1",
+      createdBy: "parent-rec-1",
+      createdAt: Date()
+    )
+
+    XCTAssertTrue(LockCodeManager.shared.applyCommandIfNeeded(command))
+    let defaults = UserDefaults(suiteName: "FamilyCommandApplyTests")!
+    LockCodeManager.shared.overrideDefaults(nil)
+    LockCodeManager.shared.overrideDefaults(defaults)
+
+    XCTAssertFalse(LockCodeManager.shared.applyCommandIfNeeded(command))
+    XCTAssertEqual(EmergencyUnblockManager.shared.currentResetEpoch, 1)
   }
 }

--- a/FoqosTests/FamilyCommandApplyTests.swift
+++ b/FoqosTests/FamilyCommandApplyTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class FamilyCommandApplyTests: XCTestCase {
+
+  override func setUp() {
+    super.setUp()
+    MainActor.assumeIsolated {
+      let defaults = UserDefaults(suiteName: "FamilyCommandApplyTests")!
+      defaults.removePersistentDomain(forName: "FamilyCommandApplyTests")
+      LockCodeManager.shared.overrideDefaults(defaults)
+      LockCodeManager.shared.resetThrottle()
+    }
+  }
+
+  override func tearDown() {
+    MainActor.assumeIsolated {
+      LockCodeManager.shared.resetThrottle()
+      LockCodeManager.shared.overrideDefaults(nil)
+    }
+    super.tearDown()
+  }
+
+  func testGivenLockedOutChild_WhenResetThrottleCommandApplied_ThenThrottleCleared() {
+    let now = Date()
+    for _ in 0..<10 {
+      LockCodeManager.shared.recordFailedAttempt(now: now)
+    }
+    XCTAssertTrue(LockCodeManager.shared.isLockedOut(now: now))
+
+    let command = FamilyCommand(
+      commandType: .resetLockCodeThrottle,
+      targetChildId: "child-rec-1",
+      createdBy: "parent-rec-1"
+    )
+    LockCodeManager.shared.applyCommand(command)
+
+    XCTAssertEqual(LockCodeManager.shared.failedAttempts, 0)
+    XCTAssertFalse(LockCodeManager.shared.isLockedOut(now: now))
+  }
+}

--- a/FoqosTests/HeartbeatManagerTests.swift
+++ b/FoqosTests/HeartbeatManagerTests.swift
@@ -1,0 +1,104 @@
+import UserNotifications
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class HeartbeatManagerTests: XCTestCase {
+  private var suiteName: String!
+  private var defaults: UserDefaults!
+  private var scheduler: FakeHeartbeatNotificationScheduler!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "HeartbeatManagerTests-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+    scheduler = FakeHeartbeatNotificationScheduler()
+  }
+
+  override func tearDown() async throws {
+    defaults.removePersistentDomain(forName: suiteName)
+    scheduler = nil
+    defaults = nil
+    suiteName = nil
+    try await super.tearDown()
+  }
+
+  func testGivenAuthRevokedAlertInFlight_WhenSchedulingAgain_ThenDoesNotScheduleDuplicate() {
+    let manager = managerWithDeniedDevice()
+
+    manager.scheduleNotifications()
+    manager.scheduleNotifications()
+
+    XCTAssertEqual(scheduler.addedRequests.count, 1)
+    XCTAssertNil(manager.monitoredDevices.first?.authRevokedNotifiedAt)
+  }
+
+  func testGivenAuthRevokedAlertAddFails_WhenCompleted_ThenMarkerRemainsNilAndNextRefreshRetries() {
+    let manager = managerWithDeniedDevice()
+
+    manager.scheduleNotifications()
+    scheduler.completeNextAdd(error: FakeHeartbeatNotificationScheduler.StubError())
+    manager.scheduleNotifications()
+
+    XCTAssertEqual(scheduler.addedRequests.count, 2)
+    XCTAssertNil(manager.monitoredDevices.first?.authRevokedNotifiedAt)
+  }
+
+  func testGivenAuthRevokedAlertAddSucceeds_WhenCompleted_ThenMarkerIsPersisted() {
+    let manager = managerWithDeniedDevice()
+
+    manager.scheduleNotifications()
+    scheduler.completeNextAdd(error: nil)
+
+    XCTAssertNotNil(manager.monitoredDevices.first?.authRevokedNotifiedAt)
+    XCTAssertEqual(manager.monitoredDevices.first?.notificationIdentifier, "heartbeat-child1|dev1")
+  }
+
+  private func managerWithDeniedDevice() -> HeartbeatManager {
+    let manager = HeartbeatManager(defaults: defaults, notificationScheduler: scheduler)
+    manager.monitoredDevices = [
+      MonitoredDevice(
+        deviceIdentifier: "dev1",
+        deviceName: "iPhone",
+        childUserRecordName: "child1",
+        lastSeenAt: Date(),
+        isSuppressed: false,
+        notificationIdentifier: nil,
+        authorizationStatus: "denied",
+        authRevokedNotifiedAt: nil
+      )
+    ]
+    return manager
+  }
+}
+
+@MainActor
+private final class FakeHeartbeatNotificationScheduler: HeartbeatNotificationScheduling {
+  struct StubError: Error {}
+
+  private(set) var addedRequests: [UNNotificationRequest] = []
+  private var completions: [@MainActor @Sendable (Error?) -> Void] = []
+
+  func requestAuthorization(
+    options: UNAuthorizationOptions,
+    completionHandler: @MainActor @Sendable @escaping (Bool, Error?) -> Void
+  ) {
+    completionHandler(true, nil)
+  }
+
+  func add(
+    _ request: UNNotificationRequest,
+    completionHandler: @MainActor @Sendable @escaping (Error?) -> Void
+  ) {
+    addedRequests.append(request)
+    completions.append(completionHandler)
+  }
+
+  func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {}
+
+  func completeNextAdd(error: Error?) {
+    let completion = completions.removeFirst()
+    completion(error)
+  }
+}

--- a/FoqosTests/LockCodeChangedPinRegressionTests.swift
+++ b/FoqosTests/LockCodeChangedPinRegressionTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class LockCodeChangedPinRegressionTests: XCTestCase {
+
+  private let oldPin = "1234"
+  private let newPin = "5678"
+  private let childId = "child-device-001"
+
+  private func code(_ pin: String) -> FamilyLockCode {
+    FamilyLockCode(code: pin, scope: .allChildren)
+  }
+
+  func testGivenConnectedRefreshWithChangedPin_ThenNewCodeAdoptedAndOldDropped() {
+    let resolved = LockCodeManager.resolveLockCodes(
+      fetched: [code(newPin)],
+      isConnected: true,
+      persisted: [code(oldPin)]
+    )
+
+    XCTAssertTrue(
+      LockCodeManager.verifyCode(
+        newPin,
+        forChildId: childId,
+        mode: .child,
+        authorizationType: .child,
+        codes: resolved.cache),
+      "New PIN must verify after a connected refresh")
+    XCTAssertFalse(
+      LockCodeManager.verifyCode(
+        oldPin,
+        forChildId: childId,
+        mode: .child,
+        authorizationType: .child,
+        codes: resolved.cache),
+      "Revoked old PIN must not verify after a connected refresh")
+  }
+
+  func testGivenDisconnectedRefresh_ThenLastSyncedCodesRetained() {
+    let resolved = LockCodeManager.resolveLockCodes(
+      fetched: [],
+      isConnected: false,
+      persisted: [code(oldPin)]
+    )
+
+    XCTAssertTrue(
+      LockCodeManager.verifyCode(
+        oldPin,
+        forChildId: childId,
+        mode: .child,
+        authorizationType: .child,
+        codes: resolved.cache),
+      "Offline, the last-synced PIN must still verify")
+  }
+}

--- a/FoqosTests/Mocks/MockAuthorizationRequesting.swift
+++ b/FoqosTests/Mocks/MockAuthorizationRequesting.swift
@@ -1,0 +1,23 @@
+import FamilyControls
+
+@testable import FamilyFoqos
+
+@MainActor
+final class MockAuthorizationRequesting: AuthorizationRequesting {
+  enum Outcome {
+    case success
+    case failure(Error)
+  }
+
+  struct StubError: Error {}
+
+  var outcome: Outcome = .success
+  private(set) var requestedMembers: [FamilyControlsMember] = []
+
+  func requestAuthorization(for member: FamilyControlsMember) async throws {
+    requestedMembers.append(member)
+    if case .failure(let error) = outcome {
+      throw error
+    }
+  }
+}

--- a/FoqosTests/Mocks/MockAuthorizationRequesting.swift
+++ b/FoqosTests/Mocks/MockAuthorizationRequesting.swift
@@ -1,3 +1,4 @@
+import Combine
 import FamilyControls
 
 @testable import FamilyFoqos
@@ -12,12 +13,28 @@ final class MockAuthorizationRequesting: AuthorizationRequesting {
   struct StubError: Error {}
 
   var outcome: Outcome = .success
+  var authorizationStatus: AuthorizationStatus {
+    statusSubject.value
+  }
+  var authorizationStatusPublisher: AnyPublisher<AuthorizationStatus, Never> {
+    statusSubject.eraseToAnyPublisher()
+  }
   private(set) var requestedMembers: [FamilyControlsMember] = []
+
+  private let statusSubject: CurrentValueSubject<AuthorizationStatus, Never>
+
+  init(initialStatus: AuthorizationStatus = .notDetermined) {
+    self.statusSubject = CurrentValueSubject(initialStatus)
+  }
 
   func requestAuthorization(for member: FamilyControlsMember) async throws {
     requestedMembers.append(member)
     if case .failure(let error) = outcome {
       throw error
     }
+  }
+
+  func sendStatus(_ status: AuthorizationStatus) {
+    statusSubject.send(status)
   }
 }

--- a/FoqosTests/MonitoredDeviceTests.swift
+++ b/FoqosTests/MonitoredDeviceTests.swift
@@ -174,4 +174,79 @@ final class MonitoredDeviceTests: XCTestCase {
     XCTAssertNil(decoded.authorizationStatus)
     XCTAssertFalse(decoded.isAuthRevoked)
   }
+
+  func testShouldScheduleAuthRevokedAlert_trueWhenRevokedAndNeverNotified() {
+    let now = Date()
+    let device = MonitoredDevice(
+      deviceIdentifier: "dev1",
+      deviceName: "iPhone",
+      childUserRecordName: "child1",
+      lastSeenAt: now,
+      isSuppressed: false,
+      notificationIdentifier: nil,
+      authorizationStatus: "denied",
+      authRevokedNotifiedAt: nil
+    )
+    XCTAssertTrue(device.shouldScheduleAuthRevokedAlert())
+  }
+
+  func testShouldScheduleAuthRevokedAlert_falseWhenAlreadyNotified() {
+    let now = Date()
+    let device = MonitoredDevice(
+      deviceIdentifier: "dev1",
+      deviceName: "iPhone",
+      childUserRecordName: "child1",
+      lastSeenAt: now,
+      isSuppressed: false,
+      notificationIdentifier: nil,
+      authorizationStatus: "denied",
+      authRevokedNotifiedAt: now
+    )
+    XCTAssertFalse(device.shouldScheduleAuthRevokedAlert())
+  }
+
+  func testShouldScheduleAuthRevokedAlert_falseWhenApproved() {
+    let now = Date()
+    let device = MonitoredDevice(
+      deviceIdentifier: "dev1",
+      deviceName: "iPhone",
+      childUserRecordName: "child1",
+      lastSeenAt: now,
+      isSuppressed: false,
+      notificationIdentifier: nil,
+      authorizationStatus: "approved",
+      authRevokedNotifiedAt: nil
+    )
+    XCTAssertFalse(device.shouldScheduleAuthRevokedAlert())
+  }
+
+  func testCarriedAuthRevokedNotifiedAt_preservesMarkerWhileStillDenied() {
+    let now = Date()
+    let carried = MonitoredDevice.carriedAuthRevokedNotifiedAt(previous: now, newStatus: "denied")
+    XCTAssertEqual(carried, now)
+  }
+
+  func testCarriedAuthRevokedNotifiedAt_clearsMarkerWhenBackToApproved() {
+    let now = Date()
+    let carried = MonitoredDevice.carriedAuthRevokedNotifiedAt(previous: now, newStatus: "approved")
+    XCTAssertNil(carried, "Re-arm so a genuine re-revocation alerts again")
+  }
+
+  func testCarriedAuthRevokedNotifiedAt_clearsMarkerWhenStatusNil() {
+    let now = Date()
+    XCTAssertNil(MonitoredDevice.carriedAuthRevokedNotifiedAt(previous: now, newStatus: nil))
+  }
+
+  func testPersistence_backwardsCompatible_missingAuthRevokedNotifiedAt() throws {
+    // A device saved before authRevokedNotifiedAt existed must decode with the field nil.
+    let json = """
+      {"deviceIdentifier":"dev1","deviceName":"iPhone","childUserRecordName":"child1",
+       "lastSeenAt":1000000,"isSuppressed":false,"authorizationStatus":"denied"}
+      """
+    let data = json.data(using: .utf8)!
+    let decoded = try JSONDecoder().decode(MonitoredDevice.self, from: data)
+
+    XCTAssertNil(decoded.authRevokedNotifiedAt)
+    XCTAssertTrue(decoded.shouldScheduleAuthRevokedAlert(), "Legacy denied device alerts once")
+  }
 }

--- a/FoqosTests/ParticipantRemovalDecisionTests.swift
+++ b/FoqosTests/ParticipantRemovalDecisionTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class ParticipantRemovalDecisionTests: XCTestCase {
+
+  private func member(_ recordName: String, _ displayName: String) -> FamilyMember {
+    FamilyMember(userRecordName: recordName, displayName: displayName, role: .child)
+  }
+
+  func testGivenAllResolved_WhenMemberAbsentFromParticipants_ThenMemberRemoved() {
+    let existing = [member("rec-A", "Emma"), member("rec-B", "Liam")]
+    let accepted: Set<String> = ["rec-A"]
+
+    let toRemove = CloudKitNetworkService.familyMembersToRemove(
+      from: existing,
+      acceptedParticipantRecordNames: accepted,
+      hasUnresolvedAcceptedParticipant: false
+    )
+
+    XCTAssertEqual(toRemove.map { $0.userRecordName }, ["rec-B"])
+  }
+
+  func testGivenUnresolvedParticipant_WhenMemberAbsentFromParticipants_ThenNothingRemoved() {
+    let existing = [member("rec-A", "Emma"), member("rec-B", "Liam")]
+    let accepted: Set<String> = ["rec-A"]
+
+    let toRemove = CloudKitNetworkService.familyMembersToRemove(
+      from: existing,
+      acceptedParticipantRecordNames: accepted,
+      hasUnresolvedAcceptedParticipant: true
+    )
+
+    XCTAssertTrue(
+      toRemove.isEmpty,
+      "Must not delete any member while any accepted participant is unresolved")
+  }
+
+  func testGivenAllResolvedAndAllPresent_WhenNoDepartures_ThenNothingRemoved() {
+    let existing = [member("rec-A", "Emma"), member("rec-B", "Liam")]
+    let accepted: Set<String> = ["rec-A", "rec-B"]
+
+    let toRemove = CloudKitNetworkService.familyMembersToRemove(
+      from: existing,
+      acceptedParticipantRecordNames: accepted,
+      hasUnresolvedAcceptedParticipant: false
+    )
+
+    XCTAssertTrue(toRemove.isEmpty)
+  }
+
+  func testGivenNoExistingMembers_ThenNothingRemoved() {
+    let toRemove = CloudKitNetworkService.familyMembersToRemove(
+      from: [],
+      acceptedParticipantRecordNames: [],
+      hasUnresolvedAcceptedParticipant: false
+    )
+
+    XCTAssertTrue(toRemove.isEmpty)
+  }
+}

--- a/FoqosTests/RequestAuthorizerTests.swift
+++ b/FoqosTests/RequestAuthorizerTests.swift
@@ -1,0 +1,40 @@
+import FamilyControls
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class RequestAuthorizerTests: XCTestCase {
+
+  func testGivenAuthApproved_WhenRequestingChild_ThenReturnsTrueAndClearsError() async {
+    let mock = MockAuthorizationRequesting()
+    mock.outcome = .success
+    let authorizer = RequestAuthorizer(authorizationCenter: mock)
+
+    let result = await authorizer.requestAuthorization(for: .child)
+
+    XCTAssertTrue(result)
+    XCTAssertNil(authorizer.authorizationError)
+    XCTAssertEqual(mock.requestedMembers, [.child])
+  }
+
+  func testGivenAuthFails_WhenRequestingChild_ThenReturnsFalseAndSetsError() async {
+    let mock = MockAuthorizationRequesting()
+    mock.outcome = .failure(MockAuthorizationRequesting.StubError())
+    let authorizer = RequestAuthorizer(authorizationCenter: mock)
+
+    let result = await authorizer.requestAuthorization(for: .child)
+
+    XCTAssertFalse(result, "A failed request must not report success")
+    XCTAssertNotNil(authorizer.authorizationError)
+  }
+
+  func testGivenParentMode_WhenRequesting_ThenUsesIndividualMember() async {
+    let mock = MockAuthorizationRequesting()
+    let authorizer = RequestAuthorizer(authorizationCenter: mock)
+
+    _ = await authorizer.requestAuthorization(for: .parent)
+
+    XCTAssertEqual(mock.requestedMembers, [.individual])
+  }
+}

--- a/FoqosTests/RequestAuthorizerTests.swift
+++ b/FoqosTests/RequestAuthorizerTests.swift
@@ -6,6 +6,25 @@ import XCTest
 @MainActor
 final class RequestAuthorizerTests: XCTestCase {
 
+  func testGivenInjectedCenterApproved_WhenInitialized_ThenInitialStateUsesInjectedStatus() {
+    let mock = MockAuthorizationRequesting(initialStatus: .approved)
+
+    let authorizer = RequestAuthorizer(authorizationCenter: mock)
+
+    XCTAssertTrue(authorizer.isAuthorized)
+    XCTAssertEqual(authorizer.authorizationStatus, .approved)
+  }
+
+  func testGivenInjectedStatusChanges_WhenPublisherEmits_ThenAuthorizationStateUpdates() {
+    let mock = MockAuthorizationRequesting(initialStatus: .approved)
+    let authorizer = RequestAuthorizer(authorizationCenter: mock)
+
+    mock.sendStatus(.denied)
+
+    XCTAssertFalse(authorizer.isAuthorized)
+    XCTAssertEqual(authorizer.authorizationStatus, .denied)
+  }
+
   func testGivenAuthApproved_WhenRequestingChild_ThenReturnsTrueAndClearsError() async {
     let mock = MockAuthorizationRequesting()
     mock.outcome = .success


### PR DESCRIPTION
## Summary

Implements B2 from epic #263 / plan PR #291 after re-deriving the stale plan citations against current `main`.

- Fixes #241 by making FamilyMember cleanup fail-safe when an accepted share participant has an unresolved `userRecordID`.
- Fixes #232 by making Screen Time permission-lost notifications transition-keyed and race-safe across repeated heartbeat refreshes.
- Fixes #230 by applying existing parent-authored reset commands at child enforcement points: locked-out PIN dialog polling, emergency screen appear, and child foreground.
- Fixes #231 by awaiting the real FamilyControls authorization request result before committing app mode.
- Adds a #208 regression guard only; #208 was already fixed by B1/#271 and is not claimed by this PR.

Fixes #230
Fixes #232
Fixes #241
Fixes #231
Refs #208

## B2 Acceptance Rows

No parent/child-capable device pair exists (maintainer, 2026-07-12), so family-mode device acceptance is not executable in this phase at all. **Disposition: merged on automated verification; the family-mode integration rows are tracked in #326 and run when the app TestFlights onto a real child device.**

| Issue | Automated verification | Device acceptance status |
| --- | --- | --- |
| #230 Reset PIN Attempts / Reset Emergency Count processes without relaunch | `FamilyCommandApplyTests` verifies local throttle reset; full suite passed | Deferred to #326 (TestFlight milestone) |
| #232 Revoked-permissions child yields exactly one parent notification across heartbeat refreshes | `MonitoredDeviceTests` verifies once-per-revocation helper state and backward-compatible decode; full suite passed | Deferred to #326 (TestFlight milestone) |
| #241 Unresolved `userRecordID` family member survives participant sync | `ParticipantRemovalDecisionTests` verifies fail-safe keep-don't-delete behavior; full suite passed | Deferred to #326 (TestFlight milestone) |
| #231 Await real authorization callback | `RequestAuthorizerTests` verifies success/failure/member selection using the seam; full suite passed | Unit-verified per plan |
| #208 Changed PIN regression guard | `LockCodeChangedPinRegressionTests` verifies connected refresh adopts the new PIN and drops the old one | Regression guard only; no production change |

## Verification

- Bring-forward diff/symbol audit completed before simulator test runs; no semantic drift found.
- Confirmed `FamilyControlsMember` is `Equatable` in the iPhone Simulator SDK swiftinterface before writing `==` assertions.
- `./scripts/check-c2-guards.sh`
- `./scripts/check-sync-guards.sh`
- `swift-format lint --recursive .`
- `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' | xcpretty`

## Out of Scope

MD-B2-1 shared-DB `CKSubscription` push delivery is intentionally not implemented. The shipped #230 path is poll/foreground cadence only and keeps `applyCommand` gate-free while `processPendingCommands` remains child-gated; no origin-trust metadata or new remote-management capability was added.

## Summary by Sourcery

Harden family sharing, authorization, and child-command handling around B2 scenarios while adding regression and behavior tests.

Bug Fixes:
- Prevent FamilyMember records from being deleted when CloudKit share participants have unresolved user identities.
- Ensure Screen Time permission-loss notifications are sent only once per revocation and remain stable across heartbeat refreshes.
- Await the real FamilyControls authorization result before switching app modes so failures are surfaced correctly.
- Apply parent-issued reset commands at child enforcement points, ensuring lockout and emergency counters reset as intended.

Enhancements:
- Track auth-revocation notification state on monitored devices to avoid duplicate alerts and support backward-compatible decoding.
- Refine lock-code command processing to separate command application from cleanup and expose it for reuse at additional enforcement sites.

Tests:
- Add unit tests covering family member removal decisions, lock-code PIN change regression, family command application, authorization request behavior, and auth-revocation alert scheduling/back-compat.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the B2 family-command and heartbeat fixes into the app. The main changes are:

- Fail-safe FamilyMember cleanup when accepted share participants have unresolved identities.
- Transition-keyed Screen Time permission-lost notifications for monitored devices.
- Child-side processing of parent reset commands on foreground, emergency view, and lockout polling.
- Awaited FamilyControls authorization before committing selected app mode.
- Regression tests for command application, authorization, heartbeat markers, participant cleanup, and PIN refresh.

<h3>Confidence Score: 4/5</h3>

The heartbeat alert marker and command replay paths need fixes before merging.

- A failed notification add can leave the permission-lost alert marked as sent.
- A pending reset command can be applied more than once when deletion fails or refreshes overlap.
- The authorization and participant-cleanup changes look well-scoped.

Foqos/Utils/HeartbeatManager.swift; Foqos/Utils/LockCodeManager.swift

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Foqos/CloudKit/CloudKitNetworkService+Sharing.swift | Adds conservative FamilyMember cleanup that skips removals while accepted participant identities are unresolved. |
| Foqos/Models/MonitoredDevice.swift | Adds a persisted marker for once-per-revocation alerting with backward-compatible decoding. |
| Foqos/Utils/HeartbeatManager.swift | Adds transition-keyed permission-lost scheduling, but saves the marker before notification scheduling succeeds. |
| Foqos/Utils/LockCodeManager.swift | Exposes child command processing and command application, but commands can replay after delete failures or overlapping refreshes. |
| Foqos/Views/Components/LockCodeEntryView.swift | Polls pending reset commands while the child is locked out. |
| Foqos/Views/EmergencyView.swift | Processes pending child commands when the emergency screen appears. |
| Foqos/FoqosApp.swift | Processes pending child commands when the app becomes active after account checks. |
| Foqos/Utils/AuthorizationRequesting.swift | Adds a MainActor seam over FamilyControls authorization requests. |
| Foqos/Utils/RequestAuthorizer.swift | Awaits the real authorization request result and returns success or failure to callers. |
| Foqos/Views/ModeSelectionView.swift | Commits the selected mode only after authorization succeeds. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Child as Child app
  participant CK as CloudKit
  participant LCM as LockCodeManager
  participant Parent as Parent app
  participant NC as NotificationCenter

  Child->>LCM: foreground / emergency appear / lockout poll
  LCM->>CK: fetchPendingCommands()
  CK-->>LCM: reset command
  LCM->>LCM: applyCommand(command)
  LCM->>CK: deleteCommand(command)
  alt delete fails or overlapping refresh already fetched
    CK-->>LCM: command remains visible
    Child->>LCM: later poll or refresh
    LCM->>LCM: same command applied again
  end

  Parent->>Parent: refreshHeartbeats()
  Parent->>Parent: save authRevokedNotifiedAt
  Parent->>NC: add permission-lost notification
  alt add fails
    NC-->>Parent: error
    Parent->>Parent: later refresh skips retry because marker is saved
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Child as Child app
  participant CK as CloudKit
  participant LCM as LockCodeManager
  participant Parent as Parent app
  participant NC as NotificationCenter

  Child->>LCM: foreground / emergency appear / lockout poll
  LCM->>CK: fetchPendingCommands()
  CK-->>LCM: reset command
  LCM->>LCM: applyCommand(command)
  LCM->>CK: deleteCommand(command)
  alt delete fails or overlapping refresh already fetched
    CK-->>LCM: command remains visible
    Child->>LCM: later poll or refresh
    LCM->>LCM: same command applied again
  end

  Parent->>Parent: refreshHeartbeats()
  Parent->>Parent: save authRevokedNotifiedAt
  Parent->>NC: add permission-lost notification
  alt add fails
    NC-->>Parent: error
    Parent->>Parent: later refresh skips retry because marker is saved
  end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Foqos/Utils/LockCodeManager.swift`, line 341-349 ([link](https://github.com/mnbf9rca/family-foqos/blob/2a43db1c69e24ade50a25aaf1cdc2246a9fbdd30/Foqos/Utils/LockCodeManager.swift#L341-L349)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Commands Replay After Delete Failure**

   The new foreground, emergency-screen, and lockout-polling callers can reach this apply-then-delete path repeatedly. If CloudKit deletion fails or another refresh fetched the same command before deletion is visible, the same `resetEmergencyCount` command is applied again, which can advance the emergency reset state more than once for one parent action.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Test #208: guard changed PIN adoption on..."](https://github.com/mnbf9rca/family-foqos/commit/2a43db1c69e24ade50a25aaf1cdc2246a9fbdd30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43649934)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
