### PR TITLE
Fix honest sync status and automatic sync triggers

### DIFF
--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -109,6 +109,8 @@ class ProfileSyncManager: ObservableObject {
       .removeDuplicates()
       .sink { [weak self] _ in self?.recomputeSyncStatus() }
       .store(in: &cancellables)
+    reachabilityMonitor.onReconnect = { [weak self] in self?.reconnectDrivenSync() }
+    if isEnabled { reachabilityMonitor.start() }
 
     // Observe changes to sync enabled setting
     $isEnabled
@@ -118,8 +120,10 @@ class ProfileSyncManager: ObservableObject {
         SharedData.deviceSyncEnabled = enabled
         self?.recomputeSyncStatus(isEnabledOverride: enabled)
         if enabled {
+          self?.reachabilityMonitor.start()
           self?.startEngineAndMarkReadyWhenStartupCompletes()
         } else {
+          self?.reachabilityMonitor.stop()
           self?.cancelAccountResolutionRetry()
           self?.isSyncReady = false
           self?.engineController?.stop()
@@ -537,6 +541,19 @@ class ProfileSyncManager: ObservableObject {
     accountResolutionRetryTask?.cancel()
     accountResolutionRetryTask = nil
     didRetryAccountResolution = false
+  }
+
+  private func reconnectDrivenSync() {
+    guard isEnabled, isSyncReady else {
+      recomputeSyncStatus()
+      return
+    }
+    do {
+      try syncNow()
+    } catch {
+      Log.warning("reconnect syncNow skipped: \(error.localizedDescription)", category: .sync)
+    }
+    recomputeSyncStatus()
   }
 
   private func resumeAfterAmbiguity() {

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -25,9 +25,6 @@ class ProfileSyncManager: ObservableObject {
   // MARK: - Published State
 
   @Published var isEnabled: Bool = false
-  @Published var isSyncing: Bool = false
-  @Published var syncStatus: SyncStatus = .disabled
-  @Published var lastSyncDate: Date?
   @Published private(set) var syncStatusSnapshot = SyncStatusSnapshot(status: .disabled, lastSyncDate: nil)
   /// Set to true when legacy records were cleaned up and user should be notified
   @Published var shouldShowSyncUpgradeNotice = false
@@ -184,45 +181,6 @@ class ProfileSyncManager: ObservableObject {
     let next = SyncStatusSnapshot(
       status: status, lastSyncDate: engineController?.lastSuccessfulSyncDate)
     if next != syncStatusSnapshot { syncStatusSnapshot = next }
-
-    isSyncing = next.isSyncing
-    lastSyncDate = next.lastSyncDate
-    syncStatus = legacyStatus(for: status)
-  }
-
-  private func legacyStatus(for status: SyncDisplayStatus) -> SyncStatus {
-    switch status {
-    case .disabled:
-      return .disabled
-    case .syncing:
-      return .syncing
-    case .paused(let reason):
-      return .error(reason == .signedOut ? "Signed out of iCloud" : "iCloud account changed")
-    case .offline:
-      return .error("Offline")
-    case .synced, .waiting:
-      return .idle
-    }
-  }
-
-  enum SyncStatus: Equatable {
-    case disabled
-    case idle
-    case syncing
-    case error(String)
-
-    var displayText: String {
-      switch self {
-      case .disabled:
-        return "Disabled"
-      case .idle:
-        return "Synced"
-      case .syncing:
-        return "Syncing..."
-      case .error(let message):
-        return "Error: \(message)"
-      }
-    }
   }
 
   enum SyncPausedReason: Equatable {

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -27,9 +27,8 @@ class ProfileSyncManager: ObservableObject {
   @Published var isEnabled: Bool = false
   @Published var isSyncing: Bool = false
   @Published var syncStatus: SyncStatus = .disabled
-  @Published var connectedDeviceCount: Int = 0
   @Published var lastSyncDate: Date?
-  @Published var error: SyncError?
+  @Published private(set) var syncStatusSnapshot = SyncStatusSnapshot(status: .disabled, lastSyncDate: nil)
   /// Set to true when legacy records were cleaned up and user should be notified
   @Published var shouldShowSyncUpgradeNotice = false
   @Published private(set) var syncPausedReason: SyncPausedReason?
@@ -37,7 +36,12 @@ class ProfileSyncManager: ObservableObject {
   private(set) var pendingConflictName: String?
 
   /// The engine owner (I10). Wired in `attachEngine(...)` once a ModelContext exists.
-  weak var engineController: (any SyncEngineControlling)?
+  weak var engineController: (any SyncEngineControlling)? {
+    didSet {
+      engineController?.onStatusChanged = { [weak self] in self?.recomputeSyncStatus() }
+      recomputeSyncStatus()
+    }
+  }
 
   /// True once the engine is attached AND startup, including the AB-4 T1 strip, has completed.
   /// Gates send-on-enqueue so a send can never flush restored state before T1 (#286 poison).
@@ -45,6 +49,7 @@ class ProfileSyncManager: ObservableObject {
 
   /// Test-injectable defaults for the non-user-namespaced pre-attach delete buffer (#305).
   var bufferDefaults: UserDefaults = .standard
+  let reachabilityMonitor = NetworkReachabilityMonitor()
 
   // MARK: - Private State
 
@@ -97,7 +102,13 @@ class ProfileSyncManager: ObservableObject {
   private init() {
     // Load enabled state from SharedData
     isEnabled = SharedData.deviceSyncEnabled
-    syncStatus = isEnabled ? .idle : .disabled
+    recomputeSyncStatus()
+
+    reachabilityMonitor.$isOnline
+      .dropFirst()
+      .removeDuplicates()
+      .sink { [weak self] _ in self?.recomputeSyncStatus() }
+      .store(in: &cancellables)
 
     // Observe changes to sync enabled setting
     $isEnabled
@@ -105,7 +116,7 @@ class ProfileSyncManager: ObservableObject {
       .removeDuplicates()
       .sink { [weak self] enabled in
         SharedData.deviceSyncEnabled = enabled
-        self?.syncStatus = enabled ? .idle : .disabled
+        self?.recomputeSyncStatus(isEnabledOverride: enabled)
         if enabled {
           self?.startEngineAndMarkReadyWhenStartupCompletes()
         } else {
@@ -118,6 +129,77 @@ class ProfileSyncManager: ObservableObject {
   }
 
   // MARK: - Sync Status
+
+  enum SyncDisplayStatus: Equatable {
+    case disabled
+    case synced
+    case waiting(Int)
+    case syncing
+    case offline
+    case paused(SyncPausedReason)
+  }
+
+  struct SyncStatusSnapshot: Equatable {
+    let status: SyncDisplayStatus
+    let lastSyncDate: Date?
+
+    var isSyncing: Bool { status == .syncing }
+  }
+
+  static func deriveStatus(
+    isEnabled: Bool,
+    pausedReason: SyncPausedReason?,
+    isInFlight: Bool,
+    isOnline: Bool,
+    pendingCount: Int
+  ) -> SyncDisplayStatus {
+    guard isEnabled else { return .disabled }
+    if let pausedReason { return .paused(pausedReason) }
+    if isInFlight { return .syncing }
+    if !isOnline && pendingCount > 0 { return .offline }
+    if pendingCount > 0 { return .waiting(pendingCount) }
+    return .synced
+  }
+
+  private var totalPendingCount: Int {
+    let deferred =
+      deferredProfileSaveIds.count + deferredLocationSaveIds.count
+      + deferredDeleteRecordNames.count + (deferredEmergencySave ? 1 : 0)
+      + deferredEmergencyUnblockEvents.count + (deferredEmergencyEpochSave ? 1 : 0)
+    return (engineController?.pendingChangeCount ?? 0) + deferred
+  }
+
+  func recomputeSyncStatus(isEnabledOverride: Bool? = nil) {
+    let effectiveIsEnabled = isEnabledOverride ?? isEnabled
+    let status = Self.deriveStatus(
+      isEnabled: effectiveIsEnabled,
+      pausedReason: syncPausedReason,
+      isInFlight: engineController?.isInFlight ?? false,
+      isOnline: reachabilityMonitor.isOnline,
+      pendingCount: totalPendingCount)
+    let next = SyncStatusSnapshot(
+      status: status, lastSyncDate: engineController?.lastSuccessfulSyncDate)
+    if next != syncStatusSnapshot { syncStatusSnapshot = next }
+
+    isSyncing = next.isSyncing
+    lastSyncDate = next.lastSyncDate
+    syncStatus = legacyStatus(for: status)
+  }
+
+  private func legacyStatus(for status: SyncDisplayStatus) -> SyncStatus {
+    switch status {
+    case .disabled:
+      return .disabled
+    case .syncing:
+      return .syncing
+    case .paused(let reason):
+      return .error(reason == .signedOut ? "Signed out of iCloud" : "iCloud account changed")
+    case .offline:
+      return .error("Offline")
+    case .synced, .waiting:
+      return .idle
+    }
+  }
 
   enum SyncStatus: Equatable {
     case disabled
@@ -441,12 +523,14 @@ class ProfileSyncManager: ObservableObject {
       didTearDownForTest = true
     #endif
     syncPausedReason = reason
+    recomputeSyncStatus()
   }
 
   private func clearPause() {
     syncPausedReason = nil
     accountChangeConflict = nil
     pendingConflictName = nil
+    recomputeSyncStatus()
   }
 
   private func cancelAccountResolutionRetry() {
@@ -554,6 +638,7 @@ class ProfileSyncManager: ObservableObject {
   /// itself throws (review findings #4–#6, #15). Delete call sites MUST fall back to a direct
   /// local delete on `.notAttached` so the item is never silently left behind.
   func enqueueProfileSave(_ id: UUID) throws {
+    defer { recomputeSyncStatus() }
     guard let engineController else {
       deferredProfileSaveIds.insert(id)
       throw SyncEngineControllingError.notAttached
@@ -567,6 +652,7 @@ class ProfileSyncManager: ObservableObject {
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueProfileDelete(_ id: UUID) throws {
+    defer { recomputeSyncStatus() }
     guard let engineController else {
       deferredDeleteRecordNames.insert(id.uuidString)
       PreAttachDeleteBuffer.add(
@@ -583,6 +669,7 @@ class ProfileSyncManager: ObservableObject {
     }
   }
   func enqueueLocationSave(_ id: UUID) throws {
+    defer { recomputeSyncStatus() }
     guard let engineController else {
       deferredLocationSaveIds.insert(id)
       throw SyncEngineControllingError.notAttached
@@ -596,6 +683,7 @@ class ProfileSyncManager: ObservableObject {
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueLocationDelete(_ id: UUID) throws {
+    defer { recomputeSyncStatus() }
     guard let engineController else {
       deferredDeleteRecordNames.insert(id.uuidString)
       PreAttachDeleteBuffer.add(
@@ -613,6 +701,7 @@ class ProfileSyncManager: ObservableObject {
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueEmergencySettingsSave() throws {
+    defer { recomputeSyncStatus() }
     guard let engineController else {
       deferredEmergencySave = true
       throw SyncEngineControllingError.notAttached
@@ -626,6 +715,7 @@ class ProfileSyncManager: ObservableObject {
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueEmergencyUnblockEvent(_ event: SyncedEmergencyUnblockEvent) throws {
+    defer { recomputeSyncStatus() }
     guard let engineController else {
       deferredEmergencyUnblockEvents[event.recordName] = event
       throw SyncEngineControllingError.notAttached
@@ -639,6 +729,7 @@ class ProfileSyncManager: ObservableObject {
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueEmergencyEpochSave() throws {
+    defer { recomputeSyncStatus() }
     guard let engineController else {
       deferredEmergencyEpochSave = true
       throw SyncEngineControllingError.notAttached
@@ -652,6 +743,7 @@ class ProfileSyncManager: ObservableObject {
     if isSyncReady { engineController.requestSync() }
   }
   func enqueueEmergencyUnblockEventDelete(_ recordName: String) throws {
+    defer { recomputeSyncStatus() }
     guard let engineController else {
       deferredDeleteRecordNames.insert(recordName)
       PreAttachDeleteBuffer.add(
@@ -712,6 +804,7 @@ class ProfileSyncManager: ObservableObject {
   func markSyncReadyAndFlush() {
     isSyncReady = true
     drainDeferredMutations()
+    recomputeSyncStatus()
     Log.debug("Sync ready; flushing deferred mutations", category: .sync)
     engineController?.requestSync()
   }

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -46,7 +46,7 @@ class ProfileSyncManager: ObservableObject {
 
   /// Test-injectable defaults for the non-user-namespaced pre-attach delete buffer (#305).
   var bufferDefaults: UserDefaults = .standard
-  let reachabilityMonitor = NetworkReachabilityMonitor()
+  private let reachabilityMonitor = NetworkReachabilityMonitor()
 
   // MARK: - Private State
 
@@ -76,6 +76,14 @@ class ProfileSyncManager: ObservableObject {
     var disableAccountResolutionRetryForTest = false
     var accountResolutionRetryDelayNanosecondsForTest: UInt64?
     var failNextSwitchWipeFinalSaveForTest = false
+
+    var isReachabilityMonitoringForTest: Bool {
+      reachabilityMonitor.isMonitoringForTest
+    }
+
+    func handleReachabilityPathUpdateForTest(isSatisfied: Bool) {
+      reachabilityMonitor.handlePathUpdate(isSatisfied: isSatisfied)
+    }
   #endif
 
   /// Test seam: true when nothing is pending re-enqueue.

--- a/Foqos/CloudKit/SyncEngine/CKSyncEngineDriver.swift
+++ b/Foqos/CloudKit/SyncEngine/CKSyncEngineDriver.swift
@@ -179,8 +179,9 @@ final class CKSyncEngineDriver: NSObject, SyncEngineDriver, CKSyncEngineDelegate
         deletedZoneIDs: e.deletedZoneIDs, failedZoneDeletes: failedDeletes)
     case .willFetchChanges: return .willFetchChanges
     case .didFetchChanges: return .didFetchChanges
-    case .willFetchRecordZoneChanges, .didFetchRecordZoneChanges, .willSendChanges,
-      .didSendChanges:
+    case .willSendChanges: return .willSendChanges
+    case .didSendChanges: return .didSendChanges
+    case .willFetchRecordZoneChanges, .didFetchRecordZoneChanges:
       return nil  // not consumed by the controller
     @unknown default:
       return nil

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -63,7 +63,20 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   private(set) var startupTask: Task<Void, Never>?
   private(set) var flushTask: Task<Void, Never>?
   private(set) var fetchCycleSweepTask: Task<Void, Never>?
+  private var queueDrainTask: Task<Void, Never>?
+  private var queueDrainAttempt = 0
+  private var queueDrainNeedsSend = false
+  private var queueDrainRetryAfter: TimeInterval?
+  private static let queueDrainMaxDelaySeconds: Double = 64
   private var namespaceGeneration = 0
+
+  #if DEBUG
+    private var queueDrainDelayOverrideNanos: UInt64?
+    func setQueueDrainDelayForTest(_ nanos: UInt64) {
+      queueDrainDelayOverrideNanos = nanos
+    }
+    var drainTaskForTest: Task<Void, Never>? { queueDrainTask }
+  #endif
 
   // Phase E reset hooks (wired by SyncEngineController+Reset.swift).
   var onResumeReset: ((ResetIntent) -> Void)?
@@ -105,6 +118,10 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     startupTask?.cancel()
     flushTask?.cancel()
     fetchCycleSweepTask?.cancel()
+    queueDrainTask?.cancel()
+    queueDrainTask = nil
+    isSending = false
+    isFetching = false
     driver?.shutdown()
     driver = nil
     endAccountResolution()
@@ -252,6 +269,10 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     startupTask?.cancel()
     flushTask?.cancel()
     fetchCycleSweepTask?.cancel()
+    queueDrainTask?.cancel()
+    queueDrainTask = nil
+    isSending = false
+    isFetching = false
     store.engineState = nil  // pending unsent saves lost (N5); tombstones survive
     driver?.shutdown()
     driver = nil
@@ -328,10 +349,67 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       handleAccountChange(kind)
     }
     notifyStatusChanged()
+    switch event {
+    case .sentRecordZoneChanges, .sentDatabaseChanges, .didFetchChanges:
+      if queueDrainNeedsSend { scheduleQueueDrain() }
+      queueDrainNeedsSend = false
+    default:
+      break
+    }
   }
 
   private func notifyStatusChanged() {
     onStatusChanged?()
+  }
+
+  private func markQueueDrainNeeded(after error: CKError? = nil) {
+    queueDrainNeedsSend = true
+    guard let retryAfter = error.flatMap(retryAfterSeconds) else { return }
+    queueDrainRetryAfter = max(queueDrainRetryAfter ?? 0, retryAfter)
+  }
+
+  /// §1.1-safe: the send runs in this task after the CKSyncEngine event handler returns.
+  /// Send-only; replicates `requestSync`'s operational-state guard instead of fetching.
+  private func scheduleQueueDrain() {
+    guard let driver, state == .bootstrapping || state == .steady, !accountResolutionInFlight
+    else { return }
+    guard !driver.pendingRecordZoneChanges.isEmpty || !driver.pendingDatabaseChanges.isEmpty
+    else { return }
+
+    queueDrainTask?.cancel()
+    let attempt = queueDrainAttempt
+    let delayNanos = drainDelayNanos(attempt: attempt, retryAfter: queueDrainRetryAfter)
+    queueDrainRetryAfter = nil
+    queueDrainAttempt = min(attempt + 1, 5)
+    queueDrainTask = Task { @MainActor [weak self] in
+      do {
+        try await Task.sleep(nanoseconds: delayNanos)
+      } catch {
+        return
+      }
+      guard let self, let driver = self.driver,
+        self.state == .bootstrapping || self.state == .steady,
+        !self.accountResolutionInFlight
+      else { return }
+      guard !driver.pendingRecordZoneChanges.isEmpty || !driver.pendingDatabaseChanges.isEmpty
+      else { return }
+
+      Log.debug("queue-drain re-send (attempt \(attempt))", category: .sync)
+      driver.sendChanges()
+    }
+  }
+
+  private func drainDelayNanos(attempt: Int, retryAfter: TimeInterval?) -> UInt64 {
+    #if DEBUG
+      if let override = queueDrainDelayOverrideNanos { return override }
+    #endif
+    let backoff = min(pow(2.0, Double(attempt + 1)), Self.queueDrainMaxDelaySeconds)
+    let delay = retryAfter ?? backoff
+    return UInt64(max(0, delay) * 1_000_000_000)
+  }
+
+  private func retryAfterSeconds(_ error: CKError) -> TimeInterval? {
+    error.retryAfterSeconds ?? (error as NSError).userInfo[CKErrorRetryAfterKey] as? TimeInterval
   }
 
   // MARK: - T5/T6 zone deletions (§8.4, S-3, S-4)
@@ -364,6 +442,10 @@ final class SyncEngineController: SyncEngineDriverDelegate {
         SharedData.deviceSyncEnabled = false
         flushTask = Task { [weak self] in await self?.sessionSync.flushSessionCache() }
         NotificationCenter.default.post(name: .syncEnginePurged, object: nil)  // one-time notice (Phase F UI)
+        queueDrainTask?.cancel()
+        queueDrainTask = nil
+        isSending = false
+        isFetching = false
         driver?.shutdown()
         driver = nil
         state = .purged
@@ -434,6 +516,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     let modificationReenqueues = apply.drainReenqueues()
     SyncDiagnostics.repairReenqueue(source: "fetched_modifications", recordIDs: modificationReenqueues)
     for recordID in modificationReenqueues {  // CRA-1
+      markQueueDrainNeeded()
       driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
     }
     var deletionOutcomes: [String] = []
@@ -449,6 +532,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     let deletionReenqueues = apply.drainReenqueues()
     SyncDiagnostics.repairReenqueue(source: "fetched_deletions", recordIDs: deletionReenqueues)
     for recordID in deletionReenqueues {
+      markQueueDrainNeeded()
       driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
     }
   }
@@ -524,6 +608,9 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       SyncDiagnostics.sentDeleteFailed(recordID: id, error: error)
       handleFailedDelete(recordID: id, error: error)
     }
+    if (!savedRecords.isEmpty || !deletedRecordIDs.isEmpty) && !queueDrainNeedsSend {
+      queueDrainAttempt = 0
+    }
   }
 
   // MARK: - T4b sentDatabaseChanges routing (§5.5)
@@ -533,7 +620,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   /// are all "confirmed" from the resetIntent's perspective — Phase E's `ResetController`
   /// advances its stage via `onZoneChangeConfirmed`; nothing is persisted here. A save
   /// failing with `.serverRecordChanged` (zone already exists) is likewise confirmed. Any
-  /// other retriable failure is re-added and left to the engine's own backoff; a
+  /// other retriable failure is re-added for the explicit gated queue-drain scheduler; a
   /// non-retriable save failure is logged and resetIntent is left as-is (nothing to
   /// recover to).
   private func handleSentDatabaseChanges(
@@ -559,7 +646,8 @@ final class SyncEngineController: SyncEngineDriverDelegate {
           resolveSeedName(Self.seedZoneMarkerName)  // I11 observable-clear (Fix 5)
         }
       } else if isRetriable(error) {
-        driver.add(pendingDatabaseChanges: [.saveZone(zone)])  // rely on engine backoff
+        markQueueDrainNeeded(after: error)
+        driver.add(pendingDatabaseChanges: [.saveZone(zone)])  // explicit gated queue-drain re-send
       } else {
         Log.error("Non-retriable zone save failure: \(error.code)", category: .sync)
       }
@@ -568,8 +656,12 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       if error.code == .zoneNotFound {
         onZoneChangeConfirmed?([], [zoneID])  // already gone ⇒ confirmed
       } else if isRetriable(error) {
+        markQueueDrainNeeded(after: error)
         driver.add(pendingDatabaseChanges: [.deleteZone(zoneID)])
       }
+    }
+    if (!savedZones.isEmpty || !deletedZoneIDs.isEmpty) && !queueDrainNeedsSend {
+      queueDrainAttempt = 0
     }
   }
 
@@ -599,23 +691,28 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       _ = apply.applyFetchedModification(server, isPendingDeleteOrTombstoned: blockedPredicate())
       // CRA-1: drain any re-enqueues the apply produced (§5.1 equal-version divergence).
       for recordID in apply.drainReenqueues() {
+        markQueueDrainNeeded(after: error)
         driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
       }
       // branch 0 / server-newer: apply merged, no re-add. branch E (equal+differing): apply
       // bumped+enqueued+surfaced inside §5.1, drained above. local strictly newer: re-add
       // here.
       if localIsStrictlyNewer(record.recordType, name: name, server: server) {
+        markQueueDrainNeeded(after: error)
         driver.add(pendingRecordZoneChanges: [.saveRecord(record.recordID)])
       }
     case .zoneNotFound:
       seedZoneAndRecords()  // branch Z: saveZone + intent-first seed
+      markQueueDrainNeeded(after: error)
       driver.add(pendingRecordZoneChanges: [.saveRecord(record.recordID)])
     case .unknownItem:
       store.setSystemFields(nil, for: name)  // branch U-save
+      markQueueDrainNeeded(after: error)
       driver.add(pendingRecordZoneChanges: [.saveRecord(record.recordID)])
       resolveSeedName(name)  // I11 observable-clear (Fix 5): this attempt is resolved
     default:
       if isRetriable(error) {
+        markQueueDrainNeeded(after: error)
         driver.add(pendingRecordZoneChanges: [.saveRecord(record.recordID)])  // branch R, once
       } else {
         surfaceConflict(forRecordName: name, record: record)  // branch F
@@ -637,9 +734,11 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       }
     case .zoneNotFound:  // branch Z (delete): recreate + re-add the delete
       seedZoneAndRecords()
+      markQueueDrainNeeded(after: error)
       driver.add(pendingRecordZoneChanges: [.deleteRecord(id)])
     default:
       if isRetriable(error) {
+        markQueueDrainNeeded(after: error)
         driver.add(pendingRecordZoneChanges: [.deleteRecord(id)])  // branch R
       } else {
         store.clearTombstone(recordName: name)  // branch F for a delete: surfaced, not looping
@@ -842,6 +941,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
           // CRA-1: drain any re-enqueues the apply produced (I9 auto-heal / §5.1
           // equal-version divergence) so they actually reach CloudKit.
           for recordID in apply.drainReenqueues() {
+            markQueueDrainNeeded()
             driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
           }
           if outcome == .applied {
@@ -871,7 +971,12 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       }
     }
     for recordID in apply.drainReenqueues() {
+      markQueueDrainNeeded()
       driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+    }
+    if queueDrainNeedsSend {
+      scheduleQueueDrain()
+      queueDrainNeedsSend = false
     }
   }
 

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -122,6 +122,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     queueDrainTask = nil
     isSending = false
     isFetching = false
+    lastSuccessfulSyncDate = nil
     driver?.shutdown()
     driver = nil
     endAccountResolution()
@@ -273,6 +274,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     queueDrainTask = nil
     isSending = false
     isFetching = false
+    lastSuccessfulSyncDate = nil
     store.engineState = nil  // pending unsent saves lost (N5); tombstones survive
     driver?.shutdown()
     driver = nil
@@ -404,6 +406,8 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       if let override = queueDrainDelayOverrideNanos { return override }
     #endif
     let backoff = min(pow(2.0, Double(attempt + 1)), Self.queueDrainMaxDelaySeconds)
+    // Deliberately honor CKError retry-after semantics: a server-provided 0 means retry now
+    // and overrides this local exponential backoff.
     let delay = retryAfter ?? backoff
     return UInt64(max(0, delay) * 1_000_000_000)
   }
@@ -446,6 +450,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
         queueDrainTask = nil
         isSending = false
         isFetching = false
+        lastSuccessfulSyncDate = nil
         driver?.shutdown()
         driver = nil
         state = .purged

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -43,6 +43,12 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   private(set) var isSending = false
   private(set) var isFetching = false
   var isInFlight: Bool { isSending || isFetching }
+  var pendingChangeCount: Int {
+    guard let driver else { return 0 }
+    return driver.pendingRecordZoneChanges.count + driver.pendingDatabaseChanges.count
+  }
+  private(set) var lastSuccessfulSyncDate: Date?
+  var onStatusChanged: (@MainActor () -> Void)?
   // Widened to internal (Phase F, Task 131): `+Cutover`'s `requestSync`/`enqueue*` are the
   // only other-file collaborators that read/forward through these.
   var driver: SyncEngineDriver!
@@ -321,6 +327,11 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     case .accountChange(let kind):
       handleAccountChange(kind)
     }
+    notifyStatusChanged()
+  }
+
+  private func notifyStatusChanged() {
+    onStatusChanged?()
   }
 
   // MARK: - T5/T6 zone deletions (§8.4, S-3, S-4)
@@ -464,6 +475,11 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     failedRecordDeletes: [(recordID: CKRecord.ID, error: CKError)]
   ) {
     isSending = false
+    if (!savedRecords.isEmpty || !deletedRecordIDs.isEmpty) && failedRecordSaves.isEmpty
+      && failedRecordDeletes.isEmpty
+    {
+      lastSuccessfulSyncDate = Date()
+    }
     SyncDiagnostics.sentBatch(
       savedRecords: savedRecords, failedRecordSaves: failedRecordSaves,
       deletedRecordIDs: deletedRecordIDs, failedRecordDeletes: failedRecordDeletes)
@@ -527,6 +543,11 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     failedZoneDeletes: [(zoneID: CKRecordZone.ID, error: CKError)]
   ) {
     isSending = false
+    if (!savedZones.isEmpty || !deletedZoneIDs.isEmpty) && failedZoneSaves.isEmpty
+      && failedZoneDeletes.isEmpty
+    {
+      lastSuccessfulSyncDate = Date()
+    }
     onZoneChangeConfirmed?(savedZones, deletedZoneIDs)
     if savedZones.contains(zoneID) {
       resolveSeedName(Self.seedZoneMarkerName)  // I11 observable-clear (Fix 5): saveZone confirmed
@@ -701,6 +722,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   /// synchronously (never awaits from inside a fetch event, B-7).
   private func handleDidFetchChanges() {
     isFetching = false
+    lastSuccessfulSyncDate = Date()
     if state == .bootstrapping { state = .steady }  // T2
     let generation = namespaceGeneration
     fetchCycleSweepTask = Task { [weak self] in

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -40,6 +40,9 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       Log.debug("state \(oldValue) -> \(state) (main=\(Thread.isMainThread))", category: .sync)
     }
   }
+  private(set) var isSending = false
+  private(set) var isFetching = false
+  var isInFlight: Bool { isSending || isFetching }
   // Widened to internal (Phase F, Task 131): `+Cutover`'s `requestSync`/`enqueue*` are the
   // only other-file collaborators that read/forward through these.
   var driver: SyncEngineDriver!
@@ -295,6 +298,10 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       handleWillFetchChanges()
     case .didFetchChanges:
       handleDidFetchChanges()
+    case .willSendChanges:
+      isSending = true
+    case .didSendChanges:
+      isSending = false
     case .fetchedRecordZoneChanges(let modifications, let deletions):
       handleFetchedRecordZoneChanges(modifications: modifications, deletions: deletions)
     case .sentRecordZoneChanges(
@@ -456,6 +463,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     deletedRecordIDs: [CKRecord.ID],
     failedRecordDeletes: [(recordID: CKRecord.ID, error: CKError)]
   ) {
+    isSending = false
     SyncDiagnostics.sentBatch(
       savedRecords: savedRecords, failedRecordSaves: failedRecordSaves,
       deletedRecordIDs: deletedRecordIDs, failedRecordDeletes: failedRecordDeletes)
@@ -518,6 +526,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     deletedZoneIDs: [CKRecordZone.ID],
     failedZoneDeletes: [(zoneID: CKRecordZone.ID, error: CKError)]
   ) {
+    isSending = false
     onZoneChangeConfirmed?(savedZones, deletedZoneIDs)
     if savedZones.contains(zoneID) {
       resolveSeedName(Self.seedZoneMarkerName)  // I11 observable-clear (Fix 5): saveZone confirmed
@@ -676,6 +685,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   /// those recreations (round-5) — the drain must happen at the START of the first cycle
   /// after confirmation, not before.
   private func handleWillFetchChanges() {
+    isFetching = true
     currentCycle += 1
     let drained = confirmDeleteCycle.filter { $0.value < currentCycle }.map { $0.key }
     SyncDiagnostics.echoGuardDrained(currentCycle: currentCycle, recordNames: drained)
@@ -690,6 +700,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   /// unit of async work rather than run inline, since `didFetchChanges` itself must return
   /// synchronously (never awaits from inside a fetch event, B-7).
   private func handleDidFetchChanges() {
+    isFetching = false
     if state == .bootstrapping { state = .steady }  // T2
     let generation = namespaceGeneration
     fetchCycleSweepTask = Task { [weak self] in

--- a/Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift
@@ -7,6 +7,10 @@ protocol SyncEngineControlling: AnyObject {
   func start()
   func stop()
   func requestSync()
+  var isInFlight: Bool { get }
+  var pendingChangeCount: Int { get }
+  var lastSuccessfulSyncDate: Date? { get }
+  var onStatusChanged: (@MainActor () -> Void)? { get set }
   func beginAccountResolution()
   func endAccountResolution()
   func prepareForAccountSwitch()

--- a/Foqos/CloudKit/SyncEngine/SyncEngineEvent.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineEvent.swift
@@ -40,4 +40,6 @@ enum SyncEngineEvent {
     failedZoneDeletes: [(zoneID: CKRecordZone.ID, error: CKError)])  // T4b §5.5
   case willFetchChanges  // AB-3 cycle delimiter
   case didFetchChanges  // T2; AB-3; drives §5.6 sweep + echo-guard drain
+  case willSendChanges  // in-flight bracket (status, #316)
+  case didSendChanges  // in-flight bracket (status, #316)
 }

--- a/Foqos/Utils/NetworkReachabilityMonitor.swift
+++ b/Foqos/Utils/NetworkReachabilityMonitor.swift
@@ -1,0 +1,47 @@
+import Combine
+import Foundation
+import Network
+
+@MainActor
+final class NetworkReachabilityMonitor: ObservableObject {
+  @Published private(set) var isOnline: Bool = true
+  var onReconnect: (@MainActor () -> Void)?
+
+  private var monitor: NWPathMonitor?
+  private let queue = DispatchQueue(label: "com.cynexia.family-foqos.reachability")
+  private var lastKnownSatisfied: Bool?
+
+  #if DEBUG
+    var isMonitoringForTest: Bool { monitor != nil }
+  #endif
+
+  func start() {
+    guard monitor == nil else { return }
+    let monitor = NWPathMonitor()
+    self.monitor = monitor
+    monitor.pathUpdateHandler = { [weak self] path in
+      let isSatisfied = path.status == .satisfied
+      Task { @MainActor in
+        self?.handlePathUpdate(isSatisfied: isSatisfied)
+      }
+    }
+    monitor.start(queue: queue)
+  }
+
+  func stop() {
+    monitor?.cancel()
+    monitor = nil
+    lastKnownSatisfied = nil
+  }
+
+  func handlePathUpdate(isSatisfied: Bool) {
+    let wasSatisfied = lastKnownSatisfied
+    lastKnownSatisfied = isSatisfied
+    isOnline = isSatisfied
+
+    if wasSatisfied == false && isSatisfied {
+      Log.info("Network reconnected; re-driving sync", category: .sync)
+      onReconnect?()
+    }
+  }
+}

--- a/Foqos/Views/SettingsView.swift
+++ b/Foqos/Views/SettingsView.swift
@@ -31,15 +31,38 @@ struct SettingsView: View {
   }
 
   private var syncStatusColor: Color {
-    switch profileSyncManager.syncStatus {
+    switch profileSyncManager.syncStatusSnapshot.status {
     case .disabled:
       return .gray
-    case .idle:
+    case .synced:
       return .green
     case .syncing:
+      return themeManager.themeColor
+    case .waiting:
       return .orange
-    case .error:
-      return .red
+    case .offline:
+      return .gray
+    case .paused:
+      return .orange
+    }
+  }
+
+  private var syncStatusLabel: String {
+    switch profileSyncManager.syncStatusSnapshot.status {
+    case .disabled:
+      return "Disabled"
+    case .synced:
+      return "Synced"
+    case .waiting(let count):
+      return "Waiting to sync (\(count) changes)"
+    case .syncing:
+      return "Syncing…"
+    case .offline:
+      return "Offline"
+    case .paused(.signedOut):
+      return "Signed out of iCloud"
+    case .paused(.accountChanged):
+      return "iCloud account changed"
     }
   }
 
@@ -170,7 +193,7 @@ struct SettingsView: View {
                 .foregroundStyle(.primary)
               Spacer()
               HStack(spacing: 8) {
-                if profileSyncManager.isSyncing {
+                if profileSyncManager.syncStatusSnapshot.isSyncing {
                   ProgressView()
                     .scaleEffect(0.8)
                 } else {
@@ -178,13 +201,13 @@ struct SettingsView: View {
                     .fill(syncStatusColor)
                     .frame(width: 8, height: 8)
                 }
-                Text(profileSyncManager.syncStatus.displayText)
+                Text(syncStatusLabel)
                   .foregroundStyle(.secondary)
                   .font(.subheadline)
               }
             }
 
-            if let lastSync = profileSyncManager.lastSyncDate {
+            if let lastSync = profileSyncManager.syncStatusSnapshot.lastSyncDate {
               HStack {
                 Text("Last Synced")
                   .foregroundStyle(.primary)
@@ -208,13 +231,13 @@ struct SettingsView: View {
                 Text("Sync Now")
                   .foregroundColor(.primary)
                 Spacer()
-                if profileSyncManager.isSyncing {
+                if profileSyncManager.syncStatusSnapshot.isSyncing {
                   ProgressView()
                     .scaleEffect(0.8)
                 }
               }
             }
-            .disabled(profileSyncManager.isSyncing)
+            .disabled(profileSyncManager.syncStatusSnapshot.isSyncing)
           }
         } header: {
           Text("Device Sync")

--- a/FoqosTests/Mocks/MockSyncEngineControlling.swift
+++ b/FoqosTests/Mocks/MockSyncEngineControlling.swift
@@ -21,6 +21,10 @@ final class MockSyncEngineControlling: SyncEngineControlling {
   private(set) var enqueuedEmergencyUnblockEventDeletes: [String] = []
   private(set) var deferredDeletes: [String] = []
   private(set) var recordedDisabledTombstones: [String] = []
+  var isInFlight = false
+  var pendingChangeCount = 0
+  var lastSuccessfulSyncDate: Date?
+  var onStatusChanged: (@MainActor () -> Void)?
 
   /// Set by a test to make every `enqueue*` verb below throw instead of recording — used to
   /// verify a genuine funnel throw propagates through the facade instead of being swallowed
@@ -31,6 +35,7 @@ final class MockSyncEngineControlling: SyncEngineControlling {
   func start() { startCount += 1 }
   func stop() { stopCount += 1 }
   func requestSync() { requestSyncCount += 1 }
+  func fireStatusChangedForTest() { onStatusChanged?() }
   func beginAccountResolution() { beginAccountResolutionCount += 1 }
   func endAccountResolution() { endAccountResolutionCount += 1 }
   func prepareForAccountSwitch() { prepareForAccountSwitchCount += 1 }

--- a/FoqosTests/Mocks/MockSyncEngineDriver.swift
+++ b/FoqosTests/Mocks/MockSyncEngineDriver.swift
@@ -80,6 +80,18 @@ final class MockSyncEngineDriver: SyncEngineDriver {
     sendChangesCount = 0
   }
 
+  func setPendingRecordZoneChangesForTest(
+    _ changes: [CKSyncEngine.PendingRecordZoneChange]
+  ) {
+    pendingRecordZoneChanges = changes
+  }
+
+  func setPendingDatabaseChangesForTest(
+    _ changes: [CKSyncEngine.PendingDatabaseChange]
+  ) {
+    pendingDatabaseChanges = changes
+  }
+
   func fetchRecord(_ id: CKRecord.ID) async -> FetchRecordResult {
     fetchedRecordIDs.append(id)
     return fetchRecordResults[id.recordName] ?? defaultFetchRecordResult

--- a/FoqosTests/NetworkReachabilityMonitorTests.swift
+++ b/FoqosTests/NetworkReachabilityMonitorTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class NetworkReachabilityMonitorTests: XCTestCase {
+  func testReconnectFiresOnlyOnUnsatisfiedToSatisfiedEdge() {
+    let monitor = NetworkReachabilityMonitor()
+    var reconnects = 0
+    monitor.onReconnect = { reconnects += 1 }
+
+    monitor.handlePathUpdate(isSatisfied: true)
+    XCTAssertTrue(monitor.isOnline)
+    XCTAssertEqual(reconnects, 0)
+
+    monitor.handlePathUpdate(isSatisfied: false)
+    XCTAssertFalse(monitor.isOnline)
+    XCTAssertEqual(reconnects, 0)
+
+    monitor.handlePathUpdate(isSatisfied: true)
+    XCTAssertTrue(monitor.isOnline)
+    XCTAssertEqual(reconnects, 1)
+
+    monitor.handlePathUpdate(isSatisfied: true)
+    XCTAssertEqual(reconnects, 1)
+  }
+}

--- a/FoqosTests/SyncEngineFacadeTests.swift
+++ b/FoqosTests/SyncEngineFacadeTests.swift
@@ -27,10 +27,10 @@ final class SyncEngineFacadeTests: XCTestCase {
     bufferSuiteName = "SyncEngineFacadeTests-buffer-\(UUID().uuidString)"
     bufferDefaults = UserDefaults(suiteName: bufferSuiteName)!
     manager.bufferDefaults = bufferDefaults
-    mock = MockSyncEngineControlling()
-    manager.engineController = mock
     manager.isSyncReady = false
     manager.isEnabled = false
+    mock = MockSyncEngineControlling()
+    manager.engineController = mock
   }
 
   override func tearDown() async throws {
@@ -49,7 +49,7 @@ final class SyncEngineFacadeTests: XCTestCase {
     XCTAssertEqual(mock.startCount, 1)
     XCTAssertEqual(mock.stopCount, 0)
     XCTAssertTrue(SharedData.deviceSyncEnabled)
-    XCTAssertEqual(manager.syncStatus, .idle)
+    XCTAssertEqual(manager.syncStatusSnapshot.status, .synced)
   }
 
   func testGivenController_WhenToggledOffAfterOn_ThenStopIsCalled() {
@@ -59,7 +59,7 @@ final class SyncEngineFacadeTests: XCTestCase {
     XCTAssertEqual(mock.startCount, 1)
     XCTAssertEqual(mock.stopCount, 1)
     XCTAssertFalse(SharedData.deviceSyncEnabled)
-    XCTAssertEqual(manager.syncStatus, .disabled)
+    XCTAssertEqual(manager.syncStatusSnapshot.status, .disabled)
   }
 
   func testGivenController_WhenFacadeVerbsCalled_ThenTheyForward() throws {

--- a/FoqosTests/SyncEngineQueueDrainTests.swift
+++ b/FoqosTests/SyncEngineQueueDrainTests.swift
@@ -1,0 +1,160 @@
+import CloudKit
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class SyncEngineQueueDrainTests: XCTestCase {
+  var suiteName: String!
+  var defaults: UserDefaults!
+  var container: ModelContainer!
+  var context: ModelContext!
+  var store: SyncEngineStore!
+  var driver: MockSyncEngineDriver!
+  var apply: SyncApplyService!
+  var provider: RecordProvider!
+  var emergencyManager: EmergencyUnblockManager!
+  var sessionSync: MockSessionSyncFlushing!
+  var sessionController: MockSessionController!
+  var profileDeleteCommitScheduler: ManualProfileDeleteCommitScheduler!
+  let deviceId = "device-A"
+  let userRecordName = "user-A"
+  let zoneID = CKRecordZone.ID(
+    zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "SyncEngineQueueDrainTests-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+    SharedData.configure(suite: defaults)
+    container = try TestModelContainer.create()
+    context = container.mainContext
+    store = SyncEngineStore(userRecordName: userRecordName, defaults: defaults)
+    driver = MockSyncEngineDriver()
+    sessionController = MockSessionController()
+    profileDeleteCommitScheduler = ManualProfileDeleteCommitScheduler()
+    emergencyManager = EmergencyUnblockManager(defaults: defaults)
+    apply = SyncApplyService(
+      modelContext: context, store: store, sessionController: sessionController,
+      emergencyManager: emergencyManager, deviceId: deviceId,
+      scheduleProfileDeleteCommit: profileDeleteCommitScheduler.schedule)
+    provider = RecordProvider(
+      modelContext: context, store: store, emergencyManager: emergencyManager, deviceId: deviceId)
+    sessionSync = MockSessionSyncFlushing()
+    SyncConflictManager.shared.clearAll()
+  }
+
+  override func tearDown() async throws {
+    SyncConflictManager.shared.clearAll()
+    UserDefaults().removePersistentDomain(forName: suiteName)
+    try await super.tearDown()
+  }
+
+  func testRetriableReAddSchedulesADrainSend() async {
+    let controller = makeStartedController()
+    controller.setQueueDrainDelayForTest(0)
+    driver.reset()
+
+    controller.handle(
+      .sentRecordZoneChanges(
+        savedRecords: [],
+        failedRecordSaves: [(sampleRecord(), CKError(.serviceUnavailable))],
+        deletedRecordIDs: [], failedRecordDeletes: []))
+    await controller.drainTaskForTest?.value
+
+    XCTAssertGreaterThanOrEqual(driver.sendChangesCount, 1)
+  }
+
+  func testDrainDoesNotSendWhenNothingReAdded() async {
+    let controller = makeStartedController()
+    controller.setQueueDrainDelayForTest(0)
+    driver.reset()
+
+    controller.handle(
+      .sentRecordZoneChanges(
+        savedRecords: [sampleRecord()], failedRecordSaves: [], deletedRecordIDs: [],
+        failedRecordDeletes: []))
+    await controller.drainTaskForTest?.value
+
+    XCTAssertEqual(driver.sendChangesCount, 0)
+  }
+
+  func testFetchSideReAddAlsoDrainsOnDidFetchChanges() async {
+    let id = UUID()
+    let local = BlockedProfiles(id: id, name: "Local", syncVersion: 5)
+    context.insert(local)
+    try? context.save()
+    let controller = makeStartedController()
+    controller.setQueueDrainDelayForTest(0)
+    let remoteRecord = makeProfileRecord(id: id, version: 5, name: "Remote")
+    remoteRecord[SyncedProfile.FieldKey.updatedAt.rawValue] = local.updatedAt.addingTimeInterval(-10)
+
+    controller.handle(.fetchedRecordZoneChanges(modifications: [remoteRecord], deletions: []))
+    driver.reset()
+    controller.handle(.didFetchChanges)
+    await controller.drainTaskForTest?.value
+
+    XCTAssertGreaterThanOrEqual(driver.sendChangesCount, 1)
+  }
+
+  func testDrainGatedOffWhenNonOperational() async {
+    let controller = makeStartedController()
+    controller.setQueueDrainDelayForTest(0)
+    controller.forceStateForTest(.disabled)
+    driver.reset()
+
+    controller.handle(
+      .sentRecordZoneChanges(
+        savedRecords: [],
+        failedRecordSaves: [(sampleRecord(), CKError(.serviceUnavailable))],
+        deletedRecordIDs: [], failedRecordDeletes: []))
+    await controller.drainTaskForTest?.value
+
+    XCTAssertEqual(driver.sendChangesCount, 0)
+  }
+
+  func testStopCancelsPendingDrainAndClearsInFlight() {
+    let controller = makeStartedController()
+    controller.setQueueDrainDelayForTest(1_000_000_000)
+    controller.handle(.willSendChanges)
+    controller.handle(
+      .sentRecordZoneChanges(
+        savedRecords: [],
+        failedRecordSaves: [(sampleRecord(), CKError(.serviceUnavailable))],
+        deletedRecordIDs: [], failedRecordDeletes: []))
+
+    controller.stop()
+
+    XCTAssertNil(controller.drainTaskForTest)
+    XCTAssertFalse(controller.isInFlight)
+  }
+
+  private func makeStartedController() -> SyncEngineController {
+    let controller = SyncEngineController(
+      modelContext: context,
+      store: store,
+      driverFactory: { [driver] _ in driver! },
+      apply: apply,
+      provider: provider,
+      sessionSync: sessionSync,
+      deviceId: deviceId)
+    controller.start()
+    controller.startupTask?.cancel()
+    return controller
+  }
+
+  private func recordID(_ name: String) -> CKRecord.ID {
+    CKRecord.ID(recordName: name, zoneID: zoneID)
+  }
+
+  private func sampleRecord() -> CKRecord {
+    makeProfileRecord(id: UUID(), version: 1)
+  }
+
+  private func makeProfileRecord(id: UUID, version: Int, name: String = "Profile") -> CKRecord {
+    let profile = BlockedProfiles(id: id, name: name, syncVersion: version)
+    let synced = SyncedProfile(from: profile, originDeviceId: "device-B")
+    return synced.toCKRecord(in: zoneID)
+  }
+}

--- a/FoqosTests/SyncEngineStatusTests.swift
+++ b/FoqosTests/SyncEngineStatusTests.swift
@@ -70,6 +70,53 @@ final class SyncEngineStatusTests: XCTestCase {
     XCTAssertFalse(controller.isInFlight)
   }
 
+  func testPendingChangeCountCountsOutboundRecordAndDatabaseChanges() {
+    let controller = makeStartedController()
+    driver.setPendingRecordZoneChangesForTest([
+      .saveRecord(recordID("save-1")),
+      .deleteRecord(recordID("delete-1")),
+    ])
+    driver.setPendingDatabaseChangesForTest([.saveZone(CKRecordZone(zoneID: zoneID))])
+
+    XCTAssertEqual(controller.pendingChangeCount, 3)
+  }
+
+  func testDidFetchStampsLastSyncAndFiresStatusHook() {
+    let controller = makeStartedController()
+    var ticks = 0
+    controller.onStatusChanged = { ticks += 1 }
+
+    XCTAssertNil(controller.lastSuccessfulSyncDate)
+    controller.handle(.didFetchChanges)
+
+    XCTAssertNotNil(controller.lastSuccessfulSyncDate)
+    XCTAssertGreaterThanOrEqual(ticks, 1)
+  }
+
+  func testSentStampsLastSyncOnlyWithProgressAndNoFailure() {
+    let controller = makeStartedController()
+
+    controller.handle(
+      .sentRecordZoneChanges(
+        savedRecords: [], failedRecordSaves: [], deletedRecordIDs: [],
+        failedRecordDeletes: []))
+    XCTAssertNil(controller.lastSuccessfulSyncDate)
+
+    controller.handle(
+      .sentRecordZoneChanges(
+        savedRecords: [sampleRecord()], failedRecordSaves: [], deletedRecordIDs: [],
+        failedRecordDeletes: []))
+    let afterProgress = controller.lastSuccessfulSyncDate
+    XCTAssertNotNil(afterProgress)
+
+    controller.handle(
+      .sentRecordZoneChanges(
+        savedRecords: [sampleRecord()],
+        failedRecordSaves: [(sampleRecord(), CKError(.serviceUnavailable))],
+        deletedRecordIDs: [], failedRecordDeletes: []))
+    XCTAssertEqual(controller.lastSuccessfulSyncDate, afterProgress)
+  }
+
   private func makeStartedController() -> SyncEngineController {
     let controller = SyncEngineController(
       modelContext: context,
@@ -81,5 +128,19 @@ final class SyncEngineStatusTests: XCTestCase {
       deviceId: deviceId)
     controller.start()
     return controller
+  }
+
+  private func recordID(_ name: String) -> CKRecord.ID {
+    CKRecord.ID(recordName: name, zoneID: zoneID)
+  }
+
+  private func sampleRecord() -> CKRecord {
+    let record = CKRecord(recordType: SyncedProfile.recordType, recordID: recordID(UUID().uuidString))
+    record[SyncedProfile.FieldKey.profileId.rawValue] = UUID().uuidString
+    record[SyncedProfile.FieldKey.name.rawValue] = "Profile"
+    record[SyncedProfile.FieldKey.order.rawValue] = 0
+    record[SyncedProfile.FieldKey.version.rawValue] = 1
+    record[SyncedProfile.FieldKey.originDeviceId.rawValue] = "device-B"
+    return record
   }
 }

--- a/FoqosTests/SyncEngineStatusTests.swift
+++ b/FoqosTests/SyncEngineStatusTests.swift
@@ -1,0 +1,85 @@
+import CloudKit
+import SwiftData
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class SyncEngineStatusTests: XCTestCase {
+  var suiteName: String!
+  var defaults: UserDefaults!
+  var container: ModelContainer!
+  var context: ModelContext!
+  var store: SyncEngineStore!
+  var driver: MockSyncEngineDriver!
+  var apply: SyncApplyService!
+  var provider: RecordProvider!
+  var emergencyManager: EmergencyUnblockManager!
+  var sessionSync: MockSessionSyncFlushing!
+  var sessionController: MockSessionController!
+  var profileDeleteCommitScheduler: ManualProfileDeleteCommitScheduler!
+  let deviceId = "device-A"
+  let userRecordName = "user-A"
+  let zoneID = CKRecordZone.ID(
+    zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)
+
+  override func setUp() async throws {
+    try await super.setUp()
+    suiteName = "SyncEngineStatusTests-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+    SharedData.configure(suite: defaults)
+    container = try TestModelContainer.create()
+    context = container.mainContext
+    store = SyncEngineStore(userRecordName: userRecordName, defaults: defaults)
+    driver = MockSyncEngineDriver()
+    sessionController = MockSessionController()
+    profileDeleteCommitScheduler = ManualProfileDeleteCommitScheduler()
+    emergencyManager = EmergencyUnblockManager(defaults: defaults)
+    apply = SyncApplyService(
+      modelContext: context, store: store, sessionController: sessionController,
+      emergencyManager: emergencyManager, deviceId: deviceId,
+      scheduleProfileDeleteCommit: profileDeleteCommitScheduler.schedule)
+    provider = RecordProvider(
+      modelContext: context, store: store, emergencyManager: emergencyManager, deviceId: deviceId)
+    sessionSync = MockSessionSyncFlushing()
+    SyncConflictManager.shared.clearAll()
+  }
+
+  override func tearDown() async throws {
+    SyncConflictManager.shared.clearAll()
+    UserDefaults().removePersistentDomain(forName: suiteName)
+    try await super.tearDown()
+  }
+
+  func testInFlightTracksSendAndFetchBrackets() {
+    let controller = makeStartedController()
+
+    XCTAssertFalse(controller.isInFlight)
+    controller.handle(.willSendChanges)
+    XCTAssertTrue(controller.isInFlight)
+    controller.handle(
+      .sentRecordZoneChanges(
+        savedRecords: [], failedRecordSaves: [], deletedRecordIDs: [],
+        failedRecordDeletes: []))
+    controller.handle(.didSendChanges)
+    XCTAssertFalse(controller.isInFlight)
+
+    controller.handle(.willFetchChanges)
+    XCTAssertTrue(controller.isInFlight)
+    controller.handle(.didFetchChanges)
+    XCTAssertFalse(controller.isInFlight)
+  }
+
+  private func makeStartedController() -> SyncEngineController {
+    let controller = SyncEngineController(
+      modelContext: context,
+      store: store,
+      driverFactory: { [driver] _ in driver! },
+      apply: apply,
+      provider: provider,
+      sessionSync: sessionSync,
+      deviceId: deviceId)
+    controller.start()
+    return controller
+  }
+}

--- a/FoqosTests/SyncEngineStatusTests.swift
+++ b/FoqosTests/SyncEngineStatusTests.swift
@@ -117,6 +117,38 @@ final class SyncEngineStatusTests: XCTestCase {
     XCTAssertEqual(controller.lastSuccessfulSyncDate, afterProgress)
   }
 
+  func testPrepareForAccountSwitchClearsLastSuccessfulSyncDate() {
+    let controller = makeStartedController()
+    stampLastSuccessfulSync(on: controller)
+    XCTAssertNotNil(controller.lastSuccessfulSyncDate)
+
+    controller.prepareForAccountSwitch()
+
+    XCTAssertNil(controller.lastSuccessfulSyncDate)
+  }
+
+  func testStopClearsLastSuccessfulSyncDate() {
+    let controller = makeStartedController()
+    stampLastSuccessfulSync(on: controller)
+    XCTAssertNotNil(controller.lastSuccessfulSyncDate)
+
+    controller.stop()
+
+    XCTAssertNil(controller.lastSuccessfulSyncDate)
+  }
+
+  func testPurgedZoneDeletionClearsLastSuccessfulSyncDate() {
+    let controller = makeStartedController()
+    stampLastSuccessfulSync(on: controller)
+    XCTAssertNotNil(controller.lastSuccessfulSyncDate)
+
+    controller.handle(
+      .fetchedDatabaseChanges(
+        modifiedZoneIDs: [], deletedZones: [(zoneID: zoneID, reason: .purged)]))
+
+    XCTAssertNil(controller.lastSuccessfulSyncDate)
+  }
+
   private func makeStartedController() -> SyncEngineController {
     let controller = SyncEngineController(
       modelContext: context,
@@ -142,5 +174,9 @@ final class SyncEngineStatusTests: XCTestCase {
     record[SyncedProfile.FieldKey.version.rawValue] = 1
     record[SyncedProfile.FieldKey.originDeviceId.rawValue] = "device-B"
     return record
+  }
+
+  private func stampLastSuccessfulSync(on controller: SyncEngineController) {
+    controller.handle(.didFetchChanges)
   }
 }

--- a/FoqosTests/SyncStatusDerivationTests.swift
+++ b/FoqosTests/SyncStatusDerivationTests.swift
@@ -93,19 +93,19 @@ final class SyncStatusDerivationTests: XCTestCase {
     manager.isEnabled = true
     manager.isSyncReady = true
 
-    manager.reachabilityMonitor.handlePathUpdate(isSatisfied: true)
-    manager.reachabilityMonitor.handlePathUpdate(isSatisfied: false)
-    manager.reachabilityMonitor.handlePathUpdate(isSatisfied: true)
+    manager.handleReachabilityPathUpdateForTest(isSatisfied: true)
+    manager.handleReachabilityPathUpdateForTest(isSatisfied: false)
+    manager.handleReachabilityPathUpdateForTest(isSatisfied: true)
 
     XCTAssertGreaterThanOrEqual(mock.requestSyncCount, 1)
   }
 
   func testDisableStopsMonitor() {
     manager.isEnabled = true
-    XCTAssertTrue(manager.reachabilityMonitor.isMonitoringForTest)
+    XCTAssertTrue(manager.isReachabilityMonitoringForTest)
 
     manager.isEnabled = false
 
-    XCTAssertFalse(manager.reachabilityMonitor.isMonitoringForTest)
+    XCTAssertFalse(manager.isReachabilityMonitoringForTest)
   }
 }

--- a/FoqosTests/SyncStatusDerivationTests.swift
+++ b/FoqosTests/SyncStatusDerivationTests.swift
@@ -88,4 +88,24 @@ final class SyncStatusDerivationTests: XCTestCase {
     XCTAssertEqual(manager.syncStatusSnapshot.status, .synced)
     XCTAssertNotNil(manager.syncStatusSnapshot.lastSyncDate)
   }
+
+  func testReconnectDrivesSyncNowWhenReady() {
+    manager.isEnabled = true
+    manager.isSyncReady = true
+
+    manager.reachabilityMonitor.handlePathUpdate(isSatisfied: true)
+    manager.reachabilityMonitor.handlePathUpdate(isSatisfied: false)
+    manager.reachabilityMonitor.handlePathUpdate(isSatisfied: true)
+
+    XCTAssertGreaterThanOrEqual(mock.requestSyncCount, 1)
+  }
+
+  func testDisableStopsMonitor() {
+    manager.isEnabled = true
+    XCTAssertTrue(manager.reachabilityMonitor.isMonitoringForTest)
+
+    manager.isEnabled = false
+
+    XCTAssertFalse(manager.reachabilityMonitor.isMonitoringForTest)
+  }
 }

--- a/FoqosTests/SyncStatusDerivationTests.swift
+++ b/FoqosTests/SyncStatusDerivationTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class SyncStatusDerivationTests: XCTestCase {
+  var testSuiteName: String!
+  var manager: ProfileSyncManager!
+  var mock: MockSyncEngineControlling!
+  private var savedEnabled = false
+  private var savedIsSyncReady = false
+  private var savedController: (any SyncEngineControlling)?
+  private var savedBufferDefaults: UserDefaults!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    testSuiteName = "SyncStatusDerivationTests-\(UUID().uuidString)"
+    SharedData.configure(suite: UserDefaults(suiteName: testSuiteName)!)
+    manager = ProfileSyncManager.shared
+    savedEnabled = manager.isEnabled
+    savedIsSyncReady = manager.isSyncReady
+    savedController = manager.engineController
+    savedBufferDefaults = manager.bufferDefaults
+    manager.isSyncReady = false
+    manager.isEnabled = false
+    mock = MockSyncEngineControlling()
+    manager.engineController = mock
+  }
+
+  override func tearDown() async throws {
+    manager.engineController = savedController
+    manager.isSyncReady = savedIsSyncReady
+    manager.isEnabled = savedEnabled
+    manager.bufferDefaults = savedBufferDefaults
+    UserDefaults().removePersistentDomain(forName: testSuiteName)
+    try await super.tearDown()
+  }
+
+  func testDeriveStatusPrecedence() {
+    typealias Manager = ProfileSyncManager
+    XCTAssertEqual(
+      Manager.deriveStatus(
+        isEnabled: false, pausedReason: nil, isInFlight: false, isOnline: true,
+        pendingCount: 5),
+      .disabled)
+    XCTAssertEqual(
+      Manager.deriveStatus(
+        isEnabled: true, pausedReason: .signedOut, isInFlight: true, isOnline: true,
+        pendingCount: 5),
+      .paused(.signedOut))
+    XCTAssertEqual(
+      Manager.deriveStatus(
+        isEnabled: true, pausedReason: nil, isInFlight: true, isOnline: true,
+        pendingCount: 5),
+      .syncing)
+    XCTAssertEqual(
+      Manager.deriveStatus(
+        isEnabled: true, pausedReason: nil, isInFlight: false, isOnline: false,
+        pendingCount: 5),
+      .offline)
+    XCTAssertEqual(
+      Manager.deriveStatus(
+        isEnabled: true, pausedReason: nil, isInFlight: false, isOnline: false,
+        pendingCount: 0),
+      .synced)
+    XCTAssertEqual(
+      Manager.deriveStatus(
+        isEnabled: true, pausedReason: nil, isInFlight: false, isOnline: true,
+        pendingCount: 3),
+      .waiting(3))
+    XCTAssertEqual(
+      Manager.deriveStatus(
+        isEnabled: true, pausedReason: nil, isInFlight: false, isOnline: true,
+        pendingCount: 0),
+      .synced)
+  }
+
+  func testSnapshotRepublishesWhenControllerFiresStatusHook() {
+    manager.isEnabled = true
+    mock.pendingChangeCount = 2
+    mock.isInFlight = false
+    mock.fireStatusChangedForTest()
+    XCTAssertEqual(manager.syncStatusSnapshot.status, .waiting(2))
+
+    mock.pendingChangeCount = 0
+    mock.lastSuccessfulSyncDate = Date()
+    mock.fireStatusChangedForTest()
+    XCTAssertEqual(manager.syncStatusSnapshot.status, .synced)
+    XCTAssertNotNil(manager.syncStatusSnapshot.lastSyncDate)
+  }
+}


### PR DESCRIPTION
Fixes #316
Fixes #335

## Summary
- Derive Settings sync status from real engine state: pending outbound queues, deferred facade queues, in-flight send/fetch, paused reason, online state, and last successful sync.
- Add real Sync Now feedback via CKSyncEngine send/fetch brackets.
- Add NWPathMonitor reconnect trigger that calls gated `syncNow()` on offline->online edge.
- Add explicit gated queue-drain resend with CKError retry-after/backoff for re-added pending changes, including send-side and fetch-side re-adds.
- Keep `automaticallySync = false`.
- Address review feedback by clearing stale last-sync dates on teardown, encapsulating the reachability monitor behind debug test seams, and documenting deliberate `retryAfter == 0` handling.

## Verification
- Task 0 baseline subset on current main/post-#347: `SyncEngineControllerTests` + `SyncEngineFacadeTests` passed on iPhone 17 UUID `B9E4A679-BDF3-4541-A59F-DA4BE21F80ED`.
- Review-fix focused tests: `SyncEngineStatusTests` + `SyncStatusDerivationTests` passed.
- Full suite: 1093 passed, 0 failed, 0 skipped on iPhone 17 UUID `B9E4A679-BDF3-4541-A59F-DA4BE21F80ED`.
- `swift-format lint --recursive .`: clean.
- `scripts/check-sync-guards.sh`: clean.
- `git diff --check main..HEAD`: clean.

## Device Verification
- DV-1: Passed — maintainer device pass on 2026-07-14. Device A showed `Offline` after offline edit; queued change synced automatically to Device B without manual Sync Now. Evidence: `docs/plans/FamilyFoqos-Logs-2026-07-14-225132.log` and `docs/plans/FamilyFoqos-Logs-2026-07-14-225116.log`.
- DV-2: Passed — maintainer device pass on 2026-07-14. Forced concurrent edit surfaced the expected `Sync Conflict` banner, then automatically resolved to the later Device A edit without manual Sync Now. Evidence: Device A save confirmed at 21:50:27Z in `docs/plans/FamilyFoqos-Logs-2026-07-14-225132.log`; Device B hit `serverRecordChanged` at 21:50:40Z and applied `equal_divergence_remote_wins` in `docs/plans/FamilyFoqos-Logs-2026-07-14-225116.log`.
- DV-3: Pending — maintainer device pass.
- DV-4: Pending — maintainer device pass.
- DV-5: Pending — maintainer device pass.
- DV-6: Pending — maintainer device pass.

## Deviations
- The implementation was first committed locally on `fix/316-335-sync-status-triggers`, but push was rejected by the repository verified-signature rule. Per the AFK/signing instruction, those unsigned commits were not amended or force-pushed. A signed, tree-identical replay branch, `fix/316-335-sync-status-triggers-signed`, was created from `main` and pushed for this PR.
- The PR was opened with the GitHub connector after the signed branch pushed successfully. Follow-up review processing used `gh` outside the sandbox.
