### PR TITLE
Fix W3-B active-anywhere locks, pre-attach deletes, delete watermark

### DIFF
--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -191,6 +191,9 @@ class ProfileSyncManager: ObservableObject {
     pendingController = controller
     ownedEngineController = controller
     engineController = controller
+    for recordName in PreAttachDeleteBuffer.drainAll(defaults: bufferDefaults) {
+      controller.recordDisabledDeleteTombstone(recordName: recordName)
+    }
     if isEnabled {
       controller.start()
       // Wait for the bounded startup sequence (I12 recovery, §5.6 retry sweep, T1 seed

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -68,6 +68,10 @@ class ProfileSyncManager: ObservableObject {
     SharedData.deviceSyncId.uuidString
   }
 
+  private var preAttachBufferUserRecordName: String? {
+    CloudKitManager.shared.currentUserRecordID?.recordName
+  }
+
   // MARK: - Initialization
 
   private init() {
@@ -191,9 +195,13 @@ class ProfileSyncManager: ObservableObject {
     pendingController = controller
     ownedEngineController = controller
     engineController = controller
-    for recordName in PreAttachDeleteBuffer.pending(defaults: bufferDefaults) {
-      controller.recordDisabledDeleteTombstone(recordName: recordName)
-      PreAttachDeleteBuffer.acknowledge(recordName, defaults: bufferDefaults)
+    for entry in PreAttachDeleteBuffer.pending(defaults: bufferDefaults) {
+      guard entry.userRecordName == nil || entry.userRecordName == userRecordName else {
+        continue
+      }
+      controller.recordDisabledDeleteTombstone(recordName: entry.recordName)
+      PreAttachDeleteBuffer.acknowledge(
+        entry.recordName, userRecordName: entry.userRecordName, defaults: bufferDefaults)
     }
     if isEnabled {
       controller.start()
@@ -255,14 +263,16 @@ class ProfileSyncManager: ObservableObject {
   func enqueueProfileDelete(_ id: UUID) throws {
     guard let engineController else {
       deferredDeleteRecordNames.insert(id.uuidString)
-      PreAttachDeleteBuffer.add(id.uuidString, defaults: bufferDefaults)
+      PreAttachDeleteBuffer.add(
+        id.uuidString, userRecordName: preAttachBufferUserRecordName, defaults: bufferDefaults)
       throw SyncEngineControllingError.notAttached
     }
     do {
       try engineController.enqueueProfileDelete(id, requestSyncAfterPendingDelete: isSyncReady)
     } catch SyncEngineControllingError.notAttached {
       deferredDeleteRecordNames.insert(id.uuidString)
-      PreAttachDeleteBuffer.add(id.uuidString, defaults: bufferDefaults)
+      PreAttachDeleteBuffer.add(
+        id.uuidString, userRecordName: preAttachBufferUserRecordName, defaults: bufferDefaults)
       throw SyncEngineControllingError.notAttached
     }
   }
@@ -282,14 +292,16 @@ class ProfileSyncManager: ObservableObject {
   func enqueueLocationDelete(_ id: UUID) throws {
     guard let engineController else {
       deferredDeleteRecordNames.insert(id.uuidString)
-      PreAttachDeleteBuffer.add(id.uuidString, defaults: bufferDefaults)
+      PreAttachDeleteBuffer.add(
+        id.uuidString, userRecordName: preAttachBufferUserRecordName, defaults: bufferDefaults)
       throw SyncEngineControllingError.notAttached
     }
     do {
       try engineController.enqueueLocationDelete(id)
     } catch SyncEngineControllingError.notAttached {
       deferredDeleteRecordNames.insert(id.uuidString)
-      PreAttachDeleteBuffer.add(id.uuidString, defaults: bufferDefaults)
+      PreAttachDeleteBuffer.add(
+        id.uuidString, userRecordName: preAttachBufferUserRecordName, defaults: bufferDefaults)
       throw SyncEngineControllingError.notAttached
     }
     if isSyncReady { engineController.requestSync() }
@@ -336,14 +348,16 @@ class ProfileSyncManager: ObservableObject {
   func enqueueEmergencyUnblockEventDelete(_ recordName: String) throws {
     guard let engineController else {
       deferredDeleteRecordNames.insert(recordName)
-      PreAttachDeleteBuffer.add(recordName, defaults: bufferDefaults)
+      PreAttachDeleteBuffer.add(
+        recordName, userRecordName: preAttachBufferUserRecordName, defaults: bufferDefaults)
       throw SyncEngineControllingError.notAttached
     }
     do {
       try engineController.enqueueEmergencyUnblockEventDelete(recordName)
     } catch SyncEngineControllingError.notAttached {
       deferredDeleteRecordNames.insert(recordName)
-      PreAttachDeleteBuffer.add(recordName, defaults: bufferDefaults)
+      PreAttachDeleteBuffer.add(
+        recordName, userRecordName: preAttachBufferUserRecordName, defaults: bufferDefaults)
       throw SyncEngineControllingError.notAttached
     }
     if isSyncReady { engineController.requestSync() }
@@ -353,7 +367,8 @@ class ProfileSyncManager: ObservableObject {
   /// Best-effort because the caller is already on a committed local-delete path.
   func recordDisabledDeleteTombstone(recordName: String) {
     guard let engineController else {
-      PreAttachDeleteBuffer.add(recordName, defaults: bufferDefaults)
+      PreAttachDeleteBuffer.add(
+        recordName, userRecordName: preAttachBufferUserRecordName, defaults: bufferDefaults)
       Log.info("Disabled-delete tombstone buffered pre-attach (\(recordName))", category: .sync)
       return
     }

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -40,6 +40,9 @@ class ProfileSyncManager: ObservableObject {
   /// Gates send-on-enqueue so a send can never flush restored state before T1 (#286 poison).
   var isSyncReady = false
 
+  /// Test-injectable defaults for the non-user-namespaced pre-attach delete buffer (#305).
+  var bufferDefaults: UserDefaults = .standard
+
   // MARK: - Private State
 
   private var cancellables = Set<AnyCancellable>()
@@ -248,12 +251,14 @@ class ProfileSyncManager: ObservableObject {
   func enqueueProfileDelete(_ id: UUID) throws {
     guard let engineController else {
       deferredDeleteRecordNames.insert(id.uuidString)
+      PreAttachDeleteBuffer.add(id.uuidString, defaults: bufferDefaults)
       throw SyncEngineControllingError.notAttached
     }
     do {
       try engineController.enqueueProfileDelete(id, requestSyncAfterPendingDelete: isSyncReady)
     } catch SyncEngineControllingError.notAttached {
       deferredDeleteRecordNames.insert(id.uuidString)
+      PreAttachDeleteBuffer.add(id.uuidString, defaults: bufferDefaults)
       throw SyncEngineControllingError.notAttached
     }
   }
@@ -273,12 +278,14 @@ class ProfileSyncManager: ObservableObject {
   func enqueueLocationDelete(_ id: UUID) throws {
     guard let engineController else {
       deferredDeleteRecordNames.insert(id.uuidString)
+      PreAttachDeleteBuffer.add(id.uuidString, defaults: bufferDefaults)
       throw SyncEngineControllingError.notAttached
     }
     do {
       try engineController.enqueueLocationDelete(id)
     } catch SyncEngineControllingError.notAttached {
       deferredDeleteRecordNames.insert(id.uuidString)
+      PreAttachDeleteBuffer.add(id.uuidString, defaults: bufferDefaults)
       throw SyncEngineControllingError.notAttached
     }
     if isSyncReady { engineController.requestSync() }
@@ -325,12 +332,14 @@ class ProfileSyncManager: ObservableObject {
   func enqueueEmergencyUnblockEventDelete(_ recordName: String) throws {
     guard let engineController else {
       deferredDeleteRecordNames.insert(recordName)
+      PreAttachDeleteBuffer.add(recordName, defaults: bufferDefaults)
       throw SyncEngineControllingError.notAttached
     }
     do {
       try engineController.enqueueEmergencyUnblockEventDelete(recordName)
     } catch SyncEngineControllingError.notAttached {
       deferredDeleteRecordNames.insert(recordName)
+      PreAttachDeleteBuffer.add(recordName, defaults: bufferDefaults)
       throw SyncEngineControllingError.notAttached
     }
     if isSyncReady { engineController.requestSync() }
@@ -340,9 +349,8 @@ class ProfileSyncManager: ObservableObject {
   /// Best-effort because the caller is already on a committed local-delete path.
   func recordDisabledDeleteTombstone(recordName: String) {
     guard let engineController else {
-      Log.warning(
-        "Disabled-delete tombstone dropped: engine not attached yet (\(recordName))",
-        category: .sync)
+      PreAttachDeleteBuffer.add(recordName, defaults: bufferDefaults)
+      Log.info("Disabled-delete tombstone buffered pre-attach (\(recordName))", category: .sync)
       return
     }
     engineController.recordDisabledDeleteTombstone(recordName: recordName)

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -191,8 +191,9 @@ class ProfileSyncManager: ObservableObject {
     pendingController = controller
     ownedEngineController = controller
     engineController = controller
-    for recordName in PreAttachDeleteBuffer.drainAll(defaults: bufferDefaults) {
+    for recordName in PreAttachDeleteBuffer.pending(defaults: bufferDefaults) {
       controller.recordDisabledDeleteTombstone(recordName: recordName)
+      PreAttachDeleteBuffer.acknowledge(recordName, defaults: bufferDefaults)
     }
     if isEnabled {
       controller.start()

--- a/Foqos/CloudKit/SessionController.swift
+++ b/Foqos/CloudKit/SessionController.swift
@@ -8,4 +8,5 @@ protocol SessionController: AnyObject {
   var activeSession: BlockedProfileSession? { get }
   func startRemoteSession(context: ModelContext, profileId: UUID, sessionId: UUID, startTime: Date)
   func stopRemoteSession(context: ModelContext, profileId: UUID)
+  func setRemoteSessionActive(_ isActive: Bool, profileId: UUID)
 }

--- a/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
+++ b/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
@@ -130,6 +130,7 @@ final class MutationFunnel {
       guard let profile = try BlockedProfiles.findProfile(byID: profileId, in: modelContext) else {
         throw MutationFunnelError.entityNotFound
       }
+      store.setDeleteWatermark(recordName: recordName, value: Double(profile.syncVersion))
       try BlockedProfiles.deleteProfile(profile, in: modelContext)
       let deleteZoneID = zoneID
       let saveOverride = saveOverride
@@ -149,6 +150,7 @@ final class MutationFunnel {
           }
           guard try BlockedProfiles.findProfile(byID: profileId, in: modelContext) == nil else {
             store.clearTombstone(recordName: recordName)
+            store.clearDeleteWatermark(recordName: recordName)
             Log.error(
               "Deferred profile delete save completed but \(recordName) is still present",
               category: .sync
@@ -161,6 +163,7 @@ final class MutationFunnel {
           onPendingDeleteEnqueued()
         } catch {
           store.clearTombstone(recordName: recordName)
+          store.clearDeleteWatermark(recordName: recordName)
           modelContext.rollback()
           Log.error(
             "Deferred profile delete save failed for \(recordName): \(error.localizedDescription)",
@@ -171,6 +174,7 @@ final class MutationFunnel {
       return
     } catch {
       store.clearTombstone(recordName: recordName)
+      store.clearDeleteWatermark(recordName: recordName)
       modelContext.rollback()
       throw error
     }
@@ -187,10 +191,15 @@ final class MutationFunnel {
       guard let location = try SavedLocation.find(byID: locationId, in: modelContext) else {
         throw MutationFunnelError.entityNotFound
       }
+      store.setDeleteWatermark(
+        recordName: recordName,
+        value: location.updatedAt.timeIntervalSinceReferenceDate
+      )
       repaired = try BlockedProfiles.removeLocationReference(locationId, in: modelContext)
       try SavedLocation.delete(location, in: modelContext)
     } catch {
       store.clearTombstone(recordName: recordName)
+      store.clearDeleteWatermark(recordName: recordName)
       modelContext.rollback()
       throw error
     }

--- a/Foqos/CloudKit/SyncEngine/PreAttachDeleteBuffer.swift
+++ b/Foqos/CloudKit/SyncEngine/PreAttachDeleteBuffer.swift
@@ -12,6 +12,20 @@ enum PreAttachDeleteBuffer {
     defaults.set(Array(names), forKey: defaultsKey)
   }
 
+  static func pending(defaults: UserDefaults = .standard) -> [String] {
+    defaults.stringArray(forKey: defaultsKey) ?? []
+  }
+
+  static func acknowledge(_ recordName: String, defaults: UserDefaults = .standard) {
+    var names = Set(defaults.stringArray(forKey: defaultsKey) ?? [])
+    names.remove(recordName)
+    if names.isEmpty {
+      defaults.removeObject(forKey: defaultsKey)
+    } else {
+      defaults.set(Array(names), forKey: defaultsKey)
+    }
+  }
+
   static func drainAll(defaults: UserDefaults = .standard) -> [String] {
     let names = defaults.stringArray(forKey: defaultsKey) ?? []
     defaults.removeObject(forKey: defaultsKey)

--- a/Foqos/CloudKit/SyncEngine/PreAttachDeleteBuffer.swift
+++ b/Foqos/CloudKit/SyncEngine/PreAttachDeleteBuffer.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Durable, non-user-namespaced buffer for delete intents formed before the per-user
+/// `SyncEngineStore` exists. Drained into store tombstones when `attachEngine` builds the store.
+@MainActor
+enum PreAttachDeleteBuffer {
+  static let defaultsKey = "family_foqos_pending_preattach_deletes"
+
+  static func add(_ recordName: String, defaults: UserDefaults = .standard) {
+    var names = Set(defaults.stringArray(forKey: defaultsKey) ?? [])
+    names.insert(recordName)
+    defaults.set(Array(names), forKey: defaultsKey)
+  }
+
+  static func drainAll(defaults: UserDefaults = .standard) -> [String] {
+    let names = defaults.stringArray(forKey: defaultsKey) ?? []
+    defaults.removeObject(forKey: defaultsKey)
+    return names
+  }
+}

--- a/Foqos/CloudKit/SyncEngine/PreAttachDeleteBuffer.swift
+++ b/Foqos/CloudKit/SyncEngine/PreAttachDeleteBuffer.swift
@@ -1,34 +1,66 @@
 import Foundation
 
-/// Durable, non-user-namespaced buffer for delete intents formed before the per-user
-/// `SyncEngineStore` exists. Drained into store tombstones when `attachEngine` builds the store.
+/// Durable buffer for delete intents formed before the per-user `SyncEngineStore` exists.
+/// Entries carry best-effort user provenance so attach only promotes names for the resolved user.
 @MainActor
 enum PreAttachDeleteBuffer {
   static let defaultsKey = "family_foqos_pending_preattach_deletes"
 
-  static func add(_ recordName: String, defaults: UserDefaults = .standard) {
-    var names = Set(defaults.stringArray(forKey: defaultsKey) ?? [])
-    names.insert(recordName)
-    defaults.set(Array(names), forKey: defaultsKey)
+  struct PendingDelete: Codable, Equatable {
+    var recordName: String
+    var userRecordName: String?
   }
 
-  static func pending(defaults: UserDefaults = .standard) -> [String] {
-    defaults.stringArray(forKey: defaultsKey) ?? []
+  static func add(
+    _ recordName: String,
+    userRecordName: String? = nil,
+    defaults: UserDefaults = .standard
+  ) {
+    var entries = pending(defaults: defaults)
+    let entry = PendingDelete(recordName: recordName, userRecordName: userRecordName)
+    guard !entries.contains(entry) else { return }
+    entries.append(entry)
+    save(entries, defaults: defaults)
   }
 
   static func acknowledge(_ recordName: String, defaults: UserDefaults = .standard) {
-    var names = Set(defaults.stringArray(forKey: defaultsKey) ?? [])
-    names.remove(recordName)
-    if names.isEmpty {
-      defaults.removeObject(forKey: defaultsKey)
-    } else {
-      defaults.set(Array(names), forKey: defaultsKey)
+    let entries = pending(defaults: defaults).filter { $0.recordName != recordName }
+    save(entries, defaults: defaults)
+  }
+
+  static func acknowledge(
+    _ recordName: String,
+    userRecordName: String?,
+    defaults: UserDefaults = .standard
+  ) {
+    let entries = pending(defaults: defaults).filter {
+      !($0.recordName == recordName && $0.userRecordName == userRecordName)
+    }
+    save(entries, defaults: defaults)
+  }
+
+  static func pending(defaults: UserDefaults = .standard) -> [PendingDelete] {
+    if let data = defaults.data(forKey: defaultsKey),
+      let entries = try? JSONDecoder().decode([PendingDelete].self, from: data)
+    {
+      return entries
+    }
+    return (defaults.stringArray(forKey: defaultsKey) ?? []).map {
+      PendingDelete(recordName: $0, userRecordName: nil)
     }
   }
 
   static func drainAll(defaults: UserDefaults = .standard) -> [String] {
-    let names = defaults.stringArray(forKey: defaultsKey) ?? []
+    let names = pending(defaults: defaults).map(\.recordName)
     defaults.removeObject(forKey: defaultsKey)
     return names
+  }
+
+  private static func save(_ entries: [PendingDelete], defaults: UserDefaults) {
+    if entries.isEmpty {
+      defaults.removeObject(forKey: defaultsKey)
+    } else {
+      defaults.set(try? JSONEncoder().encode(entries), forKey: defaultsKey)
+    }
   }
 }

--- a/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
@@ -535,6 +535,15 @@ final class SyncApplyService {
             localVersion: localVersion, newLocalVersion: existing.syncVersion)
         }
       } else {
+        if let watermark = store.deleteWatermark(for: recordName),
+          synced.lastModified.timeIntervalSinceReferenceDate <= watermark
+        {
+          SyncDiagnostics.locationApply(
+            locationId: synced.locationId, branch: "stale_delete_echo_skipped",
+            localVersion: nil, newLocalVersion: 0)
+          store.removeFailedApply(recordName: recordName)
+          return .skippedStaleDelete
+        }
         let location = SavedLocation(
           id: synced.locationId,
           name: synced.name,
@@ -546,6 +555,7 @@ final class SyncApplyService {
         )
         modelContext.insert(location)
         try commit()
+        store.clearDeleteWatermark(recordName: recordName)
         SyncDiagnostics.locationApply(
           locationId: synced.locationId, branch: "created", localVersion: nil,
           newLocalVersion: location.syncVersion)

--- a/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
@@ -7,7 +7,7 @@ import SwiftData
 /// own-origin apply skip. Not wired into any engine in Phase B.
 @MainActor
 final class SyncApplyService {
-  enum ApplyOutcome { case applied, skippedPendingDelete, ignored, failed }
+  enum ApplyOutcome { case applied, skippedPendingDelete, skippedStaleDelete, ignored, failed }
   enum DeletionOutcome { case deleted, notPresent, ignored }
 
   private let modelContext: ModelContext
@@ -277,12 +277,25 @@ final class SyncApplyService {
   private func applyDecodedProfile(
     _ synced: SyncedProfile, record: CKRecord
   ) throws -> ApplyOutcome {
+    let recordName = record.recordID.recordName
     guard
       let existing = try BlockedProfiles.findProfile(byID: synced.profileId, in: modelContext)
     else {
+      if let watermark = store.deleteWatermark(for: recordName),
+        Double(synced.version) <= watermark
+      {
+        SyncDiagnostics.profileApply(
+          profileId: synced.profileId, branch: "stale_delete_echo_skipped",
+          remoteVersion: synced.version, localVersion: nil,
+          remoteSchema: synced.profileSchemaVersion, localSchema: nil,
+          remoteGeofenceRefCount: synced.geofenceRule?.locationReferences.count,
+          localGeofenceRefCount: nil)
+        return .skippedStaleDelete
+      }
       createLocalProfile(from: synced)
       try commit()
       storeSystemFields(record)
+      store.clearDeleteWatermark(recordName: recordName)
       SyncDiagnostics.profileApply(
         profileId: synced.profileId, branch: "created", remoteVersion: synced.version,
         localVersion: nil, remoteSchema: synced.profileSchemaVersion, localSchema: nil,

--- a/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
@@ -241,6 +241,7 @@ final class SyncApplyService {
     else {
       return .ignored
     }
+    sessionController.setRemoteSessionActive(false, profileId: id)
     // §5.2: an explicit deletion stops the matching remote-started session (#203).
     if sessionController.activeSession?.blockedProfile.id == id {
       sessionController.stopRemoteSession(context: modelContext, profileId: id)
@@ -653,6 +654,7 @@ final class SyncApplyService {
       SyncDiagnostics.sessionApply(profileId: profileId, branch: "own_origin_noop")
       return
     }
+    sessionController.setRemoteSessionActive(session.isActive, profileId: profileId)
     let localActive = sessionController.activeSession?.blockedProfile.id == profileId
     if session.isActive && !localActive {
       if let startTime = session.startTime {

--- a/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
@@ -123,6 +123,7 @@ final class SyncApplyService {
     do {
       guard let profile = try BlockedProfiles.findProfile(byID: id, in: modelContext) else {
         clearDeletionBookkeeping(recordName: recordName)  // intent already satisfied
+        sessionController.setRemoteSessionActive(false, profileId: id)
         SyncDiagnostics.profileDeletionApplied(
           profileId: id, existed: false, stoppedActiveSession: false, outcome: .notPresent)
         return .notPresent
@@ -137,8 +138,9 @@ final class SyncApplyService {
       try BlockedProfiles.deleteProfile(profile, in: modelContext)  // defers save
       let saveOverride = saveOverride
       let profileDeleteCommitObserver = profileDeleteCommitObserver
+      let sessionController = sessionController
       scheduleProfileDeleteCommit {
-        [modelContext, store, id, recordName, saveOverride, profileDeleteCommitObserver] in
+        [modelContext, store, sessionController, id, recordName, saveOverride, profileDeleteCommitObserver] in
         do {
           // Remote apply failures are persisted as failedApplies and retried by the sync
           // controller, not surfaced as UI action errors. Controller side effects wait until
@@ -162,6 +164,7 @@ final class SyncApplyService {
           store.setSystemFields(nil, for: recordName)
           store.clearTombstone(recordName: recordName)
           store.removeFailedApply(recordName: recordName)
+          sessionController.setRemoteSessionActive(false, profileId: id)
           profileDeleteCommitObserver?(recordName)
         } catch {
           modelContext.rollback()

--- a/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
@@ -127,6 +127,7 @@ final class SyncApplyService {
           profileId: id, existed: false, stoppedActiveSession: false, outcome: .notPresent)
         return .notPresent
       }
+      store.setDeleteWatermark(recordName: recordName, value: Double(profile.syncVersion))
       // §5.2 / #203: if the deleted profile owns the active session, stop it first so
       // restrictions are deactivated and the manager does not retain a deleted model.
       let stoppedActiveSession = sessionController.activeSession?.blockedProfile.id == id
@@ -164,6 +165,7 @@ final class SyncApplyService {
           profileDeleteCommitObserver?(recordName)
         } catch {
           modelContext.rollback()
+          store.clearDeleteWatermark(recordName: recordName)
           store.addFailedApply(
             FailedApply(
               recordName: recordName, recordType: SyncedProfile.recordType, op: .delete))
@@ -178,6 +180,7 @@ final class SyncApplyService {
       return .deleted
     } catch {
       modelContext.rollback()
+      store.clearDeleteWatermark(recordName: recordName)
       store.addFailedApply(
         FailedApply(
           recordName: recordName, recordType: SyncedProfile.recordType, op: .delete))
@@ -193,6 +196,10 @@ final class SyncApplyService {
     do {
       let location = try SavedLocation.find(byID: id, in: modelContext)
       if let location {
+        store.setDeleteWatermark(
+          recordName: recordName,
+          value: location.updatedAt.timeIntervalSinceReferenceDate
+        )
         try SavedLocation.delete(location, in: modelContext)  // saves internally
       }
 
@@ -216,6 +223,7 @@ final class SyncApplyService {
       return outcome
     } catch {
       modelContext.rollback()
+      store.clearDeleteWatermark(recordName: recordName)
       store.addFailedApply(
         FailedApply(
           recordName: recordName, recordType: SyncedLocation.recordType, op: .delete))

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -861,6 +861,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       if entityExists(recordName: name) {
         // Local delete never completed — fail-toward-keep (E-3).
         store.clearTombstone(recordName: name)
+        store.clearDeleteWatermark(recordName: name)
         continue
       }
       // Recovered intent ⇒ verify-before-delete.
@@ -1277,6 +1278,7 @@ enum SyncDiagnostics {
     switch outcome {
     case .applied: return "applied"
     case .skippedPendingDelete: return "skipped_pending_delete"
+    case .skippedStaleDelete: return "skipped_stale_delete"
     case .ignored: return "ignored"
     case .failed: return "failed"
     }

--- a/Foqos/CloudKit/SyncEngine/SyncEngineStore.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineStore.swift
@@ -185,7 +185,7 @@ final class SyncEngineStore {
   /// Guard value captured at delete time: `Double(syncVersion)` for profiles,
   /// `updatedAt.timeIntervalSinceReferenceDate` for locations. Unlike the I12 tombstone, this
   /// survives confirmation to gate locally-absent create branches against stale delete echoes.
-  static let maxDeleteWatermarkEntries = 512
+  static let deleteWatermarkWarningThreshold = 512
 
   private struct DeleteWatermarkEntry: Codable {
     var recordName: String
@@ -204,8 +204,11 @@ final class SyncEngineStore {
     locked {
       var all = self.deleteWatermarkEntries.filter { $0.recordName != recordName }
       all.append(DeleteWatermarkEntry(recordName: recordName, value: value))
-      if all.count > Self.maxDeleteWatermarkEntries {
-        all = Array(all.suffix(Self.maxDeleteWatermarkEntries))
+      if all.count > Self.deleteWatermarkWarningThreshold {
+        Log.warning(
+          "Delete watermark count \(all.count) exceeds telemetry threshold "
+            + "\(Self.deleteWatermarkWarningThreshold)",
+          category: .sync)
       }
       self.encodeStore(all, "delete_watermarks")
     }

--- a/Foqos/CloudKit/SyncEngine/SyncEngineStore.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineStore.swift
@@ -180,6 +180,44 @@ final class SyncEngineStore {
     }
   }
 
+  // MARK: - Delete version watermark (#315)
+
+  /// Guard value captured at delete time: `Double(syncVersion)` for profiles,
+  /// `updatedAt.timeIntervalSinceReferenceDate` for locations. Unlike the I12 tombstone, this
+  /// survives confirmation to gate locally-absent create branches against stale delete echoes.
+  static let maxDeleteWatermarkEntries = 512
+
+  private struct DeleteWatermarkEntry: Codable {
+    var recordName: String
+    var value: Double
+  }
+
+  private var deleteWatermarkEntries: [DeleteWatermarkEntry] {
+    decoded([DeleteWatermarkEntry].self, "delete_watermarks") ?? []
+  }
+
+  func deleteWatermark(for recordName: String) -> Double? {
+    deleteWatermarkEntries.first { $0.recordName == recordName }?.value
+  }
+
+  func setDeleteWatermark(recordName: String, value: Double) {
+    locked {
+      var all = self.deleteWatermarkEntries.filter { $0.recordName != recordName }
+      all.append(DeleteWatermarkEntry(recordName: recordName, value: value))
+      if all.count > Self.maxDeleteWatermarkEntries {
+        all = Array(all.suffix(Self.maxDeleteWatermarkEntries))
+      }
+      self.encodeStore(all, "delete_watermarks")
+    }
+  }
+
+  func clearDeleteWatermark(recordName: String) {
+    locked {
+      let all = self.deleteWatermarkEntries.filter { $0.recordName != recordName }
+      self.encodeStore(all, "delete_watermarks")
+    }
+  }
+
   // MARK: - Failed applies (§2.1 failedApplies, §5.6)
 
   var failedApplies: Set<FailedApply> {

--- a/Foqos/Utils/RemotelyActiveStore.swift
+++ b/Foqos/Utils/RemotelyActiveStore.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+@MainActor
+enum RemotelyActiveStore {
+  static let defaultsKey = "family_foqos_remotely_active_profiles"
+
+  static func load(defaults: UserDefaults = .standard) -> Set<UUID> {
+    let strings = defaults.stringArray(forKey: defaultsKey) ?? []
+    return Set(strings.compactMap(UUID.init(uuidString:)))
+  }
+
+  static func save(_ ids: Set<UUID>, defaults: UserDefaults = .standard) {
+    defaults.set(ids.map(\.uuidString), forKey: defaultsKey)
+  }
+}

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -13,6 +13,7 @@ class StrategyManager: ObservableObject {
   private let profileSyncManager: ProfileSyncManager
   private let sessionSyncService: SessionSyncService
   private let locationManager: LocationManager
+  private let remoteActiveDefaults: UserDefaults
 
   /// #201: persisted intents for session-stops dropped by a failed/exhausted CAS write.
   /// Internal (not private) so Phase-E tests can assert routing without a live CloudKit call.
@@ -21,6 +22,7 @@ class StrategyManager: ObservableObject {
   @Published var elapsedTime: TimeInterval = 0
   @Published var timerTask: Task<Void, Never>?
   @Published var activeSession: BlockedProfileSession?
+  @Published private(set) var remotelyActiveProfileIds: Set<UUID>
 
   @Published var showCustomStrategyView: Bool = false
   @Published var customStrategyView: (any View)? = nil
@@ -40,7 +42,8 @@ class StrategyManager: ObservableObject {
     locationManager: LocationManager = .shared,
     appBlocker: RestrictionApplying = AppBlockerUtil(),
     backstopRegistrar: BackstopRegistering = DeviceActivityBackstopRegistrar(),
-    timersUtil: TimersUtilScheduling = TimersUtil()
+    timersUtil: TimersUtilScheduling = TimersUtil(),
+    remoteActiveDefaults: UserDefaults = .standard
   ) {
     self.geofenceEvaluator = geofenceEvaluator
     self.emergencyUnblockManager = emergencyUnblockManager
@@ -48,9 +51,11 @@ class StrategyManager: ObservableObject {
     self.profileSyncManager = profileSyncManager
     self.sessionSyncService = sessionSyncService
     self.locationManager = locationManager
+    self.remoteActiveDefaults = remoteActiveDefaults
     self.appBlocker = appBlocker
     self.backstopRegistrar = backstopRegistrar
     self.timersUtil = timersUtil
+    self.remotelyActiveProfileIds = RemotelyActiveStore.load(defaults: remoteActiveDefaults)
   }
 
   // Track if we're currently processing a remote session change
@@ -67,6 +72,15 @@ class StrategyManager: ObservableObject {
 
   var isBlocking: Bool {
     return activeSession?.isActive == true
+  }
+
+  func setRemoteSessionActive(_ isActive: Bool, profileId: UUID) {
+    if isActive {
+      remotelyActiveProfileIds.insert(profileId)
+    } else {
+      remotelyActiveProfileIds.remove(profileId)
+    }
+    RemotelyActiveStore.save(remotelyActiveProfileIds, defaults: remoteActiveDefaults)
   }
 
   var isBreakActive: Bool {

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -113,7 +113,9 @@ struct BlockedProfileView: View {
   }
 
   private var isBlocking: Bool {
-    strategyManager.activeSession?.isActive ?? false
+    if strategyManager.activeSession?.isActive == true { return true }
+    if let id = profile?.id, strategyManager.remotelyActiveProfileIds.contains(id) { return true }
+    return false
   }
 
   /// Whether this profile is managed and requires code for editing

--- a/Foqos/Views/SavedLocationsView.swift
+++ b/Foqos/Views/SavedLocationsView.swift
@@ -10,6 +10,7 @@ struct SavedLocationsView: View {
   @ObservedObject private var appModeManager = AppModeManager.shared
   @ObservedObject private var lockCodeManager = LockCodeManager.shared
   @ObservedObject private var profileSyncManager = ProfileSyncManager.shared
+  @ObservedObject private var strategyManager = StrategyManager.shared
 
   @SafeQuery(sort: \SavedLocation.name) private var locations: [SavedLocation]
   @SafeQuery private var profiles: [BlockedProfiles]
@@ -24,13 +25,22 @@ struct SavedLocationsView: View {
 
   /// Location IDs that are in use by profiles with active sessions
   private var locationsInUseByActiveProfiles: [UUID: String] {
+    Self.locationsInUse(
+      profiles: profiles,
+      hasLocalActiveSession: { $0.sessions.valid.contains { $0.isActive } },
+      remotelyActiveProfileIds: strategyManager.remotelyActiveProfileIds)
+  }
+
+  static func locationsInUse(
+    profiles: [BlockedProfiles],
+    hasLocalActiveSession: (BlockedProfiles) -> Bool,
+    remotelyActiveProfileIds: Set<UUID>
+  ) -> [UUID: String] {
     var result: [UUID: String] = [:]
     for profile in profiles {
-      // Check if profile has an active session
-      let hasActiveSession = profile.sessions.valid.contains { $0.isActive }
-      guard hasActiveSession else { continue }
+      let active = hasLocalActiveSession(profile) || remotelyActiveProfileIds.contains(profile.id)
+      guard active else { continue }
 
-      // Get location IDs from the profile's geofence rule
       if let rule = profile.geofenceRule {
         for ref in rule.locationReferences {
           result[ref.savedLocationId] = profile.name
@@ -193,6 +203,13 @@ struct SavedLocationsView: View {
 
   private func deleteLocation(_ location: SavedLocation) {
     let locationId = location.id
+
+    if let profileName = locationsInUseByActiveProfiles[locationId] {
+      errorMessage =
+        "\"\(location.name)\" is in use by \"\(profileName)\", which is currently running "
+        + "on this or another device. Stop that profile before deleting the location."
+      return
+    }
 
     do {
       if profileSyncManager.isEnabled {

--- a/FoqosTests/DeleteWatermarkStoreTests.swift
+++ b/FoqosTests/DeleteWatermarkStoreTests.swift
@@ -1,0 +1,53 @@
+import FoqosShared
+import Foundation
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class DeleteWatermarkStoreTests: XCTestCase {
+  private var suiteName: String!
+  private var defaults: UserDefaults!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "DeleteWatermarkStoreTests-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+    SharedData.configure(suite: UserDefaults(suiteName: "\(suiteName!)-shared")!)
+  }
+
+  override func tearDown() async throws {
+    UserDefaults().removePersistentDomain(forName: suiteName)
+    UserDefaults().removePersistentDomain(forName: "\(suiteName!)-shared")
+    try await super.tearDown()
+  }
+
+  private func makeStore() -> SyncEngineStore {
+    SyncEngineStore(userRecordName: "userA", defaults: defaults)
+  }
+
+  func testGivenWatermarkSet_WhenRead_ThenReturnsValueUntilCleared() {
+    let store = makeStore()
+    store.setDeleteWatermark(recordName: "p1", value: 5)
+    XCTAssertEqual(store.deleteWatermark(for: "p1"), 5)
+    store.clearDeleteWatermark(recordName: "p1")
+    XCTAssertNil(store.deleteWatermark(for: "p1"))
+  }
+
+  func testGivenWatermarkReset_WhenSetAgain_ThenOverwrites() {
+    let store = makeStore()
+    store.setDeleteWatermark(recordName: "p1", value: 5)
+    store.setDeleteWatermark(recordName: "p1", value: 7)
+    XCTAssertEqual(store.deleteWatermark(for: "p1"), 7)
+  }
+
+  func testGivenMoreThanCap_WhenSet_ThenOldestEvicted() {
+    let store = makeStore()
+    let cap = SyncEngineStore.maxDeleteWatermarkEntries
+    for index in 0...cap {
+      store.setDeleteWatermark(recordName: "r\(index)", value: Double(index))
+    }
+    XCTAssertNil(store.deleteWatermark(for: "r0"), "oldest evicted past the FIFO cap")
+    XCTAssertEqual(store.deleteWatermark(for: "r\(cap)"), Double(cap))
+  }
+}

--- a/FoqosTests/DeleteWatermarkStoreTests.swift
+++ b/FoqosTests/DeleteWatermarkStoreTests.swift
@@ -41,13 +41,13 @@ final class DeleteWatermarkStoreTests: XCTestCase {
     XCTAssertEqual(store.deleteWatermark(for: "p1"), 7)
   }
 
-  func testGivenMoreThanCap_WhenSet_ThenOldestEvicted() {
+  func testGivenMoreThanWarningThreshold_WhenSet_ThenOldestRetained() {
     let store = makeStore()
-    let cap = SyncEngineStore.maxDeleteWatermarkEntries
-    for index in 0...cap {
+    let threshold = SyncEngineStore.deleteWatermarkWarningThreshold
+    for index in 0...threshold {
       store.setDeleteWatermark(recordName: "r\(index)", value: Double(index))
     }
-    XCTAssertNil(store.deleteWatermark(for: "r0"), "oldest evicted past the FIFO cap")
-    XCTAssertEqual(store.deleteWatermark(for: "r\(cap)"), Double(cap))
+    XCTAssertEqual(store.deleteWatermark(for: "r0"), 0, "oldest retained past the warning threshold")
+    XCTAssertEqual(store.deleteWatermark(for: "r\(threshold)"), Double(threshold))
   }
 }

--- a/FoqosTests/LocationInUseTests.swift
+++ b/FoqosTests/LocationInUseTests.swift
@@ -1,0 +1,50 @@
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class LocationInUseTests: XCTestCase {
+  private func makeProfile(locationId: UUID, in context: ModelContext) throws -> BlockedProfiles {
+    let profile = BlockedProfiles(name: "Homework")
+    profile.geofenceRule = ProfileGeofenceRule(
+      ruleType: .outside,
+      locationReferences: [ProfileLocationReference(savedLocationId: locationId)],
+      allowEmergencyOverride: true)
+    context.insert(profile)
+    try context.save()
+    return profile
+  }
+
+  func testGivenRemotelyActiveProfileWithGeofence_WhenComputingInUse_ThenLocationLocked()
+    throws
+  {
+    let container = try TestModelContainer.create()
+    let context = container.mainContext
+    let locationId = UUID()
+    let profile = try makeProfile(locationId: locationId, in: context)
+
+    let inUse = SavedLocationsView.locationsInUse(
+      profiles: [profile],
+      hasLocalActiveSession: { _ in false },
+      remotelyActiveProfileIds: [profile.id])
+
+    XCTAssertEqual(
+      inUse[locationId], profile.name,
+      "#311: a location used by a profile running on another device must be locked here")
+  }
+
+  func testGivenInactiveProfileWithGeofence_WhenComputingInUse_ThenLocationFree() throws {
+    let container = try TestModelContainer.create()
+    let context = container.mainContext
+    let locationId = UUID()
+    let profile = try makeProfile(locationId: locationId, in: context)
+
+    let inUse = SavedLocationsView.locationsInUse(
+      profiles: [profile],
+      hasLocalActiveSession: { _ in false },
+      remotelyActiveProfileIds: [])
+
+    XCTAssertNil(inUse[locationId])
+  }
+}

--- a/FoqosTests/Mocks/MockSessionController.swift
+++ b/FoqosTests/Mocks/MockSessionController.swift
@@ -6,6 +6,7 @@ import SwiftData
 @MainActor
 class MockSessionController: SessionController {
   var activeSession: BlockedProfileSession? = nil
+  var setRemoteSessionActiveCalls: [(Bool, UUID)] = []
 
   var startRemoteSessionCalled = false
   var startRemoteSessionProfileId: UUID?
@@ -24,5 +25,9 @@ class MockSessionController: SessionController {
   func stopRemoteSession(context: ModelContext, profileId: UUID) {
     stopRemoteSessionCalled = true
     stopRemoteSessionProfileId = profileId
+  }
+
+  func setRemoteSessionActive(_ isActive: Bool, profileId: UUID) {
+    setRemoteSessionActiveCalls.append((isActive, profileId))
   }
 }

--- a/FoqosTests/MutationFunnelTests.swift
+++ b/FoqosTests/MutationFunnelTests.swift
@@ -336,6 +336,31 @@ final class MutationFunnelTests: XCTestCase {
     XCTAssertEqual(driver.pendingRecordZoneChanges, [.deleteRecord(recordID(recordName))])
   }
 
+  func testGivenProfileAtVersion_WhenEnqueueDelete_ThenDeleteWatermarkRecordsVersion() throws {
+    let profileId = UUID()
+    let recordName = profileId.uuidString
+    let container = try TestModelContainer.create()
+    let context = ModelContext(container)
+    try insertProfile(in: context, id: profileId, name: "Homework", syncVersion: 4)
+
+    let store = makeStore()
+    let driver = MockSyncEngineDriver()
+    let scheduler = ManualProfileDeleteCommitScheduler()
+    let funnel = MutationFunnel(
+      modelContext: context,
+      store: store,
+      driver: driver,
+      deviceId: "device-A",
+      scheduleProfileDeleteCommit: scheduler.schedule
+    )
+
+    try funnel.enqueueDelete(profileId: profileId)
+
+    XCTAssertEqual(
+      store.deleteWatermark(for: recordName), 4.0,
+      "#315: watermark must capture the profile version deleted by the funnel")
+  }
+
   func testGivenDeleteScheduledButCommitNotRun_WhenStoreReloads_ThenTombstoneSurvivesAndEntityStillExists()
     throws
   {
@@ -732,6 +757,39 @@ final class MutationFunnelTests: XCTestCase {
     XCTAssertTrue(store.deleteTombstones.keys.contains(recordName))
     XCTAssertEqual(driver.pendingRecordZoneChanges, [.deleteRecord(recordID(recordName))])
     _ = now
+  }
+
+  func testGivenLocation_WhenEnqueueDelete_ThenDeleteWatermarkRecordsUpdatedAt() throws {
+    let now = Date()
+    let locationId = UUID()
+    let recordName = locationId.uuidString
+    let container = try TestModelContainer.create()
+    let context = ModelContext(container)
+    let location = SavedLocation(
+      id: locationId,
+      name: "Home",
+      latitude: 1,
+      longitude: 2,
+      updatedAt: now
+    )
+    context.insert(location)
+    try context.save()
+
+    let store = makeStore()
+    let driver = MockSyncEngineDriver()
+    let funnel = MutationFunnel(
+      modelContext: context,
+      store: store,
+      driver: driver,
+      deviceId: "device-A"
+    )
+
+    try funnel.enqueueDelete(locationId: locationId)
+
+    let watermark = try XCTUnwrap(
+      store.deleteWatermark(for: recordName),
+      "#315: location delete watermark must capture updatedAt before delete")
+    XCTAssertEqual(watermark, now.timeIntervalSinceReferenceDate, accuracy: 0.000_001)
   }
 
   func testGivenLocationReferencedByProfile_WhenEnqueueDelete_ThenRepairsAndPushesProfile()

--- a/FoqosTests/PreAttachDeleteBufferTests.swift
+++ b/FoqosTests/PreAttachDeleteBufferTests.swift
@@ -35,4 +35,24 @@ final class PreAttachDeleteBufferTests: XCTestCase {
   func testGivenNoBuffer_WhenDrained_ThenEmpty() {
     XCTAssertTrue(PreAttachDeleteBuffer.drainAll(defaults: defaults).isEmpty)
   }
+
+  func testGivenBufferedDeletes_WhenPendingReadWithoutAcknowledge_ThenBufferRemains() {
+    PreAttachDeleteBuffer.add("A", defaults: defaults)
+    PreAttachDeleteBuffer.add("B", defaults: defaults)
+
+    XCTAssertEqual(Set(PreAttachDeleteBuffer.pending(defaults: defaults)), ["A", "B"])
+    XCTAssertEqual(
+      Set(PreAttachDeleteBuffer.pending(defaults: defaults)),
+      ["A", "B"],
+      "reading pending names must not clear the only durable copy before tombstone promotion")
+  }
+
+  func testGivenBufferedDeletes_WhenAcknowledgingOne_ThenOnlyThatNameClears() {
+    PreAttachDeleteBuffer.add("A", defaults: defaults)
+    PreAttachDeleteBuffer.add("B", defaults: defaults)
+
+    PreAttachDeleteBuffer.acknowledge("A", defaults: defaults)
+
+    XCTAssertEqual(Set(PreAttachDeleteBuffer.pending(defaults: defaults)), ["B"])
+  }
 }

--- a/FoqosTests/PreAttachDeleteBufferTests.swift
+++ b/FoqosTests/PreAttachDeleteBufferTests.swift
@@ -40,9 +40,9 @@ final class PreAttachDeleteBufferTests: XCTestCase {
     PreAttachDeleteBuffer.add("A", defaults: defaults)
     PreAttachDeleteBuffer.add("B", defaults: defaults)
 
-    XCTAssertEqual(Set(PreAttachDeleteBuffer.pending(defaults: defaults)), ["A", "B"])
+    XCTAssertEqual(Set(PreAttachDeleteBuffer.pending(defaults: defaults).map(\.recordName)), ["A", "B"])
     XCTAssertEqual(
-      Set(PreAttachDeleteBuffer.pending(defaults: defaults)),
+      Set(PreAttachDeleteBuffer.pending(defaults: defaults).map(\.recordName)),
       ["A", "B"],
       "reading pending names must not clear the only durable copy before tombstone promotion")
   }
@@ -53,6 +53,27 @@ final class PreAttachDeleteBufferTests: XCTestCase {
 
     PreAttachDeleteBuffer.acknowledge("A", defaults: defaults)
 
-    XCTAssertEqual(Set(PreAttachDeleteBuffer.pending(defaults: defaults)), ["B"])
+    XCTAssertEqual(Set(PreAttachDeleteBuffer.pending(defaults: defaults).map(\.recordName)), ["B"])
+  }
+
+  func testGivenBufferedDeleteWithProvenance_WhenPendingRead_ThenPreservesOriginUser() {
+    PreAttachDeleteBuffer.add("A", userRecordName: "user-A", defaults: defaults)
+    PreAttachDeleteBuffer.add("B", userRecordName: nil, defaults: defaults)
+
+    let pending = PreAttachDeleteBuffer.pending(defaults: defaults)
+
+    XCTAssertEqual(pending.first { $0.recordName == "A" }?.userRecordName, "user-A")
+    XCTAssertNil(pending.first { $0.recordName == "B" }?.userRecordName)
+  }
+
+  func testGivenBufferedDeleteWithProvenance_WhenAcknowledgingMatchingUser_ThenOnlyMatchingEntryClears() {
+    PreAttachDeleteBuffer.add("A", userRecordName: "user-A", defaults: defaults)
+    PreAttachDeleteBuffer.add("A", userRecordName: "user-B", defaults: defaults)
+
+    PreAttachDeleteBuffer.acknowledge("A", userRecordName: "user-A", defaults: defaults)
+
+    let pending = PreAttachDeleteBuffer.pending(defaults: defaults)
+    XCTAssertEqual(pending.map(\.recordName), ["A"])
+    XCTAssertEqual(pending.first?.userRecordName, "user-B")
   }
 }

--- a/FoqosTests/PreAttachDeleteBufferTests.swift
+++ b/FoqosTests/PreAttachDeleteBufferTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class PreAttachDeleteBufferTests: XCTestCase {
+  private var suiteName: String!
+  private var defaults: UserDefaults!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "PreAttachDeleteBufferTests-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+  }
+
+  override func tearDown() async throws {
+    UserDefaults().removePersistentDomain(forName: suiteName)
+    try await super.tearDown()
+  }
+
+  func testGivenBufferedDeletes_WhenDrained_ThenReturnsAllAndClears() {
+    PreAttachDeleteBuffer.add("A", defaults: defaults)
+    PreAttachDeleteBuffer.add("B", defaults: defaults)
+    PreAttachDeleteBuffer.add("A", defaults: defaults)
+
+    let drained = Set(PreAttachDeleteBuffer.drainAll(defaults: defaults))
+
+    XCTAssertEqual(drained, ["A", "B"])
+    XCTAssertTrue(
+      PreAttachDeleteBuffer.drainAll(defaults: defaults).isEmpty,
+      "drain must clear durably")
+  }
+
+  func testGivenNoBuffer_WhenDrained_ThenEmpty() {
+    XCTAssertTrue(PreAttachDeleteBuffer.drainAll(defaults: defaults).isEmpty)
+  }
+}

--- a/FoqosTests/ProfileEditGateTests.swift
+++ b/FoqosTests/ProfileEditGateTests.swift
@@ -36,4 +36,11 @@ final class ProfileEditGateTests: XCTestCase {
       ProfileEditGate.editingDisabled(
         isBlocking: true, isManaged: false, isUnlocked: true, mode: .individual, lockActive: false))
   }
+
+  func testGivenRemoteActiveProfile_WhenComputingGate_ThenEditingDisabled() {
+    XCTAssertTrue(
+      ProfileEditGate.editingDisabled(
+        isBlocking: true, isManaged: false, isUnlocked: true, mode: .individual, lockActive: false),
+      "#311: a profile active on another device must be passed through as blocking")
+  }
 }

--- a/FoqosTests/RemotelyActiveProfilesTests.swift
+++ b/FoqosTests/RemotelyActiveProfilesTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class RemotelyActiveProfilesTests: XCTestCase {
+  private var suiteName: String!
+  private var defaults: UserDefaults!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "RemotelyActiveProfilesTests-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+  }
+
+  override func tearDown() async throws {
+    UserDefaults().removePersistentDomain(forName: suiteName)
+    try await super.tearDown()
+  }
+
+  func testGivenRemoteActiveState_WhenSet_ThenPersistsAndClears() {
+    let profileId = UUID()
+    let manager = StrategyManager(remoteActiveDefaults: defaults)
+
+    manager.setRemoteSessionActive(true, profileId: profileId)
+
+    XCTAssertTrue(manager.remotelyActiveProfileIds.contains(profileId))
+    XCTAssertTrue(
+      StrategyManager(remoteActiveDefaults: defaults).remotelyActiveProfileIds.contains(profileId),
+      "#311: active-anywhere locks must survive relaunch")
+
+    manager.setRemoteSessionActive(false, profileId: profileId)
+
+    XCTAssertFalse(manager.remotelyActiveProfileIds.contains(profileId))
+    XCTAssertFalse(
+      StrategyManager(remoteActiveDefaults: defaults).remotelyActiveProfileIds.contains(profileId))
+  }
+}

--- a/FoqosTests/SyncApplyServiceTests.swift
+++ b/FoqosTests/SyncApplyServiceTests.swift
@@ -349,6 +349,44 @@ final class SyncApplyServiceTests: XCTestCase {
     XCTAssertEqual(try SavedLocation.find(byID: id, in: context)?.name, "Cafe")
   }
 
+  func testGivenDeletedLocation_WhenStaleEchoFetched_ThenLocationNotRecreated() throws {
+    let now = Date()
+    let id = UUID()
+    store.setDeleteWatermark(
+      recordName: id.uuidString, value: now.timeIntervalSinceReferenceDate)
+    let synced = SyncedLocation(
+      locationId: id, name: "Stale Cafe", latitude: 5, longitude: 6, defaultRadiusMeters: 80,
+      isLocked: false, lastModified: now)
+
+    let outcome = makeService().applyFetchedModification(
+      synced.toCKRecord(in: zoneID), isPendingDeleteOrTombstoned: noPendingDelete)
+
+    XCTAssertEqual(outcome, .skippedStaleDelete)
+    XCTAssertNil(
+      try SavedLocation.find(byID: id, in: context),
+      "#315: a location echo at or below the delete watermark must not recreate it")
+    XCTAssertEqual(store.deleteWatermark(for: id.uuidString), now.timeIntervalSinceReferenceDate)
+  }
+
+  func testGivenDeletedLocation_WhenNewerRecreationFetched_ThenLocationCreated() throws {
+    let now = Date()
+    let id = UUID()
+    store.setDeleteWatermark(
+      recordName: id.uuidString, value: now.timeIntervalSinceReferenceDate)
+    let synced = SyncedLocation(
+      locationId: id, name: "New Cafe", latitude: 5, longitude: 6, defaultRadiusMeters: 80,
+      isLocked: false, lastModified: now.addingTimeInterval(60))
+
+    let outcome = makeService().applyFetchedModification(
+      synced.toCKRecord(in: zoneID), isPendingDeleteOrTombstoned: noPendingDelete)
+
+    XCTAssertEqual(outcome, .applied)
+    XCTAssertEqual(try SavedLocation.find(byID: id, in: context)?.name, "New Cafe")
+    XCTAssertNil(
+      store.deleteWatermark(for: id.uuidString),
+      "newer location recreation supersedes the delete watermark")
+  }
+
   func testGivenNewerRemoteLocation_WhenApplied_ThenNothingReenqueued() throws {
     let now = Date()
     let apply = makeService()

--- a/FoqosTests/SyncApplyServiceTests.swift
+++ b/FoqosTests/SyncApplyServiceTests.swift
@@ -106,6 +106,40 @@ final class SyncApplyServiceTests: XCTestCase {
     XCTAssertNotNil(store.systemFields(for: id.uuidString), "systemFields stored after durable apply")
   }
 
+  func testGivenConfirmedProfileDelete_WhenStaleEchoFetched_ThenProfileNotRecreated() throws {
+    let now = Date()
+    let id = UUID()
+    store.setDeleteWatermark(recordName: id.uuidString, value: 3)
+    let record = makeProfileRecord(
+      id: id, name: "Stale", version: 3, originDeviceId: "device-B", now: now)
+
+    let outcome = makeService().applyFetchedModification(
+      record, isPendingDeleteOrTombstoned: noPendingDelete)
+
+    XCTAssertEqual(outcome, .skippedStaleDelete)
+    XCTAssertNil(
+      try BlockedProfiles.findProfile(byID: id, in: context),
+      "#315: a stale <=-version echo must not recreate the deleted profile")
+    XCTAssertEqual(store.deleteWatermark(for: id.uuidString), 3)
+  }
+
+  func testGivenConfirmedProfileDelete_WhenHigherVersionRecreationFetched_ThenProfileCreated() throws {
+    let now = Date()
+    let id = UUID()
+    store.setDeleteWatermark(recordName: id.uuidString, value: 3)
+    let record = makeProfileRecord(
+      id: id, name: "Recreated", version: 4, originDeviceId: "device-B", now: now)
+
+    let outcome = makeService().applyFetchedModification(
+      record, isPendingDeleteOrTombstoned: noPendingDelete)
+
+    XCTAssertEqual(outcome, .applied)
+    XCTAssertEqual(try BlockedProfiles.findProfile(byID: id, in: context)?.name, "Recreated")
+    XCTAssertNil(
+      store.deleteWatermark(for: id.uuidString),
+      "higher-version recreation supersedes the delete watermark")
+  }
+
   // MARK: - S-18 / I9
 
   func testGivenSchemaVersions_WhenProfileModificationApplied_ThenI9GatePreserved() throws {

--- a/FoqosTests/SyncApplyServiceTests.swift
+++ b/FoqosTests/SyncApplyServiceTests.swift
@@ -585,6 +585,39 @@ final class SyncApplyServiceTests: XCTestCase {
     XCTAssertNil(try SavedLocation.find(byID: id, in: context))
   }
 
+  func testGivenFetchedLocationDelete_WhenSameTimestampEchoFetched_ThenLocationNotRecreated()
+    throws
+  {
+    let now = Date()
+    let id = UUID()
+    let location = SavedLocation(
+      id: id, name: "Home", latitude: 1, longitude: 2, defaultRadiusMeters: 100,
+      isLocked: false, updatedAt: now, syncVersion: 1)
+    context.insert(location)
+    try context.save()
+
+    let service = makeService()
+    XCTAssertEqual(
+      service.applyFetchedDeletion(
+        recordID: CKRecord.ID(recordName: id.uuidString, zoneID: zoneID),
+        recordType: SyncedLocation.recordType),
+      .deleted)
+
+    let watermark = try XCTUnwrap(store.deleteWatermark(for: id.uuidString))
+    XCTAssertEqual(watermark, now.timeIntervalSinceReferenceDate, accuracy: 0.000_001)
+
+    let echo = SyncedLocation(
+      locationId: id, name: "Echo", latitude: 1, longitude: 2, defaultRadiusMeters: 100,
+      isLocked: false, lastModified: now)
+    let outcome = service.applyFetchedModification(
+      echo.toCKRecord(in: zoneID), isPendingDeleteOrTombstoned: noPendingDelete)
+
+    XCTAssertEqual(outcome, .skippedStaleDelete)
+    XCTAssertNil(
+      try SavedLocation.find(byID: id, in: context),
+      "#329: fetched-delete location watermarks must block same-timestamp echoes")
+  }
+
   func testGivenReferencingProfile_WhenLocationDeletionApplied_ThenRepairedAndReenqueued()
     throws
   {
@@ -723,6 +756,66 @@ final class SyncApplyServiceTests: XCTestCase {
 
     XCTAssertNil(try BlockedProfiles.findProfile(byID: id, in: ModelContext(container)))
     XCTAssertNil(store.systemFields(for: id.uuidString))
+  }
+
+  func testGivenFetchedProfileDeleteAtV3_WhenSameVersionRepushFetched_ThenProfileNotRecreated()
+    throws
+  {
+    let now = Date()
+    let id = UUID()
+    let profile = BlockedProfiles(id: id, name: "RemoteDelete", syncVersion: 3)
+    context.insert(profile)
+    try context.save()
+
+    let scheduler = ManualProfileDeleteCommitScheduler()
+    let service = makeService(scheduleProfileDeleteCommit: scheduler.schedule)
+
+    XCTAssertEqual(
+      service.applyFetchedDeletion(
+        recordID: CKRecord.ID(recordName: id.uuidString, zoneID: zoneID),
+        recordType: SyncedProfile.recordType),
+      .deleted)
+    scheduler.runNext()
+
+    XCTAssertEqual(store.deleteWatermark(for: id.uuidString), 3)
+    XCTAssertNil(try BlockedProfiles.findProfile(byID: id, in: context))
+
+    let repush = makeProfileRecord(
+      id: id, name: "V1 Repush", version: 3, originDeviceId: "device-v1", now: now)
+    let outcome = service.applyFetchedModification(repush, isPendingDeleteOrTombstoned: noPendingDelete)
+
+    XCTAssertEqual(outcome, .skippedStaleDelete)
+    XCTAssertNil(
+      try BlockedProfiles.findProfile(byID: id, in: context),
+      "#329: fetched-delete devices must not materialize same-version V1 re-pushes")
+  }
+
+  func testGivenFetchedProfileDeleteAtV3_WhenHigherVersionRecreationFetched_ThenProfileCreated()
+    throws
+  {
+    let now = Date()
+    let id = UUID()
+    let profile = BlockedProfiles(id: id, name: "RemoteDelete", syncVersion: 3)
+    context.insert(profile)
+    try context.save()
+
+    let scheduler = ManualProfileDeleteCommitScheduler()
+    let service = makeService(scheduleProfileDeleteCommit: scheduler.schedule)
+
+    XCTAssertEqual(
+      service.applyFetchedDeletion(
+        recordID: CKRecord.ID(recordName: id.uuidString, zoneID: zoneID),
+        recordType: SyncedProfile.recordType),
+      .deleted)
+    scheduler.runNext()
+
+    let recreation = makeProfileRecord(
+      id: id, name: "Recreated", version: 4, originDeviceId: "device-B", now: now)
+    let outcome = service.applyFetchedModification(recreation, isPendingDeleteOrTombstoned: noPendingDelete)
+
+    XCTAssertEqual(outcome, .applied)
+    XCTAssertEqual(try BlockedProfiles.findProfile(byID: id, in: context)?.name, "Recreated")
+    XCTAssertNil(store.deleteWatermark(for: id.uuidString))
   }
 
   func testGivenRemoteProfileDeletionSaveFails_WhenDeferredCommitRuns_ThenCommitObserverNotCalled()

--- a/FoqosTests/SyncApplyServiceTests.swift
+++ b/FoqosTests/SyncApplyServiceTests.swift
@@ -676,11 +676,18 @@ final class SyncApplyServiceTests: XCTestCase {
   }
 
   func testGivenDeletionForAbsentProfile_WhenApplied_ThenNotPresentNoMutation() throws {
+    let id = UUID()
+
     XCTAssertEqual(
       makeService().applyFetchedDeletion(
-        recordID: CKRecord.ID(recordName: UUID().uuidString, zoneID: zoneID),
+        recordID: CKRecord.ID(recordName: id.uuidString, zoneID: zoneID),
         recordType: SyncedProfile.recordType),
       .notPresent)
+    XCTAssertEqual(
+      sessionController.setRemoteSessionActiveCalls.map { $0.1 },
+      [id],
+      "a satisfied profile delete clears any durable remote-active lock for that profile")
+    XCTAssertEqual(sessionController.setRemoteSessionActiveCalls.map { $0.0 }, [false])
   }
 
   func testGivenSessionDeletion_WhenLocalActive_ThenMirrorStopped() throws {
@@ -756,6 +763,33 @@ final class SyncApplyServiceTests: XCTestCase {
 
     XCTAssertNil(try BlockedProfiles.findProfile(byID: id, in: ModelContext(container)))
     XCTAssertNil(store.systemFields(for: id.uuidString))
+  }
+
+  func testGivenRemoteActiveProfile_WhenFetchedProfileDeleteCommits_ThenRemoteActiveClearsAfterCommit()
+    throws
+  {
+    let id = UUID()
+    let profile = BlockedProfiles(id: id, name: "RemoteDelete", syncVersion: 1)
+    context.insert(profile)
+    try context.save()
+
+    let scheduler = ManualProfileDeleteCommitScheduler()
+    let service = makeService(scheduleProfileDeleteCommit: scheduler.schedule)
+
+    XCTAssertEqual(
+      service.applyFetchedDeletion(
+        recordID: CKRecord.ID(recordName: id.uuidString, zoneID: zoneID),
+        recordType: SyncedProfile.recordType),
+      .deleted)
+    XCTAssertTrue(
+      sessionController.setRemoteSessionActiveCalls.isEmpty,
+      "remote-active must not clear before the deferred delete is durably saved")
+
+    scheduler.runNext()
+
+    XCTAssertEqual(sessionController.setRemoteSessionActiveCalls.count, 1)
+    XCTAssertEqual(sessionController.setRemoteSessionActiveCalls.first?.0, false)
+    XCTAssertEqual(sessionController.setRemoteSessionActiveCalls.first?.1, id)
   }
 
   func testGivenFetchedProfileDeleteAtV3_WhenSameVersionRepushFetched_ThenProfileNotRecreated()
@@ -845,6 +879,9 @@ final class SyncApplyServiceTests: XCTestCase {
     scheduler.runNext()
 
     XCTAssertTrue(committedNames.isEmpty)
+    XCTAssertTrue(
+      sessionController.setRemoteSessionActiveCalls.isEmpty,
+      "rollback must leave the remote-active lock intact for retry")
     XCTAssertNotNil(store.systemFields(for: id.uuidString), "failed commit keeps deletion bookkeeping")
     XCTAssertEqual(store.deleteTombstones[id.uuidString] ?? nil, "tag-1")
   }

--- a/FoqosTests/SyncEngineAttachTests.swift
+++ b/FoqosTests/SyncEngineAttachTests.swift
@@ -92,6 +92,45 @@ final class SyncEngineAttachTests: XCTestCase {
     store.clearTombstone(recordName: recordName)
   }
 
+  func testGivenPreAttachDeleteBufferedForAnotherUser_WhenAttachEngine_ThenEntrySurvivesForOriginalUser()
+    async throws
+  {
+    manager.isEnabled = false
+    let recordName = "pre-attach-\(UUID().uuidString)"
+    let userA = "user-attach-buffer-A-\(UUID().uuidString)"
+    let userB = "user-attach-buffer-B-\(UUID().uuidString)"
+    PreAttachDeleteBuffer.add(recordName, userRecordName: userA, defaults: bufferDefaults)
+
+    await manager.attachEngine(
+      modelContext: container.mainContext,
+      emergencyManager: EmergencyUnblockManager(),
+      userRecordNameProvider: { userB },
+      driverFactory: { _ in CutoverRecordingDriver(stateSerialization: nil) })
+
+    let storeB = SyncEngineStore(userRecordName: userB)
+    XCTAssertFalse(
+      storeB.deleteTombstones.keys.contains(recordName),
+      "a delete buffered under user A must not become a tombstone for user B")
+    XCTAssertEqual(
+      PreAttachDeleteBuffer.pending(defaults: bufferDefaults).map(\.recordName),
+      [recordName],
+      "mismatched provenance must remain pending for a later matching attach")
+
+    manager.engineController = nil
+    await manager.attachEngine(
+      modelContext: container.mainContext,
+      emergencyManager: EmergencyUnblockManager(),
+      userRecordNameProvider: { userA },
+      driverFactory: { _ in CutoverRecordingDriver(stateSerialization: nil) })
+
+    let storeA = SyncEngineStore(userRecordName: userA)
+    XCTAssertTrue(
+      storeA.deleteTombstones.keys.contains(recordName),
+      "the original user's later attach must promote its buffered delete")
+    XCTAssertTrue(PreAttachDeleteBuffer.pending(defaults: bufferDefaults).isEmpty)
+    storeA.clearTombstone(recordName: recordName)
+  }
+
   func testGivenEngineAttachedWhileDisabled_WhenSyncEnabledLater_ThenStartupMarksReadyAndDrainsDeferredDelete()
     async throws
   {

--- a/FoqosTests/SyncEngineAttachTests.swift
+++ b/FoqosTests/SyncEngineAttachTests.swift
@@ -12,6 +12,9 @@ final class SyncEngineAttachTests: XCTestCase {
   private var savedEnabled = false
   private var savedIsSyncReady = false
   private var savedController: (any SyncEngineControlling)?
+  private var savedBufferDefaults: UserDefaults!
+  private var bufferSuiteName: String!
+  private var bufferDefaults: UserDefaults!
 
   override func setUp() async throws {
     try await super.setUp()
@@ -22,6 +25,10 @@ final class SyncEngineAttachTests: XCTestCase {
     savedEnabled = manager.isEnabled
     savedIsSyncReady = manager.isSyncReady
     savedController = manager.engineController
+    savedBufferDefaults = manager.bufferDefaults
+    bufferSuiteName = "SyncEngineAttachTests-buffer-\(UUID().uuidString)"
+    bufferDefaults = UserDefaults(suiteName: bufferSuiteName)!
+    manager.bufferDefaults = bufferDefaults
     manager.isSyncReady = false
   }
 
@@ -29,6 +36,8 @@ final class SyncEngineAttachTests: XCTestCase {
     manager.engineController = savedController
     manager.isSyncReady = savedIsSyncReady
     manager.isEnabled = savedEnabled
+    manager.bufferDefaults = savedBufferDefaults
+    UserDefaults().removePersistentDomain(forName: bufferSuiteName)
     UserDefaults().removePersistentDomain(forName: testSuiteName)
     try await super.tearDown()
   }
@@ -60,6 +69,27 @@ final class SyncEngineAttachTests: XCTestCase {
 
     XCTAssertNotNil(manager.engineController)
     XCTAssertTrue(driver.enqueuedZoneSaveNames.isEmpty)  // start() not called
+  }
+
+  func testGivenPreAttachDeleteBuffer_WhenAttachEngine_ThenDrainedIntoStoreTombstone() async throws {
+    manager.isEnabled = false
+    let driver = CutoverRecordingDriver(stateSerialization: nil)
+    let recordName = "pre-attach-\(UUID().uuidString)"
+    let userRecordName = "user-attach-buffer-\(UUID().uuidString)"
+    PreAttachDeleteBuffer.add(recordName, defaults: bufferDefaults)
+
+    await manager.attachEngine(
+      modelContext: container.mainContext,
+      emergencyManager: EmergencyUnblockManager(),
+      userRecordNameProvider: { userRecordName },
+      driverFactory: { _ in driver })
+
+    XCTAssertTrue(PreAttachDeleteBuffer.drainAll(defaults: bufferDefaults).isEmpty)
+    let store = SyncEngineStore(userRecordName: userRecordName)
+    XCTAssertTrue(
+      store.deleteTombstones.keys.contains(recordName),
+      "#305: attach must promote buffered pre-attach deletes into store tombstones")
+    store.clearTombstone(recordName: recordName)
   }
 
   func testGivenEngineAttachedWhileDisabled_WhenSyncEnabledLater_ThenStartupMarksReadyAndDrainsDeferredDelete()

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -559,12 +559,14 @@ final class SyncEngineControllerTests: XCTestCase {
     try? context.save()
     store.engineState = Data([0x01])
     store.setTombstone(recordName: id.uuidString, changeTag: "tag-1")
+    store.setDeleteWatermark(recordName: id.uuidString, value: 1)
 
     let controller = makeController()
     controller.start()
     await controller.startupTask?.value
 
     XCTAssertNil(store.deleteTombstones[id.uuidString], "entity present ⇒ abort, clear tombstone")
+    XCTAssertNil(store.deleteWatermark(for: id.uuidString), "entity present ⇒ abort, clear watermark")
     XCTAssertTrue(pendingDeleteNames().isEmpty, "no delete enqueued")
   }
 

--- a/FoqosTests/SyncEngineFacadeTests.swift
+++ b/FoqosTests/SyncEngineFacadeTests.swift
@@ -11,6 +11,9 @@ final class SyncEngineFacadeTests: XCTestCase {
   private var savedEnabled = false
   private var savedIsSyncReady = false
   private var savedController: (any SyncEngineControlling)?
+  private var savedBufferDefaults: UserDefaults!
+  private var bufferSuiteName: String!
+  private var bufferDefaults: UserDefaults!
 
   override func setUp() async throws {
     try await super.setUp()
@@ -20,6 +23,10 @@ final class SyncEngineFacadeTests: XCTestCase {
     savedEnabled = manager.isEnabled
     savedIsSyncReady = manager.isSyncReady
     savedController = manager.engineController
+    savedBufferDefaults = manager.bufferDefaults
+    bufferSuiteName = "SyncEngineFacadeTests-buffer-\(UUID().uuidString)"
+    bufferDefaults = UserDefaults(suiteName: bufferSuiteName)!
+    manager.bufferDefaults = bufferDefaults
     mock = MockSyncEngineControlling()
     manager.engineController = mock
     manager.isSyncReady = false
@@ -30,6 +37,8 @@ final class SyncEngineFacadeTests: XCTestCase {
     manager.engineController = savedController
     manager.isSyncReady = savedIsSyncReady
     manager.isEnabled = savedEnabled
+    manager.bufferDefaults = savedBufferDefaults
+    UserDefaults().removePersistentDomain(forName: bufferSuiteName)
     UserDefaults().removePersistentDomain(forName: testSuiteName)
     try await super.tearDown()
   }
@@ -99,6 +108,7 @@ final class SyncEngineFacadeTests: XCTestCase {
     manager.recordDisabledDeleteTombstone(recordName: "p1")
 
     XCTAssertEqual(mock.recordedDisabledTombstones, [])
+    XCTAssertEqual(PreAttachDeleteBuffer.drainAll(defaults: bufferDefaults), ["p1"])
   }
 
   func testGivenReadyController_WhenEnqueueProfileSave_ThenRequestSyncIsScheduled() throws {
@@ -224,6 +234,28 @@ final class SyncEngineFacadeTests: XCTestCase {
       "a GC delete dropped before attach is replayed through the existing deferred-delete path")
     XCTAssertEqual(attached.requestSyncCount, 1)
     XCTAssertTrue(manager.hasNoDeferredMutations)
+  }
+
+  func testGivenNotAttached_WhenEnqueueProfileDelete_ThenDeleteIsBufferedDurably() throws {
+    let id = UUID()
+    manager.engineController = nil
+
+    XCTAssertThrowsError(try manager.enqueueProfileDelete(id)) { error in
+      XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+    }
+
+    XCTAssertEqual(Set(PreAttachDeleteBuffer.drainAll(defaults: bufferDefaults)), [id.uuidString])
+  }
+
+  func testGivenNotAttached_WhenEnqueueLocationDelete_ThenDeleteIsBufferedDurably() throws {
+    let id = UUID()
+    manager.engineController = nil
+
+    XCTAssertThrowsError(try manager.enqueueLocationDelete(id)) { error in
+      XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+    }
+
+    XCTAssertEqual(Set(PreAttachDeleteBuffer.drainAll(defaults: bufferDefaults)), [id.uuidString])
   }
 
   func testGivenNotAttached_WhenEnqueueProfileDelete_ThenTombstoneDeleteIsReplayedOnReady() throws {

--- a/FoqosTests/SyncEngineFacadeTests.swift
+++ b/FoqosTests/SyncEngineFacadeTests.swift
@@ -245,6 +245,13 @@ final class SyncEngineFacadeTests: XCTestCase {
     }
 
     XCTAssertEqual(Set(PreAttachDeleteBuffer.drainAll(defaults: bufferDefaults)), [id.uuidString])
+
+    let attached = MockSyncEngineControlling()
+    manager.engineController = attached
+    manager.markSyncReadyAndFlush()
+
+    XCTAssertEqual(attached.deferredDeletes, [id.uuidString])
+    XCTAssertTrue(manager.hasNoDeferredMutations)
   }
 
   func testGivenNotAttached_WhenEnqueueLocationDelete_ThenDeleteIsBufferedDurably() throws {
@@ -256,6 +263,13 @@ final class SyncEngineFacadeTests: XCTestCase {
     }
 
     XCTAssertEqual(Set(PreAttachDeleteBuffer.drainAll(defaults: bufferDefaults)), [id.uuidString])
+
+    let attached = MockSyncEngineControlling()
+    manager.engineController = attached
+    manager.markSyncReadyAndFlush()
+
+    XCTAssertEqual(attached.deferredDeletes, [id.uuidString])
+    XCTAssertTrue(manager.hasNoDeferredMutations)
   }
 
   func testGivenNotAttached_WhenEnqueueProfileDelete_ThenTombstoneDeleteIsReplayedOnReady() throws {


### PR DESCRIPTION
## Summary

Implements W3-B from the merged Wave 3 plan as one implementation PR: #315 with bundled #329, #305, and #311. D4 was already merged in #333 and is not touched here.

## Per-task summary

### #315 + #329 delete watermark
- Added a UserDefaults-backed delete-version watermark store in `SyncEngineStore`.
- Wrote profile/location delete watermarks from local funnel deletes and clear them on rollback.
- Gated profile and location create applies with delete-wins-at-equal-version semantics (`synced.version <= watermark`).
- Cleared stale watermarks when I12 entity-present recovery proves the entity still exists.
- Task 315.5 / #329 writes the same watermark at fetched-delete apply sites, so non-deleting V2 devices also drop stale V1 re-pushes.

### #305 durable pre-attach deferred deletes
- Added a UserDefaults-backed `PreAttachDeleteBuffer` for delete intents formed before the per-user `SyncEngineStore` exists.
- Buffered nil-controller and `.notAttached` delete paths, including disabled tombstones.
- Drained buffered names into store tombstones during attach.
- Post-review fix: attach now reads pending names without clearing them, records each tombstone, then acknowledges that name so a kill before promotion cannot lose the only durable copy.

### #311 active-anywhere edit/delete locks
- Added durable remotely-active profile tracking in `StrategyManager`, populated from synced session state even when no local mirror session can materialize.
- Profile edit/delete locks now treat remote active profiles as blocking.
- Stop-rule location in-use checks now include remotely active profiles and have a hard delete guard with a cross-device message.

## Deviations / rationale

- #305 uses `pending` + per-record `acknowledge` rather than only `drainAll` during attach. This closes the clear-before-promote durability window found during final review.
- Existing `drainAll` remains for tests/callers that explicitly need destructive drain semantics.
- No SwiftData schema changes were added; all durable state in this PR is UserDefaults-backed.
- No convergence, re-delete, reconciliation, or server-cleanup logic was added for #329. The accepted residual remains: while a live V1 device keeps re-pushing, the CloudKit server record may persist, but V2 devices that have applied the delete do not materialize it. The residual self-resolves when the V1 device upgrades.

## Verification

- `swift-format lint --recursive .` passed.
- `scripts/check-sync-guards.sh` passed.
- `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -resultBundlePath /tmp/w3b-review-r1-20260713.xcresult | xcpretty` passed.
- Test count: baseline 972, after 999.
- Final read-only code review completed; one Critical #305 durability finding was fixed and the reviewer confirmed it resolved.

## Device-row table

| Row | Status | Notes |
| --- | --- | --- |
| #315 same-device stale delete echo gating | Run | Covered by unit/simulator tests. |
| #329 non-deleting V2 device receives fetched delete, then V1 re-pushes same-version record | Not run — maintainer device pass | Requires mixed-version/two-device setup; unit coverage simulates fetched-delete watermark behavior. |
| #329 higher-version recreation after fetched delete | Not run — maintainer device pass | Requires two-device/manual validation for real CloudKit propagation; unit coverage verifies higher version applies. |
| #305 pre-attach delete survives attach and promotes to tombstone | Run | Covered by unit/simulator tests, including non-destructive read and per-record acknowledgement. |
| #311 profile edit/delete locked when active on another device | Run (device, 2026-07-13) | Verified on PR build, two devices; logs FamilyFoqos-Logs-2026-07-13-083622/083639. |
| #311 stop-rule location delete locked when profile active on another device | Run (device, 2026-07-13) | Verified on PR build, two devices; logs FamilyFoqos-Logs-2026-07-13-083622/083639. |

Fixes #311
Fixes #305
Fixes #315
Fixes #329

## Summary by Sourcery

Strengthen cross-device delete and activity semantics by adding a persistent delete watermark store, a durable pre-attach delete buffer, and remotely active profile tracking, then wiring these into sync, editing, and location deletion flows with comprehensive test coverage.

New Features:
- Introduce a persistent delete watermark store to prevent stale profile and location records from being recreated after confirmed deletes while allowing higher-version recreations.
- Add a durable pre-attach delete buffer so delete intents created before sync attachment are persisted and promoted into tombstones once the engine attaches.
- Persist and track remotely active profiles so edit and delete operations are locked when a profile is active on any device, and locations in use by such profiles cannot be removed.

Bug Fixes:
- Ensure deferred and failed delete paths clear associated delete watermarks and tombstones when entities remain present or operations roll back, preventing incorrect gating.
- Buffer disabled delete tombstones and not-attached delete operations instead of dropping them, so they are reliably replayed once the sync engine is ready.

Enhancements:
- Extend sync diagnostics with a new outcome for stale-delete skips to aid observability of delete watermark behavior.
- Wire remote session activity signals through the session controller into strategy management so active-anywhere locks survive app relaunches.

Tests:
- Add unit and integration tests covering delete watermark persistence, stale echo gating, higher-version recreation, pre-attach delete buffering semantics, remotely active profile persistence, and location in-use computation including remote activity.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds durable sync state for delete handling and active-anywhere locks. The main changes are:

- UserDefaults-backed delete watermarks for profile and location deletes.
- A pre-attach delete buffer that promotes pending deletes into store tombstones.
- Remote-active profile tracking used by profile and location edit/delete gates.
- Tests covering stale delete echoes, attach buffering, and remote-active locks.

<h3>Confidence Score: 4/5</h3>

The changed sync state paths need fixes before merging.

- Remote-active IDs can stay persisted after a fetched profile delete.
- Pre-attach delete names can be promoted into the wrong user's store.
- Capped watermarks can allow old stale delete echoes to recreate records.

SyncApplyService.swift, PreAttachDeleteBuffer.swift, SyncEngineStore.swift

<details open><summary><h3>Security Review</h3></summary>

The pre-attach delete buffer is app-wide instead of user-scoped, so pending delete names can cross a CloudKit account boundary on the same device.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Foqos/CloudKit/ProfileSyncManager.swift | Adds pre-attach delete buffering and promotion during engine attach. |
| Foqos/CloudKit/SyncEngine/PreAttachDeleteBuffer.swift | Adds a durable pending-delete set that is not scoped to a user. |
| Foqos/CloudKit/SyncEngine/SyncApplyService.swift | Adds stale-delete gating and remote-active updates, with one missing clear on profile deletion. |
| Foqos/CloudKit/SyncEngine/SyncEngineStore.swift | Adds delete watermark storage with capped retention. |
| Foqos/Utils/StrategyManager.swift | Persists remote-active profile IDs and exposes them to lock checks. |
| Foqos/Views/SavedLocationsView.swift | Extends location in-use checks to profiles active on another device. |
| Foqos/Views/BlockedProfileView.swift | Treats remote-active profiles as blocking for edit/delete UI. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Delete before engine attach] --> B[App-wide pre-attach buffer]
  B --> C[attachEngine for current user]
  C --> D[Per-user store tombstone]
  E[Local or fetched delete] --> F[Delete watermark]
  F --> G[Create apply branch]
  G -->|version or timestamp at/below watermark| H[Skip stale echo]
  G -->|newer record| I[Create and clear watermark]
  J[Remote session state] --> K[Remotely active IDs]
  K --> L[Profile edit/delete lock]
  K --> M[Location delete guard]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Delete before engine attach] --> B[App-wide pre-attach buffer]
  B --> C[attachEngine for current user]
  C --> D[Per-user store tombstone]
  E[Local or fetched delete] --> F[Delete watermark]
  F --> G[Create apply branch]
  G -->|version or timestamp at/below watermark| H[Skip stale echo]
  G -->|newer record| I[Create and clear watermark]
  J[Remote session state] --> K[Remotely active IDs]
  K --> L[Profile edit/delete lock]
  K --> M[Location delete guard]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Foqos/CloudKit/SyncEngine/SyncApplyService.swift`, line 130-136 ([link](https://github.com/mnbf9rca/family-foqos/blob/d597169f848356d1a9a8a14c13c7335558eb4910/Foqos/CloudKit/SyncEngine/SyncApplyService.swift#L130-L136)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Remote Active State Survives Delete**

   When a fetched profile delete applies for a profile that was previously marked active on another device, this path stops the local mirrored session but leaves `remotelyActiveProfileIds` persisted. The deleted profile ID can keep blocking profile edits and location deletes across relaunches, and the same stale lock can apply if the profile is later recreated at a higher version.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(#305): acknowledge pre-attach delete..."](https://github.com/mnbf9rca/family-foqos/commit/d597169f848356d1a9a8a14c13c7335558eb4910) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43748809)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

