### PR TITLE
plans the fix for #348, #349, #350, #351, #352, #353

### DIFF
--- a/docs/superpowers/plans/2026-07-14-263-composition-fixes-348-353.md
+++ b/docs/superpowers/plans/2026-07-14-263-composition-fixes-348-353.md
@@ -1,0 +1,734 @@
+# Composition-Fixes Bundle (#348–#353) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the six cross-PR composition defects the 2026-07-13 fix-composition sweep found on `main`, in one branch / one PR (the F+I pattern), each fix independently TDD'd.
+
+**Architecture:** Six independent mini-fixes, ordered #348 (HIGH) first. Each rides an existing seam rather than inventing new machinery: #348 mirrors the editor's remote-active guard into the list delete; #349 prunes the durable remote-active set on the account-transition seams the #307 fix introduced; #350 widens the `+Cutover` enqueue guards so the paused-driverless window routes into the already-built #296 defer→drain path; #351 self-heals the app-group snapshot; #352 adds a generation-invalidating owned-reminder cancel to `DeleteCleanup`; #353 gives the remote-start apply path a deterministic newest-wins arbitration whose loser stop is *synced*.
+
+**Tech Stack:** Swift 6, SwiftUI, SwiftData, CloudKit (CKSyncEngine transport), DeviceActivity, XCTest. iOS app `FamilyFoqos.xcodeproj`, scheme `FamilyFoqos`, unit-test target `FoqosTests`.
+
+## Global Constraints
+
+- **Branch:** one feature branch off `main`, one plan-only-then-implementation PR. PR title must be **"plans the fix for #348, #349, #350, #351, #352, #353"** — never "fixes" (plan-only lands first; implementation is a separate session per the house process).
+- **Never force-commit or amend.** New commits only; `git revert` to undo.
+- **Formatting:** 2-space indent, ≤100–120 col, `swift-format` clean (pre-commit hook auto-formats staged Swift). Run `swift-format lint --recursive .` before each commit.
+- **Logging:** use `Log.<level>(_, category:)`, never `print()`. Never log lock codes / personal identifiers; profile names, UUIDs, timestamps are OK.
+- **SwiftData:** `@SafeQuery` in views (never raw `@Query`); `context.save()` after mutations.
+- **Lock-check rule:** gate on `== .child`, never `!= .parent`.
+- **Tests:** `testGivenX_WhenY_ThenZ` naming; pin time with a single `let now = Date()` per test; boot the simulator ONCE (use UUID, not device name) then run repeatedly:
+  ```bash
+  xcrun simctl list devices available | grep "iPhone 17"   # pick UUID once
+  xcrun simctl boot <UUID>
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+    -destination 'platform=iOS Simulator,id=<UUID>' -only-testing:FoqosTests/<Class> | xcpretty
+  ```
+- **Grounding baseline:** all file:line citations below are against `main` at plan-authoring (worktree `5774d0a`, PR #347 not yet merged). **Task 0 refreshes every citation** before implementation begins.
+
+---
+
+## Surfaced decisions (reviewer ratifies at PR time)
+
+| # | Decision | Chosen | Alternative considered | Type |
+|---|----------|--------|------------------------|------|
+| D1 (#353) | Cross-device session arbitration rule | **Newest-wins by `startTime`** (tie-break: `profileId` string — the only value both devices share), loser's stop **synced via the non-suppressed CAS path** | First-wins / CAS-claim (no per-user CAS primitive exists; local model has only `startTime`) | **Stated in-plan decision** (maintainer delegated the rule; not a re-litigation of the settled one-active-per-user invariant) |
+| D2 (#351) | Snapshot-orphan repair strategy | **Option B-broadened** (self-heal reconcile) + rollback re-snapshot | Option A (defer snapshot removal past commit) — rejected as disproportionate 5-site blast radius for a LOW issue | Engineering trade-off, argued below |
+| D3 (#350) | Deferred-save durability | **In-memory `deferredProfileSaveIds`** (matches the deliberate #296 save-vs-delete asymmetry) | UserDefaults-durable buffer — rejected (deletes are durable; a lost save re-heals on next edit) | Noted residual, ratifiable |
+| D4 (#348) | Copy for blocked delete | **New `.remotelyActiveProfile` case**, honest "active on another device" text | Reuse `.activeProfile` (misleading — says active *here*) | UX copy, ratifiable |
+
+None require blocking maintainer escalation: D1 was explicitly delegated to this plan; D2–D4 are ratifiable at PR review. See each task for full rationale.
+
+---
+
+## Task 0: Citation refresh (absorb PR #347 if merged)
+
+**Files:** none modified — this is a verification gate.
+
+- [ ] **Step 1: Rebase/branch from current `main`.** `git fetch origin && git checkout -b fix/263-composition-fixes origin/main`. Record the base SHA.
+- [ ] **Step 2: Re-verify every file:line in Tasks 1–6.** For each cited symbol run `grep -n` (or open the file) and confirm the line still matches the quoted code. PR #347 (tail bundle: logging/widgets/README) may have shifted line numbers in `TimerActivityUtil.swift`, `Log.swift`, and widget providers — the code identity, not the line number, is authoritative. If a cited symbol moved or changed shape, update the task's line references before implementing that task.
+- [ ] **Step 3: Confirm the six issues are still OPEN and unclaimed** (`gh issue view <n> --json state`). Confirm no other PR already touched these seams.
+- [ ] **Step 4: Boot the simulator once** (UUID, not name) and run the full `FoqosTests` suite green as the clean baseline. Record the pass count.
+
+**No commit** — this is a gate, not a change.
+
+---
+
+## Task 1: #348 — guard the list swipe-delete against remotely-active profiles (HIGH)
+
+**Problem:** #334 added the "active anywhere ⇒ locked everywhere" guard only to the editor (`BlockedProfileView.isBlocking` reads `remotelyActiveProfileIds`). The list swipe-delete guard checks only the local active session and edit-lock, so a `needsAppSelection` profile (no local session) can be swiped away while it blocks on another device — the delete syncs and tears down the enforcing device's session.
+
+**Enumeration result (grounding):** the list swipe-delete is the **only** unguarded profile-delete/edit entry point. The editor's "Delete Profile" button lives inside a `Menu` wrapped in `if !isBlocking` (hidden when remote-active); carousel/home/child-dashboard have no profile-delete action and route edits through the guarded editor; `SavedLocationsView` already ORs `remotelyActiveProfileIds`.
+
+**Files:**
+- Create: `Foqos/Utils/ProfileDeleteGate.swift`
+- Create: `FoqosTests/ProfileDeleteGateTests.swift`
+- Modify: `Foqos/Views/BlockedProfileListView.swift` (enum `DeleteError` ~:24-27; guard loop ~:171-182; add `@EnvironmentObject strategyManager`)
+
+**Interfaces:**
+- Produces: `enum ProfileDeleteGate { static func blockedReason(hasLocalActiveSession: Bool, isRemotelyActive: Bool, isEditLocked: Bool) -> DeleteBlockReason? }` where `DeleteBlockReason` is `{ case active, remotelyActive, locked }`. Pure, no SwiftData — mirrors `ProfileEditGate.editingDisabled` / `SavedLocationsView.locationsInUse`.
+
+- [ ] **Step 1: Write the failing test** — `FoqosTests/ProfileDeleteGateTests.swift`, following `ProfileEditGateTests` structure:
+
+```swift
+import XCTest
+@testable import FamilyFoqos
+
+final class ProfileDeleteGateTests: XCTestCase {
+  func testGivenRemotelyActive_WhenComputingGate_ThenBlockedRemotelyActive() {
+    XCTAssertEqual(
+      ProfileDeleteGate.blockedReason(
+        hasLocalActiveSession: false, isRemotelyActive: true, isEditLocked: false),
+      .remotelyActive)
+  }
+  func testGivenLocalActive_WhenComputingGate_ThenBlockedActive() {
+    XCTAssertEqual(
+      ProfileDeleteGate.blockedReason(
+        hasLocalActiveSession: true, isRemotelyActive: false, isEditLocked: false),
+      .active)
+  }
+  func testGivenEditLocked_WhenComputingGate_ThenBlockedLocked() {
+    XCTAssertEqual(
+      ProfileDeleteGate.blockedReason(
+        hasLocalActiveSession: false, isRemotelyActive: false, isEditLocked: true),
+      .locked)
+  }
+  func testGivenNothing_WhenComputingGate_ThenNil() {
+    XCTAssertNil(
+      ProfileDeleteGate.blockedReason(
+        hasLocalActiveSession: false, isRemotelyActive: false, isEditLocked: false))
+  }
+  func testGivenLocalActiveAndRemotelyActive_WhenComputingGate_ThenActiveWins() {
+    // Local-active precedence keeps the existing "Cannot Delete Active Profile" copy for the
+    // common case; remotely-active is the new branch that was previously unguarded.
+    XCTAssertEqual(
+      ProfileDeleteGate.blockedReason(
+        hasLocalActiveSession: true, isRemotelyActive: true, isEditLocked: false),
+      .active)
+  }
+}
+```
+
+- [ ] **Step 2: Run it — expect FAIL** (`ProfileDeleteGate` undefined). `xcodebuild test … -only-testing:FoqosTests/ProfileDeleteGateTests`.
+
+- [ ] **Step 3: Implement `Foqos/Utils/ProfileDeleteGate.swift`:**
+
+```swift
+import Foundation
+
+/// Pure decision for whether a profile delete must be blocked, mirroring `ProfileEditGate`.
+/// The list-delete guard was previously missing the remotely-active term that the editor's
+/// widened `isBlocking` already carries (#348 / #311).
+enum ProfileDeleteGate {
+  enum DeleteBlockReason: Equatable {
+    case active
+    case remotelyActive
+    case locked
+  }
+
+  static func blockedReason(
+    hasLocalActiveSession: Bool,
+    isRemotelyActive: Bool,
+    isEditLocked: Bool
+  ) -> DeleteBlockReason? {
+    if hasLocalActiveSession { return .active }
+    if isRemotelyActive { return .remotelyActive }
+    if isEditLocked { return .locked }
+    return nil
+  }
+}
+```
+
+- [ ] **Step 4: Run it — expect PASS.**
+
+- [ ] **Step 5: Wire the gate into the view.** In `Foqos/Views/BlockedProfileListView.swift`:
+  1. Add the manager (it is provided at app root `FoqosApp.swift` and the editor sheet already reads it):
+     ```swift
+     @EnvironmentObject private var strategyManager: StrategyManager
+     ```
+  2. Add a `DeleteError` case + copy (D4 — honest text):
+     ```swift
+     private enum DeleteError {
+       case activeProfile
+       case remotelyActiveProfile
+       case lockedProfile
+       case fetchFailed
+       // title:
+       //   case .remotelyActiveProfile: "Active on Another Device"
+       // message:
+       //   case .remotelyActiveProfile:
+       //     "This profile is currently blocking on another device. Stop it there before deleting."
+     }
+     ```
+     Add the matching `title` and `message` arms alongside the existing `.activeProfile` arms (~:32-33, :41).
+  3. Replace the guard loop body (currently the two `if` checks) with the gate:
+     ```swift
+     for index in offsets {
+       let profile = profilesToDelete[index]
+       let reason = ProfileDeleteGate.blockedReason(
+         hasLocalActiveSession: profile.id == activeSession?.blockedProfile.id,
+         isRemotelyActive: strategyManager.remotelyActiveProfileIds.contains(profile.id),
+         isEditLocked: lockCodeManager.isEditLocked(profile))
+       switch reason {
+       case .active: deleteError = .activeProfile; return
+       case .remotelyActive: deleteError = .remotelyActiveProfile; return
+       case .locked: deleteError = .lockedProfile; return
+       case nil: break
+       }
+     }
+     ```
+
+- [ ] **Step 6: Preview/env sanity.** Confirm every `#Preview` and call site that presents `BlockedProfileListView` supplies `StrategyManager` in the environment (grep `BlockedProfileListView(` and the previews); add `.environmentObject(StrategyManager())` to any preview that lacks it, so previews still compile.
+
+- [ ] **Step 7: Build + run `ProfileDeleteGateTests` and the full suite — expect PASS.**
+
+- [ ] **Step 8: Commit** — `git commit -m "fix(#348): block list swipe-delete of a remotely-active profile"`
+
+---
+
+## Task 2: #349 — prune the durable remote-active set on account transitions + local delete
+
+**Problem:** `RemotelyActiveStore` is a single non-namespaced global key; the set is only ever cleared per-id by a session record arriving from the *attached* account's zone. After a **Combine** account switch the kept profile's id stays in the set forever (edit disabled, delete/NFC hidden, locations undeletable). The **Switch** wipe deletes the local profiles but *also* leaves their ids orphaned. Local user-initiated delete never prunes either (unbounded growth; latent false-lock on id collision).
+
+**Files:**
+- Modify: `Foqos/Utils/RemotelyActiveStore.swift` (add `clear`)
+- Modify: `Foqos/Utils/StrategyManager.swift` (add `clearAllRemoteSessionActive()` near `setRemoteSessionActive` ~:77-84)
+- Modify: `Foqos/CloudKit/ProfileSyncManager.swift` (`resolveConflictCombine` ~:396-401; `wipeLocalSyncedDataDirectly` ~:413-435)
+- Modify: the local-delete guard block in `Foqos/Views/BlockedProfileListView.swift` and `Foqos/Views/BlockedProfileView.swift` (prune-on-delete)
+- Modify: `FoqosTests/RemotelyActiveProfilesTests.swift`; `FoqosTests/ProfileSyncAccountResolverTests.swift`
+
+**Interfaces:**
+- Produces: `RemotelyActiveStore.clear(defaults:)`; `StrategyManager.clearAllRemoteSessionActive()` (mutates the `@Published` set AND persists).
+- Consumes: `ProfileSyncManager` must reach the live `StrategyManager` — it already constructs `SyncApplyService` with `StrategyManager.shared` as `sessionController` (~:238). Use `StrategyManager.shared.clearAllRemoteSessionActive()` in the resolve paths (the same singleton the views observe).
+
+**Constraint:** the prune must be **event-scoped** (account switch / delete), never on plain relaunch — `RemotelyActiveProfilesTests` asserts the #311 invariant that active-anywhere locks survive relaunch.
+
+- [ ] **Step 1: Write the failing store test** in `RemotelyActiveProfilesTests.swift`:
+
+```swift
+func testGivenRemoteActiveIds_WhenClearAll_ThenSetEmptyAndPersistsEmpty() {
+  let manager = StrategyManager(remoteActiveDefaults: defaults)
+  manager.setRemoteSessionActive(true, profileId: idA)
+  manager.setRemoteSessionActive(true, profileId: idB)
+  XCTAssertEqual(manager.remotelyActiveProfileIds, [idA, idB])
+
+  manager.clearAllRemoteSessionActive()
+
+  XCTAssertTrue(manager.remotelyActiveProfileIds.isEmpty)
+  XCTAssertTrue(RemotelyActiveStore.load(defaults: defaults).isEmpty)  // persisted, survives reload
+}
+```
+(`idA`/`idB`/`defaults` per the file's existing suite setup — reuse its per-test `UserDefaults(suiteName:)`.)
+
+- [ ] **Step 2: Run it — expect FAIL** (`clearAllRemoteSessionActive` undefined).
+
+- [ ] **Step 3: Implement.** In `RemotelyActiveStore.swift`:
+```swift
+static func clear(defaults: UserDefaults = .standard) {
+  save([], defaults: defaults)
+}
+```
+In `StrategyManager.swift` next to `setRemoteSessionActive`:
+```swift
+/// Clear the entire remote-active set. Event-scoped (account switch / wipe) — never call on
+/// plain relaunch, which would regress the #311 "active-anywhere survives relaunch" invariant.
+func clearAllRemoteSessionActive() {
+  remotelyActiveProfileIds = []
+  RemotelyActiveStore.save(remotelyActiveProfileIds, defaults: remoteActiveDefaults)
+}
+```
+
+- [ ] **Step 4: Run store test — expect PASS.**
+
+- [ ] **Step 5: Write the failing resolve-path tests** in `ProfileSyncAccountResolverTests.swift`, extending the existing `testCombineReattachesWithForcedSeedWithoutWiping` / `testSwitchWipesLocalAndEmergencyThenReattaches` harness (`makeAttachedManager`):
+
+```swift
+func testGivenRemoteActiveId_WhenCombine_ThenRemoteActiveSetCleared() async throws {
+  StrategyManager.shared.setRemoteSessionActive(true, profileId: keptId)
+  let mgr = makeAttachedManager(/* conflict with a distinct new user */)
+  await mgr.resolveConflictCombine()
+  XCTAssertTrue(StrategyManager.shared.remotelyActiveProfileIds.isEmpty)
+}
+
+func testGivenRemoteActiveId_WhenSwitch_ThenRemoteActiveSetCleared() async throws {
+  StrategyManager.shared.setRemoteSessionActive(true, profileId: keptId)
+  let mgr = makeAttachedManager(/* conflict with a distinct new user */)
+  await mgr.resolveConflictSwitchToCloud()
+  XCTAssertTrue(StrategyManager.shared.remotelyActiveProfileIds.isEmpty)
+}
+```
+(Reset `StrategyManager.shared`'s set in `tearDown`; if the harness uses a non-shared manager, prefer injecting the same `StrategyManager` instance the resolver prunes — see Step 7 note.)
+
+- [ ] **Step 6: Run — expect FAIL** (nothing prunes yet).
+
+- [ ] **Step 7: Implement the prunes.**
+  - `resolveConflictCombine()` — before/at `reattachEngine` (~:399): add `StrategyManager.shared.clearAllRemoteSessionActive()`. Correct because after reattach the new account's zone re-asserts `setRemoteSessionActive(true)` for any genuinely-active remote session via `applySessionState` (~:660).
+  - `wipeLocalSyncedDataDirectly(...)` — alongside the existing `attachedEmergencyManager?.resetAllStateForAccountSwitch()` (~:434): add `StrategyManager.shared.clearAllRemoteSessionActive()` (all local profiles are being deleted).
+  - **Note:** `ProfileSyncManager` has no stored `StrategyManager` field; use `StrategyManager.shared` (the same singleton it already passes to `SyncApplyService` at ~:238 and that the views observe). If review prefers dependency-injection, thread the `sessionController` handle instead; either way the mutation MUST go through the live `@Published` set, not a UserDefaults-only clear, or the UI will not refresh.
+
+- [ ] **Step 8: Run — expect PASS.**
+
+- [ ] **Step 9: Stale-hygiene on local delete.** In both `BlockedProfileListView.deleteProfiles` and `BlockedProfileView`'s delete branches, after a successful local delete of a profile, call `strategyManager.setRemoteSessionActive(false, profileId: id)` to drop any stale entry. (After #348 a *remotely-active* profile can no longer be locally deleted, so this is belt-and-suspenders against a race where the remote session ends between the guard and the delete — plus it bounds set growth.) Add a small assertion in `RemotelyActiveProfilesTests` that `setRemoteSessionActive(false, …)` removes only that id.
+
+- [ ] **Step 10: Full suite — expect PASS. Verify `RemotelyActiveProfilesTests`' relaunch-persistence test still passes (no regression to #311).**
+
+- [ ] **Step 11: Commit** — `git commit -m "fix(#349): prune durable remote-active set on account switch/combine and local delete"`
+
+---
+
+## Task 3: #350 — defer profile edits made during the account-change pause instead of silently dropping them
+
+**Problem:** `prepareForAccountSwitch()` nils the controller's `driver` but leaves `funnel` and `store.engineState` intact. `MutationFunnel` holds a captured non-optional `driver`; its `add(pendingRecordZoneChanges:)` is `engine?.state.add(…)` — a **silent no-op** after `shutdown()` that throws nothing, so #296's deferred-drop net (keyed on a thrown `.notAttached`) never fires. The edit's local save commits (in `finalizeSave`, before the enqueue) but the change never enqueues; same-user resume takes the ordinary-relaunch branch and re-derives nothing.
+
+**Fix (maintainer pre-endorsed defer-durably; throw/surface rejected):** widen the `+Cutover` enqueue guards from `guard let funnel` to `guard let funnel, hasLiveDriver` so the paused-driverless window **throws `.notAttached`**, which routes into the already-built #296 catch → `deferredProfileSaveIds` → existing `drainDeferredMutations()` on resume. The controller already exposes `var hasLiveDriver: Bool { driver != nil }` (`SyncEngineController.swift:84`). The Switch wipe must **clear** the deferred sets (wiped profiles must not drain into the new account).
+
+Why this is safe & complete (grounded):
+- The local edit is already durably saved by `finalizeSave`'s `modelContext.save()` *before* the sync enqueue; the funnel's own save only additionally bumps `syncVersion`. Throwing before `funnel.enqueueSave` loses nothing locally — `syncVersion` is bumped at drain instead.
+- `finalizeSave` already has `catch SyncEngineControllingError.notAttached { Log.warning("saved locally; will sync later") }` — the throw is swallowed with no user-facing error.
+- Same-user resume (`startEngineAndMarkReadyWhenStartupCompletes` → `markSyncReadyAndFlush` → `drainDeferredMutations`) and Combine (`reattachEngine` → attach → `markSyncReadyAndFlush`) **already drain** `deferredProfileSaveIds`. No new drain code.
+- Apply the same `hasLiveDriver` term to the **delete** and **location/emergency** verbs (they share the identical silent-no-op defect during the pause). Delete verbs already have `.notAttached` local-delete fallbacks at every call site and durable `PreAttachDeleteBuffer` — gating them makes a paused-window delete behave exactly like the proven pre-attach delete.
+
+**D3 residual (ratifiable):** `deferredProfileSaveIds` is in-memory (matching the deliberate #296 asymmetry — deletes durable, saves in-memory). A process kill *during* the pause loses the deferred save; on relaunch the edit is still local but ordinary-relaunch re-derives nothing. Accepted, consistent with #296 (a lost save re-heals on the next edit; a lost delete would resurrect — hence deletes are durable). Surfaced for reviewer ratification.
+
+**Files:**
+- Modify: `Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift` (verbs at ~:36-75)
+- Modify: `Foqos/CloudKit/ProfileSyncManager.swift` (`wipeLocalSyncedDataDirectly` ~:413-435 — clear deferred sets)
+- Modify: `FoqosTests/SyncEngineControllerCutoverTests.swift`; `FoqosTests/ProfileSyncAccountResolverTests.swift`
+
+**Interfaces:**
+- Consumes: `SyncEngineController.hasLiveDriver` (`:84`), the existing `deferredProfileSaveIds`/`deferredLocationSaveIds`/emergency-deferred sets and `drainDeferredMutations()`.
+- Note (grounding surprise): the test double `CutoverRecordingDriver.shutdown()` only increments a counter and its `add(…)` keeps recording, so it does **not** reproduce the production no-op. Put the assertion at the guard (which reads the controller's genuinely-nil `driver` via `hasLiveDriver`), not inside the funnel.
+
+- [ ] **Step 1: Write the failing controller test** in `SyncEngineControllerCutoverTests.swift` (real `SyncEngineController` + real store + `CutoverRecordingDriver`, harness ~:13-46; funnel-nil-throws precedent ~:121-133):
+
+```swift
+@MainActor
+func testGivenPausedDriverlessWindow_WhenEnqueueProfileSave_ThenThrowsNotAttached() throws {
+  // `controller` is the setUp-provided instance in SyncEngineControllerCutoverTests (no
+  // `makeStartedController` helper exists — drive the instance directly).
+  controller.start()                    // funnel live, driver live
+  controller.prepareForAccountSwitch()  // nils driver, leaves funnel
+  XCTAssertThrowsError(try controller.enqueueProfileSave(UUID())) { error in
+    XCTAssertEqual(error as? SyncEngineControllingError, .notAttached)
+  }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (currently the guard passes because `funnel` is non-nil, and `funnel.enqueueSave` either no-ops on the recording driver or throws `entityNotFound` for a random id — assert specifically for `.notAttached`, which today it is not).
+
+- [ ] **Step 3: Widen the guards** in `SyncEngineController+Cutover.swift`. For each mutation verb that forwards to the funnel's `driver.add` — `enqueueProfileSave`, `enqueueProfileDelete(_:requestSyncAfterPendingDelete:)`, `enqueueLocationSave`, `enqueueLocationDelete`, `enqueueEmergencySettingsSave`, `enqueueEmergencyUnblockEvent`, `enqueueEmergencyEpochSave`, `enqueueEmergencyUnblockEventDelete` — change:
+```swift
+guard let funnel else { throw SyncEngineControllingError.notAttached }
+```
+to
+```swift
+guard let funnel, hasLiveDriver else { throw SyncEngineControllingError.notAttached }
+```
+**Do NOT** gate the drain-side sinks `enqueueDeferredDelete(recordName:)` and `recordDisabledDeleteTombstone(recordName:)` — the drain re-enters through them and must run once the driver is live again.
+
+- [ ] **Step 4: Run controller test — expect PASS.**
+
+- [ ] **Step 5: Guard the legitimate attach window.** Verify in `start()` that the driver is created before/with the funnel so normal startup never hits the widened guard; if a brief funnel-before-driver window exists, confirm `markSyncReadyAndFlush()` drains anything spuriously deferred (it does — the drain runs on every ready mark). Add a one-line comment at the guard citing #350.
+
+- [ ] **Step 6: Write the failing Switch-clears-deferred test** in `ProfileSyncAccountResolverTests.swift`:
+
+```swift
+func testGivenDeferredSaveDuringPause_WhenSwitch_ThenDeferredSetsCleared() async throws {
+  let mgr = makeAttachedManager(/* different-user conflict */)
+  mgr.pauseForTest()                       // driver nil, funnel alive (or drive via prepareForAccountSwitch)
+  _ = try? mgr.enqueueProfileSave(wipedId) // lands in deferredProfileSaveIds (throws .notAttached)
+  XCTAssertFalse(mgr.hasNoDeferredMutations)
+  await mgr.resolveConflictSwitchToCloud() // wipes local profiles
+  XCTAssertTrue(mgr.hasNoDeferredMutations) // cleared — wiped profiles must not drain to new account
+}
+```
+(Use the existing `hasNoDeferredMutations` accessor at `ProfileSyncManager.swift:80`; add a minimal `#if DEBUG pauseForTest()` seam only if the harness can't reach `prepareForAccountSwitch` — prefer driving the real path.)
+
+- [ ] **Step 7: Run — expect FAIL** (Switch does not clear the deferred sets today).
+
+- [ ] **Step 8: Clear the deferred sets on wipe.** In `wipeLocalSyncedDataDirectly(...)` (the local wipe that precedes the Switch reattach), after deleting the local entities, empty `deferredProfileSaveIds`, `deferredLocationSaveIds`, `deferredDeleteRecordNames`, `deferredEmergencySave`, `deferredEmergencyUnblockEvents`, `deferredEmergencyEpochSave` (mirror the reset block at the tail of `drainDeferredMutations()` ~:702-708). Add a `Log.debug("Cleared deferred mutations for wiped account", category: .sync)`.
+
+- [ ] **Step 9: Run — expect PASS. Add a same-user-resume DRAIN assertion** (defer during pause → `start()` restart → `deferredProfileSaveIds` drains and `hasNoDeferredMutations` becomes true) to prove capture+drain end-to-end.
+
+- [ ] **Step 10: Full suite — expect PASS.**
+
+- [ ] **Step 11: Commit** — `git commit -m "fix(#350): defer profile edits during account-change pause and clear on switch wipe"`
+
+---
+
+## Task 4: #351 — self-heal the app-group snapshot after an interrupted delete
+
+**Problem:** `deleteProfile` removes the app-group snapshot synchronously (phase 1) but defers the model-delete's `context.save()`. On a deferred-save failure (rollback restores the model) or process death in the one-runloop window, the model returns but the snapshot is gone: the profile shows in-app, is omitted from the widget, and its schedule fires without blocking (the monitor extension resolves profiles only via the snapshot). #314's reconciler re-arms the schedule for the restored profile but never re-snapshots.
+
+**D2 decision — Option B-broadened + rollback re-snapshot (argued against #289's design):**
+- **Option A** (defer snapshot removal until after the durable delete commits) is the transactionally-pure fit for #289's fail-closed discipline, but the snapshot lives in app-group `UserDefaults` — it cannot join the SwiftData transaction, and deferring its removal requires threading a post-commit snapshot-removal through **all** delete paths that call `deleteProfile` (`MutationFunnel.enqueueDelete`, `SyncApplyService`, both direct-UI paths, **and** `wipeLocalSyncedDataDirectly`'s per-profile loop) plus rewriting `DeleteProfileCleanupTests`' synchronous-ordering contract. That is a 5-site blast radius and a changed, well-depended-on `deleteProfile` contract — disproportionate for a LOW issue.
+- **Chosen:** the snapshot is *always reconstructable* from the live model via `BlockedProfiles.getSnapshot(for:)`. Honor #289's fail-closed intent with a **fail-closed self-heal**: broaden the foreground reconciler to rewrite any missing snapshot for a valid profile (decoupled from schedule-eligibility — fixes grounding's Option-B gap), and re-snapshot on the two deferred-delete rollback branches so the rare failure path heals immediately without waiting for foreground.
+- **Residual (surfaced):** a schedule could fire in the window between a process-death-during-commit and the next app foreground/launch reconcile. The issue's own severity note treats a "foreground catch-up" as an acceptable heal; the reconcile runs at launch (`FoqosApp` ~:164/:290), so the window is a rare process-death AND a schedule firing before the next launch. Strictly better than status quo (heals only on next *edit*). Reviewer ratifies.
+
+**Files:**
+- Modify: `Foqos/Utils/PreActivationReminderScheduler.swift` (add a snapshot-repair pass; reconcile loop ~:51-71)
+- Modify: `Foqos/CloudKit/SyncEngine/MutationFunnel.swift` (rollback branch ~:164-172)
+- Modify: `Foqos/CloudKit/SyncEngine/SyncApplyService.swift` (delete rollback branch ~:169+)
+- Modify: `FoqosTests/PreActivationReminderSchedulerTests.swift`; `FoqosTests/MutationFunnelTests.swift`
+
+**Interfaces:**
+- Consumes: `BlockedProfiles.getSnapshot(for:)` (`:565`), `BlockedProfiles.updateSnapshot(for:)` (`:605`), `SharedData.snapshot(for:)`, `BlockedProfiles.fetchProfiles(in:)`.
+- Produces: `PreActivationReminderScheduler.reconcileMissingSnapshots(context:snapshotExists:writeSnapshot:)` — takes a `ModelContext` and fetches+`.valid`-filters internally (matching its sibling `reconcileScheduleRegistrations(context:)` — every call site carries only a `ModelContext`, never a profiles array). The `.valid` filter is **load-bearing**, not just zombie-safety: it excludes an in-flight-deleting profile (`isDeleted`/unregistered) so the reconcile can never resurrect the snapshot of a profile whose delete is mid-commit. Do not drop it.
+
+- [ ] **Step 1: Write the failing reconcile test** in `PreActivationReminderSchedulerTests.swift` (uses `TestModelContainer.create()`, `SharedData.configure(suite:)` per `ProfileSaveSnapshotTests`):
+
+```swift
+@MainActor
+func testGivenProfileWithMissingSnapshot_WhenReconcile_ThenSnapshotRewritten() throws {
+  let profile = /* insert a valid V2 profile with selected apps */
+  try context.save()
+  SharedData.removeSnapshot(for: profile.id.uuidString)   // simulate the orphan
+  XCTAssertNil(SharedData.snapshot(for: profile.id.uuidString))
+
+  PreActivationReminderScheduler.reconcileMissingSnapshots(context: context)
+
+  XCTAssertNotNil(SharedData.snapshot(for: profile.id.uuidString))
+}
+
+@MainActor
+func testGivenDeletingProfile_WhenReconcile_ThenSnapshotNotResurrected() throws {
+  let profile = /* insert a valid V2 profile */; try context.save()
+  SharedData.removeSnapshot(for: profile.id.uuidString)
+  context.delete(profile)                                 // pending delete, not yet saved
+  PreActivationReminderScheduler.reconcileMissingSnapshots(context: context)
+  XCTAssertNil(SharedData.snapshot(for: profile.id.uuidString))  // .valid excludes isDeleted
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`reconcileMissingSnapshots` undefined).
+
+- [ ] **Step 3: Implement the repair pass** in `PreActivationReminderScheduler.swift` — take a `ModelContext` and fetch internally (its sibling `reconcileScheduleRegistrations(context:)` does exactly this; no call site holds a profiles array):
+
+```swift
+/// #351: rewrite any app-group snapshot that went missing (interrupted delete / process death).
+/// Snapshots are always reconstructable from the live model, so this is a fail-closed self-heal.
+/// Runs on the same foreground/launch cadence as `reconcileScheduleRegistrations`.
+/// `.valid` is load-bearing: it excludes an in-flight-deleting profile so a mid-commit delete's
+/// snapshot is never resurrected.
+static func reconcileMissingSnapshots(
+  context: ModelContext,
+  fetch: (ModelContext) -> [BlockedProfiles] = { (try? BlockedProfiles.fetchProfiles(in: $0)) ?? [] },
+  snapshotExists: (UUID) -> Bool = { SharedData.snapshot(for: $0.uuidString) != nil },
+  writeSnapshot: (BlockedProfiles) -> Void = { BlockedProfiles.updateSnapshot(for: $0) }
+) {
+  for profile in fetch(context).valid where !snapshotExists(profile.id) {
+    writeSnapshot(profile)
+  }
+}
+```
+Wire the call next to each `reconcileScheduleRegistrations(context:)` invocation, passing the same `context`:
+- `FoqosApp.swift` ~:164 and ~:290 (both call with `context: container.mainContext`).
+- `SyncEngineController` — `reconcileScheduleRegistrations` is invoked via the stored `scheduleReconciler: (ModelContext) -> Void` closure at `~:702` (defaulted at `~:122`). Add the snapshot reconcile in the same closure body / at the same `self.scheduleReconciler(self.modelContext)` site so it rides the same `ModelContext`.
+(`[BlockedProfiles].valid` is provided by the `@SafeQuery` array extension in `Extensions.swift`; keep it.)
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Write the failing rollback re-snapshot test** in `MutationFunnelTests.swift` (deferred-commit delete path, `awaitMainActorTurn()`): drive a deferred delete whose `saveOverride` throws, then assert `SharedData.snapshot(for: id)` is non-nil after the rollback (model restored ⇒ snapshot restored).
+
+- [ ] **Step 6: Run — expect FAIL** (rollback does not re-snapshot today).
+
+- [ ] **Step 7: Re-snapshot on rollback.** In `MutationFunnel.enqueueDelete`'s deferred-commit `catch` (~:167, after `modelContext.rollback()`) and in `SyncApplyService`'s delete rollback `catch` (after its `modelContext.rollback()`), re-read the profile by id and, if present, call `BlockedProfiles.updateSnapshot(for: profile)`:
+```swift
+modelContext.rollback()
+if let restored = try? BlockedProfiles.findProfile(byID: profileId, in: modelContext) {
+  BlockedProfiles.updateSnapshot(for: restored)   // #351: model is back; rewrite its snapshot
+}
+```
+
+- [ ] **Step 8: Run — expect PASS.**
+
+- [ ] **Step 9: Full suite — expect PASS** (`DeleteProfileCleanupTests` unchanged — `deleteProfile`'s synchronous snapshot removal is deliberately left in place; Option A was rejected).
+
+- [ ] **Step 10: Commit** — `git commit -m "fix(#351): self-heal missing profile snapshot after interrupted delete"`
+
+---
+
+## Task 5: #352 — cancel the deleted profile's owned session/break reminders
+
+**Problem:** `BlockedProfiles.DeleteCleanup` cancels pre-activation reminders + DeviceActivity artifacts but omits the #227 owned reminders (`session-reminder-<uuid>` / `break-reminder-<uuid>`). A deleted profile's come-back reminder still fires — including after the #341 account-switch wipe (old profile name under the new account, since `wipeLocalSyncedDataDirectly` runs `deleteProfile` with the same defective default cleanup).
+
+**Grounding surprise:** a bare `cancelNotification(identifier:)` for the two ids is **incomplete** — owned reminders carry durable UserDefaults ownership + per-id generation counters; without invalidating the generation, an in-flight `center.add` completion re-registers the background task. A **new targeted primitive** is required, parallel to `cancelAllPreActivationReminders`, that (per id) removes it from `ownedReminderIdentifiers`, bumps its `scheduleGenerations` entry, and removes pending + delivered requests.
+
+**Files:**
+- Modify: `Foqos/Utils/TimersUtil.swift` (new `cancelOwnedReminders(for:)` near `cancelAllPreActivationReminders` ~:203; identifiers ~:78-91; generation/ownership logic mirrors `cancelAllNotifications` ~:462-470)
+- Modify: `Foqos/Models/BlockedProfiles.swift` (`DeleteCleanup` struct ~:497-503; `defaultDeleteCleanup()` ~:505-515; invocation in `deleteProfile` ~:540-544)
+- Modify: `FoqosTests/DeleteProfileCleanupTests.swift`; `FoqosTests/TimersUtilTargetedCancelTests.swift`
+
+**Interfaces:**
+- Produces: `TimersUtil.cancelOwnedReminders(for profileId: UUID)` (static, self-contained like `cancelAllPreActivationReminders`); `DeleteCleanup.cancelSessionAndBreakReminders: (UUID) -> Void`.
+
+- [ ] **Step 1: Write the failing primitive test** in `TimersUtilTargetedCancelTests.swift` (owned-reminder suite; `setUp`/`tearDown` clear `ownedReminderIdentifiersUserDefaultsKey`; assert via `ownedReminderIdentifiersForTesting` / `isOwnedReminderScheduleCurrentForTesting`, pattern at ~:83-101):
+
+```swift
+func testGivenOwnedSessionAndBreakReminders_WhenCancelOwnedReminders_ThenRemovedAndGenerationInvalidated() {
+  let timers = TimersUtil()                      // testing accessors are INSTANCE members
+  let id = UUID()
+  let sid = TimersUtil.sessionReminderIdentifier(for: id)
+  let bid = TimersUtil.breakReminderIdentifier(for: id)
+  // register session + break reminders for `id` via the owned-reminder scheduling seam,
+  // capturing each generation from beginOwnedReminderSchedule / ownedReminderScheduleGenerationForTesting
+  let sgen = timers.ownedReminderScheduleGenerationForTesting(sid)
+
+  TimersUtil.cancelOwnedReminders(for: id)
+
+  XCTAssertFalse(timers.ownedReminderIdentifiersForTesting.contains(sid))
+  XCTAssertFalse(timers.ownedReminderIdentifiersForTesting.contains(bid))
+  // generation bumped ⇒ a stale in-flight add for the captured generation is no longer current
+  XCTAssertFalse(timers.isOwnedReminderScheduleCurrentForTesting(sid, generation: sgen))
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`cancelOwnedReminders` undefined).
+
+- [ ] **Step 3: Implement `cancelOwnedReminders(for:)`** in `TimersUtil.swift`, mirroring `cancelAllNotifications` (~:462-474) exactly — `OwnedReminderState` has only `let lock = NSLock()` + `var scheduleGenerations`; `ownedReminderIdentifiers` is a `private static` UserDefaults-backed computed var (assign to it to persist); there is no `withLock` and no `persist()`:
+```swift
+static func cancelOwnedReminders(for profileId: UUID) {
+  let ids = [sessionReminderIdentifier(for: profileId), breakReminderIdentifier(for: profileId)]
+  ownedReminderState.lock.lock()
+  var identifiers = ownedReminderIdentifiers
+  for id in ids {
+    identifiers.remove(id)
+    ownedReminderState.scheduleGenerations[id] =
+      (ownedReminderState.scheduleGenerations[id] ?? 0) &+ 1   // invalidate any in-flight add
+  }
+  ownedReminderIdentifiers = identifiers                       // UserDefaults write via computed setter
+  ownedReminderState.lock.unlock()
+  let center = UNUserNotificationCenter.current()
+  center.removePendingNotificationRequests(withIdentifiers: ids)
+  center.removeDeliveredNotifications(withIdentifiers: ids)
+}
+```
+(`static`, consistent with `cancelAllPreActivationReminders` at ~:203. Confirm the exact member names at Task 0 refresh.)
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Write the failing DeleteCleanup test** by extending `DeleteProfileCleanupTests`'s single ordered-tags test: add a `cancelSessionAndBreakReminders` closure that appends a tag (asserting `profileId == profile.id`) and add that tag to the expected-order array.
+
+- [ ] **Step 6: Run — expect FAIL** (struct has no such field).
+
+- [ ] **Step 7: Wire it in** — `BlockedProfiles.swift`:
+  - Add field to `DeleteCleanup`: `let cancelSessionAndBreakReminders: (UUID) -> Void`.
+  - `defaultDeleteCleanup()`: `cancelSessionAndBreakReminders: { TimersUtil.cancelOwnedReminders(for: $0) }`.
+  - `deleteProfile` (~:540-544): `cleanup.cancelSessionAndBreakReminders(profile.id)`.
+  - **Account-wipe path needs no change** — `wipeLocalSyncedDataDirectly` inherits the fixed default via `deleteProfile`.
+
+- [ ] **Step 8: Run — expect PASS.**
+
+- [ ] **Step 9: Wipe-regression assertion.** Extend the `wipeAndReattachForTest(cleanup:newName:)` usage in `ProfileSyncAccountResolverTests` (~:204) to pass a custom `DeleteCleanup` whose `cancelSessionAndBreakReminders` records the fired ids, asserting the closure fires for the wiped profile during a Switch.
+
+- [ ] **Step 10: Full suite — expect PASS.**
+
+- [ ] **Step 11: Commit** — `git commit -m "fix(#352): cancel deleted profile's owned session/break reminders in DeleteCleanup"`
+
+---
+
+## Task 6: #353 — arbitrate remote-start vs a local active session (one active session per user)
+
+**Settled invariant (maintainer, 2026-07-14):** at most ONE active session PER USER across all that user's devices; domain = one iCloud account (a child's sessions under their own Apple ID are independent). Not up for re-litigation.
+
+**Problem:** a synced remote start for profile B while profile A blocks locally creates a second active session and orphans A's row. `SyncApplyService.applySessionState` only checks `activeSession?.blockedProfile.id == profileId` (same profile), and `StrategyManager.startRemoteSession` calls `activateSession` unconditionally — neither consults "is any session already active?". `mostRecentActiveSession` then returns whichever row has the later `startTime`, leaving the older row un-ended (the orphan) and its remote active-record lingering (which re-creates the #349 stuck-lock on other devices).
+
+**D1 — arbitration rule (stated in-plan decision; maintainer delegated the choice):**
+> **Newest-wins by `startTime`** — the session with the later `startTime` is authoritative; ties break on **`profileId` string**. Both devices compare the identical pair of absolute `Date`s (the remote `startTime` is stored verbatim), so newest-wins is symmetric ⇒ they pick the same winner regardless of clock skew; `profileId` is the tie-break because it is the only identifier BOTH devices share (see below).
+- On a remote start for B while local A (different profile) is active:
+  - **B newer** (`B.startTime > A.startTime`, or equal-and-`B.profileId.uuidString > A.profileId.uuidString`): **end A locally AND sync A's stop**, then start B.
+  - **B older**: **reject B** (do not start it); A stays. B's origin device will itself adopt A (newer) when it fetches A's record and stop B — no push needed here.
+- **The loser's stop MUST sync — and the outbox is NOT the channel.** Ending A locally under `processingRemoteChange` suppression leaves A's remote record active forever → re-creates #349's permanent "active on another device" lock on other devices and orphans A's row. `SessionStopOutbox.enqueue` only writes UserDefaults; its drain (`drainSessionStopOutbox`) fires **exclusively on a scenePhase `.active` transition** (`FoqosApp.swift:135-151`) — but a remote apply arrives while the app is **already** `.active`, so that drain never fires for the session and A's record never closes. The loser's stop MUST therefore be driven **immediately** through the real CAS: temporarily clear `processingRemoteChange` around A's `stopBlocking` so `shouldSyncSessionChange` is true and `sessionSyncService.stopSession(A)` runs on the spot, closing A's record so `setRemoteSessionActive(false)` fires everywhere. (Enqueue to the outbox additionally, as a durability backstop, but do NOT rely on it as the primary channel.)
+- **Tie-break rationale:** the `sessionId` passed to `startRemoteSession` is a throwaway `UUID()` minted per-apply (`SyncApplyService.swift:665`) and `ProfileSessionRecord` carries no session-id field, so a session-id tie-break is non-deterministic across devices. `profileId` is transmitted, stable, and known to both devices — a real total order. (Equal-`startTime` is near-impossible across independent clocks; this only makes the rare tie deterministic.)
+
+Rationale over first-wins / CAS-claim (the alternatives the maintainer named):
+- **No per-user CAS primitive exists.** `ProfileSessionRecord` is keyed per profile (`ProfileSession_<profileId>`); two different profiles never CAS-conflict, so `startSession`'s CAS cannot be reused as a per-user exclusivity claim.
+- The local model carries **no device/user field** — only `startTime` — so `startTime` (tie-broken by id) is the only robust cross-profile comparand.
+- `mostRecentActiveSession` **already** resolves to the later `startTime` on read; newest-wins on the write side makes the enforced state match what the read already shows (first-wins would surface B while the rule kept A — a divergence).
+- Distinct from the local `rejectionForStart` "reject the second *same-device* start": that guards a user double-starting on one device; this reconciles two devices that each legitimately passed their own local guard. Local `rejectionForStart` is unchanged.
+
+**Note on the invariant's "at any time":** during propagation two active records can transiently coexist; deterministic newest-wins guarantees eventual single-active. Stated explicitly.
+
+**Files:**
+- Create: `Foqos/Utils/ProfileStartArbiter.swift` (pure decision)
+- Create: `FoqosTests/ProfileStartArbiterTests.swift`
+- Modify: `Foqos/Utils/StrategyManager.swift` (`startRemoteSession` ~:1516-1564 — arbitration BEFORE `activateRestrictions` :1542; `endLocalSessionAndSyncStop` helper)
+- Modify: `FoqosTests/StrategyManagerRemoteSessionTests.swift`; `FoqosTests/SyncApplyServiceTests.swift`
+- (Decision stays centralized in `startRemoteSession`; `SyncApplyService.applySessionState` ~:654-674 unchanged — its `localActive` same-profile check remains, and it already routes cross-profile starts through `startRemoteSession`.)
+
+**Interfaces:**
+- Consumes: `BlockedProfileSession.mostRecentActiveSession(in:)`, `session.startTime`, `session.blockedProfile.id`, the session-stop CAS path used by `stopBlocking` (gated by `shouldSyncSessionChange`), `getStrategy(id: ManualBlockingStrategy.id)`.
+- Produces: a pure `ProfileStartArbiter.decide(incomingStartTime:incomingProfileId:existingStartTime:existingProfileId:) -> Decision` where `Decision` is `{ case start, reject, adopt }` (unit-testable with no SwiftData/sync); and a private `endLocalSessionAndSyncStop(_ session:context:)` on `StrategyManager` that ends the loser via `ManualBlockingStrategy` with `processingRemoteChange` **temporarily cleared** so its CAS stop actually syncs.
+
+- [ ] **Step 1: Write the failing pure-arbiter test** — `Foqos/Utils/ProfileStartArbiter.swift` decision, tested in a new `FoqosTests/ProfileStartArbiterTests.swift` (pure, no SwiftData/sync — the load-bearing convergence logic lives here, testable without the harness limits below):
+
+```swift
+import XCTest
+@testable import FamilyFoqos
+
+final class ProfileStartArbiterTests: XCTestCase {
+  let now = Date()
+  func testGivenNoExisting_ThenStart() {
+    XCTAssertEqual(
+      ProfileStartArbiter.decide(
+        incomingStartTime: now, incomingProfileId: idB,
+        existingStartTime: nil, existingProfileId: nil), .start)
+  }
+  func testGivenSameProfileActive_ThenStart() {  // same-profile join is handled upstream; not a conflict
+    XCTAssertEqual(
+      ProfileStartArbiter.decide(
+        incomingStartTime: now, incomingProfileId: idB,
+        existingStartTime: now.addingTimeInterval(-1), existingProfileId: idB), .start)
+  }
+  func testGivenIncomingNewer_ThenAdopt() {
+    XCTAssertEqual(
+      ProfileStartArbiter.decide(
+        incomingStartTime: now, incomingProfileId: idB,
+        existingStartTime: now.addingTimeInterval(-60), existingProfileId: idA), .adopt)
+  }
+  func testGivenIncomingOlder_ThenReject() {
+    XCTAssertEqual(
+      ProfileStartArbiter.decide(
+        incomingStartTime: now.addingTimeInterval(-60), incomingProfileId: idB,
+        existingStartTime: now, existingProfileId: idA), .reject)
+  }
+  func testGivenEqualStartTime_ThenDeterministicByProfileId() {
+    // Both devices compute the SAME winner from the SAME profileId pair → convergent.
+    let hi = UUID(uuidString: "FFFFFFFF-0000-0000-0000-000000000000")!
+    let lo = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+    XCTAssertEqual(
+      ProfileStartArbiter.decide(
+        incomingStartTime: now, incomingProfileId: hi,
+        existingStartTime: now, existingProfileId: lo), .adopt)
+    XCTAssertEqual(
+      ProfileStartArbiter.decide(
+        incomingStartTime: now, incomingProfileId: lo,
+        existingStartTime: now, existingProfileId: hi), .reject)
+  }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`ProfileStartArbiter` undefined). Implement it:
+
+```swift
+import Foundation
+
+/// Pure newest-wins-by-startTime arbitration for a remote session start vs the local active
+/// session (#353, settled: one active session per user). Deterministic and symmetric across
+/// devices — both compare the same absolute startTimes; ties break on profileId (the only id
+/// both devices share). `.adopt` ⇒ end the existing (loser) then start incoming; `.reject` ⇒
+/// keep existing; `.start` ⇒ no conflict (no existing, or same profile).
+enum ProfileStartArbiter {
+  enum Decision { case start, reject, adopt }
+  static func decide(
+    incomingStartTime: Date, incomingProfileId: UUID,
+    existingStartTime: Date?, existingProfileId: UUID?
+  ) -> Decision {
+    guard let existingStartTime, let existingProfileId, existingProfileId != incomingProfileId
+    else { return .start }
+    if incomingStartTime > existingStartTime { return .adopt }
+    if incomingStartTime < existingStartTime { return .reject }
+    return incomingProfileId.uuidString > existingProfileId.uuidString ? .adopt : .reject
+  }
+}
+```
+
+- [ ] **Step 3: Write the failing manager-integration tests** in `StrategyManagerRemoteSessionTests.swift` (real `StrategyManager`, `TestModelContainer.create()`, `SharedData.configure(suite:)`). Assert only **locally-observable** state (the harness has no session-sync double — `SessionSyncService` is a concrete `actor` with no protocol seam, and `.shared` `profileSyncManager.isEnabled` is false, so a sync assertion is not observable here; the sync itself is covered by routing through the standard, already-tested stop path — see Step 5):
+
+```swift
+@MainActor
+func testGivenLocalActiveNewerA_WhenRemoteStartOlderB_ThenBRejectedAKept() throws {
+  let now = Date()
+  startLocalSession(profile: profileA, startTime: now, in: context)             // A newer
+  manager.startRemoteSession(
+    context: context, profileId: profileB.id, sessionId: UUID(), startTime: now.addingTimeInterval(-60))
+  XCTAssertEqual(try BlockedProfileSession.mostRecentActiveSession(in: context)?.blockedProfile.id, profileA.id)
+  XCTAssertEqual(activeSessions(in: context).count, 1)                           // no 2nd row
+}
+
+@MainActor
+func testGivenLocalActiveOlderA_WhenRemoteStartNewerB_ThenAEndedBStartedSingleActive() throws {
+  let now = Date()
+  startLocalSession(profile: profileA, startTime: now.addingTimeInterval(-60), in: context) // A older
+  manager.startRemoteSession(
+    context: context, profileId: profileB.id, sessionId: UUID(), startTime: now)            // B newer
+  XCTAssertEqual(try BlockedProfileSession.mostRecentActiveSession(in: context)?.blockedProfile.id, profileB.id)
+  XCTAssertEqual(activeSessions(in: context).count, 1)          // A ended (endTime set) — no orphan
+  XCTAssertNotNil(aSessionFor(profileA.id, in: context)?.endTime)  // A closed locally
+}
+```
+(`startLocalSession`/`activeSessions`/`aSessionFor` are small test helpers to add if absent — inserting a session with a given `startTime` and fetching `endTime == nil` rows.)
+
+- [ ] **Step 4: Run — expect FAIL** (today B is started unconditionally, A orphaned).
+
+- [ ] **Step 5: Implement arbitration** in `startRemoteSession`. **Placement is load-bearing: the block MUST come BEFORE `appBlocker.activateRestrictions(for: B)` (currently `StrategyManager.swift:1542`)** — ending A calls `deactivateRestrictions()` globally, so if arbitration ran after B's restrictions were applied it would wipe them and B would run unblocked. Insert immediately after the `needsAppSelection` guard, before the `activateRestrictions` line:
+
+```swift
+// #353: enforce one active session per user (settled invariant). MUST run before
+// activateRestrictions(for: B) below — ending A deactivates restrictions globally.
+let existing = try? BlockedProfileSession.mostRecentActiveSession(in: context)
+switch ProfileStartArbiter.decide(
+  incomingStartTime: startTime, incomingProfileId: profileId,
+  existingStartTime: existing?.startTime, existingProfileId: existing?.blockedProfile.id) {
+case .reject:
+  Log.info("Remote start for \(profile.name) older than active session; keeping local", category: .strategy)
+  return
+case .adopt:
+  if let existing { endLocalSessionAndSyncStop(existing, context: context) }  // end A + sync its stop
+case .start:
+  break
+}
+```
+
+Implement `endLocalSessionAndSyncStop(_:context:)` — end the loser via `ManualBlockingStrategy` with `processingRemoteChange` **temporarily cleared** so the stop actually syncs (option (a); the outbox path (b) is NOT viable because `drainSessionStopOutbox` only runs on a scenePhase `.active` edge, which does not occur during an in-progress remote apply):
+
+```swift
+private func endLocalSessionAndSyncStop(_ session: BlockedProfileSession, context: ModelContext) {
+  let wasProcessing = processingRemoteChange
+  processingRemoteChange = false                       // un-suppress so the CAS stop syncs
+  _ = getStrategy(id: ManualBlockingStrategy.id).stopBlocking(context: context, session: session)
+  processingRemoteChange = wasProcessing
+  sessionStopOutbox.enqueue(profileId: session.blockedProfile.id)  // durability backstop (#201)
+}
+```
+
+- [ ] **Step 6: Run the three arbiter + two manager tests — expect PASS.**
+
+- [ ] **Step 7: Apply-layer test** in `SyncApplyServiceTests.swift` using `MockSessionController` (set `activeSession` to a session for A, apply an active record for B): assert `applySessionState` still delegates to `startRemoteSession` for the cross-profile case and does not itself create a duplicate. Keep the decision centralized in `startRemoteSession`; `applySessionState`'s existing `localActive` same-profile check stays. (Note: `MockSessionController.startRemoteSession` is a no-op stub that only records the call, so the arbitration behavior itself is proven in Steps 3/6 against the real manager, not here.)
+
+- [ ] **Step 8: Run — expect PASS.**
+
+- [ ] **Step 9: Full suite — expect PASS.** Confirm no regression in `ConcurrentSessionTests`, `SessionStopOnAbsentTests` (I1 "absence never stops"), `StrategyManagerStartTests` (#318 `rejectionForStart` unchanged).
+
+- [ ] **Step 10: Commit** — `git commit -m "fix(#353): arbitrate remote-start vs local active session (one active session per user)"`
+
+---
+
+## Device-Verification Matrix
+
+Run after the suite is green. Two-device rows require two devices on the **same iCloud account** (per the settled #353 domain); mark child-independence rows separately.
+
+| # | Scenario | Devices | Unit-covered? | Device check |
+|---|----------|---------|---------------|--------------|
+| #348 | Enforcing device stops when the other swipes a `needsAppSelection` profile → **now blocked** with "Active on Another Device" | **2 (same account)** | Gate logic yes; end-to-end cross-device teardown NO | **Required:** A blocks P; on B (P `needsAppSelection`) swipe P → expect delete refused; A keeps blocking |
+| #349 | After Combine, a previously-remote-active kept profile is editable/deletable again | **2 (same→different account)** | Prune logic yes; account-switch flow NO | **Required:** A blocks P; B combines into a new account → P no longer shows "active on another device" |
+| #349 | Switch wipe leaves no orphaned remote-active ids | 2 | yes (resolver test) | Optional spot-check |
+| #350 | Edit during iCloud sign-out pause syncs after same-user sign-in | **2 (same account)** | Capture+drain unit yes; real CKSyncEngine pause NO | **Required:** sign out on B, rename P, sign back in → A sees the rename |
+| #351 | Interrupted delete → snapshot self-heals; schedule enforces | 1 | Reconcile + rollback yes; process-death timing NO | **Recommended:** force-kill during delete commit, relaunch, confirm widget + schedule restored |
+| #352 | Deleted/wiped profile's come-back reminder does NOT fire | 1 | Cancellation unit yes; real UN delivery NO | **Recommended:** schedule a session reminder, delete the profile, confirm no notification |
+| #352 | After account-switch wipe, old profile name does not appear in a notification under the new account | **2 (different account)** | Wipe-regression unit yes | **Recommended:** verify no stale reminder post-switch |
+| #353 | Near-simultaneous starts on two devices converge to one active session (newer wins), loser's row closed everywhere | **2 (same account)** | Arbitration + synced-stop unit yes; real race NO | **Required:** start A on device 1, start B on device 2 within seconds → both converge to the newer; older row ends on both |
+| #353 | A child's own-account session is unaffected by the parent-account arbitration | **2 (different accounts)** | n/a | **Recommended:** confirm domain isolation |
+
+---
+
+## Self-Review (writing-plans checklist)
+
+**Spec coverage:** #348→Task 1, #349→Task 2, #350→Task 3, #351→Task 4, #352→Task 5, #353→Task 6, Task 0 = citation refresh, device matrix + decisions table cover the process asks (two-device rows marked; #353 arbitration stated; no blocking escalations).
+
+**Placeholder scan:** every code step carries real code or a clearly-labeled shape-not-literal contract (Task 5 Step 3, Task 6 Step 4) where the exact private field/lock names must be read at Task 0 refresh — flagged, not hand-waved.
+
+**Type consistency:** `ProfileDeleteGate.blockedReason`/`DeleteBlockReason` (T1) consistent T1-wide; `clearAllRemoteSessionActive()` / `RemotelyActiveStore.clear` (T2); `hasLiveDriver` / `deferredProfileSaveIds` / `hasNoDeferredMutations` (T3, existing symbols); `reconcileMissingSnapshots(context:)` / `updateSnapshot` / `getSnapshot` / `.valid` (T4); `cancelOwnedReminders(for:)` / `cancelSessionAndBreakReminders` (T5); `ProfileStartArbiter.decide` / `Decision{start,reject,adopt}` / `endLocalSessionAndSyncStop` / `mostRecentActiveSession` (T6).
+
+**Adversarial pass folded (2026-07-14):** a 4-lens skeptic panel refuted the draft. #350 confirmed sound (test-helper name corrected). #351 respec'd — `reconcileMissingSnapshots` takes `context:` not a `[BlockedProfiles]` (no call site holds an array); `.valid` marked load-bearing against snapshot-resurrection. #352 corrected to the real `NSLock`/UserDefaults-computed-var API (no `withLock`/`persist`) and instance-scoped test accessors. #353 hardened on three counts: loser-stop drives the CAS immediately by clearing `processingRemoteChange` (the `SessionStopOutbox` drain only fires on a scenePhase `.active` edge, absent during a remote apply — using it would re-create the #349 stuck-lock); arbitration placed strictly BEFORE `activateRestrictions(:1542)` (else ending A wipes B's restrictions → B active-but-unblocked); tie-break keyed on `profileId` (the throwaway `sessionId` is non-convergent).
+
+**Cross-fix composition guarded:** #353's synced loser-stop is the exact signal #348/#349 depend on (a lingering active record = stuck lock); #352's wipe-regression rides #349's/#350's Switch path; #350's Switch-clear and #349's Switch-prune both land in `wipeLocalSyncedDataDirectly` — implement in one coherent edit to avoid clobbering.


### PR DESCRIPTION
Plan-only (epic #263 composition-fixes bundle). Six mini-fixes, one branch/one PR, per-task TDD.

Plan: `docs/superpowers/plans/2026-07-14-263-composition-fixes-348-353.md`

- **#348** (HIGH) list swipe-delete guard mirrors the editor's remote-active check (`ProfileDeleteGate`)
- **#349** prune the durable remote-active set on Switch/Combine + local delete
- **#350** widen `+Cutover` guards to `hasLiveDriver` → paused-window edits defer+drain (clear on Switch wipe)
- **#351** self-heal missing app-group snapshot on reconcile + rollback
- **#352** generation-invalidating owned-reminder cancel in `DeleteCleanup`
- **#353** newest-wins-by-startTime remote-start arbitration; loser stop synced

Grounded at main@f99534e; 4-lens adversarial pass folded (loser-stop channel, restriction-teardown ordering, tie-break determinism, `reconcileMissingSnapshots` signature, TimersUtil API). Decisions surfaced in the plan's table; #353 arbitration rule stated per maintainer delegation. Implementation is a separate session.