### PR TITLE
Fix FU-C twin-view snapshots and empty-profile save validation

### DIFF
--- a/Foqos/Components/BlockedProfileView/BlockedProfileRow.swift
+++ b/Foqos/Components/BlockedProfileView/BlockedProfileRow.swift
@@ -2,22 +2,18 @@ import FamilyControls
 import SwiftUI
 
 struct ProfileRow: View {
-  let profile: BlockedProfiles
+  let data: ProfileRowData
 
   var formattedUpdateTime: String {
     let formatter = RelativeDateTimeFormatter()
     formatter.unitsStyle = .short
-    return formatter.localizedString(for: profile.updatedAt, relativeTo: Date())
-  }
-
-  var selectedItemsCount: Int {
-    FamilyActivityUtil.countSelectedActivities(profile.selectedActivity)
+    return formatter.localizedString(for: data.updatedAt, relativeTo: Date())
   }
 
   var body: some View {
     HStack {
       VStack(alignment: .leading, spacing: 12) {
-        Text(profile.name)
+        Text(data.name)
           .font(.headline)
 
         HStack(spacing: 4) {
@@ -32,7 +28,7 @@ struct ProfileRow: View {
 
       HStack(spacing: 4) {
         Image(systemName: "list.bullet.circle.fill")
-        Text("\(selectedItemsCount) items")
+        Text("\(data.selectedItemsCount) items")
       }
       .foregroundStyle(.secondary)
       .font(.subheadline)
@@ -48,6 +44,6 @@ struct ProfileRow: View {
     updatedAt: Date().addingTimeInterval(-3600)
   )
 
-  return ProfileRow(profile: previewProfile)
+  return ProfileRow(data: previewProfile.profileRowData)
     .padding()
 }

--- a/Foqos/Components/BlockedProfileView/GeofencePicker.swift
+++ b/Foqos/Components/BlockedProfileView/GeofencePicker.swift
@@ -91,29 +91,33 @@ struct GeofencePicker: View {
           } else {
             ForEach(savedLocations) { location in
               SafeModelView(location) { loc in
-                let isSelected = selectedLocationIds.contains(loc.id)
+                let data = loc.locationReferenceRowData
+                let locationId = data.id
+                let isSelected = selectedLocationIds.contains(locationId)
                 let binding = Binding<ProfileLocationReference>(
                   get: {
-                    locationReferences[loc.id] ?? ProfileLocationReference(savedLocationId: loc.id)
+                    locationReferences[locationId]
+                      ?? ProfileLocationReference(savedLocationId: locationId)
                   },
                   set: { newValue in
-                    locationReferences[loc.id] = newValue
+                    locationReferences[locationId] = newValue
                   }
                 )
 
                 // #298: snapshot the location inside the gate; the reference stays a live binding.
                 LocationReferenceRow(
-                  location: loc.locationReferenceRowData,
+                  location: data,
                   reference: binding,
                   isSelected: isSelected,
                   onToggle: { selected in
                     if selected {
-                      selectedLocationIds.insert(loc.id)
-                      if locationReferences[loc.id] == nil {
-                        locationReferences[loc.id] = ProfileLocationReference(savedLocationId: loc.id)
+                      selectedLocationIds.insert(locationId)
+                      if locationReferences[locationId] == nil {
+                        locationReferences[locationId] = ProfileLocationReference(
+                          savedLocationId: locationId)
                       }
                     } else {
-                      selectedLocationIds.remove(loc.id)
+                      selectedLocationIds.remove(locationId)
                     }
                   }
                 )

--- a/Foqos/Components/BlockedProfileView/GeofencePicker.swift
+++ b/Foqos/Components/BlockedProfileView/GeofencePicker.swift
@@ -101,8 +101,9 @@ struct GeofencePicker: View {
                   }
                 )
 
+                // #298: snapshot the location inside the gate; the reference stays a live binding.
                 LocationReferenceRow(
-                  location: loc,
+                  location: loc.locationReferenceRowData,
                   reference: binding,
                   isSelected: isSelected,
                   onToggle: { selected in

--- a/Foqos/Components/BlockedProfileView/LocationReferenceRow.swift
+++ b/Foqos/Components/BlockedProfileView/LocationReferenceRow.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct LocationReferenceRow: View {
   @EnvironmentObject var themeManager: ThemeManager
 
-  let location: SavedLocation
+  let location: LocationReferenceRowData
   @Binding var reference: ProfileLocationReference
   let isSelected: Bool
   let onToggle: (Bool) -> Void
@@ -154,39 +154,43 @@ struct LocationReferenceRow: View {
     @State var isSelected = true
 
     var body: some View {
+      let home = SavedLocation(
+        name: "Home",
+        latitude: 51.5074,
+        longitude: -0.1278,
+        defaultRadiusMeters: 500
+      )
+      let office = SavedLocation(
+        name: "Office",
+        latitude: 51.5155,
+        longitude: -0.1419,
+        defaultRadiusMeters: 1000,
+        isLocked: true
+      )
+      let school = SavedLocation(
+        name: "School",
+        latitude: 51.5200,
+        longitude: -0.1300,
+        defaultRadiusMeters: 250
+      )
+
       List {
         LocationReferenceRow(
-          location: SavedLocation(
-            name: "Home",
-            latitude: 51.5074,
-            longitude: -0.1278,
-            defaultRadiusMeters: 500
-          ),
+          location: home.locationReferenceRowData,
           reference: $reference,
           isSelected: isSelected,
           onToggle: { isSelected = $0 }
         )
 
         LocationReferenceRow(
-          location: SavedLocation(
-            name: "Office",
-            latitude: 51.5155,
-            longitude: -0.1419,
-            defaultRadiusMeters: 1000,
-            isLocked: true
-          ),
+          location: office.locationReferenceRowData,
           reference: .constant(ProfileLocationReference(savedLocationId: UUID(), radiusOverrideMeters: 250)),
           isSelected: true,
           onToggle: { _ in }
         )
 
         LocationReferenceRow(
-          location: SavedLocation(
-            name: "School",
-            latitude: 51.5200,
-            longitude: -0.1300,
-            defaultRadiusMeters: 250
-          ),
+          location: school.locationReferenceRowData,
           reference: .constant(ProfileLocationReference(savedLocationId: UUID())),
           isSelected: false,
           onToggle: { _ in }

--- a/Foqos/Components/BlockedProfileView/LocationReferenceRowData.swift
+++ b/Foqos/Components/BlockedProfileView/LocationReferenceRowData.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+// REGRESSION GUARD (#298): LocationReferenceRow's location accepts ONLY this value type - it can
+// no longer hold a live SavedLocation @Model. The `reference` binding stays a two-way @Binding
+// because ProfileLocationReference is a value struct.
+struct LocationReferenceRowData {
+  let id: UUID
+  let name: String
+  let isLocked: Bool
+  let defaultRadiusMeters: Double
+}
+
+extension SavedLocation {
+  /// Build the row snapshot. MUST be called only on a valid (non-zombie) model - callers gate
+  /// via `SafeModelView` before invoking. Reads live attributes/relationships.
+  ///
+  /// TRIPWIRE (#298 edit-propagation): this MUST be evaluated inside an observation-tracked
+  /// SwiftUI body (LocationReferenceRow's `SafeModelView` content closure). Those tracked reads
+  /// register the `@Observable` dependencies that make a legitimate edit rebuild the snapshot.
+  /// Do NOT memoize it, cache it on the model, or move the call into an `init` / stored property /
+  /// out of the render path - that silently stops the row updating on edits while still compiling
+  /// and passing the zombie test. Verified by
+  /// `testGivenLocationReferenceRowDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap`
+  /// and the device-gate edit step.
+  var locationReferenceRowData: LocationReferenceRowData {
+    LocationReferenceRowData(
+      id: id,
+      name: name,
+      isLocked: isLocked,
+      defaultRadiusMeters: defaultRadiusMeters
+    )
+  }
+}

--- a/Foqos/Components/BlockedProfileView/ProfileRowData.swift
+++ b/Foqos/Components/BlockedProfileView/ProfileRowData.swift
@@ -1,0 +1,34 @@
+import FamilyControls
+import Foundation
+
+// REGRESSION GUARD (#298): ProfileRow accepts ONLY this value type - it can no longer hold a
+// live BlockedProfiles @Model, so a re-render can never read a vacated store row. Reintroducing
+// `let profile: BlockedProfiles` on the view is a compile-time-visible regression.
+struct ProfileRowData {
+  let id: UUID
+  let name: String
+  let updatedAt: Date
+  let selectedItemsCount: Int
+}
+
+extension BlockedProfiles {
+  /// Build the row snapshot. MUST be called only on a valid (non-zombie) model - callers gate
+  /// via `.valid` / `SafeModelView` before invoking. Reads live attributes/relationships.
+  ///
+  /// TRIPWIRE (#298 edit-propagation): this MUST be evaluated inside an observation-tracked
+  /// SwiftUI body (ProfileRow's `SafeModelView` content closure). Those tracked reads register
+  /// the `@Observable` dependencies that make a legitimate edit rebuild the snapshot. Do NOT
+  /// memoize it, cache it on the model, or move the call into an `init` / stored property / out of
+  /// the render path - that silently stops the row updating on edits while still compiling and
+  /// passing the zombie test. Verified by
+  /// `testGivenProfileRowDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap` and the
+  /// device-gate edit step.
+  var profileRowData: ProfileRowData {
+    ProfileRowData(
+      id: id,
+      name: name,
+      updatedAt: updatedAt,
+      selectedItemsCount: FamilyActivityUtil.countSelectedActivities(selectedActivity)
+    )
+  }
+}

--- a/Foqos/Components/Sessions/SessionRow.swift
+++ b/Foqos/Components/Sessions/SessionRow.swift
@@ -4,6 +4,7 @@ import SwiftUI
 // REGRESSION GUARD (#298): SessionRow accepts ONLY this value type - it can no longer hold a live
 // BlockedProfileSession @Model, so a re-render can never read a vacated store row.
 struct SessionRowData {
+  let id: String
   let startTime: Date
   let endTime: Date?
   let breakStartTime: Date?
@@ -83,6 +84,7 @@ extension BlockedProfileSession {
   /// device-gate edit step.
   var sessionRowData: SessionRowData {
     SessionRowData(
+      id: id,
       startTime: startTime,
       endTime: endTime,
       breakStartTime: breakStartTime,

--- a/Foqos/Components/Sessions/SessionRow.swift
+++ b/Foqos/Components/Sessions/SessionRow.swift
@@ -1,57 +1,16 @@
 import Foundation
 import SwiftUI
 
-struct SessionRow: View {
-  @EnvironmentObject private var themeManager: ThemeManager
+// REGRESSION GUARD (#298): SessionRow accepts ONLY this value type - it can no longer hold a live
+// BlockedProfileSession @Model, so a re-render can never read a vacated store row.
+struct SessionRowData {
+  let startTime: Date
+  let endTime: Date?
+  let breakStartTime: Date?
+  let breakEndTime: Date?
+  let isActive: Bool
+  let durationSeconds: TimeInterval
 
-  var session: BlockedProfileSession
-
-  var body: some View {
-    VStack(alignment: .leading, spacing: 8) {
-      HStack(alignment: .firstTextBaseline, spacing: 8) {
-        Text(session.formattedDate)
-          .font(.headline)
-          .fontWeight(.semibold)
-          .lineLimit(1)
-
-        Spacer(minLength: 8)
-
-        HStack(spacing: 4) {
-          Image(systemName: "clock")
-            .font(.caption)
-          Text(session.formattedDuration)
-            .monospacedDigit()
-        }
-        .font(.subheadline)
-        .foregroundColor(.secondary)
-      }
-
-      HStack(spacing: 6) {
-        Image(systemName: "timer")
-          .font(.caption)
-        Text(session.timeRangeText)
-          .monospacedDigit()
-      }
-      .font(.subheadline)
-      .foregroundColor(.secondary)
-
-      if let breakText = session.breakRangeText {
-        HStack(spacing: 6) {
-          Image(systemName: "cup.and.saucer")
-            .font(.caption)
-          Text(breakText)
-            .font(.caption)
-            .foregroundColor(.secondary)
-            .monospacedDigit()
-            .lineLimit(1)
-        }
-      }
-    }
-    .padding(.vertical, 6)
-  }
-}
-
-extension BlockedProfileSession {
   var formattedDate: String {
     let calendar = Calendar.current
     if calendar.isDateInToday(startTime) {
@@ -98,7 +57,7 @@ extension BlockedProfileSession {
   }
 
   var formattedDuration: String {
-    let minutes = Int(duration()) / 60
+    let minutes = Int(durationSeconds) / 60
     let hours = minutes / 60
     let remainingMinutes = minutes % 60
 
@@ -107,5 +66,79 @@ extension BlockedProfileSession {
     }
 
     return "\(minutes)m"
+  }
+}
+
+extension BlockedProfileSession {
+  /// Build the row snapshot. MUST be called only on a valid (non-zombie) model - callers gate
+  /// via `SafeModelView` before invoking. Reads live attributes/relationships.
+  ///
+  /// TRIPWIRE (#298 edit-propagation): this MUST be evaluated inside an observation-tracked
+  /// SwiftUI body (SessionRow's `SafeModelView` content closure). Those tracked reads register
+  /// the `@Observable` dependencies that make a legitimate edit rebuild the snapshot. Do NOT
+  /// memoize it, cache it on the model, or move the call into an `init` / stored property / out of
+  /// the render path - that silently stops the row updating on edits while still compiling and
+  /// passing the zombie test. Verified by
+  /// `testGivenSessionRowDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap` and the
+  /// device-gate edit step.
+  var sessionRowData: SessionRowData {
+    SessionRowData(
+      startTime: startTime,
+      endTime: endTime,
+      breakStartTime: breakStartTime,
+      breakEndTime: breakEndTime,
+      isActive: isActive,
+      durationSeconds: duration()
+    )
+  }
+}
+
+struct SessionRow: View {
+  @EnvironmentObject private var themeManager: ThemeManager
+
+  let data: SessionRowData
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(alignment: .firstTextBaseline, spacing: 8) {
+        Text(data.formattedDate)
+          .font(.headline)
+          .fontWeight(.semibold)
+          .lineLimit(1)
+
+        Spacer(minLength: 8)
+
+        HStack(spacing: 4) {
+          Image(systemName: "clock")
+            .font(.caption)
+          Text(data.formattedDuration)
+            .monospacedDigit()
+        }
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+      }
+
+      HStack(spacing: 6) {
+        Image(systemName: "timer")
+          .font(.caption)
+        Text(data.timeRangeText)
+          .monospacedDigit()
+      }
+      .font(.subheadline)
+      .foregroundColor(.secondary)
+
+      if let breakText = data.breakRangeText {
+        HStack(spacing: 6) {
+          Image(systemName: "cup.and.saucer")
+            .font(.caption)
+          Text(breakText)
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .monospacedDigit()
+            .lineLimit(1)
+        }
+      }
+    }
+    .padding(.vertical, 6)
   }
 }

--- a/Foqos/Components/Settings/SavedLocationCard.swift
+++ b/Foqos/Components/Settings/SavedLocationCard.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SavedLocationCard: View {
   @EnvironmentObject var themeManager: ThemeManager
 
-  let location: SavedLocation
+  let data: SavedLocationCardData
   let onTap: () -> Void
   var inUseByProfile: String? = nil
 
@@ -31,11 +31,11 @@ struct SavedLocationCard: View {
         // Location details
         VStack(alignment: .leading, spacing: 4) {
           HStack(spacing: 6) {
-            Text(location.name)
+            Text(data.name)
               .font(.headline)
               .foregroundColor(isDisabled ? .secondary : .primary)
 
-            if location.isLocked {
+            if data.isLocked {
               Image(systemName: "lock.fill")
                 .font(.caption)
                 .foregroundColor(.orange)
@@ -47,7 +47,7 @@ struct SavedLocationCard: View {
               .font(.subheadline)
               .foregroundColor(.orange)
           } else {
-            Text("Distance: \(SavedLocation.formatRadius(location.defaultRadiusMeters))")
+            Text("Distance: \(SavedLocation.formatRadius(data.defaultRadiusMeters))")
               .font(.subheadline)
               .foregroundColor(.secondary)
           }
@@ -70,37 +70,41 @@ struct SavedLocationCard: View {
 }
 
 #Preview {
+  let home = SavedLocation(
+    name: "Home",
+    latitude: 51.5074,
+    longitude: -0.1278,
+    defaultRadiusMeters: 500,
+    isLocked: false
+  )
+  let office = SavedLocation(
+    name: "Office",
+    latitude: 51.5155,
+    longitude: -0.1419,
+    defaultRadiusMeters: 1000,
+    isLocked: true
+  )
+  let school = SavedLocation(
+    name: "School",
+    latitude: 51.5200,
+    longitude: -0.1300,
+    defaultRadiusMeters: 250,
+    isLocked: false
+  )
+
   List {
     SavedLocationCard(
-      location: SavedLocation(
-        name: "Home",
-        latitude: 51.5074,
-        longitude: -0.1278,
-        defaultRadiusMeters: 500,
-        isLocked: false
-      ),
+      data: home.savedLocationCardData,
       onTap: {}
     )
 
     SavedLocationCard(
-      location: SavedLocation(
-        name: "Office",
-        latitude: 51.5155,
-        longitude: -0.1419,
-        defaultRadiusMeters: 1000,
-        isLocked: true
-      ),
+      data: office.savedLocationCardData,
       onTap: {}
     )
 
     SavedLocationCard(
-      location: SavedLocation(
-        name: "School",
-        latitude: 51.5200,
-        longitude: -0.1300,
-        defaultRadiusMeters: 250,
-        isLocked: false
-      ),
+      data: school.savedLocationCardData,
       onTap: {},
       inUseByProfile: "Focus Mode"
     )

--- a/Foqos/Components/Settings/SavedLocationCardData.swift
+++ b/Foqos/Components/Settings/SavedLocationCardData.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+// REGRESSION GUARD (#298): SavedLocationCard accepts ONLY this value type - it can no longer hold
+// a live SavedLocation @Model, so a re-render can never read a vacated store row.
+struct SavedLocationCardData {
+  let id: UUID
+  let name: String
+  let isLocked: Bool
+  let defaultRadiusMeters: Double
+}
+
+extension SavedLocation {
+  /// Build the card snapshot. MUST be called only on a valid (non-zombie) model - callers gate
+  /// via `SafeModelView` before invoking. Reads live attributes/relationships.
+  ///
+  /// TRIPWIRE (#298 edit-propagation): this MUST be evaluated inside an observation-tracked
+  /// SwiftUI body (SavedLocationCard's `SafeModelView` content closure). Those tracked reads
+  /// register the `@Observable` dependencies that make a legitimate edit rebuild the snapshot.
+  /// Do NOT memoize it, cache it on the model, or move the call into an `init` / stored property /
+  /// out of the render path - that silently stops the card updating on edits while still compiling
+  /// and passing the zombie test. Verified by
+  /// `testGivenSavedLocationCardDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap` and
+  /// the device-gate edit step.
+  var savedLocationCardData: SavedLocationCardData {
+    SavedLocationCardData(
+      id: id,
+      name: name,
+      isLocked: isLocked,
+      defaultRadiusMeters: defaultRadiusMeters
+    )
+  }
+}

--- a/Foqos/Views/BlockedProfileListView.swift
+++ b/Foqos/Views/BlockedProfileListView.swift
@@ -70,11 +70,12 @@ struct BlockedProfileListView: View {
         SafeModelView(profile) { p in
           // #298: build the snapshot ONLY here inside the validity gate (observation-tracked);
           // do NOT hoist/memoize - see the profileRowData tripwire.
-          ProfileRow(data: p.profileRowData)
+          let data = p.profileRowData
+          ProfileRow(data: data)
             .contentShape(Rectangle())
             .onTapGesture {
               if editMode == .inactive {
-                profileToEdit = p
+                handleEditProfile(data.id)
               }
             }
         }
@@ -145,6 +146,15 @@ struct BlockedProfileListView: View {
           Text(deleteError?.message ?? "")
         }
     }
+  }
+
+  private func handleEditProfile(_ profileId: UUID) {
+    guard let profile = try? BlockedProfiles.findProfile(byID: profileId, in: context),
+      profile.isPersistentModelValid
+    else {
+      return
+    }
+    profileToEdit = profile
   }
 
   private func deleteProfiles(at offsets: IndexSet) {

--- a/Foqos/Views/BlockedProfileListView.swift
+++ b/Foqos/Views/BlockedProfileListView.swift
@@ -68,7 +68,9 @@ struct BlockedProfileListView: View {
     List {
       ForEach(profiles) { profile in
         SafeModelView(profile) { p in
-          ProfileRow(profile: p)
+          // #298: build the snapshot ONLY here inside the validity gate (observation-tracked);
+          // do NOT hoist/memoize - see the profileRowData tripwire.
+          ProfileRow(data: p.profileRowData)
             .contentShape(Rectangle())
             .onTapGesture {
               if editMode == .inactive {

--- a/Foqos/Views/BlockedProfileSessionsView.swift
+++ b/Foqos/Views/BlockedProfileSessionsView.swift
@@ -10,7 +10,7 @@ struct SessionAlertIdentifier: Identifiable {
   }
 
   let id: AlertType
-  var session: BlockedProfileSession?
+  var sessionId: String?
   var errorMessage: String?
 }
 
@@ -65,12 +65,13 @@ struct BlockedProfileSessionsView: View {
               SafeModelView(session) { s in
                 // #298: build the snapshot ONLY here inside the validity gate
                 // (observation-tracked); do NOT hoist/memoize - see the sessionRowData tripwire.
-                SessionRow(data: s.sessionRowData)
+                let data = s.sessionRowData
+                SessionRow(data: data)
                   .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                     Button(role: .destructive) {
                       alertIdentifier = SessionAlertIdentifier(
                         id: .deleteSession,
-                        session: s
+                        sessionId: data.id
                       )
                     } label: {
                       Label("Delete", systemImage: "trash")
@@ -129,7 +130,7 @@ struct BlockedProfileSessionsView: View {
       .alert(item: $alertIdentifier) { alert in
         switch alert.id {
         case .deleteSession:
-          guard let session = alert.session else {
+          guard let sessionId = alert.sessionId else {
             return Alert(title: Text("Error"))
           }
           return Alert(
@@ -139,7 +140,7 @@ struct BlockedProfileSessionsView: View {
             ),
             primaryButton: .cancel(),
             secondaryButton: .destructive(Text("Delete")) {
-              deleteSession(session)
+              deleteSession(sessionId)
             }
           )
         case .error:
@@ -161,7 +162,12 @@ struct BlockedProfileSessionsView: View {
     }
   }
 
-  private func deleteSession(_ session: BlockedProfileSession) {
+  private func deleteSession(_ sessionId: String) {
+    guard let session = try? BlockedProfileSession.findSession(byID: sessionId, in: modelContext),
+      session.isPersistentModelValid
+    else {
+      return
+    }
     modelContext.delete(session)
     do {
       try modelContext.save()

--- a/Foqos/Views/BlockedProfileSessionsView.swift
+++ b/Foqos/Views/BlockedProfileSessionsView.swift
@@ -52,7 +52,10 @@ struct BlockedProfileSessionsView: View {
       List {
         if let activeSession = activeSession {
           Section("Active Session") {
-            SessionRow(session: activeSession)
+            // #298: activeSession is a live @Model - gate before snapshotting.
+            SafeModelView(activeSession) { s in
+              SessionRow(data: s.sessionRowData)
+            }
           }
         }
 
@@ -60,7 +63,9 @@ struct BlockedProfileSessionsView: View {
           Section("Past Sessions") {
             ForEach(inactiveSessions) { session in
               SafeModelView(session) { s in
-                SessionRow(session: s)
+                // #298: build the snapshot ONLY here inside the validity gate
+                // (observation-tracked); do NOT hoist/memoize - see the sessionRowData tripwire.
+                SessionRow(data: s.sessionRowData)
                   .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                     Button(role: .destructive) {
                       alertIdentifier = SessionAlertIdentifier(

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -896,6 +896,48 @@ struct BlockedProfileView: View {
     return UInt32(clampedMinutes * 60)
   }
 
+  static func emptyProfileValidationMessage(
+    selection: FamilyActivitySelection,
+    domains: [String],
+    enableAllowMode: Bool,
+    enableAllowModeDomains: Bool,
+    needsAppSelection: Bool
+  ) -> String? {
+    emptyProfileValidationMessage(
+      selectedItemsCount: FamilyActivityUtil.countSelectedActivities(selection),
+      domains: domains,
+      enableAllowMode: enableAllowMode,
+      enableAllowModeDomains: enableAllowModeDomains,
+      needsAppSelection: needsAppSelection
+    )
+  }
+
+  static func emptyProfileValidationMessage(
+    selectedItemsCount: Int,
+    domains: [String],
+    enableAllowMode: Bool,
+    enableAllowModeDomains: Bool,
+    needsAppSelection: Bool
+  ) -> String? {
+    let hasSelectedActivity = selectedItemsCount > 0
+    let hasDomains = domains.contains {
+      !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+    let hasAllowModeContent = enableAllowMode || enableAllowModeDomains
+
+    guard !hasSelectedActivity && !hasDomains && !hasAllowModeContent else {
+      return nil
+    }
+
+    if needsAppSelection {
+      return
+        "This synced profile still needs an app selection. Select apps, app categories, Safari websites, or domains before saving."
+    }
+
+    return
+      "This profile does not block anything yet. Select apps, app categories, Safari websites, or domains before saving."
+  }
+
   private func showError(message: String) {
     alertIdentifier = AlertIdentifier(id: .error, errorMessage: message)
   }
@@ -963,6 +1005,17 @@ struct BlockedProfileView: View {
           .map { "• " + $0 }
           .joined(separator: "\n")
       )
+      return
+    }
+
+    if let validationMessage = Self.emptyProfileValidationMessage(
+      selection: selectedActivity,
+      domains: domains,
+      enableAllowMode: enableAllowMode,
+      enableAllowModeDomains: enableAllowModeDomain,
+      needsAppSelection: profile?.needsAppSelection ?? false
+    ) {
+      alertIdentifier = AlertIdentifier(id: .error, errorMessage: validationMessage)
       return
     }
 

--- a/Foqos/Views/Child/ChildDashboardView.swift
+++ b/Foqos/Views/Child/ChildDashboardView.swift
@@ -281,7 +281,8 @@ struct ChildDashboardView: View {
         VStack(spacing: 8) {
           ForEach(lockedProfiles) { profile in
             SafeModelView(profile) { p in
-              LockedProfileCard(profile: p)
+              // #298: snapshot inside the validity gate; do NOT hoist - see tripwire.
+              LockedProfileCard(data: p.lockedProfileCardData)
             }
           }
         }
@@ -349,7 +350,7 @@ struct ChildDashboardView: View {
 // MARK: - Locked Profile Card
 
 struct LockedProfileCard: View {
-  let profile: BlockedProfiles
+  let data: LockedProfileCardData
 
   var body: some View {
     HStack(spacing: 12) {
@@ -358,11 +359,11 @@ struct LockedProfileCard: View {
         .foregroundColor(.orange)
 
       VStack(alignment: .leading, spacing: 2) {
-        Text(profile.name)
+        Text(data.name)
           .font(.subheadline)
           .fontWeight(.medium)
 
-        Text("\(FamilyActivityUtil.countSelectedActivities(profile.selectedActivity)) apps blocked")
+        Text("\(data.appsBlockedCount) apps blocked")
           .font(.caption)
           .foregroundColor(.secondary)
       }

--- a/Foqos/Views/Child/LockedProfileCardData.swift
+++ b/Foqos/Views/Child/LockedProfileCardData.swift
@@ -1,0 +1,31 @@
+import FamilyControls
+import Foundation
+
+// REGRESSION GUARD (#298): LockedProfileCard accepts ONLY this value type - it can no longer hold
+// a live BlockedProfiles @Model, so a re-render can never read a vacated store row.
+struct LockedProfileCardData {
+  let id: UUID
+  let name: String
+  let appsBlockedCount: Int
+}
+
+extension BlockedProfiles {
+  /// Build the card snapshot. MUST be called only on a valid (non-zombie) model - callers gate
+  /// via `SafeModelView` before invoking. Reads live attributes/relationships.
+  ///
+  /// TRIPWIRE (#298 edit-propagation): this MUST be evaluated inside an observation-tracked
+  /// SwiftUI body (LockedProfileCard's `SafeModelView` content closure). Those tracked reads
+  /// register the `@Observable` dependencies that make a legitimate edit rebuild the snapshot.
+  /// Do NOT memoize it, cache it on the model, or move the call into an `init` / stored property /
+  /// out of the render path - that silently stops the card updating on edits while still compiling
+  /// and passing the zombie test. Verified by
+  /// `testGivenLockedProfileCardDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap` and
+  /// the device-gate edit step.
+  var lockedProfileCardData: LockedProfileCardData {
+    LockedProfileCardData(
+      id: id,
+      name: name,
+      appsBlockedCount: FamilyActivityUtil.countSelectedActivities(selectedActivity)
+    )
+  }
+}

--- a/Foqos/Views/SavedLocationsView.swift
+++ b/Foqos/Views/SavedLocationsView.swift
@@ -18,8 +18,8 @@ struct SavedLocationsView: View {
   @State private var showingAddLocation = false
   @State private var locationToEdit: SavedLocation?
   @State private var showingLockCodeEntry = false
-  @State private var pendingDeleteLocation: SavedLocation?
-  @State private var pendingEditLocation: SavedLocation?
+  @State private var pendingDeleteLocationId: UUID?
+  @State private var pendingEditLocationId: UUID?
   @State private var showingLockCodeEntryForEdit = false
   @State private var errorMessage: String?
 
@@ -84,12 +84,13 @@ struct SavedLocationsView: View {
             ForEach(locations) { location in
               SafeModelView(location) { loc in
                 // #298: snapshot inside the validity gate; do NOT hoist - see tripwire.
+                let data = loc.savedLocationCardData
                 SavedLocationCard(
-                  data: loc.savedLocationCardData,
+                  data: data,
                   onTap: {
-                    handleEdit(loc)
+                    handleEdit(data.id)
                   },
-                  inUseByProfile: locationsInUseByActiveProfiles[loc.id]
+                  inUseByProfile: locationsInUseByActiveProfiles[data.id]
                 )
               }
             }
@@ -139,10 +140,12 @@ struct SavedLocationsView: View {
             lockCodeManager.validateCode(code)
           },
           onSuccess: {
-            if let location = pendingDeleteLocation {
+            if let locationId = pendingDeleteLocationId,
+              let location = try? Self.validSavedLocation(locationId: locationId, in: context)
+            {
               deleteLocation(location)
             }
-            pendingDeleteLocation = nil
+            pendingDeleteLocationId = nil
           }
         )
       }
@@ -154,10 +157,12 @@ struct SavedLocationsView: View {
             lockCodeManager.validateCode(code)
           },
           onSuccess: {
-            if let location = pendingEditLocation {
+            if let locationId = pendingEditLocationId,
+              let location = try? Self.validSavedLocation(locationId: locationId, in: context)
+            {
               locationToEdit = location
             }
-            pendingEditLocation = nil
+            pendingEditLocationId = nil
           }
         )
       }
@@ -177,15 +182,62 @@ struct SavedLocationsView: View {
     }
   }
 
-  private func handleEdit(_ location: SavedLocation) {
-    if location.requiresLockCodeToModify(
-      mode: appModeManager.currentMode,
-      canVerifyCode: lockCodeManager.canVerifyCode)
-    {
-      pendingEditLocation = location
-      showingLockCodeEntryForEdit = true
-    } else {
-      locationToEdit = location
+  struct SavedLocationEditTarget {
+    let location: SavedLocation
+    let requiresLockCode: Bool
+  }
+
+  static func validSavedLocation(locationId: UUID, in context: ModelContext) throws
+    -> SavedLocation?
+  {
+    guard let location = try SavedLocation.find(byID: locationId, in: context),
+      location.isPersistentModelValid
+    else {
+      return nil
+    }
+    return location
+  }
+
+  static func editTarget(
+    locationId: UUID,
+    in context: ModelContext,
+    mode: AppMode,
+    canVerifyCode: Bool
+  ) throws -> SavedLocationEditTarget? {
+    guard let location = try validSavedLocation(locationId: locationId, in: context) else {
+      return nil
+    }
+
+    return SavedLocationEditTarget(
+      location: location,
+      requiresLockCode: location.requiresLockCodeToModify(
+        mode: mode,
+        canVerifyCode: canVerifyCode
+      )
+    )
+  }
+
+  private func handleEdit(_ locationId: UUID) {
+    do {
+      guard
+        let target = try Self.editTarget(
+          locationId: locationId,
+          in: context,
+          mode: appModeManager.currentMode,
+          canVerifyCode: lockCodeManager.canVerifyCode
+        )
+      else {
+        return
+      }
+
+      if target.requiresLockCode {
+        pendingEditLocationId = target.location.id
+        showingLockCodeEntryForEdit = true
+      } else {
+        locationToEdit = target.location
+      }
+    } catch {
+      errorMessage = "Failed to edit location: \(error.localizedDescription)"
     }
   }
 
@@ -194,7 +246,7 @@ struct SavedLocationsView: View {
       mode: appModeManager.currentMode,
       canVerifyCode: lockCodeManager.canVerifyCode)
     {
-      pendingDeleteLocation = location
+      pendingDeleteLocationId = location.id
       showingLockCodeEntry = true
     } else {
       // Directly delete - confirmation was already shown in AddLocationView

--- a/Foqos/Views/SavedLocationsView.swift
+++ b/Foqos/Views/SavedLocationsView.swift
@@ -83,8 +83,9 @@ struct SavedLocationsView: View {
           Section {
             ForEach(locations) { location in
               SafeModelView(location) { loc in
+                // #298: snapshot inside the validity gate; do NOT hoist - see tripwire.
                 SavedLocationCard(
-                  location: loc,
+                  data: loc.savedLocationCardData,
                   onTap: {
                     handleEdit(loc)
                   },

--- a/FoqosTests/BlockedProfileSaveValidationTests.swift
+++ b/FoqosTests/BlockedProfileSaveValidationTests.swift
@@ -1,0 +1,73 @@
+import FamilyControls
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class BlockedProfileSaveValidationTests: XCTestCase {
+  func testGivenNoAppsCategoriesWebDomainsOrDomains_WhenValidatingSave_ThenReturnsMessage() {
+    let message = BlockedProfileView.emptyProfileValidationMessage(
+      selection: FamilyActivitySelection(),
+      domains: [],
+      enableAllowMode: false,
+      enableAllowModeDomains: false,
+      needsAppSelection: false
+    )
+
+    XCTAssertEqual(
+      message,
+      "This profile does not block anything yet. Select apps, app categories, Safari websites, or domains before saving."
+    )
+  }
+
+  func testGivenDomainOnlyProfile_WhenValidatingSave_ThenAllowsSave() {
+    let message = BlockedProfileView.emptyProfileValidationMessage(
+      selection: FamilyActivitySelection(),
+      domains: ["example.com"],
+      enableAllowMode: false,
+      enableAllowModeDomains: false,
+      needsAppSelection: false
+    )
+
+    XCTAssertNil(message)
+  }
+
+  func testGivenAllowModeContent_WhenValidatingSave_ThenAllowsSave() {
+    let message = BlockedProfileView.emptyProfileValidationMessage(
+      selection: FamilyActivitySelection(),
+      domains: [],
+      enableAllowMode: true,
+      enableAllowModeDomains: false,
+      needsAppSelection: false
+    )
+
+    XCTAssertNil(message)
+  }
+
+  func testGivenAppsSelected_WhenValidatingSave_ThenAllowsSave() {
+    let message = BlockedProfileView.emptyProfileValidationMessage(
+      selectedItemsCount: 1,
+      domains: [],
+      enableAllowMode: false,
+      enableAllowModeDomains: false,
+      needsAppSelection: false
+    )
+
+    XCTAssertNil(message)
+  }
+
+  func testGivenNeedsAppSelectionProfileStillEmpty_WhenValidatingSave_ThenMessageGuidesSelection() {
+    let message = BlockedProfileView.emptyProfileValidationMessage(
+      selection: FamilyActivitySelection(),
+      domains: [],
+      enableAllowMode: false,
+      enableAllowModeDomains: false,
+      needsAppSelection: true
+    )
+
+    XCTAssertEqual(
+      message,
+      "This synced profile still needs an app selection. Select apps, app categories, Safari websites, or domains before saving."
+    )
+  }
+}

--- a/FoqosTests/SavedLocationActionRefetchTests.swift
+++ b/FoqosTests/SavedLocationActionRefetchTests.swift
@@ -1,0 +1,77 @@
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class SavedLocationActionRefetchTests: XCTestCase {
+  private var container: ModelContainer!
+  private var context: ModelContext!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    container = try TestModelContainer.create()
+    context = container.mainContext
+  }
+
+  override func tearDown() async throws {
+    context = nil
+    container = nil
+    try await super.tearDown()
+  }
+
+  func testGivenLocationDeletedAndSaved_WhenResolvingEditTap_ThenReturnsNilNoSheetPath()
+    throws
+  {
+    let location = SavedLocation(name: "Home", latitude: 0, longitude: 0)
+    context.insert(location)
+    try context.save()
+    let locationId = location.id
+
+    context.delete(location)
+    try context.save()
+
+    let target = try SavedLocationsView.editTarget(
+      locationId: locationId,
+      in: context,
+      mode: .individual,
+      canVerifyCode: false
+    )
+
+    XCTAssertNil(target)
+  }
+
+  func testGivenPendingEditLocationDeleted_WhenLockCodeSucceeds_ThenRefetchReturnsNilNoSheetPath()
+    throws
+  {
+    let location = SavedLocation(
+      name: "Locked",
+      latitude: 0,
+      longitude: 0,
+      isLocked: true
+    )
+    context.insert(location)
+    try context.save()
+    let locationId = location.id
+
+    let target = try XCTUnwrap(
+      SavedLocationsView.editTarget(
+        locationId: locationId,
+        in: context,
+        mode: .child,
+        canVerifyCode: true
+      )
+    )
+    XCTAssertTrue(target.requiresLockCode)
+
+    context.delete(location)
+    try context.save()
+
+    let pendingLocation = try SavedLocationsView.validSavedLocation(
+      locationId: locationId,
+      in: context
+    )
+
+    XCTAssertNil(pendingLocation)
+  }
+}

--- a/FoqosTests/TwinViewSnapshotTests.swift
+++ b/FoqosTests/TwinViewSnapshotTests.swift
@@ -56,6 +56,7 @@ final class TwinViewSnapshotTests: XCTestCase {
   func testGivenSessionRowData_WhenFormatted_ThenMatchesRawFieldLogic() throws {
     let now = Date()
     let data = SessionRowData(
+      id: "session-1",
       startTime: now,
       endTime: now.addingTimeInterval(3600),
       breakStartTime: nil,

--- a/FoqosTests/TwinViewSnapshotTests.swift
+++ b/FoqosTests/TwinViewSnapshotTests.swift
@@ -91,4 +91,26 @@ final class TwinViewSnapshotTests: XCTestCase {
     XCTAssertEqual(data.formattedDuration, "10m")
     _ = data.timeRangeText
   }
+
+  func testGivenSavedLocationCardDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap()
+    throws
+  {
+    let location = SavedLocation(
+      name: "Home",
+      latitude: 0,
+      longitude: 0,
+      defaultRadiusMeters: 500
+    )
+    context.insert(location)
+    try context.save()
+
+    let data = location.savedLocationCardData
+
+    context.delete(location)
+    try context.save()
+
+    XCTAssertFalse(location.isPersistentModelValid)
+    XCTAssertEqual(data.name, "Home")
+    XCTAssertEqual(data.defaultRadiusMeters, 500)
+  }
 }

--- a/FoqosTests/TwinViewSnapshotTests.swift
+++ b/FoqosTests/TwinViewSnapshotTests.swift
@@ -135,4 +135,21 @@ final class TwinViewSnapshotTests: XCTestCase {
     XCTAssertEqual(data.name, "Office")
     XCTAssertEqual(data.defaultRadiusMeters, 1000)
   }
+
+  func testGivenLockedProfileCardDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap()
+    throws
+  {
+    let profile = BlockedProfiles(name: "Managed", selectedActivity: FamilyActivitySelection())
+    context.insert(profile)
+    try context.save()
+
+    let data = profile.lockedProfileCardData
+
+    context.delete(profile)
+    try context.save()
+
+    XCTAssertFalse(profile.isPersistentModelValid)
+    XCTAssertEqual(data.name, "Managed")
+    XCTAssertEqual(data.appsBlockedCount, 0)
+  }
 }

--- a/FoqosTests/TwinViewSnapshotTests.swift
+++ b/FoqosTests/TwinViewSnapshotTests.swift
@@ -113,4 +113,26 @@ final class TwinViewSnapshotTests: XCTestCase {
     XCTAssertEqual(data.name, "Home")
     XCTAssertEqual(data.defaultRadiusMeters, 500)
   }
+
+  func testGivenLocationReferenceRowDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap()
+    throws
+  {
+    let location = SavedLocation(
+      name: "Office",
+      latitude: 0,
+      longitude: 0,
+      defaultRadiusMeters: 1000
+    )
+    context.insert(location)
+    try context.save()
+
+    let data = location.locationReferenceRowData
+
+    context.delete(location)
+    try context.save()
+
+    XCTAssertFalse(location.isPersistentModelValid)
+    XCTAssertEqual(data.name, "Office")
+    XCTAssertEqual(data.defaultRadiusMeters, 1000)
+  }
 }

--- a/FoqosTests/TwinViewSnapshotTests.swift
+++ b/FoqosTests/TwinViewSnapshotTests.swift
@@ -1,0 +1,55 @@
+import FamilyControls
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class TwinViewSnapshotTests: XCTestCase {
+  private var container: ModelContainer!
+  private var context: ModelContext!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    container = try TestModelContainer.create()
+    context = container.mainContext
+  }
+
+  override func tearDown() async throws {
+    context = nil
+    container = nil
+    try await super.tearDown()
+  }
+
+  func testGivenProfile_WhenProfileRowData_ThenMapsFields() throws {
+    let now = Date()
+    let profile = BlockedProfiles(
+      name: "School",
+      selectedActivity: FamilyActivitySelection(),
+      createdAt: now,
+      updatedAt: now
+    )
+    context.insert(profile)
+
+    let data = profile.profileRowData
+
+    XCTAssertEqual(data.id, profile.id)
+    XCTAssertEqual(data.name, "School")
+    XCTAssertEqual(data.updatedAt, now)
+    XCTAssertEqual(data.selectedItemsCount, 0)
+  }
+
+  func testGivenProfileRowDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap() throws {
+    let profile = BlockedProfiles(name: "School", selectedActivity: FamilyActivitySelection())
+    context.insert(profile)
+    try context.save()
+
+    let data = profile.profileRowData
+
+    context.delete(profile)
+    try context.save()
+
+    XCTAssertFalse(profile.isPersistentModelValid)
+    XCTAssertEqual(data.name, "School")
+  }
+}

--- a/FoqosTests/TwinViewSnapshotTests.swift
+++ b/FoqosTests/TwinViewSnapshotTests.swift
@@ -52,4 +52,43 @@ final class TwinViewSnapshotTests: XCTestCase {
     XCTAssertFalse(profile.isPersistentModelValid)
     XCTAssertEqual(data.name, "School")
   }
+
+  func testGivenSessionRowData_WhenFormatted_ThenMatchesRawFieldLogic() throws {
+    let now = Date()
+    let data = SessionRowData(
+      startTime: now,
+      endTime: now.addingTimeInterval(3600),
+      breakStartTime: nil,
+      breakEndTime: nil,
+      isActive: false,
+      durationSeconds: 3600
+    )
+
+    XCTAssertEqual(data.formattedDuration, "1h 0m")
+    XCTAssertTrue(data.timeRangeText.contains("→"))
+    XCTAssertNil(data.breakRangeText)
+  }
+
+  func testGivenSessionRowDataThenModelDeletedAndSaved_ThenValuesStillReadableNoTrap() throws {
+    let now = Date()
+    let profile = BlockedProfiles(name: "P", selectedActivity: FamilyActivitySelection())
+    context.insert(profile)
+    let session = BlockedProfileSession.createSession(
+      in: context,
+      withTag: "t",
+      withProfile: profile,
+      startTime: now
+    )
+    session.endTime = now.addingTimeInterval(600)
+    try context.save()
+
+    let data = session.sessionRowData
+
+    context.delete(session)
+    try context.save()
+
+    XCTAssertFalse(session.isPersistentModelValid)
+    XCTAssertEqual(data.formattedDuration, "10m")
+    _ = data.timeRangeText
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #298
Fixes #324

- Applied the PR #300 value-snapshot rendering pattern to the five remaining twin views: `ProfileRow`, `SessionRow`, `SavedLocationCard`, `LocationReferenceRow`, and `LockedProfileCard`.
- Added per-view snapshot data types, built only inside the existing validity gates, with tripwire/regression-guard comments and zombie-survival tests.
- Hardened delayed twin action closures so they capture value ids and re-fetch valid SwiftData models before reading or mutating.
- Added save-time editor validation for empty profiles so a local save is blocked when it would restrict nothing.
- Kept sync-apply behavior and start guards untouched; the validation runs only in `BlockedProfileView.saveProfile` before persistence.

## Per-task summary

- C0: Refreshed citations against `9befa33` (post-#336). The five twin call sites and gates still matched the Mini-plan C shape.
- C1: Converted `ProfileRow` to `ProfileRowData` behind `SafeModelView`.
- C2: Converted `SessionRow` to `SessionRowData`, moved session formatters onto the value type, and gated the active-session row before snapshotting.
- C3: Converted `SavedLocationCard` to `SavedLocationCardData`.
- C4: Converted `LocationReferenceRow` to snapshot the location while preserving the live `@Binding ProfileLocationReference`.
- C5: Converted `LockedProfileCard` to `LockedProfileCardData`.
- Review round 1: Revised delayed action closures for `SavedLocationCard`, `ProfileRow`, `SessionRow`, and `LocationReferenceRow` to avoid captured live models after render.
- #324: Added pure static empty-profile validation and wired it into the editor save path after trigger validation and before any persistence.

## Deviations / rationale

- `SavedLocationCard` uses the stored property name `data` rather than `location` so the plan's final grep for `let location: SavedLocation` cannot false-match `SavedLocationCardData`.
- Mini-plan C originally treated `onTap: { handleEdit(loc) }` as OK inside `SafeModelView`. Review showed `SafeModelView` protects render construction, not delayed button actions, so delayed closures now capture value ids and re-fetch before model reads.
- #324 includes a count-based helper overload for tests because `FamilyActivitySelection` app/category/web tokens are opaque SDK values and should not be fabricated in unit tests. The production save path still calls the selection-based overload.
- Closing sweep note: this PR only changed the five #298 twin surfaces; broader delayed-closure model-capture auditing outside those touched views remains out of scope.

## Verification

- Focused post-review gate: `SavedLocationActionRefetchTests` + `TwinViewSnapshotTests` passed on `platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED`.
- Full suite: `1013` passed, `0` failed, `0` skipped on `platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED` (baseline was `999`; this PR adds 14 tests).
- `swift-format lint --recursive .`: clean.
- #298 live-model grep guards: clean for all five twin views.

## Device-only rows

| Row | Status |
| --- | --- |
| #298 twin crash cycles and edit-propagation spot-checks | Not run — maintainer device pass |
| #302 final-verification device gate from the shared plan | Not run — maintainer device pass; Mini-plan A already shipped outside this PR |
| #301 final-verification device gate from the shared plan | Not run — maintainer device pass; Mini-plan B already shipped outside this PR |