### PR TITLE
Fix location picker empty state and edit-form scroll loss

### DIFF
--- a/Foqos/Components/BlockedProfileView/GeofencePicker.swift
+++ b/Foqos/Components/BlockedProfileView/GeofencePicker.swift
@@ -36,18 +36,15 @@ struct GeofencePicker: View {
     true
   }
 
-  struct LocationSelectionState {
-    var selectedLocationIds: Set<UUID>
-    var locationReferences: [UUID: ProfileLocationReference]
-
-    func selectAddedLocation(_ locationId: UUID) -> LocationSelectionState {
-      var updated = self
-      updated.selectedLocationIds.insert(locationId)
-      if updated.locationReferences[locationId] == nil {
-        updated.locationReferences[locationId] = ProfileLocationReference(
-          savedLocationId: locationId)
-      }
-      return updated
+  static func selectLocation(
+    _ locationId: UUID,
+    selectedLocationIds: inout Set<UUID>,
+    locationReferences: inout [UUID: ProfileLocationReference]
+  ) {
+    selectedLocationIds.insert(locationId)
+    if locationReferences[locationId] == nil {
+      locationReferences[locationId] = ProfileLocationReference(
+        savedLocationId: locationId)
     }
   }
 
@@ -226,20 +223,12 @@ struct GeofencePicker: View {
     }
   }
 
-  private func selectionState() -> LocationSelectionState {
-    LocationSelectionState(
-      selectedLocationIds: selectedLocationIds,
-      locationReferences: locationReferences
-    )
-  }
-
-  private func applySelectionState(_ state: LocationSelectionState) {
-    selectedLocationIds = state.selectedLocationIds
-    locationReferences = state.locationReferences
-  }
-
   private func selectLocation(_ locationId: UUID) {
-    applySelectionState(selectionState().selectAddedLocation(locationId))
+    Self.selectLocation(
+      locationId,
+      selectedLocationIds: &selectedLocationIds,
+      locationReferences: &locationReferences
+    )
   }
 
   private func syncStateFromRule() {

--- a/Foqos/Components/BlockedProfileView/GeofencePicker.swift
+++ b/Foqos/Components/BlockedProfileView/GeofencePicker.swift
@@ -32,6 +32,10 @@ struct GeofencePicker: View {
     savedLocations.filter { selectedLocationIds.contains($0.id) }
   }
 
+  static func shouldShowAddLocationAffordance(savedLocationCount: Int) -> Bool {
+    true
+  }
+
   struct LocationSelectionState {
     var selectedLocationIds: Set<UUID>
     var locationReferences: [UUID: ProfileLocationReference]
@@ -143,6 +147,15 @@ struct GeofencePicker: View {
                     }
                   }
                 )
+              }
+            }
+
+            if Self.shouldShowAddLocationAffordance(savedLocationCount: savedLocations.count) {
+              Button {
+                showingAddLocation = true
+              } label: {
+                Label("Add Location", systemImage: "plus")
+                  .foregroundStyle(themeManager.themeColor)
               }
             }
           }

--- a/Foqos/Components/BlockedProfileView/GeofencePicker.swift
+++ b/Foqos/Components/BlockedProfileView/GeofencePicker.swift
@@ -32,10 +32,6 @@ struct GeofencePicker: View {
     savedLocations.filter { selectedLocationIds.contains($0.id) }
   }
 
-  static func shouldShowAddLocationAffordance(savedLocationCount: Int) -> Bool {
-    true
-  }
-
   static func selectLocation(
     _ locationId: UUID,
     selectedLocationIds: inout Set<UUID>,
@@ -147,13 +143,11 @@ struct GeofencePicker: View {
               }
             }
 
-            if Self.shouldShowAddLocationAffordance(savedLocationCount: savedLocations.count) {
-              Button {
-                showingAddLocation = true
-              } label: {
-                Label("Add Location", systemImage: "plus")
-                  .foregroundStyle(themeManager.themeColor)
-              }
+            Button {
+              showingAddLocation = true
+            } label: {
+              Label("Add Location", systemImage: "plus")
+                .foregroundStyle(themeManager.themeColor)
             }
           }
         } header: {

--- a/Foqos/Components/BlockedProfileView/GeofencePicker.swift
+++ b/Foqos/Components/BlockedProfileView/GeofencePicker.swift
@@ -1,4 +1,5 @@
 import MapKit
+import SwiftData
 import SwiftUI
 
 struct GeofencePicker: View {
@@ -7,13 +8,15 @@ struct GeofencePicker: View {
   @EnvironmentObject var themeManager: ThemeManager
 
   @Binding var geofenceRule: ProfileGeofenceRule?
-  let savedLocations: [SavedLocation]
+
+  @SafeQuery(sort: \SavedLocation.name) private var savedLocations: [SavedLocation]
 
   // Local state for editing
   @State private var selectedRuleType: GeofenceRuleType = .within
   @State private var selectedLocationIds: Set<UUID> = []
   @State private var locationReferences: [UUID: ProfileLocationReference] = [:]
   @State private var allowEmergencyOverride: Bool = true
+  @State private var showingAddLocation = false
 
   // Map state
   @State private var mapRegion = MKCoordinateRegion(
@@ -27,6 +30,21 @@ struct GeofencePicker: View {
 
   private var selectedLocations: [SavedLocation] {
     savedLocations.filter { selectedLocationIds.contains($0.id) }
+  }
+
+  struct LocationSelectionState {
+    var selectedLocationIds: Set<UUID>
+    var locationReferences: [UUID: ProfileLocationReference]
+
+    func selectAddedLocation(_ locationId: UUID) -> LocationSelectionState {
+      var updated = self
+      updated.selectedLocationIds.insert(locationId)
+      if updated.locationReferences[locationId] == nil {
+        updated.locationReferences[locationId] = ProfileLocationReference(
+          savedLocationId: locationId)
+      }
+      return updated
+    }
   }
 
   var body: some View {
@@ -81,10 +99,18 @@ struct GeofencePicker: View {
                 .foregroundColor(.secondary)
               Text("No saved locations")
                 .font(.subheadline)
-              Text("Add locations in Settings to use geofence restrictions.")
+              Text("Add a location to use geofence restrictions.")
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
+
+              Button {
+                showingAddLocation = true
+              } label: {
+                Label("Add Location", systemImage: "plus")
+              }
+              .buttonStyle(.borderedProminent)
+              .tint(themeManager.themeColor)
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 16)
@@ -111,11 +137,7 @@ struct GeofencePicker: View {
                   isSelected: isSelected,
                   onToggle: { selected in
                     if selected {
-                      selectedLocationIds.insert(locationId)
-                      if locationReferences[locationId] == nil {
-                        locationReferences[locationId] = ProfileLocationReference(
-                          savedLocationId: locationId)
-                      }
+                      selectLocation(locationId)
                     } else {
                       selectedLocationIds.remove(locationId)
                     }
@@ -183,7 +205,28 @@ struct GeofencePicker: View {
       .onAppear {
         syncStateFromRule()
       }
+      .sheet(isPresented: $showingAddLocation) {
+        AddLocationView(onSave: { locationId in
+          selectLocation(locationId)
+        })
+      }
     }
+  }
+
+  private func selectionState() -> LocationSelectionState {
+    LocationSelectionState(
+      selectedLocationIds: selectedLocationIds,
+      locationReferences: locationReferences
+    )
+  }
+
+  private func applySelectionState(_ state: LocationSelectionState) {
+    selectedLocationIds = state.selectedLocationIds
+    locationReferences = state.locationReferences
+  }
+
+  private func selectLocation(_ locationId: UUID) {
+    applySelectionState(selectionState().selectAddedLocation(locationId))
   }
 
   private func syncStateFromRule() {
@@ -309,18 +352,10 @@ struct GeofenceMapPreview: View {
   struct PreviewContainer: View {
     @State var rule: ProfileGeofenceRule? = nil
 
-    let sampleLocations = [
-      SavedLocation(name: "Home", latitude: 51.5074, longitude: -0.1278, defaultRadiusMeters: 500),
-      SavedLocation(name: "Office", latitude: 51.5155, longitude: -0.1419, defaultRadiusMeters: 1000),
-      SavedLocation(name: "School", latitude: 51.5200, longitude: -0.1300, defaultRadiusMeters: 250),
-    ]
-
     var body: some View {
-      GeofencePicker(
-        geofenceRule: $rule,
-        savedLocations: sampleLocations
-      )
-      .environmentObject(ThemeManager.shared)
+      GeofencePicker(geofenceRule: $rule)
+        .environmentObject(ThemeManager.shared)
+        .modelContainer(for: SavedLocation.self, inMemory: true)
     }
   }
 

--- a/Foqos/Views/AddLocationView.swift
+++ b/Foqos/Views/AddLocationView.swift
@@ -19,6 +19,7 @@ struct AddLocationView: View {
   // If editing an existing location
   var editingLocation: SavedLocation?
   var onDelete: (() -> Void)?
+  var onSave: ((UUID) -> Void)?
 
   @State private var name: String = ""
   @State private var showingDeleteConfirmation: Bool = false
@@ -75,9 +76,14 @@ struct AddLocationView: View {
     return !name.trimmingCharacters(in: .whitespaces).isEmpty && hasSetLocation && !isDuplicateName
   }
 
-  init(editingLocation: SavedLocation? = nil, onDelete: (() -> Void)? = nil) {
+  init(
+    editingLocation: SavedLocation? = nil,
+    onDelete: (() -> Void)? = nil,
+    onSave: ((UUID) -> Void)? = nil
+  ) {
     self.editingLocation = editingLocation
     self.onDelete = onDelete
+    self.onSave = onSave
 
     if let location = editingLocation {
       _name = State(initialValue: location.name)
@@ -502,6 +508,7 @@ struct AddLocationView: View {
         Log.warning("Location saved locally; sync engine not attached yet", category: .sync)
       }
 
+      onSave?(savedLocation.id)
       dismiss()
     } catch {
       errorMessage = "Failed to save location: \(error.localizedDescription)"

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -691,9 +691,6 @@ struct BlockedProfileView: View {
             allowMode: enableAllowModeDomain
           )
         }
-        .sheet(isPresented: $showingGeofencePicker) {
-          GeofencePicker(geofenceRule: $geofenceRule)
-        }
         .sheet(isPresented: $showingGeneratedQRCode) {
           if let profileToWrite = profile {
             let url = BlockedProfiles.getProfileDeepLink(profileToWrite)
@@ -872,6 +869,9 @@ struct BlockedProfileView: View {
           }
         }
       }  // else (non-newer-schema profile)
+    }
+    .sheet(isPresented: $showingGeofencePicker) {
+      GeofencePicker(geofenceRule: $geofenceRule)
     }
   }
 

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -1106,7 +1106,7 @@ struct BlockedProfileView: View {
   BlockedProfileView()
     .environmentObject(NFCWriter())
     .environmentObject(StrategyManager.shared)
-    .modelContainer(for: BlockedProfiles.self, inMemory: true)
+    .modelContainer(for: [BlockedProfiles.self, SavedLocation.self], inMemory: true)
 }
 
 #Preview {
@@ -1119,5 +1119,5 @@ struct BlockedProfileView: View {
   BlockedProfileView(profile: previewProfile)
     .environmentObject(NFCWriter())
     .environmentObject(StrategyManager.shared)
-    .modelContainer(for: BlockedProfiles.self, inMemory: true)
+    .modelContainer(for: [BlockedProfiles.self, SavedLocation.self], inMemory: true)
 }

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -692,10 +692,7 @@ struct BlockedProfileView: View {
           )
         }
         .sheet(isPresented: $showingGeofencePicker) {
-          GeofencePicker(
-            geofenceRule: $geofenceRule,
-            savedLocations: savedLocations
-          )
+          GeofencePicker(geofenceRule: $geofenceRule)
         }
         .sheet(isPresented: $showingGeneratedQRCode) {
           if let profileToWrite = profile {

--- a/FoqosTests/GeofencePickerSelectionTests.swift
+++ b/FoqosTests/GeofencePickerSelectionTests.swift
@@ -2,7 +2,13 @@ import XCTest
 
 @testable import FamilyFoqos
 
+@MainActor
 final class GeofencePickerSelectionTests: XCTestCase {
+  func testGivenSavedLocationsExist_WhenCheckingAddAffordance_ThenAddStillAvailable() {
+    XCTAssertTrue(GeofencePicker.shouldShowAddLocationAffordance(savedLocationCount: 0))
+    XCTAssertTrue(GeofencePicker.shouldShowAddLocationAffordance(savedLocationCount: 2))
+  }
+
   func testGivenNewLocationSaved_WhenApplyingAddResult_ThenLocationIsSelectedWithDefaultReference() {
     let locationId = UUID()
 

--- a/FoqosTests/GeofencePickerSelectionTests.swift
+++ b/FoqosTests/GeofencePickerSelectionTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class GeofencePickerSelectionTests: XCTestCase {
+  func testGivenNewLocationSaved_WhenApplyingAddResult_ThenLocationIsSelectedWithDefaultReference() {
+    let locationId = UUID()
+
+    let state = GeofencePicker.LocationSelectionState(
+      selectedLocationIds: [],
+      locationReferences: [:]
+    )
+
+    let updated = state.selectAddedLocation(locationId)
+
+    XCTAssertTrue(updated.selectedLocationIds.contains(locationId))
+    XCTAssertEqual(updated.locationReferences[locationId]?.savedLocationId, locationId)
+    XCTAssertNil(updated.locationReferences[locationId]?.radiusOverrideMeters)
+  }
+}

--- a/FoqosTests/GeofencePickerSelectionTests.swift
+++ b/FoqosTests/GeofencePickerSelectionTests.swift
@@ -4,11 +4,6 @@ import XCTest
 
 @MainActor
 final class GeofencePickerSelectionTests: XCTestCase {
-  func testGivenSavedLocationsExist_WhenCheckingAddAffordance_ThenAddStillAvailable() {
-    XCTAssertTrue(GeofencePicker.shouldShowAddLocationAffordance(savedLocationCount: 0))
-    XCTAssertTrue(GeofencePicker.shouldShowAddLocationAffordance(savedLocationCount: 2))
-  }
-
   func testGivenNewLocationSaved_WhenSelectingLocation_ThenLocationIsSelectedWithDefaultReference() {
     let locationId = UUID()
     var selectedLocationIds: Set<UUID> = []

--- a/FoqosTests/GeofencePickerSelectionTests.swift
+++ b/FoqosTests/GeofencePickerSelectionTests.swift
@@ -9,18 +9,19 @@ final class GeofencePickerSelectionTests: XCTestCase {
     XCTAssertTrue(GeofencePicker.shouldShowAddLocationAffordance(savedLocationCount: 2))
   }
 
-  func testGivenNewLocationSaved_WhenApplyingAddResult_ThenLocationIsSelectedWithDefaultReference() {
+  func testGivenNewLocationSaved_WhenSelectingLocation_ThenLocationIsSelectedWithDefaultReference() {
     let locationId = UUID()
+    var selectedLocationIds: Set<UUID> = []
+    var locationReferences: [UUID: ProfileLocationReference] = [:]
 
-    let state = GeofencePicker.LocationSelectionState(
-      selectedLocationIds: [],
-      locationReferences: [:]
+    GeofencePicker.selectLocation(
+      locationId,
+      selectedLocationIds: &selectedLocationIds,
+      locationReferences: &locationReferences
     )
 
-    let updated = state.selectAddedLocation(locationId)
-
-    XCTAssertTrue(updated.selectedLocationIds.contains(locationId))
-    XCTAssertEqual(updated.locationReferences[locationId]?.savedLocationId, locationId)
-    XCTAssertNil(updated.locationReferences[locationId]?.radiusOverrideMeters)
+    XCTAssertTrue(selectedLocationIds.contains(locationId))
+    XCTAssertEqual(locationReferences[locationId]?.savedLocationId, locationId)
+    XCTAssertNil(locationReferences[locationId]?.radiusOverrideMeters)
   }
 }


### PR DESCRIPTION
Fixes #337

## Summary
- Added an in-place Add Location affordance to the geofence picker empty state.
- Reused the existing `AddLocationView` flow and added a narrow save callback that reports the saved location UUID.
- Made `GeofencePicker` own a live `@SafeQuery` for saved locations so a newly added location appears immediately and is selected without leaving the picker.
- Moved the geofence picker sheet presentation off the profile editor `Form` and onto the outer `NavigationStack`.

## Fix 2 root cause
The scroll loss was not a model/sync issue and did not require a scroll-to restoration hack. The profile editor kept its own `@State` form values; the unstable part was the scrollable `Form` subtree.

Before this PR, the geofence picker `.sheet(isPresented:)` was attached directly to the editor `Form`. Dismissing that nested sheet toggled presentation state on the `Form` modifier chain, causing SwiftUI to rebuild the form's scroll host and return the underlying form scroll view to the top. The fix keeps the geofence presentation state anchored on the outer `NavigationStack`, so the editor form remains a stable scroll container while the picker is presented and dismissed.

## Verification
- Baseline suite: 1013 tests.
- Current suite: 1014 passed, 0 failed, 0 skipped.
- `swift-format lint --recursive .` clean.
- `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' | xcpretty` passed.

## Device row
| Row | Status | Repro steps | Expected result |
| --- | --- | --- | --- |
| Maintainer device pass | Needs maintainer visual pass | 1. Open an existing profile for editing. 2. Scroll down to Location Restrictions. 3. Tap Set location restrictions. 4. Select or add a location. 5. Tap Done or dismiss back to the editor. | The editor returns to the Location Restrictions area instead of jumping to the top; when starting from no saved locations, Add Location appears in the picker empty state and the newly saved location is immediately selected. |

## Summary by Sourcery

Improve geofence location selection UX and stabilize the profile editor scroll behavior when presenting the geofence picker.

New Features:
- Add an in-place Add Location action to the geofence picker empty state that opens the existing location creation flow.
- Automatically select newly created locations in the geofence picker after saving.

Enhancements:
- Make GeofencePicker own a live SwiftData query for saved locations so changes appear immediately without reloading.
- Move geofence picker sheet presentation from the profile editor Form to the outer navigation container to avoid rebuilding the form hierarchy.
- Extend AddLocationView with an optional save callback that reports the saved location identifier for downstream use.

Tests:
- Add a unit test covering selection state updates when a new location is saved in the geofence picker.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the add-location flow directly inside the geofence picker. The main changes are:

- `GeofencePicker` now owns a live saved-location query.
- The empty state can present `AddLocationView` and select the saved UUID.
- The geofence picker sheet moved to the outer profile editor navigation stack.
- A focused selection-state unit test was added.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small preview cleanup.

- No blocking issues found in the changed production flow.
- The add-location callback preserves the new UUID in local picker state.
- The remaining issue is limited to preview hosts that do not include `SavedLocation` in their model container.

Foqos/Components/BlockedProfileView/GeofencePicker.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Foqos/Components/BlockedProfileView/GeofencePicker.swift | Adds a live saved-location query, in-picker add-location presentation, and selection helpers; preview hosts need matching model-container setup. |
| Foqos/Views/AddLocationView.swift | Adds an optional save callback that reports the saved location UUID after persistence. |
| Foqos/Views/BlockedProfileView.swift | Moves the geofence picker sheet from the form subtree to the outer navigation stack. |
| FoqosTests/GeofencePickerSelectionTests.swift | Adds coverage for selecting a newly saved location and creating its default reference. |

<sub>Reviews (1): Last reviewed commit: ["Keep profile editor form stable after ge..."](https://github.com/mnbf9rca/family-foqos/commit/a721386c5e3a5fa3f9ed14c12a9e8f5f16c2f50d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43839985)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->