### PR TITLE
docs: 1Password + direnv credentials migration design (#365, folds #364 rotation)

### DIFF
--- a/docs/superpowers/specs/2026-08-09-1password-credentials.md
+++ b/docs/superpowers/specs/2026-08-09-1password-credentials.md
@@ -40,8 +40,9 @@ files when a downstream Apple tool requires a path.
 - Truly unattended lanes must not wait indefinitely for a biometric prompt. The design must also
   retain a usable personal/biometric mode for maintainers who do not accept a new service-account
   token.
-- The credential setup composes with #363 through one named interface: the **session-start unlock
-  step**. This design does not depend on that step's internal implementation.
+- The credential setup consumes the **Session Credential Warm-up** interface defined by #363. That
+  specification owns credential inputs, token-injection custody, per-stage outcomes, and
+  failure/expiry policy; this design does not duplicate them.
 - `xcodebuild -allowProvisioningUpdates` may need ASC authentication for automatic signing.
   `-authenticationKeyPath` accepts a file path, not in-memory key content. Xcode documents the path,
   key ID, and issuer ID as a required set
@@ -56,19 +57,18 @@ files when a downstream Apple tool requires a path.
 ### Option A — read-only 1Password service account (recommended)
 
 Create a dedicated non-built-in automation vault containing only the Family Foqos ASC item. Give a
-service account `read_items` access to that vault and inject its token into the worker session as
-`OP_SERVICE_ACCOUNT_TOKEN`. The service account cannot use a Personal, Private, Employee, or default
-Shared vault, so a dedicated vault is required. Its access can be limited, inspected, rotated, and
-revoked. These constraints follow 1Password's
+service account `read_items` access to that vault. 1Password CLI uses this mode when
+`OP_SERVICE_ACCOUNT_TOKEN` is present. The service account cannot use a Personal, Private, Employee,
+or default Shared vault, so a dedicated vault is required. Its access can be limited, inspected,
+rotated, and revoked. These constraints follow 1Password's
 [service-account model](https://www.1password.dev/service-accounts/get-started) and
 [CLI authentication contract](https://www.1password.dev/service-accounts/use-with-1password-cli).
 
 This is the reliable unattended mode: `op read` does not require a biometric interaction once the
 token is present. The trade-off is real: `OP_SERVICE_ACCOUNT_TOKEN` is itself a long-lived secret in
 the worker's environment. It must never live in `.envrc`, an env file, shell history, or the repo.
-The session-start unlock step owns injecting it from an operator-approved secret store. Limiting the
-account to a one-item vault makes compromise narrower than today's raw, effectively immortal `.p8`,
-and the token is revocable and its use report is inspectable.
+Limiting the account to a one-item vault makes compromise narrower than today's raw, effectively
+immortal `.p8`, and the token is revocable and its use report is inspectable.
 
 **Status: RECOMMENDED, OPEN-FOR-MAINTAINER.** The maintainer chooses whether the unattended benefit
 justifies custody of this new token.
@@ -76,9 +76,8 @@ justifies custody of this new token.
 ### Option B — personal 1Password app integration with biometrics
 
 If `OP_SERVICE_ACCOUNT_TOKEN` is absent, `op` uses the maintainer's personal 1Password CLI/app
-integration. The session-start unlock step performs the biometric warm-up before unattended work.
-This avoids a service token, attributes access to the maintainer, and uses the existing 1Password
-unlock boundary described by the
+integration. Run **Session Credential Warm-up** before unattended work. This avoids a service token,
+attributes access to the maintainer, and uses the existing 1Password unlock boundary described by the
 [1Password app integration](https://www.1password.dev/cli/app-integration).
 
 The limitation is that a later app relock can reintroduce a prompt during a lane. A warm-up reduces
@@ -121,8 +120,7 @@ The committed setup flow is:
 1. Install the 1Password CLI and direnv; configure personal app integration if Option B is used.
 2. Add the direnv hook to the shell once.
 3. Review `.envrc`, then run `direnv allow .`. A changed `.envrc` requires a fresh allow.
-4. Enter through the session-start unlock step. It either injects `OP_SERVICE_ACCOUNT_TOKEN` for
-   Option A or warms personal biometric access for Option B.
+4. Run **Session Credential Warm-up** before any credential-using lane.
 
 Add `.direnv/` to `.gitignore`. Do not ignore `.envrc`: it is the reviewed, committed replacement for
 the env template. Retain `fastlane/.env` in `.gitignore` as defense in depth even after deleting the
@@ -221,12 +219,14 @@ credential test.
 
 1. **Choose operator-owned settings.** Select Option A or B and choose the dedicated vault/item
    names. If Option A is chosen, create a service account with read-only access to only the dedicated
-   automation vault and arrange `OP_SERVICE_ACCOUNT_TOKEN` injection through the session-start
-   unlock step. Never paste the token into a command recorded by an agent.
+   automation vault and register the required inputs with **Session Credential Warm-up**. Never
+   paste the token into a command recorded by an agent.
 2. **Prepare the code migration before creating the key.** Implement the committed `.envrc`, secret
    resolver, base64 decode, raw `key_content` handoff, gym-scoped tempfile helper, deletion of the old
    env files, `.gitignore` change, Transporter postcondition, and non-submitting verification
-   lanes/tests. The references may point to an empty placeholder item until the next step.
+   lanes/tests. The references may point to an empty placeholder item until the next step. Treat
+   steps 2-9 as a maintenance window: do not run a lane that invokes `pilot` or `deliver`, and
+   activate the no-standing-key postcondition when step 9 removes the legacy key.
 3. **Create the replacement App Manager key in App Store Connect.** Use the browser's one-time
    download. Configure an explicit private download location, keep the window between download and
    import as short as practical, and do not expose the values in a terminal transcript.
@@ -237,7 +237,7 @@ credential test.
    the browser artifact and its empty staging directory. APFS snapshots and SSD wear leveling mean
    physical erasure cannot be guaranteed.
 5. **Activate the new references.** Replace `.envrc` placeholders with the chosen vault/item/field
-   references, review them, run `direnv allow .`, and enter via the session-start unlock step.
+   references, review them, run `direnv allow .`, and run **Session Credential Warm-up**.
 6. **Verify Fastlane authentication safely.** Run `bundle exec fastlane check_asc_key`. That lane
    may report only non-sensitive facts such as key/issuer presence; it must never print the returned
    key hash or any resolved value.
@@ -285,11 +285,11 @@ restore the revoked credential.
 
 ### Authentication matrix
 
-| Mode | Setup | Expected behavior |
+| Mode | Setup via **Session Credential Warm-up** | Expected behavior |
 | --- | --- | --- |
-| Service account | Session-start unlock step injects `OP_SERVICE_ACCOUNT_TOKEN` | `.envrc` stays non-secret; Fastlane resolves the same refs with no biometric prompt. |
-| Personal/biometric | Token absent; 1Password app integration enabled and warmed by session-start unlock step | The same `.envrc` and Fastfile work. A relocked app may prompt and is an acknowledged fallback limitation. |
-| Neither available | Token absent and personal CLI unavailable/locked | Lane fails before build with a redacted authentication error; it does not use a disk fallback. |
+| Service account | Service-account mode ready | `.envrc` stays non-secret; Fastlane resolves the same refs with no biometric prompt. |
+| Personal/biometric | Personal mode ready | The same `.envrc` and Fastfile work. A relocked app may prompt and is an acknowledged fallback limitation. |
+| Neither available | Not ready | Lane fails before build with a redacted authentication error; it does not use a disk fallback. |
 
 ### Manual acceptance
 

--- a/docs/superpowers/specs/2026-08-09-1password-credentials.md
+++ b/docs/superpowers/specs/2026-08-09-1password-credentials.md
@@ -1,7 +1,7 @@
 # App Store Connect Credentials: 1Password, direnv, and Key Rotation
 
 **Date:** 2026-08-09
-**Status:** Approved design; implementation plan is a separate step
+**Status:** Approved design; two operator decisions remain open; implementation plan is separate
 **Scope:** Local Fastlane credentials for V2 / `main`; resolves storage issue
 [#365](https://github.com/mnbf9rca/family-foqos/issues/365) and makes the rotation from
 [#364](https://github.com/mnbf9rca/family-foqos/issues/364) part of the migration cutover.
@@ -128,11 +128,11 @@ Add `.direnv/` to `.gitignore`. Do not ignore `.envrc`: it is the reviewed, comm
 the env template. Retain `fastlane/.env` in `.gitignore` as defense in depth even after deleting the
 file and removing all runtime use.
 
-At base `bf97c18`, the current `.gitignore` ignores neither `.envrc` nor `.direnv/`; the
-`feat/fastlane-setup` branch adds `fastlane/.env` at `.gitignore:63`. Integration adds only
-`.direnv/` to that credential-related set and preserves the `fastlane/.env` denylist entry. A scan
-of both feature branches finds credential-path references only on `feat/fastlane-setup`;
-`feat/fastlane-demo-mode:fastlane/Fastfile` adds screenshot behavior and no credential dependency.
+At base `bf97c18`, the current `.gitignore` ignores neither `.envrc` nor `.direnv/`; Fastlane setup
+commit `2404139` adds `fastlane/.env` at `.gitignore:63`. Integration adds only `.direnv/` to that
+credential-related set and preserves the `fastlane/.env` denylist entry. A scan of both feature
+branches finds credential-path references only in Fastlane setup commit `2404139`;
+`85593e0:fastlane/Fastfile` adds screenshot behavior and no credential dependency.
 
 A leaked `op://` reference reveals vault/item/field naming metadata. It does **not** reveal or grant
 access to the referenced value; an attacker still needs an authorized 1Password user session or
@@ -178,26 +178,39 @@ Because Xcode requires `-authenticationKeyPath`, wrap only the `gym` call in a h
 
 This extends the cleanup pattern already used by `pull_metadata`, which creates its API-key JSON in
 a `Tempfile.create` block and invokes `deliver download_metadata` entirely inside that block
-(`feat/fastlane-setup:fastlane/Fastfile:106-125`). The implementation must add an ensure-path test
-that forces the wrapped operation to fail and verifies the path no longer exists.
+(`2404139:fastlane/Fastfile:106-125`). The JSON contains the same raw PEM as the gym file, so
+implementation must explicitly assert mode `0600` for both tempfiles, cover cleanup after success
+and an injected failure for both, and add `log: false` to the nested `sh` call so the live JSON path
+is not advertised in lane output.
 
 Temporary materialization is not equivalent to durable storage. The key exists briefly in process
-memory and in mode-`0600` temporary files required by Xcode or Fastlane. Fastlane's Transporter also
-materializes an API key for upload and removes its key directory in an `ensure` block
-(`fastlane_core/lib/fastlane_core/itunes_transporter.rb:864-882`). The invariant is therefore: **no
-standing plaintext private-key file survives a lane or cutover**, not the untrue claim that the key
-never exists outside 1Password.
+memory and in mode-`0600` temporary files required by Xcode or Fastlane. Fastlane's Transporter
+cleanup is not uniform. `upload` and `provider_ids` remove the generated key directory in `ensure`
+blocks (`fastlane_core/lib/fastlane_core/itunes_transporter.rb:864-882,959-982`), but `verify` calls
+the same `prepare` writer without cleanup (`itunes_transporter.rb:903-953`). For a
+`ShellScriptTransporterExecutor`, that writer creates
+`~/.appstoreconnect/private_keys/AuthKey_<key-id>.p8` instead of a temporary directory
+(`itunes_transporter.rb:68-90`). Whether current project lanes reach `verify` is not an acceptable
+security dependency.
+
+Every project lane that invokes `pilot` or `deliver`, including `pull_metadata`, must therefore
+enforce its own postcondition in an `ensure`: remove only the expected project-key file at that
+known Transporter path, then fail if any `.p8` remains below `~/.appstoreconnect/`. An unrelated
+standing key is reported for operator remediation, not silently deleted. The scoped invariant is:
+**no standing plaintext private-key file survives a credential-using Family Foqos lane or the
+cutover**. It is not the untrue claim that the key never exists outside 1Password or that the gem
+always cleans up after itself.
 
 ### What dies and what replaces it
 
 | Current dependency | Current references | Replacement |
 | --- | --- | --- |
 | `fastlane/.env` | Fastlane auto-load; `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_PATH` | Delete the file and all runtime dependence. Keep its ignore rule as a tripwire. `.envrc` supplies only `*_REF` values. |
-| `fastlane/.env.template` | `feat/fastlane-setup:fastlane/.env.template:1-4` | Delete it. Committed `.envrc` plus setup documentation is the single template. |
-| `ASC_KEY_PATH` in `asc_api_key` | `feat/fastlane-setup:fastlane/Fastfile:21-26` | Resolve base64 content, decode in Ruby, and pass raw `key_content:`. |
-| `ASC_KEY_PATH` in `gym` `xcargs` | `feat/fastlane-setup:fastlane/Fastfile:128-143` | A helper-owned mode-`0600` temporary `.p8` path scoped to `gym`. Key and issuer IDs are resolved values, never committed literals. |
-| `pull_metadata` API-key JSON | `feat/fastlane-setup:fastlane/Fastfile:106-125` | Retain the proven `Tempfile.create` handoff. Its hash now contains raw PEM produced from 1Password rather than a home-directory path. |
-| `~/.appstoreconnect/` | Existing plan/spec and the old plaintext key | Remove the old `.p8` and empty directory after successful cutover. Fastlane may recreate a transient key directory internally during Transporter work; its ensure cleanup must leave no standing key. |
+| `fastlane/.env.template` | `2404139:fastlane/.env.template:1-4` | Delete it. Committed `.envrc` plus setup documentation is the single template. |
+| `ASC_KEY_PATH` in `asc_api_key` | `2404139:fastlane/Fastfile:21-26` | Resolve base64 content, decode in Ruby, and pass raw `key_content:`. |
+| `ASC_KEY_PATH` in `gym` `xcargs` | `2404139:fastlane/Fastfile:128-143` | A helper-owned mode-`0600` temporary `.p8` path scoped to `gym`. Key and issuer IDs are resolved values, never committed literals. |
+| `pull_metadata` API-key JSON | `2404139:fastlane/Fastfile:106-125` | Retain the `Tempfile.create` handoff, require mode `0600` and symmetric cleanup tests, and suppress logging of its live path. Its hash now contains raw PEM produced from 1Password rather than a home-directory path. |
+| `~/.appstoreconnect/` | Existing plan/spec, the old plaintext key, and Fastlane Transporter's cleanup-deficient `verify` path | Remove the old `.p8` and empty directory after successful cutover. After each project lane that can invoke Transporter, surgically remove the expected project-key path and fail if any `.p8` remains. |
 | Old IDs and absolute path in docs | `docs/superpowers/plans/2026-07-30-fastlane-screenshots-submission.md` and `docs/superpowers/specs/2026-07-30-fastlane-screenshots-submission-design.md` | After revocation, replace them with a neutral 1Password item reference and scrub the obsolete path. History remains, but the revoked identifiers no longer compose with a live key. |
 
 ## Migration/cutover plan
@@ -212,8 +225,8 @@ credential test.
    unlock step. Never paste the token into a command recorded by an agent.
 2. **Prepare the code migration before creating the key.** Implement the committed `.envrc`, secret
    resolver, base64 decode, raw `key_content` handoff, gym-scoped tempfile helper, deletion of the old
-   env files, `.gitignore` change, and non-submitting verification lanes/tests. The references may
-   point to an empty placeholder item until the next step.
+   env files, `.gitignore` change, Transporter postcondition, and non-submitting verification
+   lanes/tests. The references may point to an empty placeholder item until the next step.
 3. **Create the replacement App Manager key in App Store Connect.** Use the browser's one-time
    download. Configure an explicit private download location, keep the window between download and
    import as short as practical, and do not expose the values in a terminal transcript.
@@ -259,9 +272,14 @@ restore the revoked credential.
   missing/invalid field.
 - Base64 decode rejects malformed input; the decoded value loads through the real
   `app_store_connect_api_key` path.
-- The gym helper creates a mode-`0600` file, exposes it only for the duration of the block, and
-  removes it on both success and an injected failure.
-- The existing `pull_metadata` temporary JSON cleanup remains intact.
+- The gym helper and `pull_metadata` JSON handoff both create mode-`0600` files, expose them only
+  for the duration of their blocks, and remove them on both success and an injected failure.
+- `pull_metadata` invokes its nested Fastlane process with `log: false`, so the live tempfile path
+  is not emitted to lane output.
+- Every lane that invokes `pilot` or `deliver` removes the expected project-key file and asserts
+  that no `.p8` remains below `~/.appstoreconnect/`, including when the downstream action fails.
+- A repository scan enumerates every `fastlane run` occurrence and fails if any credential-returning
+  action is invoked that way. Non-secret action examples require an explicit allowlist rationale.
 - Repository scans find no private key block, service-account token, replacement identifiers, or
   absolute credential path.
 
@@ -279,7 +297,8 @@ Before revocation, the maintainer confirms:
 
 1. `check_asc_key` succeeds without printing a key or returned credential hash;
 2. the archive-only gym probe authenticates without upload/submission;
-3. no gym `.p8` or `pull_metadata` JSON tempfile remains after success or forced failure;
+3. no gym `.p8`, `pull_metadata` JSON tempfile, or Transporter `.p8` remains after success or forced
+   failure;
 4. the selected authentication mode meets the maintainer's unattended-run policy; and
 5. the 1Password item and, if selected, service-account usage are visible to the maintainer.
 
@@ -295,6 +314,8 @@ by rotation and #365 as remediated by the 1Password migration.
 - **DECIDED:** Store/transport private-key content as base64, decode in Ruby, and pass raw PEM to
   Fastlane.
 - **DECIDED:** Xcode receives a mode-`0600`, gym-scoped temporary `.p8` with ensure cleanup.
+- **DECIDED:** Family Foqos lanes enforce the no-standing-key postcondition instead of trusting
+  Fastlane Transporter's non-uniform cleanup.
 - **RECOMMENDED / OPEN-FOR-MAINTAINER:** Use a read-only service account for reliable unattended
   runs; personal biometric authentication remains a supported runtime fallback.
 - **OPEN-FOR-MAINTAINER:** Final dedicated vault and ASC item names.

--- a/docs/superpowers/specs/2026-08-09-1password-credentials.md
+++ b/docs/superpowers/specs/2026-08-09-1password-credentials.md
@@ -1,7 +1,7 @@
-# App Store Connect Credentials: 1Password, direnv, and Key Rotation
+# App Store Connect Credentials: 1Password, Scoped `op run`, and Key Rotation
 
 **Date:** 2026-08-09
-**Status:** Approved design; two operator decisions remain open; implementation plan is separate
+**Status:** Approved design; operator decisions ratified and provisioned; implementation/cutover pending
 **Scope:** Local Fastlane credentials for V2 / `main`; resolves storage issue
 [#365](https://github.com/mnbf9rca/family-foqos/issues/365) and makes the rotation from
 [#364](https://github.com/mnbf9rca/family-foqos/issues/364) part of the migration cutover.
@@ -20,26 +20,29 @@ session transcript. The transcript was not committed, pushed, or messaged elsewh
 contains the private half of the credential. Separately, this public repository contains the old
 key ID, issuer ID, and local key path in the existing Fastlane plan and spec. Those identifiers do
 not authenticate on their own, but together with the transcript they are all the inputs needed to
-use the old private key. Rotation, rather than document deletion, is the security boundary because
+use the old private key. Rotation, rather than repository-document deletion, is the security
+boundary because
 git history and forks retain already-published identifiers.
 
 The target state has one durable source of truth for ASC credentials: 1Password. The repository
-contains only 1Password secret references. Fastlane resolves the references when a lane starts,
-keeps the private key in process memory, and materializes it only in narrowly scoped temporary
-files when a downstream Apple tool requires a path.
+contains only non-secret 1Password references in `fastlane/asc.env`. A committed wrapper invokes
+credential-using lanes through `op run`, which resolves those references only into that child
+process. Fastlane keeps the private key in process memory and materializes it only in narrowly
+scoped temporary files when a downstream Apple tool requires a path. The maintainer's ambient shell
+never holds ASC key material.
 
 ## Constraints
 
 - The repository is public. No private key, service-account token, resolved environment value, new
   key ID, new issuer ID, or machine-specific key path may be committed.
-- The replacement ASC key is created during this migration. There is no period where the new key is
-  durably stored as a plaintext home-directory credential.
+- The replacement ASC key already exists and is stored in 1Password. It is not durably stored as a
+  plaintext home-directory credential. The old key `U2UZLVHKA5` remains active until the new wiring,
+  `check_asc_key`, and Xcode path verification pass.
 - ASC key creation normally produces a one-time browser download. This design therefore does not
   claim a diskless cutover. It minimizes that initial file's lifetime and treats revocation, not
   best-effort file erasure on APFS/SSD storage, as the security boundary.
-- Truly unattended lanes must not wait indefinitely for a biometric prompt. The design must also
-  retain a usable personal/biometric mode for maintainers who do not accept a new service-account
-  token.
+- A release session may spend one biometric interaction bootstrapping the service-account token,
+  but credential-using lane child processes must not stop later for additional biometric prompts.
 - The credential setup consumes the **Session Credential Warm-up** interface defined by #363. That
   specification owns credential inputs, token-injection custody, per-stage outcomes, and
   failure/expiry policy; this design does not duplicate them.
@@ -54,7 +57,7 @@ files when a downstream Apple tool requires a path.
 
 ## Options
 
-### Option A — read-only 1Password service account (recommended)
+### Option A — read-only 1Password service account (ratified)
 
 Create a dedicated non-built-in automation vault containing only the Family Foqos ASC item. Give a
 service account `read_items` access to that vault. 1Password CLI uses this mode when
@@ -64,27 +67,28 @@ rotated, and revoked. These constraints follow 1Password's
 [service-account model](https://www.1password.dev/service-accounts/get-started) and
 [CLI authentication contract](https://www.1password.dev/service-accounts/use-with-1password-cli).
 
-This is the reliable unattended mode: `op read` does not require a biometric interaction once the
+This is the reliable unattended mode: `op run` does not require a biometric interaction once the
 token is present. The trade-off is real: `OP_SERVICE_ACCOUNT_TOKEN` is itself a long-lived secret in
-the worker's environment. It must never live in `.envrc`, an env file, shell history, or the repo.
-Limiting the account to a one-item vault makes compromise narrower than today's raw, effectively
-immortal `.p8`, and the token is revocable and its use report is inspectable.
+the worker's ambient environment for the release session. It must never live in a committed file,
+shell history, or the repository. Limiting the account to a one-item vault makes compromise narrower
+than today's raw, effectively immortal `.p8`, and the token is revocable and its use report is
+inspectable.
 
-**Status: RECOMMENDED, OPEN-FOR-MAINTAINER.** The maintainer chooses whether the unattended benefit
-justifies custody of this new token.
+**Status: RATIFIED AND PROVISIONED.** The read-only token is stored at
+`op://family-foqos/service_auth_token/OP_SERVICE_ACCOUNT_TOKEN`. Personal 1Password authentication
+retrieves it once per session; the reference, never the resolved token, is safe to document.
 
-### Option B — personal 1Password app integration with biometrics
+### Option B — personal 1Password app integration as bootstrap
 
-If `OP_SERVICE_ACCOUNT_TOKEN` is absent, `op` uses the maintainer's personal 1Password CLI/app
-integration. Run **Session Credential Warm-up** before unattended work. This avoids a service token,
-attributes access to the maintainer, and uses the existing 1Password unlock boundary described by the
-[1Password app integration](https://www.1password.dev/cli/app-integration).
+The maintainer's personal 1Password CLI/app integration performs the single biometric bootstrap
+that reads `OP_SERVICE_ACCOUNT_TOKEN` into the release-session environment. Run **Session Credential
+Warm-up** before credential-using work. This keeps personal authorization at the session boundary;
+subsequent `op run` children resolve ASC references with the scoped service account instead of
+re-prompting for personal access. The app integration follows 1Password's
+[documented authentication contract](https://www.1password.dev/cli/app-integration).
 
-The limitation is that a later app relock can reintroduce a prompt during a lane. A warm-up reduces
-that risk but cannot make long-running work as deterministic as service-account authentication.
-
-**Status: SUPPORTED FALLBACK, OPEN-FOR-MAINTAINER.** Use this when interactive authorization is an
-acceptable condition of a release session.
+**Status: DECIDED BOOTSTRAP LAYER.** Direct personal resolution of ASC values during a Fastlane lane
+is no longer the normal delivery path.
 
 ### Option C — retain a standing `.p8` for Xcode
 
@@ -96,52 +100,65 @@ migration's purpose.
 
 ## Recommendation
 
-### One committed `.envrc`, two authentication modes
+### Two-layer credential injection
 
-Use one `.envrc` for Options A and B. It exports literal 1Password references, not resolved values:
+The ratified architecture separates operator bootstrap from ASC credential delivery.
 
-```bash
-export ASC_KEY_ID_REF='op://<automation-vault>/<asc-item>/key-id'
-export ASC_ISSUER_ID_REF='op://<automation-vault>/<asc-item>/issuer-id'
-export ASC_KEY_CONTENT_BASE64_REF='op://<automation-vault>/<asc-item>/private-key-base64'
+**Layer 1 — operator-local bootstrap.** Personal 1Password app integration and direnv use an
+operator-owned `.env.tpl` to export only `OP_SERVICE_ACCOUNT_TOKEN`, resolved from
+`op://family-foqos/service_auth_token/OP_SERVICE_ACCOUNT_TOKEN`. This costs one biometric touch per
+release session. The repository documents this setup but does not ship `.env.tpl`, `.envrc`, or the
+resolved token. No ASC key ID, issuer ID, or key content enters the ambient shell.
+
+**Layer 2 — per-invocation ASC injection.** Commit `fastlane/asc.env` with exactly three non-secret
+reference mappings:
+
+```dotenv
+ASC_KEY_ID=op://family-foqos/app_store_connect_key/ASC_KEY_ID_REF
+ASC_ISSUER_ID=op://family-foqos/app_store_connect_key/ASC_ISSUER_ID_REF
+ASC_KEY_CONTENT_BASE64=op://family-foqos/app_store_connect_key/ASC_KEY_CONTENT_BASE64_REF
 ```
 
-The file needs no authentication branch. When `OP_SERVICE_ACCOUNT_TOKEN` is present, 1Password CLI
-uses the service account; otherwise it uses personal app integration. Fastlane resolves the three
-references at lane start. This keeps the actual ASC key out of the interactive shell environment
-and makes the maintainer's authentication choice runtime configuration rather than a second config
-file.
+The 1Password item and fields are decided and provisioned: vault `family-foqos`, item
+`app_store_connect_key`, non-secret fields `ASC_KEY_ID_REF` and `ASC_ISSUER_ID_REF`, and concealed
+field `ASC_KEY_CONTENT_BASE64_REF`. A credential-using invocation is:
 
-The vault and item names are **OPEN-FOR-MAINTAINER**. The item name must describe the application,
-not embed the ASC key ID. Implementation replaces the placeholders once those names are selected.
+```bash
+op run --env-file fastlane/asc.env -- bundle exec fastlane <lane>
+```
 
-The committed setup flow is:
+`op run` uses the bootstrapped service token, resolves references only for that child process, and
+masks concealed values in output. Fastlane reads the resolved `ASC_KEY_ID`, `ASC_ISSUER_ID`, and
+`ASC_KEY_CONTENT_BASE64` values with `ENV.fetch`; a bare credential-using Fastlane invocation fails
+closed instead of falling back to a disk credential.
 
-1. Install the 1Password CLI and direnv; configure personal app integration if Option B is used.
-2. Add the direnv hook to the shell once.
-3. Review `.envrc`, then run `direnv allow .`. A changed `.envrc` requires a fresh allow.
-4. Run **Session Credential Warm-up** before any credential-using lane.
+Commit a thin `scripts/fastlane.sh` wrapper so operators do not forget the prefix. It runs
+`screenshots` directly because that lane needs no ASC credential, and runs `beta`, `release`,
+`pull_metadata`, and `check_asc_key` through `op run --env-file fastlane/asc.env`. Any later
+credential-using lane joins the wrapped set explicitly.
 
-Add `.direnv/` to `.gitignore`. Do not ignore `.envrc`: it is the reviewed, committed replacement for
-the env template. Retain `fastlane/.env` in `.gitignore` as defense in depth even after deleting the
-file and removing all runtime use.
+The setup flow is:
 
-At base `bf97c18`, the current `.gitignore` ignores neither `.envrc` nor `.direnv/`; Fastlane setup
-commit `2404139` adds `fastlane/.env` at `.gitignore:63`. Integration adds only `.direnv/` to that
-credential-related set and preserves the `fastlane/.env` denylist entry. A scan of both feature
-branches finds credential-path references only in Fastlane setup commit `2404139`;
-`85593e0:fastlane/Fastfile` adds screenshot behavior and no credential dependency.
+1. Install the 1Password CLI and direnv; enable personal app integration.
+2. Configure the operator-local direnv/`.env.tpl` bootstrap for only `OP_SERVICE_ACCOUNT_TOKEN`.
+3. Run **Session Credential Warm-up** once at the start of the release session.
+4. Invoke Fastlane through `scripts/fastlane.sh`; do not call an ASC lane bare.
+
+Retain `fastlane/.env` in `.gitignore` as defense in depth after deleting the file and removing all
+runtime use. Commit `fastlane/asc.env`; it contains references, not resolved values. Delete
+`fastlane/.env.template` because the operator no longer copies or edits a Fastlane env template.
 
 A leaked `op://` reference reveals vault/item/field naming metadata. It does **not** reveal or grant
 access to the referenced value; an attacker still needs an authorized 1Password user session or
-service-account token. This is why the public `.envrc` must contain references only and why the
-service token remains outside it.
+service-account token. This is why the public refs file contains references only and why the service
+token remains confined to the operator's release-session environment.
 
 ### Base64 at the storage boundary, raw PEM at the Fastlane boundary
 
 Store the private key as base64 in 1Password. This removes PEM-newline and command-substitution
-ambiguity. Fastlane resolves `ASC_KEY_CONTENT_BASE64_REF`, decodes it with strict base64 decoding in
-Ruby, and passes the resulting raw multiline PEM as `key_content:`.
+ambiguity. `op run` resolves the `fastlane/asc.env` reference into the child-only
+`ASC_KEY_CONTENT_BASE64` value. Fastlane decodes it with strict base64 decoding in Ruby and passes
+the resulting raw multiline PEM as `key_content:`.
 
 Fastlane 2.237.0 accepts raw `key_content`; it preserves real newlines and converts literal `\\n`
 sequences to newlines
@@ -151,16 +168,21 @@ It also supports `is_key_content_base64:` and forwards that flag with the key
 (`/opt/homebrew/lib/ruby/gems/4.0.0/gems/fastlane-2.237.0/spaceship/lib/spaceship/connect_api/token.rb:52-71`).
 
 The design deliberately decodes before calling the action instead of setting
-`is_key_content_base64: true`. The action returns the original key hash, while Fastlane's Transporter
-later writes `api_key[:key]` directly to an `AuthKey_*.p8` file without consulting the base64 flag
+`is_key_content_base64: true`. Mainline consumers do handle the flag: Spaceship's token loader
+decodes it, `deliver/runner.rb:300` decodes before Transporter, and
+`pilot/build_manager.rb:416` does the same. The responsibility is distributed, however, while
+Fastlane's Transporter `prepare` writer itself is flag-blind and writes `api_key[:key]` directly to
+an `AuthKey_*.p8` file
 (`/opt/homebrew/lib/ruby/gems/4.0.0/gems/fastlane-2.237.0/fastlane_core/lib/fastlane_core/itunes_transporter.rb:68-90`).
-Passing raw PEM keeps `pilot`, `deliver`, and the existing temporary JSON handoff compatible while
-base64 still protects the 1Password-to-Ruby transport.
+Direct Transporter use or a hand-built API-key hash such as the `pull_metadata` JSON path therefore
+depends on its builder remembering which upstream decode has occurred. Strictly decoding once in
+Ruby establishes one raw-PEM invariant for every consumer and removes that distributed assumption;
+base64 still protects the 1Password-to-child-process transport. No known upstream defect is claimed.
 
-The private `asc_api_key` lane therefore replaces `ASC_KEY_PATH` with the three references, resolves
-them without logging stdout, strictly decodes the private key, and calls `app_store_connect_api_key`
-with raw `key_content`. Resolution failures, missing fields, invalid base64, or invalid PEM fail the
-lane before any build or network mutation.
+The private `asc_api_key` lane therefore replaces `ASC_KEY_PATH` with the three child-process values,
+fetches them without logging, strictly decodes the private key, and calls
+`app_store_connect_api_key` with raw `key_content`. `op run` resolution failures, missing environment
+values, invalid base64, or invalid PEM fail the lane before any build or network mutation.
 
 ### Path-only consumers get scoped temporary files
 
@@ -181,9 +203,11 @@ implementation must explicitly assert mode `0600` for both tempfiles, cover clea
 and an injected failure for both, and add `log: false` to the nested `sh` call so the live JSON path
 is not advertised in lane output.
 
-Temporary materialization is not equivalent to durable storage. The key exists briefly in process
-memory and in mode-`0600` temporary files required by Xcode or Fastlane. Fastlane's Transporter
-cleanup is not uniform. `upload` and `provider_ids` remove the generated key directory in `ensure`
+Temporary materialization is not equivalent to durable storage. The lifecycle is: at rest in
+1Password → resolved values in a credential-using `op run` child environment for that invocation →
+Fastlane memory and sensitive lane context → a gym-only or metadata-only mode-`0600` tempfile →
+ensure-driven deletion. ASC material never enters the ambient shell. Fastlane's Transporter cleanup
+is not uniform. `upload` and `provider_ids` remove the generated key directory in `ensure`
 blocks (`fastlane_core/lib/fastlane_core/itunes_transporter.rb:864-882,959-982`), but `verify` calls
 the same `prepare` writer without cleanup (`itunes_transporter.rb:903-953`). For a
 `ShellScriptTransporterExecutor`, that writer creates
@@ -197,58 +221,60 @@ known Transporter path, then fail if any `.p8` remains below `~/.appstoreconnect
 standing key is reported for operator remediation, not silently deleted. The scoped invariant is:
 **no standing plaintext private-key file survives a credential-using Family Foqos lane or the
 cutover**. It is not the untrue claim that the key never exists outside 1Password or that the gem
-always cleans up after itself.
+always cleans up after itself. Child-only `op run` injection strengthens this postcondition: the
+cleanup proof no longer has to account for ASC values lingering in the parent shell after a lane.
 
 ### What dies and what replaces it
 
 | Current dependency | Current references | Replacement |
 | --- | --- | --- |
-| `fastlane/.env` | Fastlane auto-load; `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_PATH` | Delete the file and all runtime dependence. Keep its ignore rule as a tripwire. `.envrc` supplies only `*_REF` values. |
-| `fastlane/.env.template` | `2404139:fastlane/.env.template:1-4` | Delete it. Committed `.envrc` plus setup documentation is the single template. |
-| `ASC_KEY_PATH` in `asc_api_key` | `2404139:fastlane/Fastfile:21-26` | Resolve base64 content, decode in Ruby, and pass raw `key_content:`. |
-| `ASC_KEY_PATH` in `gym` `xcargs` | `2404139:fastlane/Fastfile:128-143` | A helper-owned mode-`0600` temporary `.p8` path scoped to `gym`. Key and issuer IDs are resolved values, never committed literals. |
+| `fastlane/.env` | Fastlane auto-load; `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_PATH` | Delete the file and all runtime dependence at cutover. Keep its ignore rule as a tripwire. `scripts/fastlane.sh` injects child-only values through committed, non-secret `fastlane/asc.env`. |
+| `fastlane/.env.template` | `2404139:fastlane/.env.template:1-4` | Delete it. Its copy-and-edit job no longer exists; committed `fastlane/asc.env` plus bootstrap documentation replaces it. |
+| `ASC_KEY_PATH` in `asc_api_key` | `2404139:fastlane/Fastfile:21-26` | Fetch the child-only base64 value injected by `op run`, decode in Ruby, and pass raw `key_content:`. |
+| `ASC_KEY_PATH` in `release` and `beta` `gym` `xcargs` | `4e6b28b:fastlane/Fastfile` | A helper-owned mode-`0600` temporary `.p8` path scoped to each `gym` call. Key and issuer IDs come from the same child-only environment, never committed literals. |
 | `pull_metadata` API-key JSON | `2404139:fastlane/Fastfile:106-125` | Retain the `Tempfile.create` handoff, require mode `0600` and symmetric cleanup tests, and suppress logging of its live path. Its hash now contains raw PEM produced from 1Password rather than a home-directory path. |
 | `~/.appstoreconnect/` | Existing plan/spec, the old plaintext key, and Fastlane Transporter's cleanup-deficient `verify` path | Remove the old `.p8` and empty directory after successful cutover. After each project lane that can invoke Transporter, surgically remove the expected project-key path and fail if any `.p8` remains. |
 | Old IDs and absolute path in docs | `docs/superpowers/plans/2026-07-30-fastlane-screenshots-submission.md` and `docs/superpowers/specs/2026-07-30-fastlane-screenshots-submission-design.md` | After revocation, replace them with a neutral 1Password item reference and scrub the obsolete path. History remains, but the revoked identifiers no longer compose with a live key. |
 
 ## Migration/cutover plan
 
-The cutover keeps the old key valid until the selected authentication mode and both the Fastlane
-API and Xcode path consumers are proven. It does not upload a build or submit a release as a
-credential test.
+The cutover keeps the old key valid until the ratified service-account path and both the Fastlane API
+and Xcode path consumers are proven. It does not upload a build or submit a release merely to test
+credentials. Current operator state is explicit: the replacement key already exists in 1Password,
+while old key `U2UZLVHKA5` is not yet revoked.
 
-1. **Choose operator-owned settings.** Select Option A or B and choose the dedicated vault/item
-   names. If Option A is chosen, create a service account with read-only access to only the dedicated
-   automation vault and register the required inputs with **Session Credential Warm-up**. Never
-   paste the token into a command recorded by an agent.
-2. **Prepare the code migration before creating the key.** Implement the committed `.envrc`, secret
-   resolver, base64 decode, raw `key_content` handoff, gym-scoped tempfile helper, deletion of the old
-   env files, `.gitignore` change, Transporter postcondition, and non-submitting verification
-   lanes/tests. The references may point to an empty placeholder item until the next step. Treat
-   steps 2-9 as a maintenance window: do not run a lane that invokes `pilot` or `deliver`, and
-   activate the no-standing-key postcondition when step 9 removes the legacy key.
-3. **Create the replacement App Manager key in App Store Connect.** Use the browser's one-time
-   download. Configure an explicit private download location, keep the window between download and
-   import as short as practical, and do not expose the values in a terminal transcript.
-4. **Import immediately into 1Password.** In one local operator-controlled session, encode the
-   downloaded PEM to base64 and create the item with the new key ID, issuer ID, and base64 private
-   key. Sensitive item data must enter `op item create` via stdin/JSON, not command arguments or a
-   reusable template file. Confirm the item fields can be resolved, then best-effort overwrite/remove
-   the browser artifact and its empty staging directory. APFS snapshots and SSD wear leveling mean
-   physical erasure cannot be guaranteed.
-5. **Activate the new references.** Replace `.envrc` placeholders with the chosen vault/item/field
-   references, review them, run `direnv allow .`, and run **Session Credential Warm-up**.
-6. **Verify Fastlane authentication safely.** Run `bundle exec fastlane check_asc_key`. That lane
-   may report only non-sensitive facts such as key/issuer presence; it must never print the returned
-   key hash or any resolved value.
+1. **Record the completed provisioning.** The maintainer has provisioned the read-only service
+   account, vault `family-foqos`, item `app_store_connect_key`, and the three decided fields. The
+   replacement key is present in the concealed base64 field.
+2. **Implement the two layers before activating them.** Document the operator-local
+   `OP_SERVICE_ACCOUNT_TOKEN` bootstrap, commit `fastlane/asc.env` and `scripts/fastlane.sh`, fetch
+   child-only values in Fastlane, strictly decode raw `key_content`, add the gym-scoped tempfile
+   helper, retire the old env files, and implement the Transporter postcondition and non-submitting
+   tests. From this step through old-key revocation, treat the work as a maintenance window: do not
+   invoke `pilot` or `deliver` merely for credential testing.
+3. **Verify the 1Password field round trip.** Through an operator-controlled `op run` child, confirm
+   all three mappings resolve, the base64 field strictly decodes, and the decoded value parses as the
+   expected PEM without printing any value.
+4. **Retain the 1Password document backup deliberately.** The maintainer initially stored the PEM as
+   document item `3jey32ebbf3d4s2ktuyb64i4rq` before converting it to the concealed field. Keep that
+   document alongside the field as an accepted backup copy: both are in the same vault under the
+   same access control.
+5. **Activate the bootstrap and wrapper.** Run **Session Credential Warm-up** to place only
+   `OP_SERVICE_ACCOUNT_TOKEN` in the release-session environment, then use `scripts/fastlane.sh` for
+   every credential-using lane.
+6. **Verify Fastlane authentication safely.** Run `scripts/fastlane.sh check_asc_key`. That lane may
+   report only non-sensitive facts such as key/issuer presence; it must never print the returned key
+   hash or any resolved value.
 7. **Verify Xcode's path consumer without publishing.** Run an archive-only provisioning smoke test
-   that uses the same gym tempfile helper as `beta`/`release` but calls neither `pilot` nor `deliver`.
-   Confirm both successful authentication and removal of the temporary `.p8` after the archive.
-8. **Revoke the old ASC key.** Only after steps 6-7 pass, revoke the previously active key tracked by
-   #364 in App Store Connect. Immediately rerun `check_asc_key` to prove the configured replacement
-   still works. From this point, residual copies of the old private key cannot authenticate.
-9. **Remove old local material and references.** Best-effort secure-delete the old `.p8`, remove the
-   now-empty standing `~/.appstoreconnect/` directory, delete `fastlane/.env` and
+   through `op run` that uses the same gym tempfile helper as `beta`/`release` but calls neither
+   `pilot` nor `deliver`. Confirm successful authentication and removal of the temporary `.p8` after
+   both success and an injected failure.
+8. **Revoke the old ASC key.** Only after steps 6-7 pass, revoke `U2UZLVHKA5`, the previously active
+   key tracked by #364, in App Store Connect. Immediately rerun the wrapped `check_asc_key` to prove
+   the configured replacement still works. From this point, residual copies of the old private key
+   cannot authenticate.
+9. **Remove old local material and references.** Best-effort remove the old `.p8` and now-empty
+   standing `~/.appstoreconnect/` directory, delete `fastlane/.env` and
    `fastlane/.env.template`, and scrub the old identifiers and absolute path from the Fastlane plan
    and spec. Do not rewrite git history.
 10. **Close the exposure loop.** Search the working tree for the old key ID, issuer ID,
@@ -265,11 +291,16 @@ restore the revoked credential.
 
 ### Required automated checks
 
-- `.envrc` contains only `op://` references and non-secret shell logic; no resolved values.
-- `.direnv/` is ignored, `.envrc` is tracked, and `fastlane/.env` remains ignored.
+- `fastlane/asc.env` is tracked and contains exactly the three decided `op://` mappings; it contains
+  no resolved value.
+- The repository ships neither the operator's `.env.tpl`/`.envrc` bootstrap nor a service-account
+  token, while `fastlane/.env` remains ignored as a tripwire.
+- `scripts/fastlane.sh` routes `beta`, `release`, `pull_metadata`, and `check_asc_key` through
+  `op run --env-file fastlane/asc.env`; `screenshots` remains credential-free.
+- A bare credential-using Fastlane invocation fails at `ENV.fetch` before build or network mutation.
 - No active Fastfile or script reads `ASC_KEY_PATH` or auto-loads `fastlane/.env`.
-- Secret resolution suppresses stdout/stderr that could contain values and fails closed on every
-  missing/invalid field.
+- `op run` resolution is child-scoped, masks the concealed key value, and fails closed on every
+  missing/invalid reference; Fastlane does not print the injected values.
 - Base64 decode rejects malformed input; the decoded value loads through the real
   `app_store_connect_api_key` path.
 - The gym helper and `pull_metadata` JSON handoff both create mode-`0600` files, expose them only
@@ -285,11 +316,12 @@ restore the revoked credential.
 
 ### Authentication matrix
 
-| Mode | Setup via **Session Credential Warm-up** | Expected behavior |
+| Invocation | Setup via **Session Credential Warm-up** | Expected behavior |
 | --- | --- | --- |
-| Service account | Service-account mode ready | `.envrc` stays non-secret; Fastlane resolves the same refs with no biometric prompt. |
-| Personal/biometric | Personal mode ready | The same `.envrc` and Fastfile work. A relocked app may prompt and is an acknowledged fallback limitation. |
-| Neither available | Not ready | Lane fails before build with a redacted authentication error; it does not use a disk fallback. |
+| Wrapped ASC lane | Personal bootstrap resolves the service token once | `op run` injects ASC values only into the lane child; the lane proceeds without another biometric prompt. |
+| Bare ASC lane | Irrelevant | `ENV.fetch` fails before build; there is no ambient ASC value or disk fallback. |
+| `screenshots` | No credential input required | The wrapper runs Fastlane directly without `op run`. |
+| Missing/expired bootstrap | Not ready | `op run` fails with a redacted authentication error before Fastlane can build or mutate network state. |
 
 ### Manual acceptance
 
@@ -299,8 +331,10 @@ Before revocation, the maintainer confirms:
 2. the archive-only gym probe authenticates without upload/submission;
 3. no gym `.p8`, `pull_metadata` JSON tempfile, or Transporter `.p8` remains after success or forced
    failure;
-4. the selected authentication mode meets the maintainer's unattended-run policy; and
-5. the 1Password item and, if selected, service-account usage are visible to the maintainer.
+4. the ambient shell contains the service token but no ASC value before, during, or after the lane;
+   and
+5. the provisioned 1Password item, retained document backup, and service-account usage are visible
+   to the maintainer.
 
 After revocation, rerun the non-secret key check and repository scans. Then close #364 as remediated
 by rotation and #365 as remediated by the 1Password migration.
@@ -309,15 +343,22 @@ by rotation and #365 as remediated by the 1Password migration.
 
 - **DECIDED:** Rotation of the transcript-exposed ASC key is part of this migration's cutover.
 - **DECIDED:** 1Password is the only durable source of truth for the replacement ASC key.
-- **DECIDED:** The repository commits one `.envrc` containing references only and ignores
-  `.direnv/`.
+- **DECIDED:** Personal 1Password plus direnv bootstraps only `OP_SERVICE_ACCOUNT_TOKEN` once per
+  session; the operator-owned `.env.tpl`/`.envrc` is documented but not committed.
+- **DECIDED:** The repository commits non-secret `fastlane/asc.env`; `scripts/fastlane.sh` uses
+  child-scoped `op run` injection for every ASC lane, while `screenshots` is exempt.
+- **DECIDED:** Use the provisioned read-only service account in vault `family-foqos`; its token is
+  stored at `op://family-foqos/service_auth_token/OP_SERVICE_ACCOUNT_TOKEN`.
+- **DECIDED:** Use item `app_store_connect_key` with fields `ASC_KEY_ID_REF`, `ASC_ISSUER_ID_REF`,
+  and concealed `ASC_KEY_CONTENT_BASE64_REF`.
 - **DECIDED:** Store/transport private-key content as base64, decode in Ruby, and pass raw PEM to
   Fastlane.
 - **DECIDED:** Xcode receives a mode-`0600`, gym-scoped temporary `.p8` with ensure cleanup.
 - **DECIDED:** Family Foqos lanes enforce the no-standing-key postcondition instead of trusting
   Fastlane Transporter's non-uniform cleanup.
-- **RECOMMENDED / OPEN-FOR-MAINTAINER:** Use a read-only service account for reliable unattended
-  runs; personal biometric authentication remains a supported runtime fallback.
-- **OPEN-FOR-MAINTAINER:** Final dedicated vault and ASC item names.
+- **DECIDED:** Retain document item `3jey32ebbf3d4s2ktuyb64i4rq` as the maintainer's backup copy
+  alongside the concealed field under the same vault access control.
+- **PENDING CUTOVER:** Old key `U2UZLVHKA5` remains active until wrapped `check_asc_key` and the
+  archive-only Xcode path probe both pass.
 - **REJECTED:** A standing home-directory `.p8`, a second auth-specific `.envrc`, a history rewrite,
   or an unverifiable claim that browser-issued key creation is diskless.

--- a/docs/superpowers/specs/2026-08-09-1password-credentials.md
+++ b/docs/superpowers/specs/2026-08-09-1password-credentials.md
@@ -1,0 +1,302 @@
+# App Store Connect Credentials: 1Password, direnv, and Key Rotation
+
+**Date:** 2026-08-09
+**Status:** Approved design; implementation plan is a separate step
+**Scope:** Local Fastlane credentials for V2 / `main`; resolves storage issue
+[#365](https://github.com/mnbf9rca/family-foqos/issues/365) and makes the rotation from
+[#364](https://github.com/mnbf9rca/family-foqos/issues/364) part of the migration cutover.
+
+## Problem
+
+The current App Store Connect (ASC) private key is a long-lived plaintext `.p8` file under the
+maintainer's home directory. A gitignored `fastlane/.env` supplies its path, key ID, and issuer ID.
+This protects the private key from git, but not from another process running as the user, and it
+provides no scoped access, access record, or convenient revocation mechanism.
+
+Issue #364 makes the migration urgent enough to include rotation. A verification command in the
+committed Fastlane plan invoked `fastlane run app_store_connect_api_key`. That action returns a hash
+whose `:key` member is the complete private key, so Fastlane printed the key into a local agent
+session transcript. The transcript was not committed, pushed, or messaged elsewhere, but it now
+contains the private half of the credential. Separately, this public repository contains the old
+key ID, issuer ID, and local key path in the existing Fastlane plan and spec. Those identifiers do
+not authenticate on their own, but together with the transcript they are all the inputs needed to
+use the old private key. Rotation, rather than document deletion, is the security boundary because
+git history and forks retain already-published identifiers.
+
+The target state has one durable source of truth for ASC credentials: 1Password. The repository
+contains only 1Password secret references. Fastlane resolves the references when a lane starts,
+keeps the private key in process memory, and materializes it only in narrowly scoped temporary
+files when a downstream Apple tool requires a path.
+
+## Constraints
+
+- The repository is public. No private key, service-account token, resolved environment value, new
+  key ID, new issuer ID, or machine-specific key path may be committed.
+- The replacement ASC key is created during this migration. There is no period where the new key is
+  durably stored as a plaintext home-directory credential.
+- ASC key creation normally produces a one-time browser download. This design therefore does not
+  claim a diskless cutover. It minimizes that initial file's lifetime and treats revocation, not
+  best-effort file erasure on APFS/SSD storage, as the security boundary.
+- Truly unattended lanes must not wait indefinitely for a biometric prompt. The design must also
+  retain a usable personal/biometric mode for maintainers who do not accept a new service-account
+  token.
+- The credential setup composes with #363 through one named interface: the **session-start unlock
+  step**. This design does not depend on that step's internal implementation.
+- `xcodebuild -allowProvisioningUpdates` may need ASC authentication for automatic signing.
+  `-authenticationKeyPath` accepts a file path, not in-memory key content. Xcode documents the path,
+  key ID, and issuer ID as a required set
+  (`/Applications/Xcode.app/Contents/Developer/usr/share/man/man1/xcodebuild.1:244-265`).
+- This task changes documentation only. Later implementation must preserve the existing lane
+  behavior and must not run a submission merely to test credential loading.
+- The migration must not introduce another credential-printing probe. In particular, never invoke
+  `fastlane run` for an action that returns credential material.
+
+## Options
+
+### Option A — read-only 1Password service account (recommended)
+
+Create a dedicated non-built-in automation vault containing only the Family Foqos ASC item. Give a
+service account `read_items` access to that vault and inject its token into the worker session as
+`OP_SERVICE_ACCOUNT_TOKEN`. The service account cannot use a Personal, Private, Employee, or default
+Shared vault, so a dedicated vault is required. Its access can be limited, inspected, rotated, and
+revoked. These constraints follow 1Password's
+[service-account model](https://www.1password.dev/service-accounts/get-started) and
+[CLI authentication contract](https://www.1password.dev/service-accounts/use-with-1password-cli).
+
+This is the reliable unattended mode: `op read` does not require a biometric interaction once the
+token is present. The trade-off is real: `OP_SERVICE_ACCOUNT_TOKEN` is itself a long-lived secret in
+the worker's environment. It must never live in `.envrc`, an env file, shell history, or the repo.
+The session-start unlock step owns injecting it from an operator-approved secret store. Limiting the
+account to a one-item vault makes compromise narrower than today's raw, effectively immortal `.p8`,
+and the token is revocable and its use report is inspectable.
+
+**Status: RECOMMENDED, OPEN-FOR-MAINTAINER.** The maintainer chooses whether the unattended benefit
+justifies custody of this new token.
+
+### Option B — personal 1Password app integration with biometrics
+
+If `OP_SERVICE_ACCOUNT_TOKEN` is absent, `op` uses the maintainer's personal 1Password CLI/app
+integration. The session-start unlock step performs the biometric warm-up before unattended work.
+This avoids a service token, attributes access to the maintainer, and uses the existing 1Password
+unlock boundary described by the
+[1Password app integration](https://www.1password.dev/cli/app-integration).
+
+The limitation is that a later app relock can reintroduce a prompt during a lane. A warm-up reduces
+that risk but cannot make long-running work as deterministic as service-account authentication.
+
+**Status: SUPPORTED FALLBACK, OPEN-FOR-MAINTAINER.** Use this when interactive authorization is an
+acceptable condition of a release session.
+
+### Option C — retain a standing `.p8` for Xcode
+
+Keep `~/.appstoreconnect/` solely for `xcodebuild` while using 1Password for Fastlane API actions.
+This avoids temporary-file plumbing but leaves the highest-value secret at rest and defeats the
+migration's purpose.
+
+**Status: REJECTED.** The small implementation saving is not worth preserving the original risk.
+
+## Recommendation
+
+### One committed `.envrc`, two authentication modes
+
+Use one `.envrc` for Options A and B. It exports literal 1Password references, not resolved values:
+
+```bash
+export ASC_KEY_ID_REF='op://<automation-vault>/<asc-item>/key-id'
+export ASC_ISSUER_ID_REF='op://<automation-vault>/<asc-item>/issuer-id'
+export ASC_KEY_CONTENT_BASE64_REF='op://<automation-vault>/<asc-item>/private-key-base64'
+```
+
+The file needs no authentication branch. When `OP_SERVICE_ACCOUNT_TOKEN` is present, 1Password CLI
+uses the service account; otherwise it uses personal app integration. Fastlane resolves the three
+references at lane start. This keeps the actual ASC key out of the interactive shell environment
+and makes the maintainer's authentication choice runtime configuration rather than a second config
+file.
+
+The vault and item names are **OPEN-FOR-MAINTAINER**. The item name must describe the application,
+not embed the ASC key ID. Implementation replaces the placeholders once those names are selected.
+
+The committed setup flow is:
+
+1. Install the 1Password CLI and direnv; configure personal app integration if Option B is used.
+2. Add the direnv hook to the shell once.
+3. Review `.envrc`, then run `direnv allow .`. A changed `.envrc` requires a fresh allow.
+4. Enter through the session-start unlock step. It either injects `OP_SERVICE_ACCOUNT_TOKEN` for
+   Option A or warms personal biometric access for Option B.
+
+Add `.direnv/` to `.gitignore`. Do not ignore `.envrc`: it is the reviewed, committed replacement for
+the env template. Retain `fastlane/.env` in `.gitignore` as defense in depth even after deleting the
+file and removing all runtime use.
+
+At base `bf97c18`, the current `.gitignore` ignores neither `.envrc` nor `.direnv/`; the
+`feat/fastlane-setup` branch adds `fastlane/.env` at `.gitignore:63`. Integration adds only
+`.direnv/` to that credential-related set and preserves the `fastlane/.env` denylist entry. A scan
+of both feature branches finds credential-path references only on `feat/fastlane-setup`;
+`feat/fastlane-demo-mode:fastlane/Fastfile` adds screenshot behavior and no credential dependency.
+
+A leaked `op://` reference reveals vault/item/field naming metadata. It does **not** reveal or grant
+access to the referenced value; an attacker still needs an authorized 1Password user session or
+service-account token. This is why the public `.envrc` must contain references only and why the
+service token remains outside it.
+
+### Base64 at the storage boundary, raw PEM at the Fastlane boundary
+
+Store the private key as base64 in 1Password. This removes PEM-newline and command-substitution
+ambiguity. Fastlane resolves `ASC_KEY_CONTENT_BASE64_REF`, decodes it with strict base64 decoding in
+Ruby, and passes the resulting raw multiline PEM as `key_content:`.
+
+Fastlane 2.237.0 accepts raw `key_content`; it preserves real newlines and converts literal `\\n`
+sequences to newlines
+(`/opt/homebrew/lib/ruby/gems/4.0.0/gems/fastlane-2.237.0/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb:14-26`).
+It also supports `is_key_content_base64:` and forwards that flag with the key
+(`app_store_connect_api_key.rb:28-45,69-79`); Spaceship decodes the value before OpenSSL parses it
+(`/opt/homebrew/lib/ruby/gems/4.0.0/gems/fastlane-2.237.0/spaceship/lib/spaceship/connect_api/token.rb:52-71`).
+
+The design deliberately decodes before calling the action instead of setting
+`is_key_content_base64: true`. The action returns the original key hash, while Fastlane's Transporter
+later writes `api_key[:key]` directly to an `AuthKey_*.p8` file without consulting the base64 flag
+(`/opt/homebrew/lib/ruby/gems/4.0.0/gems/fastlane-2.237.0/fastlane_core/lib/fastlane_core/itunes_transporter.rb:68-90`).
+Passing raw PEM keeps `pilot`, `deliver`, and the existing temporary JSON handoff compatible while
+base64 still protects the 1Password-to-Ruby transport.
+
+The private `asc_api_key` lane therefore replaces `ASC_KEY_PATH` with the three references, resolves
+them without logging stdout, strictly decodes the private key, and calls `app_store_connect_api_key`
+with raw `key_content`. Resolution failures, missing fields, invalid base64, or invalid PEM fail the
+lane before any build or network mutation.
+
+### Path-only consumers get scoped temporary files
+
+The in-memory `api_key` hash remains the input to `pilot` and `deliver`. `gym` does not expose an ASC
+`api_key` option; its supported escape hatch is `xcargs`
+(`/opt/homebrew/lib/ruby/gems/4.0.0/gems/fastlane-2.237.0/gym/lib/gym/options.rb:220-225`).
+Because Xcode requires `-authenticationKeyPath`, wrap only the `gym` call in a helper that:
+
+1. creates a `Tempfile.create(["asc-auth-key", ".p8"])` block;
+2. explicitly sets mode `0600` and writes the already-decoded raw PEM;
+3. passes that path plus the resolved key and issuer IDs in `xcargs`; and
+4. exits the block immediately after `gym`, deleting the file even when `gym` raises.
+
+This extends the cleanup pattern already used by `pull_metadata`, which creates its API-key JSON in
+a `Tempfile.create` block and invokes `deliver download_metadata` entirely inside that block
+(`feat/fastlane-setup:fastlane/Fastfile:106-125`). The implementation must add an ensure-path test
+that forces the wrapped operation to fail and verifies the path no longer exists.
+
+Temporary materialization is not equivalent to durable storage. The key exists briefly in process
+memory and in mode-`0600` temporary files required by Xcode or Fastlane. Fastlane's Transporter also
+materializes an API key for upload and removes its key directory in an `ensure` block
+(`fastlane_core/lib/fastlane_core/itunes_transporter.rb:864-882`). The invariant is therefore: **no
+standing plaintext private-key file survives a lane or cutover**, not the untrue claim that the key
+never exists outside 1Password.
+
+### What dies and what replaces it
+
+| Current dependency | Current references | Replacement |
+| --- | --- | --- |
+| `fastlane/.env` | Fastlane auto-load; `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_PATH` | Delete the file and all runtime dependence. Keep its ignore rule as a tripwire. `.envrc` supplies only `*_REF` values. |
+| `fastlane/.env.template` | `feat/fastlane-setup:fastlane/.env.template:1-4` | Delete it. Committed `.envrc` plus setup documentation is the single template. |
+| `ASC_KEY_PATH` in `asc_api_key` | `feat/fastlane-setup:fastlane/Fastfile:21-26` | Resolve base64 content, decode in Ruby, and pass raw `key_content:`. |
+| `ASC_KEY_PATH` in `gym` `xcargs` | `feat/fastlane-setup:fastlane/Fastfile:128-143` | A helper-owned mode-`0600` temporary `.p8` path scoped to `gym`. Key and issuer IDs are resolved values, never committed literals. |
+| `pull_metadata` API-key JSON | `feat/fastlane-setup:fastlane/Fastfile:106-125` | Retain the proven `Tempfile.create` handoff. Its hash now contains raw PEM produced from 1Password rather than a home-directory path. |
+| `~/.appstoreconnect/` | Existing plan/spec and the old plaintext key | Remove the old `.p8` and empty directory after successful cutover. Fastlane may recreate a transient key directory internally during Transporter work; its ensure cleanup must leave no standing key. |
+| Old IDs and absolute path in docs | `docs/superpowers/plans/2026-07-30-fastlane-screenshots-submission.md` and `docs/superpowers/specs/2026-07-30-fastlane-screenshots-submission-design.md` | After revocation, replace them with a neutral 1Password item reference and scrub the obsolete path. History remains, but the revoked identifiers no longer compose with a live key. |
+
+## Migration/cutover plan
+
+The cutover keeps the old key valid until the selected authentication mode and both the Fastlane
+API and Xcode path consumers are proven. It does not upload a build or submit a release as a
+credential test.
+
+1. **Choose operator-owned settings.** Select Option A or B and choose the dedicated vault/item
+   names. If Option A is chosen, create a service account with read-only access to only the dedicated
+   automation vault and arrange `OP_SERVICE_ACCOUNT_TOKEN` injection through the session-start
+   unlock step. Never paste the token into a command recorded by an agent.
+2. **Prepare the code migration before creating the key.** Implement the committed `.envrc`, secret
+   resolver, base64 decode, raw `key_content` handoff, gym-scoped tempfile helper, deletion of the old
+   env files, `.gitignore` change, and non-submitting verification lanes/tests. The references may
+   point to an empty placeholder item until the next step.
+3. **Create the replacement App Manager key in App Store Connect.** Use the browser's one-time
+   download. Configure an explicit private download location, keep the window between download and
+   import as short as practical, and do not expose the values in a terminal transcript.
+4. **Import immediately into 1Password.** In one local operator-controlled session, encode the
+   downloaded PEM to base64 and create the item with the new key ID, issuer ID, and base64 private
+   key. Sensitive item data must enter `op item create` via stdin/JSON, not command arguments or a
+   reusable template file. Confirm the item fields can be resolved, then best-effort overwrite/remove
+   the browser artifact and its empty staging directory. APFS snapshots and SSD wear leveling mean
+   physical erasure cannot be guaranteed.
+5. **Activate the new references.** Replace `.envrc` placeholders with the chosen vault/item/field
+   references, review them, run `direnv allow .`, and enter via the session-start unlock step.
+6. **Verify Fastlane authentication safely.** Run `bundle exec fastlane check_asc_key`. That lane
+   may report only non-sensitive facts such as key/issuer presence; it must never print the returned
+   key hash or any resolved value.
+7. **Verify Xcode's path consumer without publishing.** Run an archive-only provisioning smoke test
+   that uses the same gym tempfile helper as `beta`/`release` but calls neither `pilot` nor `deliver`.
+   Confirm both successful authentication and removal of the temporary `.p8` after the archive.
+8. **Revoke the old ASC key.** Only after steps 6-7 pass, revoke the previously active key tracked by
+   #364 in App Store Connect. Immediately rerun `check_asc_key` to prove the configured replacement
+   still works. From this point, residual copies of the old private key cannot authenticate.
+9. **Remove old local material and references.** Best-effort secure-delete the old `.p8`, remove the
+   now-empty standing `~/.appstoreconnect/` directory, delete `fastlane/.env` and
+   `fastlane/.env.template`, and scrub the old identifiers and absolute path from the Fastlane plan
+   and spec. Do not rewrite git history.
+10. **Close the exposure loop.** Search the working tree for the old key ID, issuer ID,
+    `ASC_KEY_PATH`, and the old home-directory path. Expected results are historical issue context
+    only, not active configuration or current plan/spec prose. Record the replacement key only by
+    its 1Password item name.
+
+If any pre-revocation verification fails, keep the old key active, remove any failed new-key
+temporary files, and repair the migration. Do not fall back to recreating a standing `.p8`. If a
+failure occurs after revocation, fix the new 1Password path or create another replacement key; never
+restore the revoked credential.
+
+## Rollout & verification
+
+### Required automated checks
+
+- `.envrc` contains only `op://` references and non-secret shell logic; no resolved values.
+- `.direnv/` is ignored, `.envrc` is tracked, and `fastlane/.env` remains ignored.
+- No active Fastfile or script reads `ASC_KEY_PATH` or auto-loads `fastlane/.env`.
+- Secret resolution suppresses stdout/stderr that could contain values and fails closed on every
+  missing/invalid field.
+- Base64 decode rejects malformed input; the decoded value loads through the real
+  `app_store_connect_api_key` path.
+- The gym helper creates a mode-`0600` file, exposes it only for the duration of the block, and
+  removes it on both success and an injected failure.
+- The existing `pull_metadata` temporary JSON cleanup remains intact.
+- Repository scans find no private key block, service-account token, replacement identifiers, or
+  absolute credential path.
+
+### Authentication matrix
+
+| Mode | Setup | Expected behavior |
+| --- | --- | --- |
+| Service account | Session-start unlock step injects `OP_SERVICE_ACCOUNT_TOKEN` | `.envrc` stays non-secret; Fastlane resolves the same refs with no biometric prompt. |
+| Personal/biometric | Token absent; 1Password app integration enabled and warmed by session-start unlock step | The same `.envrc` and Fastfile work. A relocked app may prompt and is an acknowledged fallback limitation. |
+| Neither available | Token absent and personal CLI unavailable/locked | Lane fails before build with a redacted authentication error; it does not use a disk fallback. |
+
+### Manual acceptance
+
+Before revocation, the maintainer confirms:
+
+1. `check_asc_key` succeeds without printing a key or returned credential hash;
+2. the archive-only gym probe authenticates without upload/submission;
+3. no gym `.p8` or `pull_metadata` JSON tempfile remains after success or forced failure;
+4. the selected authentication mode meets the maintainer's unattended-run policy; and
+5. the 1Password item and, if selected, service-account usage are visible to the maintainer.
+
+After revocation, rerun the non-secret key check and repository scans. Then close #364 as remediated
+by rotation and #365 as remediated by the 1Password migration.
+
+## Decision log
+
+- **DECIDED:** Rotation of the transcript-exposed ASC key is part of this migration's cutover.
+- **DECIDED:** 1Password is the only durable source of truth for the replacement ASC key.
+- **DECIDED:** The repository commits one `.envrc` containing references only and ignores
+  `.direnv/`.
+- **DECIDED:** Store/transport private-key content as base64, decode in Ruby, and pass raw PEM to
+  Fastlane.
+- **DECIDED:** Xcode receives a mode-`0600`, gym-scoped temporary `.p8` with ensure cleanup.
+- **RECOMMENDED / OPEN-FOR-MAINTAINER:** Use a read-only service account for reliable unattended
+  runs; personal biometric authentication remains a supported runtime fallback.
+- **OPEN-FOR-MAINTAINER:** Final dedicated vault and ASC item names.
+- **REJECTED:** A standing home-directory `.p8`, a second auth-specific `.envrc`, a history rewrite,
+  or an unverifiable claim that browser-issued key creation is diskless.

--- a/docs/superpowers/specs/2026-08-09-1password-credentials.md
+++ b/docs/superpowers/specs/2026-08-09-1password-credentials.md
@@ -33,9 +33,10 @@ wrapped `check_asc_key`.
 The target state has one durable source of truth for ASC credentials: 1Password. The repository
 contains only non-secret 1Password references in `fastlane/asc.env`. A committed wrapper invokes
 credential-using lanes through `op run`, which resolves those references only into that child
-process. Fastlane keeps the private key in process memory and materializes it only in narrowly
-scoped temporary files when a downstream Apple tool requires a path. The maintainer's ambient shell
-never holds ASC key material.
+process. Family Foqos lane code keeps the private key in process memory and materializes it only in
+narrowly scoped temporary files when a downstream Apple tool requires a path; Fastlane Transporter's
+accepted residue limitation is documented below. The maintainer's ambient shell never holds ASC key
+material.
 
 ## Constraints
 
@@ -215,28 +216,20 @@ implementation must explicitly assert mode `0600` for both tempfiles, cover clea
 and an injected failure for both, and add `log: false` to the nested `sh` call so the live JSON path
 is not advertised in lane output.
 
-Temporary materialization is not equivalent to durable storage. The lifecycle is: at rest in
-1Password → resolved values in a credential-using `op run` child environment for that invocation →
-Fastlane memory and sensitive lane context → a gym-only or metadata-only mode-`0600` tempfile →
-ensure-driven deletion. ASC material never enters the ambient shell. Fastlane's Transporter cleanup
-is not uniform. `upload` and `provider_ids` remove the generated key directory in `ensure`
+Temporary materialization is not equivalent to durable storage. The project-owned lifecycle is: at
+rest in 1Password → resolved values in a credential-using `op run` child environment for that
+invocation → Fastlane memory and sensitive lane context → a gym-only or metadata-only mode-`0600`
+tempfile → ensure-driven deletion. ASC material never enters the ambient shell. Separately,
+Fastlane's Transporter cleanup is not uniform. `upload` and `provider_ids` remove the generated key
+directory in `ensure`
 blocks (`fastlane_core/lib/fastlane_core/itunes_transporter.rb:864-882,959-982`), but `verify` calls
 the same `prepare` writer without cleanup (`itunes_transporter.rb:903-953`). For a
 `ShellScriptTransporterExecutor`, that writer creates
 `~/.appstoreconnect/private_keys/AuthKey_<key-id>.p8` instead of a temporary directory
-(`itunes_transporter.rb:68-90`). Whether current project lanes reach `verify` is not an acceptable
-security dependency.
+(`itunes_transporter.rb:68-90`). Current project lanes may reach `verify`, so this behavior is an
+explicit accepted limitation rather than a cleanup guarantee.
 
-Every credential-using project lane must therefore enforce its own postcondition in an `ensure`.
-First, remove only the expected replacement-key file at the known Transporter path. Then recursively
-scan `~/.appstoreconnect/` for `*.p8`. Any residual `.p8` fails the lane from the first implementation
-run onward. There is no allowlist, warning branch, environment variable, feature flag, or activation
-toggle. An unrelated standing key is reported for operator remediation, not silently deleted. The
-scoped invariant is: **no standing plaintext private-key file survives a credential-using Family
-Foqos lane or the cutover**. It is not the untrue claim that the key never exists outside 1Password
-or that the gem always cleans up after itself.
-Child-only `op run` injection strengthens this postcondition: the cleanup proof no longer has to
-account for ASC values lingering in the parent shell after a lane.
+No runtime residue scanning. A per-lane scan of ~/.appstoreconnect was designed (allowlist, then total variants) and rejected by the maintainer as overengineering. Known limitation, accepted: fastlane Transporter's verify path may write AuthKey_<key-id>.p8 under ~/.appstoreconnect/private_keys/ without cleanup. The lanes clean up only the temporary files they themselves create (gym .p8 tempfile, pull_metadata key JSON), via ensure blocks.
 
 ### What dies and what replaces it
 
@@ -248,7 +241,7 @@ account for ASC values lingering in the parent shell after a lane.
 | `ASC_KEY_PATH` in `asc_api_key` | `2404139:fastlane/Fastfile:21-26` | Fetch the child-only base64 value injected by `op run`, decode in Ruby, and pass raw `key_content:`. |
 | `ASC_KEY_PATH` in `release` and `beta` `gym` `xcargs` | `4e6b28b:fastlane/Fastfile` | A helper-owned mode-`0600` temporary `.p8` path scoped to each `gym` call. Key and issuer IDs come from the same child-only environment, never committed literals. |
 | `pull_metadata` API-key JSON | `2404139:fastlane/Fastfile:106-125` | Retain the `Tempfile.create` handoff, require mode `0600` and symmetric cleanup tests, and suppress logging of its live path. Its hash now contains raw PEM produced from 1Password rather than a home-directory path. |
-| `~/.appstoreconnect/` | Fastlane Transporter's cleanup-deficient `verify` path; the old top-level `AuthKey_U2UZLVHKA5.p8` was deleted on 2026-08-09 | After every credential-using lane, surgically remove the expected replacement-key path, recursively scan for `.p8` files, and fail on any match. No legacy exception exists. |
+| `~/.appstoreconnect/` | Fastlane Transporter's cleanup-deficient `verify` path; the old top-level `AuthKey_U2UZLVHKA5.p8` was deleted on 2026-08-09 | Accept possible Transporter-created residue as a known limitation. Project lanes do not scan this directory; they clean up only their own gym and metadata tempfiles. |
 | Retained document `3jey32ebbf3d4s2ktuyb64i4rq` | Accepted backup copy of the replacement PEM | Keep it under the same vault access control for this cutover. Every future key rotation must update or remove both this document and `ASC_KEY_CONTENT_BASE64_REF` so retired private-key material is not silently retained. |
 | Old IDs and absolute path in docs | `docs/superpowers/plans/2026-07-30-fastlane-screenshots-submission.md` and `docs/superpowers/specs/2026-07-30-fastlane-screenshots-submission-design.md` | With revocation complete, replace them with a neutral 1Password item reference and scrub the obsolete path. History remains, but the revoked identifiers no longer compose with a live key. |
 
@@ -262,6 +255,10 @@ maintenance-window exception. The remaining cutover is repository wiring plus a 
 verification for Xcode's path consumer; it does not gate an already-completed revocation. No step
 uploads a build or submits a release merely to test credentials.
 
+Until that wiring lands, `main` cannot authenticate: its credential-using lanes still fetch the
+deleted `ASC_KEY_PATH` and fail closed before build or network mutation. `screenshots` is unaffected.
+Do not respond to the missing-file failure by recreating a standing `.p8`.
+
 1. **Record the completed provisioning and retirement.** The maintainer has provisioned the
    read-only service account, vault `family-foqos`, item `app_store_connect_key`, and the three
    decided fields. The replacement key is present in the concealed base64 field. The old key is
@@ -269,9 +266,8 @@ uploads a build or submits a release merely to test credentials.
 2. **Implement the two layers.** Commit the reference-only `.env.tpl` and
    `.envrc` bootstrap for `OP_SERVICE_ACCOUNT_TOKEN`, `fastlane/asc.env`, and
    `scripts/fastlane.sh`; fetch child-only values in Fastlane, strictly decode raw `key_content`, add
-   the gym-scoped tempfile helper, retire the old env files, and implement the Transporter
-   postcondition and non-submitting tests. From its first run, every credential-using lane must use
-   the wrapper and fail if the total recursive postcondition finds any residual `.p8`.
+   the gym-scoped tempfile helper, retire the old env files, and add non-submitting tests for
+   lane-owned tempfile cleanup. Every credential-using lane must use the wrapper.
 3. **Verify the 1Password field round trip.** Through an operator-controlled `op run` child, confirm
    all three mappings resolve, the base64 field strictly decodes, and the decoded value parses as the
    expected PEM without printing any value.
@@ -325,12 +321,6 @@ or create another replacement key. Never restore the revoked credential or recre
   for the duration of their blocks, and remove them on both success and an injected failure.
 - `pull_metadata` invokes its nested Fastlane process with `log: false`, so the live tempfile path
   is not emitted to lane output.
-- After every credential-using lane, the recursive `~/.appstoreconnect/**/*.p8` postcondition removes
-  only the expected replacement-key path and fails on any residual key, including when the
-  downstream action fails.
-- Tests prove the postcondition is total from its first implementation run: a legacy-path,
-  replacement-path, or unrelated `.p8` residual fails with no allowlist, warning branch,
-  environment variable, or activation toggle.
 - A repository scan enumerates every `fastlane run` occurrence and fails if any credential-returning
   action is invoked that way. Non-secret action examples require an explicit allowlist rationale.
 - Repository scans find no private key block, service-account token, replacement identifiers, or
@@ -351,8 +341,7 @@ Before completing the implementation, the maintainer confirms:
 
 1. `check_asc_key` succeeds without printing a key or returned credential hash;
 2. the archive-only gym probe authenticates without upload/submission;
-3. no gym `.p8`, `pull_metadata` JSON tempfile, or Transporter `.p8` remains after success or forced
-   failure;
+3. no gym `.p8` or `pull_metadata` JSON tempfile remains after success or forced failure;
 4. the ambient shell contains the service token but no ASC value before, during, or after the lane;
    and
 5. the provisioned 1Password item, retained document backup, and service-account usage are visible
@@ -379,10 +368,6 @@ pass, rerun repository scans and close #365 as remediated by the 1Password migra
 - **DECIDED:** Store/transport private-key content as base64, decode in Ruby, and pass raw PEM to
   Fastlane.
 - **DECIDED:** Xcode receives a mode-`0600`, gym-scoped temporary `.p8` with ensure cleanup.
-- **DECIDED:** Every credential-using Family Foqos lane recursively enforces the no-standing-key
-  postcondition instead of trusting Fastlane Transporter's non-uniform cleanup. It is total from the
-  first implementation run: every residual `.p8` fails, with no allowlist, warning branch, or
-  runtime activation toggle.
 - **DECIDED:** Retain document item `3jey32ebbf3d4s2ktuyb64i4rq` as the maintainer's backup copy
   alongside the concealed field under the same vault access control.
 - **PENDING CUTOVER:** Complete repository wiring and obtain a green wrapped `check_asc_key` against

--- a/docs/superpowers/specs/2026-08-09-1password-credentials.md
+++ b/docs/superpowers/specs/2026-08-09-1password-credentials.md
@@ -59,8 +59,8 @@ never holds ASC key material.
 
 ### Option A — read-only 1Password service account (ratified)
 
-Create a dedicated non-built-in automation vault containing only the Family Foqos ASC item. Give a
-service account `read_items` access to that vault. 1Password CLI uses this mode when
+Create a dedicated non-built-in automation vault containing only Family Foqos credential material.
+Give a service account `read_items` access to that vault. 1Password CLI uses this mode when
 `OP_SERVICE_ACCOUNT_TOKEN` is present. The service account cannot use a Personal, Private, Employee,
 or default Shared vault, so a dedicated vault is required. Its access can be limited, inspected,
 rotated, and revoked. These constraints follow 1Password's
@@ -70,9 +70,9 @@ rotated, and revoked. These constraints follow 1Password's
 This is the reliable unattended mode: `op run` does not require a biometric interaction once the
 token is present. The trade-off is real: `OP_SERVICE_ACCOUNT_TOKEN` is itself a long-lived secret in
 the worker's ambient environment for the release session. It must never live in a committed file,
-shell history, or the repository. Limiting the account to a one-item vault makes compromise narrower
-than today's raw, effectively immortal `.p8`, and the token is revocable and its use report is
-inspectable.
+shell history, or the repository. Limiting the account to a dedicated, narrowly scoped application
+vault makes compromise narrower than today's raw, effectively immortal `.p8`, and the token is
+revocable and its use report is inspectable.
 
 **Status: RATIFIED AND PROVISIONED.** The read-only token is stored at
 `op://family-foqos/service_auth_token/OP_SERVICE_ACCOUNT_TOKEN`. Personal 1Password authentication
@@ -104,11 +104,13 @@ migration's purpose.
 
 The ratified architecture separates operator bootstrap from ASC credential delivery.
 
-**Layer 1 — operator-local bootstrap.** Personal 1Password app integration and direnv use an
-operator-owned `.env.tpl` to export only `OP_SERVICE_ACCOUNT_TOKEN`, resolved from
-`op://family-foqos/service_auth_token/OP_SERVICE_ACCOUNT_TOKEN`. This costs one biometric touch per
-release session. The repository documents this setup but does not ship `.env.tpl`, `.envrc`, or the
-resolved token. No ASC key ID, issuer ID, or key content enters the ambient shell.
+**Layer 1 — committed reference-only bootstrap.** Personal 1Password app integration and direnv use
+committed `.env.tpl` and `.envrc` files to export only `OP_SERVICE_ACCOUNT_TOKEN`, resolved from
+`op://family-foqos/service_auth_token/OP_SERVICE_ACCOUNT_TOKEN`. Both files contain references and
+non-secret bootstrap logic only; neither contains the resolved token. The operator reviews them and
+runs `direnv allow` as the one-time consent step for that version, then personal 1Password costs one
+biometric touch per release session. No ASC key ID, issuer ID, or key content enters the ambient
+shell.
 
 **Layer 2 — per-invocation ASC injection.** Commit `fastlane/asc.env` with exactly three non-secret
 reference mappings:
@@ -140,13 +142,17 @@ credential-using lane joins the wrapped set explicitly.
 The setup flow is:
 
 1. Install the 1Password CLI and direnv; enable personal app integration.
-2. Configure the operator-local direnv/`.env.tpl` bootstrap for only `OP_SERVICE_ACCOUNT_TOKEN`.
+2. Review the committed `.env.tpl`/`.envrc` bootstrap, confirm it handles only
+   `OP_SERVICE_ACCOUNT_TOKEN`, and run `direnv allow` once to consent to that version.
 3. Run **Session Credential Warm-up** once at the start of the release session.
 4. Invoke Fastlane through `scripts/fastlane.sh`; do not call an ASC lane bare.
 
 Retain `fastlane/.env` in `.gitignore` as defense in depth after deleting the file and removing all
-runtime use. Commit `fastlane/asc.env`; it contains references, not resolved values. Delete
-`fastlane/.env.template` because the operator no longer copies or edits a Fastlane env template.
+runtime use. Commit `.envrc` and `.env.tpl`; they contain only the service-token reference and
+non-secret bootstrap logic. Add a root-anchored `/.direnv/` ignore rule because that directory may
+cache the resolved service token. Commit `fastlane/asc.env`; it contains references, not resolved
+values. Delete `fastlane/.env.template` because the operator no longer copies or edits a Fastlane
+env template.
 
 A leaked `op://` reference reveals vault/item/field naming metadata. It does **not** reveal or grant
 access to the referenced value; an attacker still needs an authorized 1Password user session or
@@ -215,14 +221,21 @@ the same `prepare` writer without cleanup (`itunes_transporter.rb:903-953`). For
 (`itunes_transporter.rb:68-90`). Whether current project lanes reach `verify` is not an acceptable
 security dependency.
 
-Every project lane that invokes `pilot` or `deliver`, including `pull_metadata`, must therefore
-enforce its own postcondition in an `ensure`: remove only the expected project-key file at that
-known Transporter path, then fail if any `.p8` remains below `~/.appstoreconnect/`. An unrelated
-standing key is reported for operator remediation, not silently deleted. The scoped invariant is:
+Every credential-using project lane must therefore enforce its own postcondition in an `ensure`.
+First, remove only the expected replacement-key file at the known Transporter path. Then recursively
+scan `~/.appstoreconnect/` for `*.p8`. During the maintenance window, the scan has one hardcoded
+allowlist entry: the exact legacy path
+`~/.appstoreconnect/private_keys/AuthKey_U2UZLVHKA5.p8`. That file produces a warning pointing to
+cutover step 9; every other residual `.p8` fails the lane, so a leaked replacement-key file is never
+tolerated. Deleting the legacy file at step 9 naturally makes the check total. There is no
+environment variable, feature flag, or activation toggle: the filesystem state that cutover already
+changes controls the transition. An unrelated standing key is reported for operator remediation,
+not silently deleted. The scoped invariant is:
 **no standing plaintext private-key file survives a credential-using Family Foqos lane or the
-cutover**. It is not the untrue claim that the key never exists outside 1Password or that the gem
-always cleans up after itself. Child-only `op run` injection strengthens this postcondition: the
-cleanup proof no longer has to account for ASC values lingering in the parent shell after a lane.
+cutover, except for the explicitly warned legacy path before step 9**. It is not the untrue claim
+that the key never exists outside 1Password or that the gem always cleans up after itself.
+Child-only `op run` injection strengthens this postcondition: the cleanup proof no longer has to
+account for ASC values lingering in the parent shell after a lane.
 
 ### What dies and what replaces it
 
@@ -230,10 +243,12 @@ cleanup proof no longer has to account for ASC values lingering in the parent sh
 | --- | --- | --- |
 | `fastlane/.env` | Fastlane auto-load; `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_PATH` | Delete the file and all runtime dependence at cutover. Keep its ignore rule as a tripwire. `scripts/fastlane.sh` injects child-only values through committed, non-secret `fastlane/asc.env`. |
 | `fastlane/.env.template` | `2404139:fastlane/.env.template:1-4` | Delete it. Its copy-and-edit job no longer exists; committed `fastlane/asc.env` plus bootstrap documentation replaces it. |
+| `.envrc`, `.env.tpl`, and `.direnv/` | Layer 1 reference-only bootstrap and direnv's cached exported environment | Commit `.envrc` and `.env.tpl` with references/non-secret logic only. Ignore `/.direnv/`, assert it is untracked, and scan the committed files for resolved service-account tokens. |
 | `ASC_KEY_PATH` in `asc_api_key` | `2404139:fastlane/Fastfile:21-26` | Fetch the child-only base64 value injected by `op run`, decode in Ruby, and pass raw `key_content:`. |
 | `ASC_KEY_PATH` in `release` and `beta` `gym` `xcargs` | `4e6b28b:fastlane/Fastfile` | A helper-owned mode-`0600` temporary `.p8` path scoped to each `gym` call. Key and issuer IDs come from the same child-only environment, never committed literals. |
 | `pull_metadata` API-key JSON | `2404139:fastlane/Fastfile:106-125` | Retain the `Tempfile.create` handoff, require mode `0600` and symmetric cleanup tests, and suppress logging of its live path. Its hash now contains raw PEM produced from 1Password rather than a home-directory path. |
-| `~/.appstoreconnect/` | Existing plan/spec, the old plaintext key, and Fastlane Transporter's cleanup-deficient `verify` path | Remove the old `.p8` and empty directory after successful cutover. After each project lane that can invoke Transporter, surgically remove the expected project-key path and fail if any `.p8` remains. |
+| `~/.appstoreconnect/` | Existing plan/spec, the old plaintext key, and Fastlane Transporter's cleanup-deficient `verify` path | After every credential-using lane, surgically remove the expected replacement-key path and recursively scan for `.p8` files. Before step 9, warn only for exact legacy path `AuthKey_U2UZLVHKA5.p8` and fail on every other match; deleting the legacy file makes the same scan require zero matches. |
+| Retained document `3jey32ebbf3d4s2ktuyb64i4rq` | Accepted backup copy of the replacement PEM | Keep it under the same vault access control for this cutover. Every future key rotation must update or remove both this document and `ASC_KEY_CONTENT_BASE64_REF` so retired private-key material is not silently retained. |
 | Old IDs and absolute path in docs | `docs/superpowers/plans/2026-07-30-fastlane-screenshots-submission.md` and `docs/superpowers/specs/2026-07-30-fastlane-screenshots-submission-design.md` | After revocation, replace them with a neutral 1Password item reference and scrub the obsolete path. History remains, but the revoked identifiers no longer compose with a live key. |
 
 ## Migration/cutover plan
@@ -246,12 +261,14 @@ while old key `U2UZLVHKA5` is not yet revoked.
 1. **Record the completed provisioning.** The maintainer has provisioned the read-only service
    account, vault `family-foqos`, item `app_store_connect_key`, and the three decided fields. The
    replacement key is present in the concealed base64 field.
-2. **Implement the two layers before activating them.** Document the operator-local
-   `OP_SERVICE_ACCOUNT_TOKEN` bootstrap, commit `fastlane/asc.env` and `scripts/fastlane.sh`, fetch
-   child-only values in Fastlane, strictly decode raw `key_content`, add the gym-scoped tempfile
-   helper, retire the old env files, and implement the Transporter postcondition and non-submitting
-   tests. From this step through old-key revocation, treat the work as a maintenance window: do not
-   invoke `pilot` or `deliver` merely for credential testing.
+2. **Implement the two layers before activating them.** Commit the reference-only `.env.tpl` and
+   `.envrc` bootstrap for `OP_SERVICE_ACCOUNT_TOKEN`, `fastlane/asc.env`, and
+   `scripts/fastlane.sh`; fetch child-only values in Fastlane, strictly decode raw `key_content`, add
+   the gym-scoped tempfile helper, retire the old env files, and implement the Transporter
+   postcondition and non-submitting tests. From this step through old-key revocation, treat the work
+   as a maintenance window. Every credential-using lane must use the wrapper and enforce the
+   single-entry legacy-path allowlist; do not invoke `pilot` or `deliver` merely for credential
+   testing.
 3. **Verify the 1Password field round trip.** Through an operator-controlled `op run` child, confirm
    all three mappings resolve, the base64 field strictly decodes, and the decoded value parses as the
    expected PEM without printing any value.
@@ -276,7 +293,9 @@ while old key `U2UZLVHKA5` is not yet revoked.
 9. **Remove old local material and references.** Best-effort remove the old `.p8` and now-empty
    standing `~/.appstoreconnect/` directory, delete `fastlane/.env` and
    `fastlane/.env.template`, and scrub the old identifiers and absolute path from the Fastlane plan
-   and spec. Do not rewrite git history.
+   and spec. Removing `AuthKey_U2UZLVHKA5.p8` also removes the postcondition's only allowlisted
+   match, so subsequent scans require zero residual `.p8` files without a configuration change. Do
+   not rewrite git history.
 10. **Close the exposure loop.** Search the working tree for the old key ID, issuer ID,
     `ASC_KEY_PATH`, and the old home-directory path. Expected results are historical issue context
     only, not active configuration or current plan/spec prose. Record the replacement key only by
@@ -293,11 +312,15 @@ restore the revoked credential.
 
 - `fastlane/asc.env` is tracked and contains exactly the three decided `op://` mappings; it contains
   no resolved value.
-- The repository ships neither the operator's `.env.tpl`/`.envrc` bootstrap nor a service-account
-  token, while `fastlane/.env` remains ignored as a tripwire.
+- `.envrc` and `.env.tpl` are tracked and contain only
+  `op://family-foqos/service_auth_token/OP_SERVICE_ACCOUNT_TOKEN` plus non-secret bootstrap logic;
+  neither contains a resolved token or any ASC value. Root-anchored `/.direnv/` prevents staging
+  direnv's cached service token, and `fastlane/.env` remains ignored as a tripwire.
 - `scripts/fastlane.sh` routes `beta`, `release`, `pull_metadata`, and `check_asc_key` through
   `op run --env-file fastlane/asc.env`; `screenshots` remains credential-free.
-- A bare credential-using Fastlane invocation fails at `ENV.fetch` before build or network mutation.
+- With the legacy `fastlane/.env` still present, a bare credential-using Fastlane invocation fails
+  at `ENV.fetch("ASC_KEY_CONTENT_BASE64")` before build or network mutation even though Fastlane may
+  auto-load the legacy key and issuer IDs.
 - No active Fastfile or script reads `ASC_KEY_PATH` or auto-loads `fastlane/.env`.
 - `op run` resolution is child-scoped, masks the concealed key value, and fails closed on every
   missing/invalid reference; Fastlane does not print the injected values.
@@ -307,8 +330,12 @@ restore the revoked credential.
   for the duration of their blocks, and remove them on both success and an injected failure.
 - `pull_metadata` invokes its nested Fastlane process with `log: false`, so the live tempfile path
   is not emitted to lane output.
-- Every lane that invokes `pilot` or `deliver` removes the expected project-key file and asserts
-  that no `.p8` remains below `~/.appstoreconnect/`, including when the downstream action fails.
+- After every credential-using lane, the recursive `~/.appstoreconnect/**/*.p8` postcondition removes
+  the expected replacement-key path, tolerates only the exact hardcoded legacy path with a step-9
+  warning, and fails for every other residual key, including when the downstream action fails.
+- Tests prove that the legacy path is the only allowlisted entry, a leaked replacement or unrelated
+  `.p8` always fails, and deleting the legacy file makes the same postcondition require zero keys
+  without an environment variable or toggle.
 - A repository scan enumerates every `fastlane run` occurrence and fails if any credential-returning
   action is invoked that way. Non-secret action examples require an explicit allowlist rationale.
 - Repository scans find no private key block, service-account token, replacement identifiers, or
@@ -329,8 +356,9 @@ Before revocation, the maintainer confirms:
 
 1. `check_asc_key` succeeds without printing a key or returned credential hash;
 2. the archive-only gym probe authenticates without upload/submission;
-3. no gym `.p8`, `pull_metadata` JSON tempfile, or Transporter `.p8` remains after success or forced
-   failure;
+3. no gym `.p8`, `pull_metadata` JSON tempfile, or replacement-key Transporter `.p8` remains after
+   success or forced failure; before step 9, the only tolerated match is the warned exact legacy
+   path;
 4. the ambient shell contains the service token but no ASC value before, during, or after the lane;
    and
 5. the provisioned 1Password item, retained document backup, and service-account usage are visible
@@ -344,7 +372,9 @@ by rotation and #365 as remediated by the 1Password migration.
 - **DECIDED:** Rotation of the transcript-exposed ASC key is part of this migration's cutover.
 - **DECIDED:** 1Password is the only durable source of truth for the replacement ASC key.
 - **DECIDED:** Personal 1Password plus direnv bootstraps only `OP_SERVICE_ACCOUNT_TOKEN` once per
-  session; the operator-owned `.env.tpl`/`.envrc` is documented but not committed.
+  session; `.env.tpl` and `.envrc` are committed with references/non-secret logic only,
+  `direnv allow` records operator consent, and only `.direnv/` is ignored because it may cache the
+  resolved token.
 - **DECIDED:** The repository commits non-secret `fastlane/asc.env`; `scripts/fastlane.sh` uses
   child-scoped `op run` injection for every ASC lane, while `screenshots` is exempt.
 - **DECIDED:** Use the provisioned read-only service account in vault `family-foqos`; its token is
@@ -354,8 +384,9 @@ by rotation and #365 as remediated by the 1Password migration.
 - **DECIDED:** Store/transport private-key content as base64, decode in Ruby, and pass raw PEM to
   Fastlane.
 - **DECIDED:** Xcode receives a mode-`0600`, gym-scoped temporary `.p8` with ensure cleanup.
-- **DECIDED:** Family Foqos lanes enforce the no-standing-key postcondition instead of trusting
-  Fastlane Transporter's non-uniform cleanup.
+- **DECIDED:** Every credential-using Family Foqos lane recursively enforces the no-standing-key
+  postcondition instead of trusting Fastlane Transporter's non-uniform cleanup. Until step 9, its
+  only hardcoded exception is the exact warned legacy path; no runtime activation toggle exists.
 - **DECIDED:** Retain document item `3jey32ebbf3d4s2ktuyb64i4rq` as the maintainer's backup copy
   alongside the concealed field under the same vault access control.
 - **PENDING CUTOVER:** Old key `U2UZLVHKA5` remains active until wrapped `check_asc_key` and the

--- a/docs/superpowers/specs/2026-08-09-1password-credentials.md
+++ b/docs/superpowers/specs/2026-08-09-1password-credentials.md
@@ -1,10 +1,11 @@
 # App Store Connect Credentials: 1Password, Scoped `op run`, and Key Rotation
 
 **Date:** 2026-08-09
-**Status:** Approved design; operator decisions ratified and provisioned; implementation/cutover pending
+**Status:** Approved design; credentials provisioned; old key revoked and local file deleted;
+implementation/wiring verification pending
 **Scope:** Local Fastlane credentials for V2 / `main`; resolves storage issue
-[#365](https://github.com/mnbf9rca/family-foqos/issues/365) and makes the rotation from
-[#364](https://github.com/mnbf9rca/family-foqos/issues/364) part of the migration cutover.
+[#365](https://github.com/mnbf9rca/family-foqos/issues/365) and records the completed rotation from
+[#364](https://github.com/mnbf9rca/family-foqos/issues/364).
 
 ## Problem
 
@@ -13,7 +14,7 @@ maintainer's home directory. A gitignored `fastlane/.env` supplies its path, key
 This protects the private key from git, but not from another process running as the user, and it
 provides no scoped access, access record, or convenient revocation mechanism.
 
-Issue #364 makes the migration urgent enough to include rotation. A verification command in the
+Issue #364 made the migration urgent enough to include rotation. A verification command in the
 committed Fastlane plan invoked `fastlane run app_store_connect_api_key`. That action returns a hash
 whose `:key` member is the complete private key, so Fastlane printed the key into a local agent
 session transcript. The transcript was not committed, pushed, or messaged elsewhere, but it now
@@ -23,6 +24,11 @@ not authenticate on their own, but together with the transcript they are all the
 use the old private key. Rotation, rather than repository-document deletion, is the security
 boundary because
 git history and forks retain already-published identifiers.
+
+On 2026-08-09, the maintainer revoked old key `U2UZLVHKA5` in App Store Connect, shredded and
+deleted its actual local file `~/.appstoreconnect/AuthKey_U2UZLVHKA5.p8`, and closed #364. The
+replacement key remains in 1Password; the remaining cutover is its repository wiring plus a green
+wrapped `check_asc_key`.
 
 The target state has one durable source of truth for ASC credentials: 1Password. The repository
 contains only non-secret 1Password references in `fastlane/asc.env`. A committed wrapper invokes
@@ -36,8 +42,8 @@ never holds ASC key material.
 - The repository is public. No private key, service-account token, resolved environment value, new
   key ID, new issuer ID, or machine-specific key path may be committed.
 - The replacement ASC key already exists and is stored in 1Password. It is not durably stored as a
-  plaintext home-directory credential. The old key `U2UZLVHKA5` remains active until the new wiring,
-  `check_asc_key`, and Xcode path verification pass.
+  plaintext home-directory credential. Old key `U2UZLVHKA5` is revoked and its local plaintext file
+  was deleted on 2026-08-09; it is not a fallback if new-key verification fails.
 - ASC key creation normally produces a one-time browser download. This design therefore does not
   claim a diskless cutover. It minimizes that initial file's lifetime and treats revocation, not
   best-effort file erasure on APFS/SSD storage, as the security boundary.
@@ -150,9 +156,9 @@ The setup flow is:
 Retain `fastlane/.env` in `.gitignore` as defense in depth after deleting the file and removing all
 runtime use. Commit `.envrc` and `.env.tpl`; they contain only the service-token reference and
 non-secret bootstrap logic. Add a root-anchored `/.direnv/` ignore rule because that directory may
-cache the resolved service token. Commit `fastlane/asc.env`; it contains references, not resolved
-values. Delete `fastlane/.env.template` because the operator no longer copies or edits a Fastlane
-env template.
+contain direnv-managed local state that must not be tracked. Commit `fastlane/asc.env`; it contains
+references, not resolved values. Delete `fastlane/.env.template` because the operator no longer
+copies or edits a Fastlane env template.
 
 A leaked `op://` reference reveals vault/item/field naming metadata. It does **not** reveal or grant
 access to the referenced value; an attacker still needs an authorized 1Password user session or
@@ -223,17 +229,12 @@ security dependency.
 
 Every credential-using project lane must therefore enforce its own postcondition in an `ensure`.
 First, remove only the expected replacement-key file at the known Transporter path. Then recursively
-scan `~/.appstoreconnect/` for `*.p8`. During the maintenance window, the scan has one hardcoded
-allowlist entry: the exact legacy path
-`~/.appstoreconnect/private_keys/AuthKey_U2UZLVHKA5.p8`. That file produces a warning pointing to
-cutover step 9; every other residual `.p8` fails the lane, so a leaked replacement-key file is never
-tolerated. Deleting the legacy file at step 9 naturally makes the check total. There is no
-environment variable, feature flag, or activation toggle: the filesystem state that cutover already
-changes controls the transition. An unrelated standing key is reported for operator remediation,
-not silently deleted. The scoped invariant is:
-**no standing plaintext private-key file survives a credential-using Family Foqos lane or the
-cutover, except for the explicitly warned legacy path before step 9**. It is not the untrue claim
-that the key never exists outside 1Password or that the gem always cleans up after itself.
+scan `~/.appstoreconnect/` for `*.p8`. Any residual `.p8` fails the lane from the first implementation
+run onward. There is no allowlist, warning branch, environment variable, feature flag, or activation
+toggle. An unrelated standing key is reported for operator remediation, not silently deleted. The
+scoped invariant is: **no standing plaintext private-key file survives a credential-using Family
+Foqos lane or the cutover**. It is not the untrue claim that the key never exists outside 1Password
+or that the gem always cleans up after itself.
 Child-only `op run` injection strengthens this postcondition: the cleanup proof no longer has to
 account for ASC values lingering in the parent shell after a lane.
 
@@ -243,32 +244,34 @@ account for ASC values lingering in the parent shell after a lane.
 | --- | --- | --- |
 | `fastlane/.env` | Fastlane auto-load; `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_PATH` | Delete the file and all runtime dependence at cutover. Keep its ignore rule as a tripwire. `scripts/fastlane.sh` injects child-only values through committed, non-secret `fastlane/asc.env`. |
 | `fastlane/.env.template` | `2404139:fastlane/.env.template:1-4` | Delete it. Its copy-and-edit job no longer exists; committed `fastlane/asc.env` plus bootstrap documentation replaces it. |
-| `.envrc`, `.env.tpl`, and `.direnv/` | Layer 1 reference-only bootstrap and direnv's cached exported environment | Commit `.envrc` and `.env.tpl` with references/non-secret logic only. Ignore `/.direnv/`, assert it is untracked, and scan the committed files for resolved service-account tokens. |
+| `.envrc`, `.env.tpl`, and `.direnv/` | Layer 1 reference-only bootstrap and direnv-managed local state | Commit `.envrc` and `.env.tpl` with references/non-secret logic only. Ignore `/.direnv/`, assert it is untracked, and scan the committed files for resolved service-account tokens. |
 | `ASC_KEY_PATH` in `asc_api_key` | `2404139:fastlane/Fastfile:21-26` | Fetch the child-only base64 value injected by `op run`, decode in Ruby, and pass raw `key_content:`. |
 | `ASC_KEY_PATH` in `release` and `beta` `gym` `xcargs` | `4e6b28b:fastlane/Fastfile` | A helper-owned mode-`0600` temporary `.p8` path scoped to each `gym` call. Key and issuer IDs come from the same child-only environment, never committed literals. |
 | `pull_metadata` API-key JSON | `2404139:fastlane/Fastfile:106-125` | Retain the `Tempfile.create` handoff, require mode `0600` and symmetric cleanup tests, and suppress logging of its live path. Its hash now contains raw PEM produced from 1Password rather than a home-directory path. |
-| `~/.appstoreconnect/` | Existing plan/spec, the old plaintext key, and Fastlane Transporter's cleanup-deficient `verify` path | After every credential-using lane, surgically remove the expected replacement-key path and recursively scan for `.p8` files. Before step 9, warn only for exact legacy path `AuthKey_U2UZLVHKA5.p8` and fail on every other match; deleting the legacy file makes the same scan require zero matches. |
+| `~/.appstoreconnect/` | Fastlane Transporter's cleanup-deficient `verify` path; the old top-level `AuthKey_U2UZLVHKA5.p8` was deleted on 2026-08-09 | After every credential-using lane, surgically remove the expected replacement-key path, recursively scan for `.p8` files, and fail on any match. No legacy exception exists. |
 | Retained document `3jey32ebbf3d4s2ktuyb64i4rq` | Accepted backup copy of the replacement PEM | Keep it under the same vault access control for this cutover. Every future key rotation must update or remove both this document and `ASC_KEY_CONTENT_BASE64_REF` so retired private-key material is not silently retained. |
-| Old IDs and absolute path in docs | `docs/superpowers/plans/2026-07-30-fastlane-screenshots-submission.md` and `docs/superpowers/specs/2026-07-30-fastlane-screenshots-submission-design.md` | After revocation, replace them with a neutral 1Password item reference and scrub the obsolete path. History remains, but the revoked identifiers no longer compose with a live key. |
+| Old IDs and absolute path in docs | `docs/superpowers/plans/2026-07-30-fastlane-screenshots-submission.md` and `docs/superpowers/specs/2026-07-30-fastlane-screenshots-submission-design.md` | With revocation complete, replace them with a neutral 1Password item reference and scrub the obsolete path. History remains, but the revoked identifiers no longer compose with a live key. |
 
 ## Migration/cutover plan
 
-The cutover keeps the old key valid until the ratified service-account path and both the Fastlane API
-and Xcode path consumers are proven. It does not upload a build or submit a release merely to test
-credentials. Current operator state is explicit: the replacement key already exists in 1Password,
-while old key `U2UZLVHKA5` is not yet revoked.
+The credential retirement is already complete: on 2026-08-09 the maintainer revoked
+`U2UZLVHKA5`, shredded and deleted the top-level local file
+`~/.appstoreconnect/AuthKey_U2UZLVHKA5.p8`, and closed #364. There is no fallback key and no
+maintenance-window exception. The remaining cutover is repository wiring plus a green wrapped
+`check_asc_key` against the replacement key. The archive-only probe remains implementation
+verification for Xcode's path consumer; it does not gate an already-completed revocation. No step
+uploads a build or submits a release merely to test credentials.
 
-1. **Record the completed provisioning.** The maintainer has provisioned the read-only service
-   account, vault `family-foqos`, item `app_store_connect_key`, and the three decided fields. The
-   replacement key is present in the concealed base64 field.
-2. **Implement the two layers before activating them.** Commit the reference-only `.env.tpl` and
+1. **Record the completed provisioning and retirement.** The maintainer has provisioned the
+   read-only service account, vault `family-foqos`, item `app_store_connect_key`, and the three
+   decided fields. The replacement key is present in the concealed base64 field. The old key is
+   revoked, its actual top-level local `.p8` is deleted, and #364 is closed as of 2026-08-09.
+2. **Implement the two layers.** Commit the reference-only `.env.tpl` and
    `.envrc` bootstrap for `OP_SERVICE_ACCOUNT_TOKEN`, `fastlane/asc.env`, and
    `scripts/fastlane.sh`; fetch child-only values in Fastlane, strictly decode raw `key_content`, add
    the gym-scoped tempfile helper, retire the old env files, and implement the Transporter
-   postcondition and non-submitting tests. From this step through old-key revocation, treat the work
-   as a maintenance window. Every credential-using lane must use the wrapper and enforce the
-   single-entry legacy-path allowlist; do not invoke `pilot` or `deliver` merely for credential
-   testing.
+   postcondition and non-submitting tests. From its first run, every credential-using lane must use
+   the wrapper and fail if the total recursive postcondition finds any residual `.p8`.
 3. **Verify the 1Password field round trip.** Through an operator-controlled `op run` child, confirm
    all three mappings resolve, the base64 field strictly decodes, and the decoded value parses as the
    expected PEM without printing any value.
@@ -286,25 +289,17 @@ while old key `U2UZLVHKA5` is not yet revoked.
    through `op run` that uses the same gym tempfile helper as `beta`/`release` but calls neither
    `pilot` nor `deliver`. Confirm successful authentication and removal of the temporary `.p8` after
    both success and an injected failure.
-8. **Revoke the old ASC key.** Only after steps 6-7 pass, revoke `U2UZLVHKA5`, the previously active
-   key tracked by #364, in App Store Connect. Immediately rerun the wrapped `check_asc_key` to prove
-   the configured replacement still works. From this point, residual copies of the old private key
-   cannot authenticate.
-9. **Remove old local material and references.** Best-effort remove the old `.p8` and now-empty
-   standing `~/.appstoreconnect/` directory, delete `fastlane/.env` and
-   `fastlane/.env.template`, and scrub the old identifiers and absolute path from the Fastlane plan
-   and spec. Removing `AuthKey_U2UZLVHKA5.p8` also removes the postcondition's only allowlisted
-   match, so subsequent scans require zero residual `.p8` files without a configuration change. Do
-   not rewrite git history.
-10. **Close the exposure loop.** Search the working tree for the old key ID, issuer ID,
+8. **Remove old configuration and references.** Delete any now-empty standing
+   `~/.appstoreconnect/` directory, `fastlane/.env`, and `fastlane/.env.template`; scrub the old
+   identifiers and absolute path from the Fastlane plan and spec. Do not rewrite git history.
+9. **Close the exposure loop.** Search the working tree for the old key ID, issuer ID,
     `ASC_KEY_PATH`, and the old home-directory path. Expected results are historical issue context
     only, not active configuration or current plan/spec prose. Record the replacement key only by
     its 1Password item name.
 
-If any pre-revocation verification fails, keep the old key active, remove any failed new-key
-temporary files, and repair the migration. Do not fall back to recreating a standing `.p8`. If a
-failure occurs after revocation, fix the new 1Password path or create another replacement key; never
-restore the revoked credential.
+If verification fails, remove any failed new-key temporary files and repair the new 1Password path
+or create another replacement key. Never restore the revoked credential or recreate a standing
+`.p8` fallback.
 
 ## Rollout & verification
 
@@ -315,7 +310,7 @@ restore the revoked credential.
 - `.envrc` and `.env.tpl` are tracked and contain only
   `op://family-foqos/service_auth_token/OP_SERVICE_ACCOUNT_TOKEN` plus non-secret bootstrap logic;
   neither contains a resolved token or any ASC value. Root-anchored `/.direnv/` prevents staging
-  direnv's cached service token, and `fastlane/.env` remains ignored as a tripwire.
+  direnv-managed local state, and `fastlane/.env` remains ignored as a tripwire.
 - `scripts/fastlane.sh` routes `beta`, `release`, `pull_metadata`, and `check_asc_key` through
   `op run --env-file fastlane/asc.env`; `screenshots` remains credential-free.
 - With the legacy `fastlane/.env` still present, a bare credential-using Fastlane invocation fails
@@ -331,11 +326,11 @@ restore the revoked credential.
 - `pull_metadata` invokes its nested Fastlane process with `log: false`, so the live tempfile path
   is not emitted to lane output.
 - After every credential-using lane, the recursive `~/.appstoreconnect/**/*.p8` postcondition removes
-  the expected replacement-key path, tolerates only the exact hardcoded legacy path with a step-9
-  warning, and fails for every other residual key, including when the downstream action fails.
-- Tests prove that the legacy path is the only allowlisted entry, a leaked replacement or unrelated
-  `.p8` always fails, and deleting the legacy file makes the same postcondition require zero keys
-  without an environment variable or toggle.
+  only the expected replacement-key path and fails on any residual key, including when the
+  downstream action fails.
+- Tests prove the postcondition is total from its first implementation run: a legacy-path,
+  replacement-path, or unrelated `.p8` residual fails with no allowlist, warning branch,
+  environment variable, or activation toggle.
 - A repository scan enumerates every `fastlane run` occurrence and fails if any credential-returning
   action is invoked that way. Non-secret action examples require an explicit allowlist rationale.
 - Repository scans find no private key block, service-account token, replacement identifiers, or
@@ -352,29 +347,29 @@ restore the revoked credential.
 
 ### Manual acceptance
 
-Before revocation, the maintainer confirms:
+Before completing the implementation, the maintainer confirms:
 
 1. `check_asc_key` succeeds without printing a key or returned credential hash;
 2. the archive-only gym probe authenticates without upload/submission;
-3. no gym `.p8`, `pull_metadata` JSON tempfile, or replacement-key Transporter `.p8` remains after
-   success or forced failure; before step 9, the only tolerated match is the warned exact legacy
-   path;
+3. no gym `.p8`, `pull_metadata` JSON tempfile, or Transporter `.p8` remains after success or forced
+   failure;
 4. the ambient shell contains the service token but no ASC value before, during, or after the lane;
    and
 5. the provisioned 1Password item, retained document backup, and service-account usage are visible
    to the maintainer.
 
-After revocation, rerun the non-secret key check and repository scans. Then close #364 as remediated
-by rotation and #365 as remediated by the 1Password migration.
+Revocation and #364 closure are already complete. After the wiring and wrapped non-secret key check
+pass, rerun repository scans and close #365 as remediated by the 1Password migration.
 
 ## Decision log
 
-- **DECIDED:** Rotation of the transcript-exposed ASC key is part of this migration's cutover.
+- **COMPLETED 2026-08-09:** Old ASC key `U2UZLVHKA5` was revoked, its actual top-level local file
+  `~/.appstoreconnect/AuthKey_U2UZLVHKA5.p8` was shredded and deleted, and #364 was closed.
 - **DECIDED:** 1Password is the only durable source of truth for the replacement ASC key.
 - **DECIDED:** Personal 1Password plus direnv bootstraps only `OP_SERVICE_ACCOUNT_TOKEN` once per
   session; `.env.tpl` and `.envrc` are committed with references/non-secret logic only,
-  `direnv allow` records operator consent, and only `.direnv/` is ignored because it may cache the
-  resolved token.
+  `direnv allow` records operator consent, and only `.direnv/` is ignored because it may contain
+  direnv-managed local state.
 - **DECIDED:** The repository commits non-secret `fastlane/asc.env`; `scripts/fastlane.sh` uses
   child-scoped `op run` injection for every ASC lane, while `screenshots` is exempt.
 - **DECIDED:** Use the provisioned read-only service account in vault `family-foqos`; its token is
@@ -385,11 +380,12 @@ by rotation and #365 as remediated by the 1Password migration.
   Fastlane.
 - **DECIDED:** Xcode receives a mode-`0600`, gym-scoped temporary `.p8` with ensure cleanup.
 - **DECIDED:** Every credential-using Family Foqos lane recursively enforces the no-standing-key
-  postcondition instead of trusting Fastlane Transporter's non-uniform cleanup. Until step 9, its
-  only hardcoded exception is the exact warned legacy path; no runtime activation toggle exists.
+  postcondition instead of trusting Fastlane Transporter's non-uniform cleanup. It is total from the
+  first implementation run: every residual `.p8` fails, with no allowlist, warning branch, or
+  runtime activation toggle.
 - **DECIDED:** Retain document item `3jey32ebbf3d4s2ktuyb64i4rq` as the maintainer's backup copy
   alongside the concealed field under the same vault access control.
-- **PENDING CUTOVER:** Old key `U2UZLVHKA5` remains active until wrapped `check_asc_key` and the
-  archive-only Xcode path probe both pass.
+- **PENDING CUTOVER:** Complete repository wiring and obtain a green wrapped `check_asc_key` against
+  the replacement key. The revoked key is not a fallback.
 - **REJECTED:** A standing home-directory `.p8`, a second auth-specific `.envrc`, a history rewrite,
   or an unverifiable claim that browser-issued key creation is diskless.


### PR DESCRIPTION
Records the maintainer-ratified two-layer credential architecture: committed reference-only .envrc/.env.tpl files use personal 1Password plus direnv to bootstrap only OP_SERVICE_ACCOUNT_TOKEN, while committed fastlane/asc.env references are resolved by op run into each Fastlane child. Old key U2UZLVHKA5 was revoked, its actual top-level local .p8 was shredded/deleted, and #364 was closed on 2026-08-09. Runtime residue scanning was rejected as overengineering: lanes clean up only their gym and metadata tempfiles, while possible Fastlane Transporter verify residue is an accepted limitation. Remaining cutover is repository wiring plus a green wrapped check_asc_key; this design addresses #365 and consumes the Session Credential Warm-up interface from #362/#363.