### PR TITLE
Fix tail bundle: logging privacy, widget freshness, dashboard honesty, README

### DIFF
--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -163,6 +163,10 @@ class CloudKitManager: ObservableObject {
     try await networkService.sendCommand(command)
   }
 
+  func commandIsPending(_ command: FamilyCommand) async throws -> Bool {
+    try await networkService.commandIsPending(command)
+  }
+
   func fetchPendingCommands() async throws -> [FamilyCommand] {
     return try await networkService.fetchPendingCommands(currentUserRecordID: currentUserRecordID)
   }

--- a/Foqos/CloudKit/CloudKitNetworkService+Commands.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Commands.swift
@@ -41,6 +41,26 @@ extension CloudKitNetworkService {
     }
   }
 
+  /// #331: true while the parent's queued command record still exists in the private DB. A V2 child
+  /// deletes it after processing; a V1 child never does, so the parent honestly keeps waiting.
+  func commandIsPending(_ command: FamilyCommand) async throws -> Bool {
+    let recordID = CKRecord.ID(
+      recordName: FamilyCommand.recordName(
+        commandType: command.commandType,
+        targetChildId: command.targetChildId,
+        parentId: command.createdBy
+      ),
+      zoneID: policyZoneID
+    )
+
+    do {
+      _ = try await privateDatabase.record(for: recordID)
+      return true
+    } catch let error as CKError where error.code == .unknownItem {
+      return false
+    }
+  }
+
   func fetchPendingCommands(currentUserRecordID: CKRecord.ID?) async throws -> [FamilyCommand] {
     let zones = try await sharedDatabase.allRecordZones()
 

--- a/Foqos/CloudKit/CloudKitNetworkService+FamilyMembers.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+FamilyMembers.swift
@@ -6,8 +6,9 @@ extension CloudKitNetworkService {
   // MARK: - Family Member Management
 
   func saveFamilyMember(_ member: FamilyMember) async throws {
+    // PII-SAFE LOG (#252): log the UUID + role, never the real person name.
     Log.info(
-      "Saving family member '\(member.displayName)' as \(member.role.displayName)",
+      "Saving family member \(member.redactedLogLabel) as \(member.role.displayName)",
       category: .cloudKit)
 
     try await createPolicyZoneIfNeeded()
@@ -17,7 +18,7 @@ extension CloudKitNetworkService {
 
     do {
       _ = try await privateDatabase.save(record)
-      Log.info("Saved family member: \(member.displayName)", category: .cloudKit)
+      Log.info("Saved family member: \(member.redactedLogLabel)", category: .cloudKit)
     } catch {
       Log.error("Failed to save family member: \(error)", category: .cloudKit)
       throw CloudKitError.saveFailed(error)
@@ -33,7 +34,7 @@ extension CloudKitNetworkService {
 
     do {
       try await privateDatabase.deleteRecord(withID: recordID)
-      Log.info("Deleted family member: \(member.displayName)", category: .cloudKit)
+      Log.info("Deleted family member: \(member.redactedLogLabel)", category: .cloudKit)
     } catch {
       throw CloudKitError.deleteFailed(error)
     }
@@ -58,10 +59,9 @@ extension CloudKitNetworkService {
     try await privateDatabase.save(share)
     self.activeZoneShare = share
 
-    let name =
-      participant.userIdentity.nameComponents?.formatted()
-      ?? participant.userIdentity.lookupInfo?.emailAddress ?? "Unknown"
-    Log.info("Removed participant '\(name)' from share", category: .cloudKit)
+    let participantId = participant.userIdentity.userRecordID?.recordName ?? "unknown"
+    // PII-SAFE LOG (#252): log only the opaque CK record name, never nameComponents/email.
+    Log.info("Removed participant \(participantId) from share", category: .cloudKit)
     // NOTE: Manager handles refreshShareParticipants() after this call
   }
 

--- a/Foqos/Components/Debug/DebugRedaction.swift
+++ b/Foqos/Components/Debug/DebugRedaction.swift
@@ -3,15 +3,33 @@ import Foundation
 /// #247: child-mode redaction for Debug Mode values that are replayable credentials.
 enum DebugRedaction {
   private static let shortNFCTagMask = "••••••"
+  private static let lowercaseHexDigits = CharacterSet(charactersIn: "0123456789abcdef")
 
-  /// Masks only the physical-unblock NFC UID in Child mode. The QR value is deliberately not
-  /// handled here: the stored QR value is a SHA-256 digest, and scanner code compares
-  /// `sha256(scanned) == digest`, so the displayed digest is preimage-resistant and non-replayable.
+  /// Masks the physical-unblock NFC UID in Child mode because the stored UID is replayable.
   static func physicalUnblockNFCTagIdForDisplay(_ raw: String?, mode: AppMode) -> String? {
     guard let raw else { return nil }
     guard mode == .child else { return raw }
+    return maskCredential(raw)
+  }
+
+  /// #247 deliberate asymmetry: QR values have three forms. A 64-lowercase-hex value is the
+  /// SHA-256 digest and stays visible; legacy plaintext is replayable and gets the same mask as NFC.
+  static func physicalUnblockQRCodeIdForDisplay(_ raw: String?, mode: AppMode) -> String? {
+    guard let raw else { return nil }
+    guard mode == .child else { return raw }
+    guard !isLowercaseHexDigest(raw) else { return raw }
+
+    return maskCredential(raw)
+  }
+
+  private static func maskCredential(_ raw: String) -> String {
     guard raw.count >= 8 else { return shortNFCTagMask }
 
     return "\(raw.prefix(2))…\(raw.suffix(2))"
+  }
+
+  private static func isLowercaseHexDigest(_ raw: String) -> Bool {
+    guard raw.count == 64 else { return false }
+    return raw.unicodeScalars.allSatisfy { lowercaseHexDigits.contains($0) }
   }
 }

--- a/Foqos/Components/Debug/DebugRedaction.swift
+++ b/Foqos/Components/Debug/DebugRedaction.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// #247: child-mode redaction for Debug Mode values that are replayable credentials.
+enum DebugRedaction {
+  private static let shortNFCTagMask = "••••••"
+
+  /// Masks only the physical-unblock NFC UID in Child mode. The QR value is deliberately not
+  /// handled here: the stored QR value is a SHA-256 digest, and scanner code compares
+  /// `sha256(scanned) == digest`, so the displayed digest is preimage-resistant and non-replayable.
+  static func physicalUnblockNFCTagIdForDisplay(_ raw: String?, mode: AppMode) -> String? {
+    guard let raw else { return nil }
+    guard mode == .child else { return raw }
+    guard raw.count >= 8 else { return shortNFCTagMask }
+
+    return "\(raw.prefix(2))…\(raw.suffix(2))"
+  }
+}

--- a/Foqos/Components/Debug/ProfileDebugCard.swift
+++ b/Foqos/Components/Debug/ProfileDebugCard.swift
@@ -59,7 +59,13 @@ struct ProfileDebugCard: View {
             mode: AppModeManager.shared.currentMode
           ) ?? "nil"
         )
-        DebugRow(label: "QR Code ID", value: profile.physicalUnblockQRCodeId ?? "nil")
+        DebugRow(
+          label: "QR Code ID",
+          value: DebugRedaction.physicalUnblockQRCodeIdForDisplay(
+            profile.physicalUnblockQRCodeId,
+            mode: AppModeManager.shared.currentMode
+          ) ?? "nil"
+        )
       }
 
       Divider()

--- a/Foqos/Components/Debug/ProfileDebugCard.swift
+++ b/Foqos/Components/Debug/ProfileDebugCard.swift
@@ -52,7 +52,13 @@ struct ProfileDebugCard: View {
 
       // Physical Unlock
       Group {
-        DebugRow(label: "NFC Tag ID", value: profile.physicalUnblockNFCTagId ?? "nil")
+        DebugRow(
+          label: "NFC Tag ID",
+          value: DebugRedaction.physicalUnblockNFCTagIdForDisplay(
+            profile.physicalUnblockNFCTagId,
+            mode: AppModeManager.shared.currentMode
+          ) ?? "nil"
+        )
         DebugRow(label: "QR Code ID", value: profile.physicalUnblockQRCodeId ?? "nil")
       }
 

--- a/Foqos/Models/FamilyLockCode.swift
+++ b/Foqos/Models/FamilyLockCode.swift
@@ -62,9 +62,10 @@ struct FamilyLockCode: Codable, Identifiable, Equatable {
     return Data(bytes).base64EncodedString()
   }
 
-  // TODO: Consider using PBKDF2 or Argon2 for hardened security against brute-force
-  // attacks on 4-digit PINs. SHA256+salt is acceptable for v1 family app use case
-  // but could be strengthened for higher-stakes scenarios.
+  // The lock code is stored hashed. It is a low-stakes secret — parental friction, not a
+  // credential guarding high-value data. Offline brute-force requires device-level access
+  // (jailbreak), outside this app's threat model. Current protection is proportionate by
+  // maintainer ruling (issue #240, 2026-07-10); no further hardening planned.
   private static func hashCode(_ code: String, salt: String) -> String {
     let combined = code + salt
     let data = Data(combined.utf8)

--- a/Foqos/Models/FamilyMember.swift
+++ b/Foqos/Models/FamilyMember.swift
@@ -63,6 +63,12 @@ struct FamilyMember: Codable, Identifiable, Equatable {
 
 }
 
+extension FamilyMember {
+  /// PII-SAFE LOG (#252): the only value permitted in log lines that reference a family member.
+  /// Returns the non-PII UUID, never `displayName` (a real person name) or any email.
+  var redactedLogLabel: String { id.uuidString }
+}
+
 // MARK: - CloudKit Record Conversion
 
 extension FamilyMember {

--- a/Foqos/Utils/LiveActivityManager.swift
+++ b/Foqos/Utils/LiveActivityManager.swift
@@ -2,6 +2,15 @@ import ActivityKit
 import Foundation
 import SwiftUI
 
+/// #249: pure startSessionActivity action, testable without ActivityKit runtime support.
+enum LiveActivityAction: Equatable {
+  case start
+  case update
+  case recreate
+  case end
+  case skip
+}
+
 @MainActor
 class LiveActivityManager: ObservableObject {
   // Published property for live activity reference
@@ -22,6 +31,23 @@ class LiveActivityManager: ObservableObject {
       return ActivityAuthorizationInfo().areActivitiesEnabled
     }
     return false
+  }
+
+  /// #249: a profile switch must recreate the activity because the profile name is an immutable
+  /// ActivityAttribute. Disabled switched-in profiles end any stale activity instead of updating it.
+  nonisolated static func decideAction(
+    currentProfileId: UUID?,
+    incomingProfileId: UUID,
+    enableLiveActivity: Bool,
+    hasCurrentActivity: Bool
+  ) -> LiveActivityAction {
+    guard enableLiveActivity else {
+      return hasCurrentActivity ? .end : .skip
+    }
+    guard hasCurrentActivity else {
+      return .start
+    }
+    return currentProfileId == incomingProfileId ? .update : .recreate
   }
 
   // Save activity ID using AppStorage

--- a/Foqos/Utils/LiveActivityManager.swift
+++ b/Foqos/Utils/LiveActivityManager.swift
@@ -18,6 +18,8 @@ class LiveActivityManager: ObservableObject {
 
   // Use AppStorage for persisting the activity ID across app launches
   @AppStorage("family_foqos_current_activity_id") private var storedActivityId: String = ""
+  @AppStorage("family_foqos_current_activity_profile_id")
+  private var storedActivityProfileId: String = ""
 
   static let shared = LiveActivityManager()
 
@@ -31,6 +33,10 @@ class LiveActivityManager: ObservableObject {
       return ActivityAuthorizationInfo().areActivitiesEnabled
     }
     return false
+  }
+
+  private var currentActivityProfileId: UUID? {
+    storedActivityProfileId.isEmpty ? nil : UUID(uuidString: storedActivityProfileId)
   }
 
   /// #249: a profile switch must recreate the activity because the profile name is an immutable
@@ -58,6 +64,7 @@ class LiveActivityManager: ObservableObject {
   // Remove activity ID from AppStorage
   private func removeActivityId() {
     storedActivityId = ""
+    storedActivityProfileId = ""
   }
 
   // Restore existing activity from system if available
@@ -92,19 +99,32 @@ class LiveActivityManager: ObservableObject {
       restoreExistingActivity()
     }
 
-    // Check if we already have an activity running
-    if currentActivity != nil {
-      Log.info("Live Activity is already running, will update instead", category: .liveActivity)
+    let action = Self.decideAction(
+      currentProfileId: currentActivityProfileId,
+      incomingProfileId: session.blockedProfile.id,
+      enableLiveActivity: session.blockedProfile.enableLiveActivity,
+      hasCurrentActivity: currentActivity != nil
+    )
+
+    switch action {
+    case .skip:
+      Log.info("Live Activity disabled for profile, nothing to do", category: .liveActivity)
+    case .update:
+      Log.info("Live Activity already running for this profile, updating", category: .liveActivity)
       updateSessionActivity(session: session)
-      return
+    case .end:
+      Log.info("Live Activity disabled for switched-in profile, ending", category: .liveActivity)
+      endSessionActivity()
+    case .recreate:
+      Log.info("Profile switched, recreating Live Activity for new name", category: .liveActivity)
+      endSessionActivity()
+      requestActivity(session: session)
+    case .start:
+      requestActivity(session: session)
     }
+  }
 
-    if session.blockedProfile.enableLiveActivity == false {
-      Log.info("Activity is disabled for profile", category: .liveActivity)
-      return
-    }
-
-    // Create and start the activity
+  private func requestActivity(session: BlockedProfileSession) {
     let profileName = session.blockedProfile.name
     let message = FocusMessages.getRandomMessage()
     let attributes = FoqosWidgetAttributes(name: profileName, message: message)
@@ -126,11 +146,10 @@ class LiveActivityManager: ObservableObject {
       currentActivity = activity
 
       saveActivityId(activity.id)
+      storedActivityProfileId = session.blockedProfile.id.uuidString
       Log.info("Started Live Activity with ID: \(activity.id) for profile: \(profileName)", category: .liveActivity)
-      return
     } catch {
       Log.info("Error starting Live Activity: \(error.localizedDescription)", category: .liveActivity)
-      return
     }
   }
 

--- a/Foqos/Views/DebugView.swift
+++ b/Foqos/Views/DebugView.swift
@@ -194,10 +194,15 @@ struct DebugView: View {
       markdown += "- **Custom Reminder Message:** \(customMessage)\n"
     }
 
-    if let nfcTagId = profile.physicalUnblockNFCTagId {
+    if let nfcTagId = DebugRedaction.physicalUnblockNFCTagIdForDisplay(
+      profile.physicalUnblockNFCTagId,
+      mode: AppModeManager.shared.currentMode
+    ) {
       markdown += "- **Physical Unlock NFC Tag ID:** \(nfcTagId)\n"
     }
 
+    // #247 deliberate asymmetry: QR stores and exports only a SHA-256 digest; unlike the NFC UID,
+    // it is not a replayable stored credential, so Debug Mode leaves it visible for diagnostics.
     if let qrCodeId = profile.physicalUnblockQRCodeId {
       markdown += "- **Physical Unlock QR Code ID:** \(qrCodeId)\n"
     }

--- a/Foqos/Views/DebugView.swift
+++ b/Foqos/Views/DebugView.swift
@@ -201,9 +201,12 @@ struct DebugView: View {
       markdown += "- **Physical Unlock NFC Tag ID:** \(nfcTagId)\n"
     }
 
-    // #247 deliberate asymmetry: QR stores and exports only a SHA-256 digest; unlike the NFC UID,
-    // it is not a replayable stored credential, so Debug Mode leaves it visible for diagnostics.
-    if let qrCodeId = profile.physicalUnblockQRCodeId {
+    // #247 deliberate asymmetry: QR exports the visible digest form, but legacy plaintext QR values
+    // are replayable credentials and get the same child-mode mask as the NFC UID.
+    if let qrCodeId = DebugRedaction.physicalUnblockQRCodeIdForDisplay(
+      profile.physicalUnblockQRCodeId,
+      mode: AppModeManager.shared.currentMode
+    ) {
       markdown += "- **Physical Unlock QR Code ID:** \(qrCodeId)\n"
     }
 

--- a/Foqos/Views/Parent/ParentDashboardView.swift
+++ b/Foqos/Views/Parent/ParentDashboardView.swift
@@ -997,7 +997,7 @@ struct FamilyMemberCard: View {
   @State private var showRemoveConfirmation = false
   @State private var isResettingEmergency = false
   @State private var isResettingThrottle = false
-  @State private var showResetSuccess = false
+  @State private var resetStatus: ParentResetCommandStatus = .idle
   @State private var showResetError = false
   @State private var resetErrorMessage = ""
 
@@ -1026,6 +1026,12 @@ struct FamilyMemberCard: View {
         Text("Added \(member.enrolledAt, style: .date)")
           .font(.caption)
           .foregroundColor(.secondary)
+
+        if let statusText = resetStatus.displayText {
+          Text(statusText)
+            .font(.caption2)
+            .foregroundColor(resetStatus == .confirmed ? .green : .secondary)
+        }
       }
 
       Spacer()
@@ -1060,14 +1066,21 @@ struct FamilyMemberCard: View {
         if isResettingEmergency || isResettingThrottle {
           ProgressView()
             .scaleEffect(0.8)
-        } else if showResetSuccess {
-          Image(systemName: "checkmark.circle.fill")
-            .foregroundColor(.green)
         } else {
-          Image(systemName: "ellipsis.circle")
-            .foregroundColor(.secondary)
+          switch resetStatus {
+          case .awaitingChild:
+            Image(systemName: "paperplane.circle")
+              .foregroundColor(.secondary)
+          case .confirmed:
+            Image(systemName: "checkmark.circle.fill")
+              .foregroundColor(.green)
+          case .idle:
+            Image(systemName: "ellipsis.circle")
+              .foregroundColor(.secondary)
+          }
         }
       }
+      .accessibilityLabel(resetStatus.displayText ?? "More")
       .alert("Error", isPresented: $showResetError) {
         Button("OK", role: .cancel) {}
       } message: {
@@ -1102,6 +1115,7 @@ struct FamilyMemberCard: View {
       return
     }
 
+    resetStatus = .idle
     isResettingEmergency = true
 
     Task {
@@ -1115,13 +1129,7 @@ struct FamilyMemberCard: View {
 
         await MainActor.run {
           isResettingEmergency = false
-          showResetSuccess = true
-        }
-
-        // Auto-dismiss success after 2 seconds
-        try? await Task.sleep(nanoseconds: 2_000_000_000)
-        await MainActor.run {
-          showResetSuccess = false
+          resetStatus = .afterSuccessfulSave
         }
       } catch {
         await MainActor.run {
@@ -1142,6 +1150,7 @@ struct FamilyMemberCard: View {
       return
     }
 
+    resetStatus = .idle
     isResettingThrottle = true
 
     Task {
@@ -1155,13 +1164,7 @@ struct FamilyMemberCard: View {
 
         await MainActor.run {
           isResettingThrottle = false
-          showResetSuccess = true
-        }
-
-        // Auto-dismiss success after 2 seconds
-        try? await Task.sleep(nanoseconds: 2_000_000_000)
-        await MainActor.run {
-          showResetSuccess = false
+          resetStatus = .afterSuccessfulSave
         }
       } catch {
         await MainActor.run {

--- a/Foqos/Views/Parent/ParentDashboardView.swift
+++ b/Foqos/Views/Parent/ParentDashboardView.swift
@@ -1131,6 +1131,7 @@ struct FamilyMemberCard: View {
           isResettingEmergency = false
           resetStatus = .afterSuccessfulSave
         }
+        await pollForConfirmation(command)
       } catch {
         await MainActor.run {
           isResettingEmergency = false
@@ -1166,6 +1167,7 @@ struct FamilyMemberCard: View {
           isResettingThrottle = false
           resetStatus = .afterSuccessfulSave
         }
+        await pollForConfirmation(command)
       } catch {
         await MainActor.run {
           isResettingThrottle = false
@@ -1173,6 +1175,24 @@ struct FamilyMemberCard: View {
           showResetError = true
         }
       }
+    }
+  }
+
+  private func pollForConfirmation(_ command: FamilyCommand) async {
+    for _ in 0..<5 {
+      try? await Task.sleep(nanoseconds: 3_000_000_000)
+
+      let stillPending: Bool
+      do {
+        stillPending = try await CloudKitManager.shared.commandIsPending(command)
+      } catch {
+        return
+      }
+
+      let next = ParentResetCommandStatus.afterConfirmationProbe(
+        commandStillPending: stillPending)
+      await MainActor.run { resetStatus = next }
+      if next == .confirmed { return }
     }
   }
 }

--- a/Foqos/Views/Parent/ParentDashboardView.swift
+++ b/Foqos/Views/Parent/ParentDashboardView.swift
@@ -550,8 +550,10 @@ struct ParentDashboardView: View {
       if heartbeatManager.monitoredDevices.isEmpty {
         EmptyMemberCard(
           icon: "antenna.radiowaves.left.and.right",
-          title: "No Devices",
-          description: "Child devices will appear here when they activate a profile"
+          title: "No devices reporting",
+          description:
+            "Devices appear here once they report status. A child on an older app version won't "
+            + "appear even while actively blocking — update their app to see it here."
         )
       } else {
         ForEach(heartbeatManager.monitoredDevices) { device in

--- a/Foqos/Views/Parent/ParentResetCommandStatus.swift
+++ b/Foqos/Views/Parent/ParentResetCommandStatus.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// #331: honest status of a parent-to-child reset command on the family dashboard. Saving the
+/// command to CloudKit only queues it; confirmation comes only when the child deletes the command
+/// record after processing.
+enum ParentResetCommandStatus: Equatable {
+  case idle
+  case awaitingChild
+  case confirmed
+
+  static let afterSuccessfulSave: ParentResetCommandStatus = .awaitingChild
+
+  static func afterConfirmationProbe(commandStillPending: Bool) -> ParentResetCommandStatus {
+    commandStillPending ? .awaitingChild : .confirmed
+  }
+
+  var displayText: String? {
+    switch self {
+    case .idle:
+      return nil
+    case .awaitingChild:
+      return "Sent — waiting for child to confirm"
+    case .confirmed:
+      return "Confirmed by child"
+    }
+  }
+}

--- a/FoqosDeviceMonitor/DeviceActivityMonitorExtension.swift
+++ b/FoqosDeviceMonitor/DeviceActivityMonitorExtension.swift
@@ -9,6 +9,7 @@ import DeviceActivity
 import FoqosShared
 import ManagedSettings
 import OSLog
+import WidgetKit
 
 private let log = Logger(
   subsystem: "com.cynexia.family-foqos.monitor",
@@ -24,6 +25,9 @@ class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     SharedData.configure(
       suite: UserDefaults(suiteName: "group.com.cynexia.family-foqos")!
     )
+    TimerActivityUtil.reloadWidgets = {
+      WidgetCenter.shared.reloadTimelines(ofKind: "ProfileControlWidget")
+    }
     super.init()
   }
 

--- a/FoqosTests/DebugRedactionTests.swift
+++ b/FoqosTests/DebugRedactionTests.swift
@@ -21,6 +21,40 @@ final class DebugRedactionTests: XCTestCase {
     XCTAssertNil(DebugRedaction.physicalUnblockNFCTagIdForDisplay(nil, mode: .child))
   }
 
+  func testGivenQRDigest_WhenChildMode_ThenVisible() {
+    let digest = String(repeating: "a", count: 64)
+
+    XCTAssertEqual(
+      DebugRedaction.physicalUnblockQRCodeIdForDisplay(digest, mode: .child),
+      digest
+    )
+  }
+
+  func testGivenLegacyQRPlaintext_WhenChildModeAndEightCharacters_ThenMasksMiddle() {
+    XCTAssertEqual(
+      DebugRedaction.physicalUnblockQRCodeIdForDisplay("legacy12", mode: .child),
+      "le…12"
+    )
+  }
+
+  func testGivenLegacyQRPlaintext_WhenChildModeAndSevenCharacters_ThenFullConstantMask() {
+    XCTAssertEqual(
+      DebugRedaction.physicalUnblockQRCodeIdForDisplay("legacy1", mode: .child),
+      "••••••"
+    )
+  }
+
+  func testGivenUppercaseOrNonHexQR_WhenChildMode_ThenTreatedAsLegacyPlaintext() {
+    XCTAssertEqual(
+      DebugRedaction.physicalUnblockQRCodeIdForDisplay(String(repeating: "A", count: 64), mode: .child),
+      "AA…AA"
+    )
+    XCTAssertEqual(
+      DebugRedaction.physicalUnblockQRCodeIdForDisplay(String(repeating: "g", count: 64), mode: .child),
+      "gg…gg"
+    )
+  }
+
   func testGivenNFCId_WhenParentMode_ThenRaw() {
     XCTAssertEqual(
       DebugRedaction.physicalUnblockNFCTagIdForDisplay("ABCDEF12", mode: .parent),
@@ -32,6 +66,13 @@ final class DebugRedactionTests: XCTestCase {
     XCTAssertEqual(
       DebugRedaction.physicalUnblockNFCTagIdForDisplay("ABCDEF12", mode: .individual),
       "ABCDEF12"
+    )
+  }
+
+  func testGivenQRValue_WhenParentMode_ThenRaw() {
+    XCTAssertEqual(
+      DebugRedaction.physicalUnblockQRCodeIdForDisplay("legacy-plaintext", mode: .parent),
+      "legacy-plaintext"
     )
   }
 }

--- a/FoqosTests/DebugRedactionTests.swift
+++ b/FoqosTests/DebugRedactionTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class DebugRedactionTests: XCTestCase {
+  func testGivenNFCId_WhenChildModeAndEightCharacters_ThenMasksMiddle() {
+    XCTAssertEqual(
+      DebugRedaction.physicalUnblockNFCTagIdForDisplay("ABCDEF12", mode: .child),
+      "AB…12"
+    )
+  }
+
+  func testGivenNFCId_WhenChildModeAndSevenCharacters_ThenFullConstantMask() {
+    XCTAssertEqual(
+      DebugRedaction.physicalUnblockNFCTagIdForDisplay("ABCDEFG", mode: .child),
+      "••••••"
+    )
+  }
+
+  func testGivenNFCId_WhenChildModeAndNil_ThenNil() {
+    XCTAssertNil(DebugRedaction.physicalUnblockNFCTagIdForDisplay(nil, mode: .child))
+  }
+
+  func testGivenNFCId_WhenParentMode_ThenRaw() {
+    XCTAssertEqual(
+      DebugRedaction.physicalUnblockNFCTagIdForDisplay("ABCDEF12", mode: .parent),
+      "ABCDEF12"
+    )
+  }
+
+  func testGivenNFCId_WhenIndividualMode_ThenRaw() {
+    XCTAssertEqual(
+      DebugRedaction.physicalUnblockNFCTagIdForDisplay("ABCDEF12", mode: .individual),
+      "ABCDEF12"
+    )
+  }
+}

--- a/FoqosTests/FamilyMemberLogRedactionTests.swift
+++ b/FoqosTests/FamilyMemberLogRedactionTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class FamilyMemberLogRedactionTests: XCTestCase {
+  func testGivenMember_WhenRedactedLogLabel_ThenIsUUIDAndContainsNoName() {
+    let id = UUID()
+    let member = FamilyMember(
+      id: id,
+      userRecordName: "urn_abc",
+      displayName: "Emma",
+      role: .child
+    )
+
+    XCTAssertEqual(member.redactedLogLabel, id.uuidString)
+    XCTAssertFalse(member.redactedLogLabel.contains("Emma"), "must not leak displayName")
+  }
+}

--- a/FoqosTests/LiveActivityManagerTests.swift
+++ b/FoqosTests/LiveActivityManagerTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import XCTest
+
+@testable import FamilyFoqos
+
+final class LiveActivityManagerTests: XCTestCase {
+  func testGivenNoActivityAndEnabled_WhenDecide_ThenStart() {
+    XCTAssertEqual(
+      LiveActivityManager.decideAction(
+        currentProfileId: nil,
+        incomingProfileId: UUID(),
+        enableLiveActivity: true,
+        hasCurrentActivity: false
+      ),
+      .start
+    )
+  }
+
+  func testGivenNoActivityAndDisabled_WhenDecide_ThenSkip() {
+    XCTAssertEqual(
+      LiveActivityManager.decideAction(
+        currentProfileId: nil,
+        incomingProfileId: UUID(),
+        enableLiveActivity: false,
+        hasCurrentActivity: false
+      ),
+      .skip
+    )
+  }
+
+  func testGivenActivityForSameProfileEnabled_WhenDecide_ThenUpdate() {
+    let profileId = UUID()
+
+    XCTAssertEqual(
+      LiveActivityManager.decideAction(
+        currentProfileId: profileId,
+        incomingProfileId: profileId,
+        enableLiveActivity: true,
+        hasCurrentActivity: true
+      ),
+      .update
+    )
+  }
+
+  func testGivenActivityForDifferentProfileEnabled_WhenDecide_ThenRecreate() {
+    XCTAssertEqual(
+      LiveActivityManager.decideAction(
+        currentProfileId: UUID(),
+        incomingProfileId: UUID(),
+        enableLiveActivity: true,
+        hasCurrentActivity: true
+      ),
+      .recreate
+    )
+  }
+
+  func testGivenActivityForDifferentProfileDisabled_WhenDecide_ThenEnd() {
+    XCTAssertEqual(
+      LiveActivityManager.decideAction(
+        currentProfileId: UUID(),
+        incomingProfileId: UUID(),
+        enableLiveActivity: false,
+        hasCurrentActivity: true
+      ),
+      .end
+    )
+  }
+
+  func testGivenActivityForSameProfileDisabled_WhenDecide_ThenEnd() {
+    let profileId = UUID()
+
+    XCTAssertEqual(
+      LiveActivityManager.decideAction(
+        currentProfileId: profileId,
+        incomingProfileId: profileId,
+        enableLiveActivity: false,
+        hasCurrentActivity: true
+      ),
+      .end
+    )
+  }
+
+  func testGivenActivityButUnknownProfileEnabled_WhenDecide_ThenRecreate() {
+    XCTAssertEqual(
+      LiveActivityManager.decideAction(
+        currentProfileId: nil,
+        incomingProfileId: UUID(),
+        enableLiveActivity: true,
+        hasCurrentActivity: true
+      ),
+      .recreate
+    )
+  }
+
+  func testGivenActivityButUnknownProfileDisabled_WhenDecide_ThenEnd() {
+    XCTAssertEqual(
+      LiveActivityManager.decideAction(
+        currentProfileId: nil,
+        incomingProfileId: UUID(),
+        enableLiveActivity: false,
+        hasCurrentActivity: true
+      ),
+      .end
+    )
+  }
+}

--- a/FoqosTests/LogFileEnumerationTests.swift
+++ b/FoqosTests/LogFileEnumerationTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class LogFileEnumerationTests: XCTestCase {
+  func testGivenMainAppBundleId_WhenLogBaseName_ThenApp() {
+    XCTAssertEqual(Log.logBaseName(forBundleIdentifier: "com.cynexia.family-foqos"), "app")
+  }
+
+  func testGivenMonitorBundleId_WhenLogBaseName_ThenMonitor() {
+    XCTAssertEqual(
+      Log.logBaseName(forBundleIdentifier: "com.cynexia.family-foqos.FoqosDeviceMonitor"),
+      "monitor"
+    )
+  }
+
+  func testGivenWidgetBundleId_WhenLogBaseName_ThenWidget() {
+    XCTAssertEqual(
+      Log.logBaseName(forBundleIdentifier: "com.cynexia.family-foqos.FoqosWidget"),
+      "widget"
+    )
+  }
+
+  func testGivenShieldBundleId_WhenLogBaseName_ThenShield() {
+    XCTAssertEqual(
+      Log.logBaseName(forBundleIdentifier: "com.cynexia.family-foqos.FoqosShieldConfig"),
+      "shield"
+    )
+  }
+
+  func testGivenUnknownBundleId_WhenLogBaseName_ThenSanitizedAndDistinct() {
+    let tag = Log.logBaseName(forBundleIdentifier: "com.cynexia.family-FoqosTests")
+
+    XCTAssertNotEqual(tag, "app")
+    XCTAssertFalse(tag.contains("."))
+    XCTAssertEqual(tag, "com-cynexia-family-foqostests")
+  }
+
+  func testGivenNilBundleId_WhenLogBaseName_ThenApp() {
+    XCTAssertEqual(Log.logBaseName(forBundleIdentifier: nil), "app")
+  }
+
+  func testGivenMultiProcessFiles_WhenEnumerating_ThenAllIncludedLegacyExcluded() throws {
+    let fileManager = FileManager.default
+    let dir = fileManager.temporaryDirectory.appendingPathComponent("LogEnum-\(UUID().uuidString)")
+    try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+    defer { try? fileManager.removeItem(at: dir) }
+
+    let expected = ["foqos-app.log", "foqos-monitor.log", "foqos-monitor.1.log"]
+    for name in expected {
+      try "x".write(to: dir.appendingPathComponent(name), atomically: true, encoding: .utf8)
+    }
+    try "x".write(to: dir.appendingPathComponent("foqos.log"), atomically: true, encoding: .utf8)
+    try "x".write(to: dir.appendingPathComponent("notes.txt"), atomically: true, encoding: .utf8)
+
+    let names = Set(
+      Log.allLogFileURLs(inDirectory: dir, using: fileManager).map(\.lastPathComponent))
+    XCTAssertEqual(names, Set(expected))
+  }
+
+  func testGivenTwoProcessCurrentFiles_WhenStagingName_ThenDistinct() {
+    let app = URL(fileURLWithPath: "/tmp/foqos-app.log")
+    let monitor = URL(fileURLWithPath: "/tmp/foqos-monitor.log")
+
+    XCTAssertEqual(Log.stagingDestinationName(for: app), "foqos-app.log")
+    XCTAssertNotEqual(Log.stagingDestinationName(for: app), Log.stagingDestinationName(for: monitor))
+  }
+}

--- a/FoqosTests/LogTailTests.swift
+++ b/FoqosTests/LogTailTests.swift
@@ -122,4 +122,25 @@ final class LogTailTests: XCTestCase {
     }
     XCTAssertTrue(hasMarker, "Copied files should contain the logged marker")
   }
+
+  func testGivenDestinationCollision_WhenCopyingToStaging_ThenThrows() throws {
+    let marker = "COPY_COLLISION_TEST_\(UUID().uuidString)"
+    Log.info(marker, category: .app)
+
+    guard let source = Log.shared.getLogFileURLs().first else {
+      XCTFail("Expected at least one log file")
+      return
+    }
+
+    let stagingDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("LogCopyCollisionTest-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(
+      at: stagingDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: stagingDir) }
+
+    let collision = stagingDir.appendingPathComponent(Log.stagingDestinationName(for: source))
+    try "existing".write(to: collision, atomically: true, encoding: .utf8)
+
+    XCTAssertThrowsError(try Log.shared.copyLogFilesToStagingDirectory(stagingDir))
+  }
 }

--- a/FoqosTests/ParentResetCommandStatusTests.swift
+++ b/FoqosTests/ParentResetCommandStatusTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class ParentResetCommandStatusTests: XCTestCase {
+  func testAfterSuccessfulSave_IsAwaitingChild_NotConfirmed() {
+    XCTAssertEqual(ParentResetCommandStatus.afterSuccessfulSave, .awaitingChild)
+    XCTAssertNotEqual(ParentResetCommandStatus.afterSuccessfulSave, .confirmed)
+  }
+
+  func testConfirmationProbe_StillPending_IsAwaitingChild() {
+    XCTAssertEqual(
+      ParentResetCommandStatus.afterConfirmationProbe(commandStillPending: true),
+      .awaitingChild
+    )
+  }
+
+  func testConfirmationProbe_Gone_IsConfirmed() {
+    XCTAssertEqual(
+      ParentResetCommandStatus.afterConfirmationProbe(commandStillPending: false),
+      .confirmed
+    )
+  }
+
+  func testDisplayText_Awaiting_IsHonestAndNotSuccess() {
+    XCTAssertEqual(
+      ParentResetCommandStatus.awaitingChild.displayText,
+      "Sent — waiting for child to confirm"
+    )
+    XCTAssertFalse(
+      ParentResetCommandStatus.awaitingChild.displayText!.lowercased().contains("success"),
+      "must not claim success at save time (#331a)"
+    )
+  }
+
+  func testDisplayText_Confirmed_AndIdle() {
+    XCTAssertEqual(ParentResetCommandStatus.confirmed.displayText, "Confirmed by child")
+    XCTAssertNil(ParentResetCommandStatus.idle.displayText)
+  }
+}

--- a/FoqosTests/ScheduleTimerActivityTests.swift
+++ b/FoqosTests/ScheduleTimerActivityTests.swift
@@ -1,5 +1,14 @@
+import DeviceActivity
 import FoqosShared
 import XCTest
+
+private final class ReloadSpy: @unchecked Sendable {
+  private(set) var count = 0
+
+  func fire() {
+    count += 1
+  }
+}
 
 final class ScheduleTimerActivityTests: XCTestCase {
   private var suiteName: String!
@@ -196,5 +205,35 @@ final class ScheduleTimerActivityTests: XCTestCase {
     XCTAssertNil(
       SharedData.getActiveSharedSession(),
       "legacy branch must suppress a window already stopped this window (#229)")
+  }
+
+  func testGivenStartFunnelWithNoSnapshot_WhenInvoked_ThenWidgetReloadFiredOnce() {
+    let original = TimerActivityUtil.reloadWidgets
+    defer { TimerActivityUtil.reloadWidgets = original }
+    let spy = ReloadSpy()
+    TimerActivityUtil.reloadWidgets = { spy.fire() }
+
+    let activity = DeviceActivityName(
+      rawValue: "\(ScheduleTimerActivity.id):\(UUID().uuidString)")
+    TimerActivityUtil.startTimerActivity(for: activity)
+
+    XCTAssertEqual(
+      spy.count,
+      1,
+      "each start funnel must request exactly one widget reload (#238)"
+    )
+  }
+
+  func testGivenStopFunnelWithNoSnapshot_WhenInvoked_ThenWidgetReloadFiredOnce() {
+    let original = TimerActivityUtil.reloadWidgets
+    defer { TimerActivityUtil.reloadWidgets = original }
+    let spy = ReloadSpy()
+    TimerActivityUtil.reloadWidgets = { spy.fire() }
+
+    let activity = DeviceActivityName(
+      rawValue: "\(ScheduleTimerActivity.id):\(UUID().uuidString)")
+    TimerActivityUtil.stopTimerActivity(for: activity)
+
+    XCTAssertEqual(spy.count, 1)
   }
 }

--- a/Packages/FoqosShared/Sources/FoqosShared/Log.swift
+++ b/Packages/FoqosShared/Sources/FoqosShared/Log.swift
@@ -351,15 +351,26 @@ public final class Log: @unchecked Sendable {  // SAFETY: entries/file I/O prote
   /// not provide an all-or-nothing filesystem transaction if a copy fails.
   /// - Parameter stagingDir: Destination directory (must already exist).
   public func copyLogFilesToStagingDirectory(_ stagingDir: URL) throws {
-    queue.sync {
+    try queue.sync {
       let urls = _getLogFileURLsUnsafe()
       for url in urls {
         let destURL = stagingDir.appendingPathComponent(Self.stagingDestinationName(for: url))
-        // #250 best-effort: sibling processes can rotate/remove their own files between
-        // enumeration and copy. Skip a vanished file rather than abort the whole export.
-        try? fileManager.copyItem(at: url, to: destURL)
+        do {
+          try fileManager.copyItem(at: url, to: destURL)
+        } catch {
+          // #250 best-effort only for sibling-process rotation/removal races. Other copy
+          // failures mean the export is incomplete for a real reason and should surface.
+          guard Self.isVanishedSourceCopyError(error) else { throw error }
+        }
       }
     }
+  }
+
+  private static func isVanishedSourceCopyError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    guard nsError.domain == NSCocoaErrorDomain else { return false }
+    let code = CocoaError.Code(rawValue: nsError.code)
+    return code == .fileNoSuchFile || code == .fileReadNoSuchFile
   }
 
   /// Get combined log content as a string

--- a/Packages/FoqosShared/Sources/FoqosShared/Log.swift
+++ b/Packages/FoqosShared/Sources/FoqosShared/Log.swift
@@ -103,14 +103,67 @@ public final class Log: @unchecked Sendable {  // SAFETY: entries/file I/O prote
   /// Whether to persist logs to file
   public let fileLoggingEnabled: Bool = true
 
-  private var logDirectory: URL? {
+  // MARK: - Per-process log file naming (#250)
+
+  public static let appGroupIdentifier = "group.com.cynexia.family-foqos"
+  private static let processLogTag = logBaseName(forBundleIdentifier: Bundle.main.bundleIdentifier)
+
+  /// #250: a distinct per-process basename tag so app/extensions never write to the same file.
+  public static func logBaseName(forBundleIdentifier bundleID: String?) -> String {
+    guard let bundleID, !bundleID.isEmpty else { return "app" }
+    if bundleID.hasSuffix(".FoqosDeviceMonitor") { return "monitor" }
+    if bundleID.hasSuffix(".FoqosWidget") { return "widget" }
+    if bundleID.hasSuffix(".FoqosShieldConfig") { return "shield" }
+    if bundleID == "com.cynexia.family-foqos" { return "app" }
+    return bundleID.lowercased()
+      .replacingOccurrences(of: ".", with: "-")
+      .replacingOccurrences(of: "_", with: "-")
+      .replacingOccurrences(of: "/", with: "-")
+  }
+
+  /// #250: every per-process log file in the shared directory, newest-first with a stable tie-break.
+  public static func allLogFileURLs(inDirectory dir: URL, using fileManager: FileManager) -> [URL] {
     guard
-      let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-        .first
-    else {
+      let entries = try? fileManager.contentsOfDirectory(
+        at: dir, includingPropertiesForKeys: [.contentModificationDateKey])
+    else { return [] }
+
+    let logFiles = entries.filter {
+      $0.lastPathComponent.hasPrefix("foqos-") && $0.pathExtension == "log"
+    }
+    return logFiles.sorted { lhs, rhs in
+      let lhsDate =
+        (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+        ?? .distantPast
+      let rhsDate =
+        (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+        ?? .distantPast
+      if lhsDate != rhsDate { return lhsDate > rhsDate }
+      return lhs.lastPathComponent < rhs.lastPathComponent
+    }
+  }
+
+  /// #250: staging destination name = already-unique per-process basename.
+  public static func stagingDestinationName(for fileURL: URL) -> String {
+    fileURL.lastPathComponent
+  }
+
+  private var logDirectory: URL? {
+    let baseDir: URL
+    if let container = fileManager.containerURL(
+      forSecurityApplicationGroupIdentifier: Self.appGroupIdentifier)
+    {
+      baseDir = container
+    } else if let appSupport = fileManager.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first {
+      baseDir = appSupport
+    } else {
       return nil
     }
-    let logsDir = appSupport.appendingPathComponent("Logs", isDirectory: true)
+
+    let logsDir = baseDir.appendingPathComponent("Logs", isDirectory: true)
     if !fileManager.fileExists(atPath: logsDir.path) {
       try? fileManager.createDirectory(at: logsDir, withIntermediateDirectories: true)
     }
@@ -118,7 +171,7 @@ public final class Log: @unchecked Sendable {  // SAFETY: entries/file I/O prote
   }
 
   private var currentLogFile: URL? {
-    logDirectory?.appendingPathComponent("foqos.log")
+    logDirectory?.appendingPathComponent("foqos-\(Self.processLogTag).log")
   }
 
   private init() {
@@ -249,11 +302,12 @@ public final class Log: @unchecked Sendable {  // SAFETY: entries/file I/O prote
 
   private func rotateLogFiles() {
     guard let logDir = logDirectory, let currentFile = currentLogFile else { return }
+    let tag = Self.processLogTag
 
     // Remove oldest if at max
     for i in stride(from: maxLogFiles - 1, through: 1, by: -1) {
-      let oldFile = logDir.appendingPathComponent("foqos.\(i).log")
-      let newFile = logDir.appendingPathComponent("foqos.\(i + 1).log")
+      let oldFile = logDir.appendingPathComponent("foqos-\(tag).\(i).log")
+      let newFile = logDir.appendingPathComponent("foqos-\(tag).\(i + 1).log")
       if fileManager.fileExists(atPath: oldFile.path) {
         if i == maxLogFiles - 1 {
           try? fileManager.removeItem(at: oldFile)
@@ -264,7 +318,7 @@ public final class Log: @unchecked Sendable {  // SAFETY: entries/file I/O prote
     }
 
     // Move current to .1
-    let rotatedFile = logDir.appendingPathComponent("foqos.1.log")
+    let rotatedFile = logDir.appendingPathComponent("foqos-\(tag).1.log")
     try? fileManager.moveItem(at: currentFile, to: rotatedFile)
   }
 
@@ -280,24 +334,11 @@ public final class Log: @unchecked Sendable {  // SAFETY: entries/file I/O prote
     return queue.sync { entries }
   }
 
-  /// Get all log file URLs — MUST be called from within `queue` (or `queue.sync`)
+  /// Get all log file URLs (every process's files in the shared container) — MUST be called from
+  /// within `queue` (or `queue.sync`).
   private func _getLogFileURLsUnsafe() -> [URL] {
     guard let logDir = logDirectory else { return [] }
-
-    var urls: [URL] = []
-
-    if let currentFile = currentLogFile, fileManager.fileExists(atPath: currentFile.path) {
-      urls.append(currentFile)
-    }
-
-    for i in 1..<maxLogFiles {
-      let rotatedFile = logDir.appendingPathComponent("foqos.\(i).log")
-      if fileManager.fileExists(atPath: rotatedFile.path) {
-        urls.append(rotatedFile)
-      }
-    }
-
-    return urls
+    return Self.allLogFileURLs(inDirectory: logDir, using: fileManager)
   }
 
   /// Get all log file URLs for export (thread-safe)
@@ -309,14 +350,14 @@ public final class Log: @unchecked Sendable {  // SAFETY: entries/file I/O prote
   /// Runs within the serial queue so no rotation can occur mid-copy, but does
   /// not provide an all-or-nothing filesystem transaction if a copy fails.
   /// - Parameter stagingDir: Destination directory (must already exist).
-  /// - Throws: If any file copy fails.
   public func copyLogFilesToStagingDirectory(_ stagingDir: URL) throws {
-    try queue.sync {
+    queue.sync {
       let urls = _getLogFileURLsUnsafe()
-      for (index, url) in urls.enumerated() {
-        let destName = index == 0 ? "foqos-current.log" : "foqos-\(index).log"
-        let destURL = stagingDir.appendingPathComponent(destName)
-        try fileManager.copyItem(at: url, to: destURL)
+      for url in urls {
+        let destURL = stagingDir.appendingPathComponent(Self.stagingDestinationName(for: url))
+        // #250 best-effort: sibling processes can rotate/remove their own files between
+        // enumeration and copy. Skip a vanished file rather than abort the whole export.
+        try? fileManager.copyItem(at: url, to: destURL)
       }
     }
   }

--- a/Packages/FoqosShared/Sources/FoqosShared/Timers/TimerActivityUtil.swift
+++ b/Packages/FoqosShared/Sources/FoqosShared/Timers/TimerActivityUtil.swift
@@ -1,7 +1,16 @@
 import DeviceActivity
+import WidgetKit
 
 public class TimerActivityUtil {
+  /// #238: reload the home-screen widget after every scheduled interval event. Overridable in
+  /// tests; the default reloads the whole ProfileControlWidget kind across all profiles.
+  public nonisolated(unsafe) static var reloadWidgets: @Sendable () -> Void = {
+    WidgetCenter.shared.reloadTimelines(ofKind: "ProfileControlWidget")
+  }
+
   public static func startTimerActivity(for activity: DeviceActivityName) {
+    defer { Self.reloadWidgets() }
+
     let parts = getTimerParts(from: activity)
 
     guard let timerActivity = getTimerActivity(for: parts.deviceActivityId),
@@ -14,6 +23,8 @@ public class TimerActivityUtil {
   }
 
   public static func stopTimerActivity(for activity: DeviceActivityName) {
+    defer { Self.reloadWidgets() }
+
     let parts = getTimerParts(from: activity)
 
     guard let timerActivity = getTimerActivity(for: parts.deviceActivityId),

--- a/Packages/FoqosShared/Sources/FoqosShared/Timers/TimerActivityUtil.swift
+++ b/Packages/FoqosShared/Sources/FoqosShared/Timers/TimerActivityUtil.swift
@@ -1,12 +1,9 @@
 import DeviceActivity
-import WidgetKit
 
 public class TimerActivityUtil {
   /// #238: reload the home-screen widget after every scheduled interval event. Overridable in
-  /// tests; the default reloads the whole ProfileControlWidget kind across all profiles.
-  public nonisolated(unsafe) static var reloadWidgets: @Sendable () -> Void = {
-    WidgetCenter.shared.reloadTimelines(ofKind: "ProfileControlWidget")
-  }
+  /// tests and configured by the monitor extension so FoqosShared does not link WidgetKit.
+  public nonisolated(unsafe) static var reloadWidgets: @Sendable () -> Void = {}
 
   public static func startTimerActivity(for activity: DeviceActivityName) {
     defer { Self.reloadWidgets() }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Family Foqos adds:
 But still has all these features from the original Foqos app:
 
 - **🏷️ NFC & QR Blocking**: Start or stop sessions with a quick tag tap or QR scan
-- **🧩 Mix & Match Strategies**: Manual, NFC, QR, NFC + Manual, QR + Manual, NFC + Timer, QR + Timer
+- **🧩 Start Triggers & Stop Conditions**: Mix and match how each profile *starts* (manual, NFC, QR, schedule, deep link) and how it *stops* (manual, timer, NFC, QR, schedule, deep link) — no fixed "strategy" to pick
 - **⏱️ Timer-Based Blocking**: Block for a set duration, then unblock with NFC or QR
 - **🔐 Physical Unblock**: Optionally require a specific tag or code to stop
 - **📱 Profiles for Life**: Create profiles for work, study, sleep — whatever you need
@@ -112,48 +112,55 @@ family-foqos/
 - **WidgetKit** — Home Screen widgets
 - **App Intents** — Shortcuts and automation
 
-## 🔒 Blocking Strategies
+## 🔒 Start Triggers & Stop Conditions
 
-All strategies live in `Foqos/Models/Strategies/` and are orchestrated by `Foqos/Utils/StrategyManager.swift`.
+A profile in Family Foqos (schema v2) is configured by two independent value types — **how it
+starts** and **how it stops** — rather than by picking a single "strategy". Both are stored as
+JSON on the profile (`startTriggersData` / `stopConditionsData` in
+`Foqos/Models/BlockedProfiles.swift`) and surfaced through the computed `startTriggers` /
+`stopConditions` properties.
 
-- **NFC Tags (`NFCBlockingStrategy`)**
+### Start triggers (`Foqos/Models/ProfileStartTriggers.swift`)
 
-  - Start: scan any NFC tag to start the selected profile
-  - Stop: scan the same tag to stop the session
-  - **Physical Unblock (optional)**: set `physicalUnblockNFCTagId` on a profile to require that exact tag to stop (ignores the session's start tag)
+Any combination of:
 
-- **QR Codes (`QRCodeBlockingStrategy`)**
+- `manual` — start from within the app
+- `anyNFC` — start by scanning any NFC tag
+- `specificNFC` — start only by scanning the tag stored in `startNFCTagId`
+- `anyQR` — start by scanning any QR code
+- `specificQR` — start only by scanning the code stored in `startQRCodeId`
+- `schedule` — start automatically on the profile's schedule
+- `deepLink` — start via the profile's deep link (see below)
 
-  - Start: scan any QR code to start the selected profile
-  - Stop: scan the same QR code to stop the session
-  - **Physical Unblock (optional)**: set `physicalUnblockQRCodeId` on a profile to require that exact code to stop (ignores the session's start code)
-  - The app can display/share a QR representing the profile's deep link using `QRCodeView`
+Helpers: `hasNFC` (any NFC start), `hasQR` (any QR start), `isValid` (at least one trigger set).
 
-- **Manual (`ManualBlockingStrategy`)**
+### Stop conditions (`Packages/FoqosShared/Sources/FoqosShared/ProfileStopConditions.swift`)
 
-  - Start/Stop entirely from within the app (no external tag/code required)
+Any combination of:
 
-- **NFC + Manual (`NFCManualBlockingStrategy`)**
+- `manual` — stop from within the app
+- `timer` — stop automatically after a chosen duration
+- `anyNFC` — stop by scanning any NFC tag
+- `sameNFC` — stop only by scanning the same tag that started the session
+- `specificNFC` — stop only by scanning the tag stored in `stopNFCTagId`
+- `anyQR` / `sameQR` / `specificQR` — the QR-code equivalents (`stopQRCodeId` holds the specific code)
+- `schedule` — stop automatically on the profile's schedule
+- `deepLink` — stop via the profile's deep link
 
-  - Start: manually from within the app
-  - Stop: scan any NFC tag (restricted to `physicalUnblockNFCTagId` if set)
+Helpers: `isValid`, `hasNFC`, `hasQR`, `requiresPhysicalItemOnly` (true when the only way to stop
+is a physical tag/code — used to warn the user before they start).
 
-- **QR + Manual (`QRManualBlockingStrategy`)**
+The specific-item IDs `startNFCTagId` / `startQRCodeId` / `stopNFCTagId` / `stopQRCodeId`
+supersede the legacy `physicalUnblockNFCTagId` / `physicalUnblockQRCodeId` fields.
 
-  - Start: manually from within the app
-  - Stop: scan any QR code (restricted to `physicalUnblockQRCodeId` if set)
-
-- **NFC + Timer (`NFCTimerBlockingStrategy`)** ⏱️
-
-  - Start: select a duration (timer) from within the app
-  - Stop: scan any NFC tag to end early (restricted to `physicalUnblockNFCTagId` if set)
-  - Perfect for time-boxed focus sessions with a physical exit mechanism
-
-- **QR + Timer (`QRTimerBlockingStrategy`)** ⏱️
-
-  - Start: select a duration (timer) from within the app
-  - Stop: scan any QR code to end early (restricted to `physicalUnblockQRCodeId` if set)
-  - Perfect for time-boxed focus sessions with a physical exit mechanism
+> **Legacy V1 strategy classes.** The classes in `Foqos/Models/Strategies/` (`NFCBlockingStrategy`,
+> `QRCodeBlockingStrategy`, `ManualBlockingStrategy`, `NFCManualBlockingStrategy`,
+> `QRManualBlockingStrategy`, `NFCTimerBlockingStrategy`, `QRTimerBlockingStrategy`, …) and the
+> `physicalUnblock*` fields exist **only** to execute unmigrated V1 profiles and to sync with V1
+> devices; V1 profiles are resolved to start/stop actions via
+> `Foqos/Utils/StartStopActionResolver.swift`. V2 profiles carry `profileSchemaVersion == 2` and
+> leave `blockingStrategyId` unset — there is no strategy-picker UI. (Removal of the legacy
+> `blockingStrategyId` system is tracked in #59.)
 
 ### QR deep links
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="./Foqos/Assets.xcassets/AppIcon.appiconset/AppIcon~ios-marketing.png" width="250" style="border-radius: 40px;">
 </p>
 
-<h1 align="center"><a href="TODO">Family Foqos</a></h1>
+<h1 align="center"><a href="https://github.com/mnbf9rca/family-foqos">Family Foqos</a></h1>
 
 <p align="center">
   <strong>Focus, the physical way</strong>
@@ -36,7 +36,7 @@ But still has all these features from the original Foqos app:
 
 ## 📋 Requirements
 
-- iOS 17.6+
+- iOS 18.6+
 - iPhone with NFC capability (for NFC features)
 - Screen Time permissions (for app blocking)
 
@@ -44,7 +44,7 @@ But still has all these features from the original Foqos app:
 
 ### From the App Store
 
-1. Download Foqos from the [App Store](TODO)
+1. Family Foqos is not yet published on the App Store — build it from source (see the Development section below)
 2. Grant Screen Time permissions when prompted
 3. Create your first blocking profile
 4. Optionally set up NFC tags or a QR code and start focusing
@@ -71,9 +71,9 @@ But still has all these features from the original Foqos app:
 
 ### Prerequisites
 
-- Xcode 15.0+
-- iOS 17.0+ SDK
-- Swift 5.9+
+- Xcode 16.0+
+- iOS 18.6+ SDK
+- Swift 6.0
 - Apple Developer Account (for Screen Time and NFC entitlements)
 
 ### Building the Project
@@ -202,7 +202,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🔗 Links
 
-- [App Store](TODO)
+- App Store — not yet published (build from source via the GitHub repo above)
 - [GitHub Issues](https://github.com/mnbf9rca/family-foqos/issues)
 - [Donate to Common Sense Media](https://www.commonsensemedia.org/donate)
 


### PR DESCRIPTION
## Summary

Implements the tail bundle H -> G -> #331 -> J1 + #240 on one branch, plus the approved PR #347 review round:

- Redacts family-member names/emails from exportable logs and moves logs into app-group per-process files.
- Makes log export copy failures proportionate: source-vanished rotation races are skipped, exceptional copy failures are surfaced.
- Masks child Debug Mode physical-unblock credentials by form: NFC UIDs are masked; QR values that are exactly 64 lowercase hex characters are treated as visible digests; legacy QR plaintext values are masked with the same masked-middle rule.
- Reloads `ProfileControlWidget` timelines from DeviceActivity interval funnels while keeping `WidgetKit` out of `FoqosShared`.
- Recreates Live Activities on profile switch and ends stale activities when the switched-in profile disables Live Activity.
- Makes parent reset-command UI honest for older-version children: save success now means waiting, confirmation requires child deletion of the command record.
- Updates README requirements/link prose and V2 start-trigger/stop-condition docs.
- Replaces the #240 lock-code hashing TODO with the calibrated low-stakes-secret threat-model comment.

Fixes #252
Fixes #247
Fixes #250
Fixes #238
Fixes #249
Fixes #331
Fixes #253
Fixes #254
Fixes #240

## Deviations / notes

- #247 follows the amended 2026-07-14 issue-body ruling: child mode masks `physicalUnblockNFCTagId`; QR values are visible only when they are exactly 64 lowercase hex digest strings, while legacy plaintext QR values use the same masked-middle credential treatment.
- #238 review fix keeps `TimerActivityUtil.reloadWidgets` as the shared seam but moves the `WidgetCenter` adapter to the monitor extension so `FoqosShared` does not import `WidgetKit`.
- #331 review feedback about hydrating pending reset status after card recreation was rejected for this PR; the live card remains visibly `Sent — waiting for child to confirm`, and rehydration is a separate future enhancement.
- J1 is docs prose, so acceptance is grep/self-review against project settings and models rather than unit tests.
- #240 is comment-only; no hashing/KDF/gating/schema/sync behavior changed.

## Review round

- `6b0bee2` `fix(#250): surface exceptional log export copy failures`
- `73460c7` `fix(#238): keep WidgetKit out of shared timer package`
- `3376081` `fix(#247): mask legacy QR debug credentials in child mode`

All five inline review threads were replied to and resolved. General Sourcery feedback was answered with the log-export fix and the #331 rehydration rejection rationale.

## Verification

- Focused tests: `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -only-testing:FoqosTests/DebugRedactionTests -only-testing:FoqosTests/LogTailTests -only-testing:FoqosTests/ScheduleTimerActivityTests | xcpretty` -> passed.
- Full suite: `xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=B9E4A679-BDF3-4541-A59F-DA4BE21F80ED' -resultBundlePath /tmp/family-foqos-pr347-review-r1.xcresult | xcpretty` -> passed.
- `.xcresult` metrics: 1076 total, 1076 passed, 0 failed, 0 skipped, result `Passed`.
- `swift-format lint --recursive .` -> passed.
- `scripts/check-sync-guards.sh` -> passed.

## Pending — maintainer device pass

- #247 Debug Mode: on a child device, verify NFC UID masks as first2/last2 or constant mask under 8 chars; verify 64-lowercase-hex QR digests remain visible; verify legacy/plaintext QR values are masked; verify parent/individual still show raw values.
- #250 log export: on device, produce app + monitor extension logs, export logs, verify `foqos-app.log` and `foqos-monitor.log` are included with no collisions and exceptional copy failures surface.
- #238 widget: with app force-quit, let scheduled start/stop intervals fire and verify `ProfileControlWidget` refreshes without launching app.
- #249 Live Activity: switch manual -> scheduled and scheduled -> manual profiles; verify banner shows the new profile name, and a switched-in disabled profile ends the banner.
- #331 mixed-version dashboard: V2 parent + V1 child shows honest empty Device Status copy and reset stays `Sent — waiting for child to confirm`; V2 child positive path flips to `Confirmed by child` after command processing/deletion.