### PR TITLE
build: wire Fastlane credentials through 1Password (#365)

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -1,0 +1,1 @@
+export OP_SERVICE_ACCOUNT_TOKEN="op://family-foqos/service_auth_token/OP_SERVICE_ACCOUNT_TOKEN"

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+eval "$(op inject -i .env.tpl)"

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,9 @@ vendor/bundle/
 .worktrees/
 docs/plans/
 docs/codebase-analysis/
+
+/.direnv/
+
+# Agent Message Queue
+.agent-mail/
+.amqrc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,20 @@
+AllCops:
+  TargetRubyVersion: 4.0
+  NewCops: enable
+  Include:
+    - scripts/**/*.rb
+    - fastlane/*.rb
+    - fastlane/Fastfile
+  Exclude:
+    - vendor/**/*
+
+Metrics:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+# Executable Ruby harnesses follow the repository's existing test-script naming convention.
+Naming/FileName:
+  Exclude:
+    - scripts/test-*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "https://rubygems.org"
 
 gem "fastlane", "2.237.0"
+
+group :development do
+  gem "rubocop", "1.88.2", require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
+    ast (2.4.3)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
     aws-partitions (1.1279.0)
@@ -176,6 +177,8 @@ GEM
     json (2.21.2)
     jwt (3.2.0)
       base64
+    language_server-protocol (3.17.0.6)
+    lint_roller (1.1.0)
     logger (1.7.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
@@ -188,10 +191,18 @@ GEM
     optparse (0.8.1)
     os (1.1.4)
     ostruct (0.6.3)
+    parallel (2.1.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
     plist (3.7.2)
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
+    regexp_parser (2.12.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -199,6 +210,21 @@ GEM
     retriable (3.8.0)
     rexml (3.4.4)
     rouge (3.28.0)
+    rubocop (1.88.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
     security (0.1.5)
@@ -240,12 +266,14 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (= 2.237.0)
+  rubocop (= 1.88.2)
 
 CHECKSUMS
   CFPropertyList (3.0.8) sha256=2c99d0d980536d3d7ab252f7bd59ac8be50fbdd1ff487c98c949bb66bb114261
   abbrev (0.1.2) sha256=ad1b4eaaaed4cb722d5684d63949e4bde1d34f2a95e20db93aecfe7cbac74242
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   artifactory (3.0.17) sha256=3023d5c964c31674090d655a516f38ca75665c15084140c08b7f2841131af263
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
   aws-partitions (1.1279.0) sha256=9baa4f75bca3e5efe4d4df27655ae640aaaa1f6e2d3cf59fda3dad19689ae435
@@ -302,6 +330,8 @@ CHECKSUMS
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
@@ -314,14 +344,23 @@ CHECKSUMS
   optparse (0.8.1) sha256=42bea10d53907ccff4f080a69991441d611fbf8733b60ed1ce9ee365ce03bd1a
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
+  parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
   plist (3.7.2) sha256=d37a4527cc1116064393df4b40e1dbbc94c65fa9ca2eec52edf9a13616718a42
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
   retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rouge (3.28.0) sha256=0d6de482c7624000d92697772ab14e48dca35629f8ddf3f4b21c99183fd70e20
+  rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
   security (0.1.5) sha256=3a977a0eca7706e804c96db0dd9619e0a94969fe3aac9680fcfc2bf9b8a833b7

--- a/docs/superpowers/plans/2026-08-09-1password-wiring.md
+++ b/docs/superpowers/plans/2026-08-09-1password-wiring.md
@@ -1,0 +1,324 @@
+# 1Password Fastlane Wiring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route every App Store Connect Fastlane lane through child-scoped 1Password references,
+strictly decode raw key material in Ruby, and ensure every project-created tempfile is removed.
+
+**Architecture:** A focused `ASCCredentials` Ruby module owns decoding and sensitive tempfiles.
+`Fastfile` composes those helpers around the existing gym and metadata flows; a shell wrapper
+decides which lanes require `op run`. The operator bootstrap files and reference mappings are
+committed but contain only `op://` references.
+
+**Tech Stack:** Ruby 4 / Fastlane 2.237.0, Bash, 1Password CLI, direnv.
+
+## Global Constraints
+
+- Authoritative design: commit `0fe0d05f453a8463223115e43b98e667e5e5c9b1`, plus the maintainer's
+  later superseding decision to reject runtime Transporter residue scans as overengineering.
+- Never print a private key, service-account token, resolved 1Password value, or new issuer ID.
+- Strictly decode `ASC_KEY_CONTENT_BASE64` once in Ruby and pass raw PEM as `key_content`; never set
+  `is_key_content_base64`.
+- Keep the namespaced `ASC_*` variables. Never use Fastlane's implicit `APP_STORE_CONNECT_*`
+  environment names.
+- Do not run Xcode, a simulator, `pilot`, `deliver`, an upload, a submission, or key revocation.
+- Do not delete `fastlane/.env` during this implementation. Its key path now dangles and is not a
+  credential fallback; never recreate the deleted legacy key file.
+- Do not scan `~/.appstoreconnect`, add residue allowlists, or implement a per-lane residue
+  postcondition. Transporter verify residue is a maintainer-accepted known limitation.
+- Bootstrap configuration is a maintainer-approved exception to test-first code: its exact two
+  reference-only files and ignore entries are specified verbatim and verified structurally.
+
+---
+
+### Task 1: Commit the reference-only bootstrap layer
+
+**Files:**
+- Create: `.env.tpl`
+- Create: `.envrc`
+- Modify: `.gitignore`
+
+**Interfaces:**
+- Produces: operator-approved `OP_SERVICE_ACCOUNT_TOKEN` bootstrap for the Session Credential
+  Warm-up; `.direnv/`, `.agent-mail/`, and `.amqrc` remain untracked.
+
+- [ ] **Step 1: Add the exact non-secret bootstrap files**
+
+`.env.tpl`:
+
+```bash
+export OP_SERVICE_ACCOUNT_TOKEN="op://family-foqos/service_auth_token/OP_SERVICE_ACCOUNT_TOKEN"
+```
+
+`.envrc`:
+
+```bash
+eval "$(op inject -i .env.tpl)"
+```
+
+- [ ] **Step 2: Add the exact ignore entries**
+
+```gitignore
+/.direnv/
+
+# Agent Message Queue
+.agent-mail/
+.amqrc
+```
+
+- [ ] **Step 3: Verify only references are committed**
+
+Run:
+
+```bash
+bash -n .envrc
+git check-ignore .direnv/probe .agent-mail/probe .amqrc
+git diff --check
+```
+
+Expected: Bash syntax succeeds; all three probe paths are printed as ignored; diff check is quiet.
+
+- [ ] **Step 4: Commit separately**
+
+```bash
+git add .env.tpl .envrc .gitignore
+git commit -m "build: commit direnv bootstrap layer + amq ignores (maintainer request)" \
+  -m ".env.tpl and .envrc contain op:// references only. Resolution requires the operator's 1Password authentication, so the committed files expose no credential value."
+```
+
+---
+
+### Task 2: Specify credential-helper behavior with a failing test
+
+**Files:**
+- Create: `scripts/test-asc-credentials.rb`
+- Create later: `fastlane/asc_credentials.rb`
+
+**Interfaces:**
+- Produces: `ASCCredentials.decode_private_key`, `with_private_key_tempfile`,
+  and `with_api_key_json_tempfile`.
+
+- [ ] **Step 1: Write the real-behavior test first**
+
+The harness must generate an ephemeral EC key in memory and test these literal outcomes:
+
+```ruby
+raw_pem = OpenSSL::PKey::EC.generate("prime256v1").to_pem
+encoded = Base64.strict_encode64(raw_pem)
+raise "decode mismatch" unless ASCCredentials.decode_private_key(encoded) == raw_pem
+
+assert_tempfile_contract(:with_private_key_tempfile, raw_pem)
+assert_tempfile_contract(:with_api_key_json_tempfile, { key: raw_pem })
+```
+
+For each tempfile helper, assert mode `0600` while yielded and absence after both a successful block
+and an injected exception. Also assert malformed base64 and decoded non-PEM input fail closed.
+
+- [ ] **Step 2: Run RED**
+
+Run: `ruby scripts/test-asc-credentials.rb`
+
+Expected: FAIL because `fastlane/asc_credentials.rb` does not exist.
+
+---
+
+### Task 3: Implement the minimal credential helper
+
+**Files:**
+- Create: `fastlane/asc_credentials.rb`
+- Test: `scripts/test-asc-credentials.rb`
+
+**Interfaces:**
+- `decode_private_key(encoded) -> String` returns validated raw PEM or raises `CredentialError`.
+- `with_private_key_tempfile(raw_pem) { |absolute_path| ... }` yields a mode-`0600` file.
+- `with_api_key_json_tempfile(api_key) { |absolute_path| ... }` yields mode-`0600` JSON.
+
+- [ ] **Step 1: Implement strict decode and tempfile lifecycle**
+
+Use `Base64.strict_decode64`, validate with `OpenSSL::PKey.read`, and translate parse/decode failures
+to a redacted `CredentialError`. Both tempfile helpers use `Tempfile.create`, explicit
+`chmod(0600)`, binary-safe writes, `flush`, block-scoped yield, and automatic ensure cleanup.
+
+- [ ] **Step 2: Run GREEN and mutation-check**
+
+Run: `ruby scripts/test-asc-credentials.rb`
+
+Expected: `PASS: ASC credential decode and tempfile lifecycle`.
+
+Mentally mutate strict decoding, explicit chmod, or failure cleanup; each mutation must break a
+named harness case.
+
+---
+
+### Task 4: Specify wrapper routing behavior
+
+**Files:**
+- Create: `scripts/test-fastlane-credential-routing.sh`
+- Create later: `scripts/fastlane.sh`
+- Create later: `fastlane/asc.env`
+
+**Interfaces:**
+- `scripts/fastlane.sh <lane> ...` routes ASC lanes through `op run`; other lanes run Bundler
+  directly with every original argument preserved.
+
+- [ ] **Step 1: Write the routing harness first**
+
+Use a temporary `PATH` containing recording `brew`, `op`, and `bundle` executables. Assert:
+
+- `check_asc_key`, `pull_metadata`, `beta`, and `release` execute `op run --env-file` with the
+  absolute repository `fastlane/asc.env` and preserve trailing arguments;
+- `screenshots`, `lanes`, `gates`, and `build_number` execute Bundler directly;
+- a missing `op` fails before Bundler with a friendly message; and
+- no credential value appears in captured output.
+
+- [ ] **Step 2: Run RED**
+
+Run: `bash scripts/test-fastlane-credential-routing.sh`
+
+Expected: FAIL because the wrapper and refs file do not exist.
+
+---
+
+### Task 5: Implement child-scoped routing
+
+**Files:**
+- Create: `fastlane/asc.env`
+- Create: `scripts/fastlane.sh`
+- Test: `scripts/test-fastlane-credential-routing.sh`
+- Delete later with Fastfile wiring: `fastlane/.env.template`
+
+**Interfaces:**
+- Consumes only the three provisioned `op://family-foqos/app_store_connect_key/...` references.
+
+- [ ] **Step 1: Add the refs file**
+
+Commit exactly three assignments and a comment warning that the names must never become Fastlane's
+implicit `APP_STORE_CONNECT_API_KEY_*` forms.
+
+- [ ] **Step 2: Add the executable lane wrapper**
+
+Use the Homebrew Ruby path, an explicit credential-lane case, a friendly `command -v op` failure,
+and `exec op run --env-file "$(dirname "$0")/../fastlane/asc.env" -- bundle exec fastlane "$@"`.
+All non-credential lanes execute `bundle exec fastlane "$@"` directly. Mark the script executable.
+
+- [ ] **Step 3: Run GREEN**
+
+Run:
+
+```bash
+bash -n scripts/fastlane.sh
+bash scripts/test-fastlane-credential-routing.sh
+```
+
+Expected: syntax check is quiet and the routing harness prints PASS.
+
+---
+
+### Task 6: Wire Fastfile to raw PEM and scoped cleanup
+
+**Files:**
+- Modify: `fastlane/Fastfile`
+- Delete: `fastlane/.env.template`
+- Test: `scripts/test-asc-credentials.rb`
+
+**Interfaces:**
+- Consumes the helper APIs from Task 3 and child-only `ASC_KEY_ID`, `ASC_ISSUER_ID`, and
+  `ASC_KEY_CONTENT_BASE64`.
+
+- [ ] **Step 1: Replace the disk-key API lane**
+
+Require `asc_credentials`. `asc_api_key` must fetch all three namespaced variables, call
+`ASCCredentials.decode_private_key`, and pass raw `key_content:` with no base64 flag or path.
+
+- [ ] **Step 2: Scope the gym key file**
+
+In both `beta` and `release`, wrap only `gym` in `with_private_key_tempfile(api_key.fetch(:key))`.
+Build `-authenticationKeyPath`, key ID, and issuer ID from the yielded path and resolved hash.
+
+- [ ] **Step 3: Scope metadata JSON**
+
+Use `with_api_key_json_tempfile(api_key)` around the nested `deliver download_metadata` command and
+set `log: false`. Do not add runtime Transporter residue scanning.
+
+- [ ] **Step 4: Minimize check output and retire the template**
+
+`check_asc_key` may print the resolved key ID plus boolean issuer/key presence, never issuer content
+or a returned key hash. Delete `fastlane/.env.template`; keep the `fastlane/.env` ignore rule.
+
+- [ ] **Step 5: Parse and fail-closed checks**
+
+Run:
+
+```bash
+bundle exec fastlane lanes
+bundle exec fastlane check_asc_key
+```
+
+Expected: lane listing exits 0 with every lane. Bare `check_asc_key` exits nonzero at `ENV.fetch`
+before build/network work and names only the missing variable.
+
+---
+
+### Task 7: Full non-Xcode verification and wiring commit
+
+**Files:** All implementation files from Tasks 2–6.
+
+- [ ] **Step 1: Run the complete local suite one command at a time**
+
+```bash
+ruby scripts/test-asc-credentials.rb
+bash scripts/test-fastlane-credential-routing.sh
+ruby scripts/test-archive-storage.rb
+bash scripts/test-check-prod-schema.sh
+bash scripts/test-fastlane-gates.sh
+bash -n scripts/fastlane.sh
+bundle exec fastlane lanes
+```
+
+- [ ] **Step 2: Run secret and stale-path scans**
+
+Search the active diff for the revoked key ID, `BEGIN PRIVATE`, resolved token/key material,
+the stale disk-key environment variable, and implicit `APP_STORE_CONNECT_API_KEY_*` names. Require
+the revoked ID and secret/path scans to be empty; allow only the explicit warning comment for the
+implicit names.
+
+- [ ] **Step 3: Attempt the live non-mutating credential check**
+
+First test only whether `OP_SERVICE_ACCOUNT_TOKEN` is present, without printing it. If present, run
+`./scripts/fastlane.sh check_asc_key` and record literal redacted output: the key ID must not be
+the revoked key ID, issuer/key presence must be true, and no PEM material may appear. If unavailable,
+a biometric prompt is required, or authentication fails, stop the live check and report the exact
+redacted failure. No live fallback key exists; never improvise credentials.
+
+- [ ] **Step 4: Commit the wiring**
+
+```bash
+git add fastlane scripts docs/superpowers/plans/2026-08-09-1password-wiring.md
+git commit -m "build: wire Fastlane credentials through 1Password"
+```
+
+Do not amend either commit.
+
+---
+
+### Task 8: Review and publish
+
+- [ ] **Step 1: Request adversarial review**
+
+Send the full commit range and verification output to `reviewer` on `review/365-wiring`. Require
+specific review of raw-vs-base64 handling, implicit env-name avoidance, tempfile failure cleanup,
+shell routing, and secret-output risks.
+
+- [ ] **Step 2: Address all gating findings with new commits**
+
+Use technical verification; never amend or force-push.
+
+- [ ] **Step 3: Push and open the PR**
+
+Push `feat/365-1pw-wiring` and open a draft PR to `main`. The terse body states what changed, the
+scoped lifecycle “the project-created gym and metadata tempfiles are mode-0600 and ensure-deleted,”
+the accepted Transporter residue limitation, and the remaining maintainer verification: wrapped
+`check_asc_key` plus the archive-only path probe. Revocation and local legacy-file deletion are
+already complete.

--- a/docs/superpowers/plans/2026-08-09-1password-wiring.md
+++ b/docs/superpowers/plans/2026-08-09-1password-wiring.md
@@ -27,7 +27,7 @@ committed but contain only `op://` references.
 - Do not delete `fastlane/.env` during this implementation. Its key path now dangles and is not a
   credential fallback; never recreate the deleted legacy key file.
 - Do not scan `~/.appstoreconnect`, add residue allowlists, or implement a per-lane residue
-  postcondition. Transporter verify residue is a maintainer-accepted known limitation.
+  postcondition. Transporter verification residue is a maintainer-accepted known limitation.
 - Bootstrap configuration is a maintainer-approved exception to test-first code: its exact two
   reference-only files and ignore entries are specified verbatim and verified structurally.
 

--- a/docs/superpowers/plans/2026-08-09-1password-wiring.md
+++ b/docs/superpowers/plans/2026-08-09-1password-wiring.md
@@ -16,7 +16,7 @@ committed but contain only `op://` references.
 
 ## Global Constraints
 
-- Authoritative design: commit `0fe0d05f453a8463223115e43b98e667e5e5c9b1`, plus the maintainer's
+- Authoritative design: commit `0944afeb0e6dcdec150af9c0772f3b0f3a98c76d`, plus the maintainer's
   later superseding decision to reject runtime Transporter residue scans as overengineering.
 - Never print a private key, service-account token, resolved 1Password value, or new issuer ID.
 - Strictly decode `ASC_KEY_CONTENT_BASE64` once in Ruby and pass raw PEM as `key_content`; never set

--- a/fastlane/.env.template
+++ b/fastlane/.env.template
@@ -1,4 +1,0 @@
-# Copy to fastlane/.env and fill in. fastlane auto-loads fastlane/.env.
-ASC_KEY_ID=
-ASC_ISSUER_ID=
-ASC_KEY_PATH=

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,31 +1,33 @@
-require "fileutils"
-require "json"
-require "shellwords"
-require File.expand_path("archive_storage", __dir__)
-require File.expand_path("asc_credentials", __dir__)
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'shellwords'
+require File.expand_path('archive_storage', __dir__)
+require File.expand_path('asc_credentials', __dir__)
 
 # Runs under Homebrew Ruby via Bundler: export PATH="$(brew --prefix ruby)/bin:$PATH" && bundle exec fastlane <lane>
 default_platform(:ios)
 
-XCODEPROJ = "FamilyFoqos.xcodeproj"
-SCHEME = "FamilyFoqos"
-ARCHIVE_DIR = File.expand_path("~/Archives/family-foqos")
-REPO_ROOT = File.expand_path("..", __dir__)
-RELEASE_BLOCKING_LABEL = "release-blocking"
-XCTEST_DEVICES_DIR = File.expand_path("~/Library/Developer/XCTestDevices")
-SNAPSHOT_DEVICE_NAME = "iPhone 17 Pro Max"
+XCODEPROJ = 'FamilyFoqos.xcodeproj'
+SCHEME = 'FamilyFoqos'
+ARCHIVE_DIR = File.expand_path('~/Archives/family-foqos')
+REPO_ROOT = File.expand_path('..', __dir__)
+RELEASE_BLOCKING_LABEL = 'release-blocking'
+XCTEST_DEVICES_DIR = File.expand_path('~/Library/Developer/XCTestDevices')
+SNAPSHOT_DEVICE_NAME = 'iPhone 17 Pro Max'
 
 platform :ios do
   private_lane :preflight do
     ensure_git_status_clean
-    ensure_git_branch(branch: "main")
+    ensure_git_branch(branch: 'main')
   end
 
   private_lane :asc_api_key do
     app_store_connect_api_key(
-      key_id: ENV.fetch("ASC_KEY_ID"),
-      issuer_id: ENV.fetch("ASC_ISSUER_ID"),
-      key_content: ASCCredentials.decode_private_key(ENV.fetch("ASC_KEY_CONTENT_BASE64"))
+      key_id: ENV.fetch('ASC_KEY_ID'),
+      issuer_id: ENV.fetch('ASC_ISSUER_ID'),
+      key_content: ASCCredentials.decode_private_key(ENV.fetch('ASC_KEY_CONTENT_BASE64'))
     )
   end
 
@@ -36,8 +38,8 @@ platform :ios do
       gym(
         project: XCODEPROJ,
         scheme: SCHEME,
-        configuration: "Release",
-        export_method: "app-store",
+        configuration: 'Release',
+        export_method: 'app-store',
         xcargs: "CURRENT_PROJECT_VERSION=#{build} -allowProvisioningUpdates " \
                 "-authenticationKeyPath #{Shellwords.escape(key_path)} " \
                 "-authenticationKeyID #{api_key.fetch(:key_id)} " \
@@ -48,9 +50,9 @@ platform :ios do
 
   private_lane :assert_no_release_blockers do
     # Fail closed: if gh errors (network, auth), sh raises and the lane aborts.
-    labels_out = sh("gh label list --json name --limit 1000", log: false)
+    labels_out = sh('gh label list --json name --limit 1000', log: false)
     labels = JSON.parse(labels_out)
-    unless labels.any? { |label| label["name"] == RELEASE_BLOCKING_LABEL }
+    unless labels.any? { |label| label['name'] == RELEASE_BLOCKING_LABEL }
       UI.user_error!("Required GitHub label is missing: #{RELEASE_BLOCKING_LABEL}")
     end
 
@@ -60,20 +62,20 @@ platform :ios do
     )
     issues = JSON.parse(out)
     unless issues.empty?
-      list = issues.map { |i| "##{i["number"]} #{i["title"]}" }.join("\n  ")
+      list = issues.map { |i| "##{i['number']} #{i['title']}" }.join("\n  ")
       UI.user_error!("Release blocked by open release-blocking issues:\n  #{list}")
     end
-    sh("bash", File.join(REPO_ROOT, "scripts/check-prod-schema.sh"))
+    sh('bash', File.join(REPO_ROOT, 'scripts/check-prod-schema.sh'))
   end
 
   # Preserves the archive and dSYMs before anything is uploaded to Apple.
   private_lane :preserve_archive_locally do
     archive = lane_context[SharedValues::XCODEBUILD_ARCHIVE]
-    UI.user_error!("No xcarchive in lane context") if archive.nil? || !File.exist?(archive)
+    UI.user_error!('No xcarchive in lane context') if archive.nil? || !File.exist?(archive)
 
-    version = get_version_number(xcodeproj: XCODEPROJ, target: "FamilyFoqos")
+    version = get_version_number(xcodeproj: XCODEPROJ, target: 'FamilyFoqos')
     build = derived_build_number
-    sha = sh("git rev-parse --short=7 HEAD", log: false).strip
+    sha = sh('git rev-parse --short=7 HEAD', log: false).strip
     stem = "FamilyFoqos-#{version}-#{build}-#{sha}"
 
     FileUtils.mkdir_p(ARCHIVE_DIR)
@@ -83,8 +85,8 @@ platform :ios do
 
     dsym_zip = File.join(ARCHIVE_DIR, "#{stem}-dSYMs.zip")
     FileUtils.rm_f(dsym_zip)
-    Dir.chdir(File.join(archive, "dSYMs")) do
-      sh("zip", "-qr", dsym_zip, ".")
+    Dir.chdir(File.join(archive, 'dSYMs')) do
+      sh('zip', '-qr', dsym_zip, '.')
     end
 
     {
@@ -109,19 +111,19 @@ platform :ios do
         asset: artifacts[:dsym_zip]
       ) { |args| sh(*args) }
       UI.success("dSYMs attached to GitHub release #{tag}")
-    rescue => e
+    rescue StandardError => e
       UI.important("GitHub release upload FAILED (local archive is safe): #{e.message}")
     end
   end
 
   private_lane :assert_framed_screenshots do
-    screenshots_directory = File.expand_path("screenshots", __dir__)
-    expected_names = [
-      "01-home-active",
-      "02-profile-editor",
-      "03-parent-dashboard"
+    screenshots_directory = File.expand_path('screenshots', __dir__)
+    expected_names = %w[
+      01-home-active
+      02-profile-editor
+      03-parent-dashboard
     ]
-    framed = Dir.glob(File.join(screenshots_directory, "en-GB", "*_framed.png"))
+    framed = Dir.glob(File.join(screenshots_directory, 'en-GB', '*_framed.png'))
     missing = expected_names.reject do |name|
       framed.any? { |path| File.basename(path).include?(name) }
     end
@@ -130,19 +132,19 @@ platform :ios do
         "Expected 3 framed en-GB screenshots; found #{framed.count}, missing: #{missing.join(', ')}"
       )
     end
-    UI.success("Validated 3 framed en-GB screenshots")
+    UI.success('Validated 3 framed en-GB screenshots')
   end
 
   def derived_build_number
-    sh("git rev-list --count HEAD", log: false).strip
+    sh('git rev-list --count HEAD', log: false).strip
   end
 
-  desc "Prints the derived build number (sanity check)"
+  desc 'Prints the derived build number (sanity check)'
   lane :build_number do
     UI.message("Derived build number: #{derived_build_number}")
   end
 
-  desc "Validate the ASC API key loads (prints no secret material)"
+  desc 'Validate the ASC API key loads (prints no secret material)'
   lane :check_asc_key do
     key = asc_api_key
     # The non-secret key ID confirms rotation; keep the issuer and key material presence-only.
@@ -152,12 +154,12 @@ platform :ios do
     )
   end
 
-  desc "Run release-blocker gates only"
+  desc 'Run release-blocker gates only'
   lane :gates do
     assert_no_release_blockers
   end
 
-  desc "Build, upload metadata+screenshots+binary, and (after confirmation) submit for review"
+  desc 'Build, upload metadata+screenshots+binary, and (after confirmation) submit for review'
   lane :release do
     preflight
     assert_no_release_blockers
@@ -165,21 +167,19 @@ platform :ios do
     build = derived_build_number
     build_app_store_archive(api_key: api_key, build: build)
     archive_artifacts = preserve_archive_locally
-    unless UI.confirm("Submit this build for App Store review?")
-      UI.user_error!("Submission cancelled by user")
-    end
+    UI.user_error!('Submission cancelled by user') unless UI.confirm('Submit this build for App Store review?')
     assert_framed_screenshots
     deliver(
       api_key: api_key,
       submit_for_review: true,
       automatic_release: false,
-      screenshots_path: "./fastlane/screenshots",
-      metadata_path: "./fastlane/metadata"
+      screenshots_path: './fastlane/screenshots',
+      metadata_path: './fastlane/metadata'
     )
     publish_archive_dsyms(artifacts: archive_artifacts, prerelease: false)
   end
 
-  desc "Preserve the archive, upload to TestFlight, then publish dSYMs"
+  desc 'Preserve the archive, upload to TestFlight, then publish dSYMs'
   lane :beta do
     preflight
     assert_no_release_blockers
@@ -191,28 +191,28 @@ platform :ios do
     publish_archive_dsyms(artifacts: archive_artifacts, prerelease: true)
   end
 
-  desc "Pull current App Store metadata into fastlane/metadata"
+  desc 'Pull current App Store metadata into fastlane/metadata'
   lane :pull_metadata do
     api_key = asc_api_key
     ASCCredentials.with_api_key_json_tempfile(api_key) do |key_path|
       sh(
-        "bundle",
-        "exec",
-        "fastlane",
-        "deliver",
-        "download_metadata",
-        "--api_key_path",
+        'bundle',
+        'exec',
+        'fastlane',
+        'deliver',
+        'download_metadata',
+        '--api_key_path',
         key_path,
-        "--metadata_path",
-        File.join(REPO_ROOT, "fastlane", "metadata"),
-        "--force",
-        "true",
+        '--metadata_path',
+        File.join(REPO_ROOT, 'fastlane', 'metadata'),
+        '--force',
+        'true',
         log: false
       )
     end
   end
 
-  desc "Regenerate all App Store screenshots (demo mode + snapshot + frameit)"
+  desc 'Regenerate all App Store screenshots (demo mode + snapshot + frameit)'
   lane :screenshots do
     before = Dir.exist?(XCTEST_DEVICES_DIR) ? Dir.children(XCTEST_DEVICES_DIR) : []
     UI.message("XCTestDevices before snapshot: #{before.count}")
@@ -230,13 +230,13 @@ platform :ios do
           next
         end
 
-        device_plist = File.join(XCTEST_DEVICES_DIR, udid, "device.plist")
+        device_plist = File.join(XCTEST_DEVICES_DIR, udid, 'device.plist')
         begin
           device_name = sh(
-            "plutil", "-extract", "name", "raw", "-o", "-", device_plist, log: false
+            'plutil', '-extract', 'name', 'raw', '-o', '-', device_plist, log: false
           ).strip
-        rescue => error
-          UI.important("Preserving XCTestDevices entry #{udid}; name unavailable: #{error.message}")
+        rescue StandardError => e
+          UI.important("Preserving XCTestDevices entry #{udid}; name unavailable: #{e.message}")
           next
         end
         expected_name = /\A(?:Clone \d+ of )?#{Regexp.escape(SNAPSHOT_DEVICE_NAME)}\z/
@@ -246,11 +246,11 @@ platform :ios do
         end
 
         begin
-          sh("xcrun", "simctl", "--set", XCTEST_DEVICES_DIR, "shutdown", udid, log: false)
-        rescue => error
-          UI.message("Test simulator #{udid} was already stopped: #{error.message}")
+          sh('xcrun', 'simctl', '--set', XCTEST_DEVICES_DIR, 'shutdown', udid, log: false)
+        rescue StandardError => e
+          UI.message("Test simulator #{udid} was already stopped: #{e.message}")
         end
-        sh("xcrun", "simctl", "--set", XCTEST_DEVICES_DIR, "delete", udid, log: false)
+        sh('xcrun', 'simctl', '--set', XCTEST_DEVICES_DIR, 'delete', udid, log: false)
         UI.message("Removed run-created test simulator #{udid}")
       end
 
@@ -258,14 +258,12 @@ platform :ios do
       UI.message("XCTestDevices after cleanup: #{remaining.count}")
     end
 
-    screenshots_directory = File.expand_path("screenshots", __dir__)
-    background = File.join(screenshots_directory, "background.png")
-    unless File.exist?(background)
-      sh("magick", "-size", "1320x2868", "xc:#1a1a2e", background)
-    end
+    screenshots_directory = File.expand_path('screenshots', __dir__)
+    background = File.join(screenshots_directory, 'background.png')
+    sh('magick', '-size', '1320x2868', 'xc:#1a1a2e', background) unless File.exist?(background)
 
-    font_source = "/System/Library/Fonts/SFNS.ttf"
-    font_link = File.join(screenshots_directory, "SFNS.ttf")
+    font_source = '/System/Library/Fonts/SFNS.ttf'
+    font_link = File.join(screenshots_directory, 'SFNS.ttf')
     UI.user_error!("Required frameit font is missing: #{font_source}") unless File.exist?(font_source)
     created_font_link = false
     unless File.exist?(font_link)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -145,6 +145,7 @@ platform :ios do
   desc "Validate the ASC API key loads (prints no secret material)"
   lane :check_asc_key do
     key = asc_api_key
+    # The non-secret key ID confirms rotation; keep the issuer and key material presence-only.
     UI.success(
       "ASC key loaded: key_id=#{key[:key_id]}, " \
       "issuer_present=#{!key[:issuer_id].to_s.empty?}, key_present=#{!key[:key].to_s.empty?}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,8 @@
 require "fileutils"
 require "json"
-require "tempfile"
+require "shellwords"
 require File.expand_path("archive_storage", __dir__)
+require File.expand_path("asc_credentials", __dir__)
 
 # Runs under Homebrew Ruby via Bundler: export PATH="$(brew --prefix ruby)/bin:$PATH" && bundle exec fastlane <lane>
 default_platform(:ios)
@@ -24,8 +25,25 @@ platform :ios do
     app_store_connect_api_key(
       key_id: ENV.fetch("ASC_KEY_ID"),
       issuer_id: ENV.fetch("ASC_ISSUER_ID"),
-      key_filepath: ENV.fetch("ASC_KEY_PATH")
+      key_content: ASCCredentials.decode_private_key(ENV.fetch("ASC_KEY_CONTENT_BASE64"))
     )
+  end
+
+  private_lane :build_app_store_archive do |options|
+    api_key = options.fetch(:api_key)
+    build = options.fetch(:build)
+    ASCCredentials.with_private_key_tempfile(api_key.fetch(:key)) do |key_path|
+      gym(
+        project: XCODEPROJ,
+        scheme: SCHEME,
+        configuration: "Release",
+        export_method: "app-store",
+        xcargs: "CURRENT_PROJECT_VERSION=#{build} -allowProvisioningUpdates " \
+                "-authenticationKeyPath #{Shellwords.escape(key_path)} " \
+                "-authenticationKeyID #{api_key.fetch(:key_id)} " \
+                "-authenticationKeyIssuerID #{api_key.fetch(:issuer_id)}"
+      )
+    end
   end
 
   private_lane :assert_no_release_blockers do
@@ -127,7 +145,10 @@ platform :ios do
   desc "Validate the ASC API key loads (prints no secret material)"
   lane :check_asc_key do
     key = asc_api_key
-    UI.success("ASC key loaded: key_id=#{key[:key_id]}, issuer_id=#{key[:issuer_id]}, key_present=#{!key[:key].to_s.empty?}")
+    UI.success(
+      "ASC key loaded: key_id=#{key[:key_id]}, " \
+      "issuer_present=#{!key[:issuer_id].to_s.empty?}, key_present=#{!key[:key].to_s.empty?}"
+    )
   end
 
   desc "Run release-blocker gates only"
@@ -141,16 +162,7 @@ platform :ios do
     assert_no_release_blockers
     api_key = asc_api_key
     build = derived_build_number
-    gym(
-      project: XCODEPROJ,
-      scheme: SCHEME,
-      configuration: "Release",
-      export_method: "app-store",
-      xcargs: "CURRENT_PROJECT_VERSION=#{build} -allowProvisioningUpdates " \
-              "-authenticationKeyPath #{File.expand_path(ENV.fetch('ASC_KEY_PATH'))} " \
-              "-authenticationKeyID #{ENV.fetch('ASC_KEY_ID')} " \
-              "-authenticationKeyIssuerID #{ENV.fetch('ASC_ISSUER_ID')}"
-    )
+    build_app_store_archive(api_key: api_key, build: build)
     archive_artifacts = preserve_archive_locally
     unless UI.confirm("Submit this build for App Store review?")
       UI.user_error!("Submission cancelled by user")
@@ -172,16 +184,7 @@ platform :ios do
     assert_no_release_blockers
     api_key = asc_api_key
     build = derived_build_number
-    gym(
-      project: XCODEPROJ,
-      scheme: SCHEME,
-      configuration: "Release",
-      export_method: "app-store",
-      xcargs: "CURRENT_PROJECT_VERSION=#{build} -allowProvisioningUpdates " \
-              "-authenticationKeyPath #{File.expand_path(ENV.fetch('ASC_KEY_PATH'))} " \
-              "-authenticationKeyID #{ENV.fetch('ASC_KEY_ID')} " \
-              "-authenticationKeyIssuerID #{ENV.fetch('ASC_ISSUER_ID')}"
-    )
+    build_app_store_archive(api_key: api_key, build: build)
     archive_artifacts = preserve_archive_locally
     pilot(api_key: api_key, skip_waiting_for_build_processing: true)
     publish_archive_dsyms(artifacts: archive_artifacts, prerelease: true)
@@ -190,9 +193,7 @@ platform :ios do
   desc "Pull current App Store metadata into fastlane/metadata"
   lane :pull_metadata do
     api_key = asc_api_key
-    Tempfile.create(["asc-api-key", ".json"]) do |key_file|
-      key_file.write(JSON.generate(api_key))
-      key_file.flush
+    ASCCredentials.with_api_key_json_tempfile(api_key) do |key_path|
       sh(
         "bundle",
         "exec",
@@ -200,11 +201,12 @@ platform :ios do
         "deliver",
         "download_metadata",
         "--api_key_path",
-        key_file.path,
+        key_path,
         "--metadata_path",
         File.join(REPO_ROOT, "fastlane", "metadata"),
         "--force",
-        "true"
+        "true",
+        log: false
       )
     end
   end

--- a/fastlane/asc.env
+++ b/fastlane/asc.env
@@ -1,0 +1,4 @@
+# Keep these project-namespaced ASC_* names; APP_STORE_CONNECT_API_KEY_* names trigger implicit Fastlane fallbacks.
+ASC_KEY_ID=op://family-foqos/app_store_connect_key/ASC_KEY_ID_REF
+ASC_ISSUER_ID=op://family-foqos/app_store_connect_key/ASC_ISSUER_ID_REF
+ASC_KEY_CONTENT_BASE64=op://family-foqos/app_store_connect_key/ASC_KEY_CONTENT_BASE64_REF

--- a/fastlane/asc_credentials.rb
+++ b/fastlane/asc_credentials.rb
@@ -1,0 +1,35 @@
+require "base64"
+require "json"
+require "openssl"
+require "tempfile"
+
+module ASCCredentials
+  class CredentialError < StandardError; end
+
+  def self.decode_private_key(encoded)
+    decoded = Base64.strict_decode64(encoded)
+    OpenSSL::PKey.read(decoded)
+    decoded
+  rescue ArgumentError, OpenSSL::PKey::PKeyError
+    raise CredentialError, "ASC private key is not valid base64-encoded PEM"
+  end
+
+  def self.with_private_key_tempfile(raw_pem, &block)
+    with_sensitive_tempfile("asc-auth-key", ".p8", raw_pem, &block)
+  end
+
+  def self.with_api_key_json_tempfile(api_key, &block)
+    with_sensitive_tempfile("asc-api-key", ".json", JSON.generate(api_key), &block)
+  end
+
+  def self.with_sensitive_tempfile(basename, extension, contents)
+    Tempfile.create([basename, extension]) do |file|
+      file.chmod(0o600)
+      file.binmode
+      file.write(contents)
+      file.flush
+      yield file.path
+    end
+  end
+  private_class_method :with_sensitive_tempfile
+end

--- a/fastlane/asc_credentials.rb
+++ b/fastlane/asc_credentials.rb
@@ -1,7 +1,9 @@
-require "base64"
-require "json"
-require "openssl"
-require "tempfile"
+# frozen_string_literal: true
+
+require 'base64'
+require 'json'
+require 'openssl'
+require 'tempfile'
 
 module ASCCredentials
   class CredentialError < StandardError; end
@@ -11,15 +13,15 @@ module ASCCredentials
     OpenSSL::PKey.read(decoded)
     decoded
   rescue ArgumentError, OpenSSL::PKey::PKeyError
-    raise CredentialError, "ASC private key is not valid base64-encoded PEM"
+    raise CredentialError, 'ASC private key is not valid base64-encoded PEM'
   end
 
-  def self.with_private_key_tempfile(raw_pem, &block)
-    with_sensitive_tempfile("asc-auth-key", ".p8", raw_pem, &block)
+  def self.with_private_key_tempfile(raw_pem, &)
+    with_sensitive_tempfile('asc-auth-key', '.p8', raw_pem, &)
   end
 
-  def self.with_api_key_json_tempfile(api_key, &block)
-    with_sensitive_tempfile("asc-api-key", ".json", JSON.generate(api_key), &block)
+  def self.with_api_key_json_tempfile(api_key, &)
+    with_sensitive_tempfile('asc-api-key', '.json', JSON.generate(api_key), &)
   end
 
   def self.with_sensitive_tempfile(basename, extension, contents)

--- a/scripts/fastlane.sh
+++ b/scripts/fastlane.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
-export PATH="$(brew --prefix ruby)/bin:$PATH"
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew is required to run Fastlane. Install Homebrew, then run: brew install ruby" >&2
+  exit 127
+fi
+
+if ! ruby_prefix="$(brew --prefix ruby 2>/dev/null)" || [[ -z "$ruby_prefix" ]]; then
+  echo "Homebrew Ruby is required to run Fastlane. Install it with: brew install ruby" >&2
+  exit 1
+fi
+
+export PATH="$ruby_prefix/bin:$PATH"
 
 case "${1:-}" in
   beta|release|pull_metadata|check_asc_key)

--- a/scripts/fastlane.sh
+++ b/scripts/fastlane.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+export PATH="$(brew --prefix ruby)/bin:$PATH"
+
+case "${1:-}" in
+  beta|release|pull_metadata|check_asc_key)
+    if ! command -v op >/dev/null 2>&1; then
+      echo "1Password CLI 'op' is required for credential-using Fastlane lanes." >&2
+      exit 127
+    fi
+    exec op run --env-file "$(dirname "$0")/../fastlane/asc.env" -- \
+      bundle exec fastlane "$@"
+    ;;
+  *)
+    exec bundle exec fastlane "$@"
+    ;;
+esac

--- a/scripts/test-asc-credentials.rb
+++ b/scripts/test-asc-credentials.rb
@@ -1,0 +1,100 @@
+require "base64"
+require "json"
+require "openssl"
+require "tmpdir"
+
+helper_path = File.expand_path("../fastlane/asc_credentials.rb", __dir__)
+unless File.exist?(helper_path)
+  warn "FAIL: fastlane/asc_credentials.rb is missing"
+  exit 1
+end
+
+require helper_path
+
+def assert(condition, message)
+  return if condition
+
+  warn "FAIL: #{message}"
+  exit 1
+end
+
+def assert_deleted_after_failure
+  yielded_path = nil
+  begin
+    yield(lambda { |path| yielded_path = path })
+    assert(false, "injected tempfile failure did not propagate")
+  rescue RuntimeError => error
+    raise unless error.message == "injected failure"
+  end
+  assert(!File.exist?(yielded_path), "failed tempfile block left #{yielded_path}")
+end
+
+raw_pem = OpenSSL::PKey::EC.generate("prime256v1").to_pem
+encoded = Base64.strict_encode64(raw_pem)
+assert(ASCCredentials.decode_private_key(encoded) == raw_pem, "strict decode changed the key")
+
+[
+  "not base64!",
+  Base64.strict_encode64("decoded, but not a key")
+].each do |invalid_value|
+  begin
+    ASCCredentials.decode_private_key(invalid_value)
+    assert(false, "invalid encoded key material must fail closed")
+  rescue ASCCredentials::CredentialError => error
+    assert(!error.message.include?(invalid_value), "decode error exposed input material")
+  end
+end
+
+private_path = nil
+ASCCredentials.with_private_key_tempfile(raw_pem) do |path|
+  private_path = path
+  assert(File.exist?(path), "private-key tempfile was not created")
+  assert((File.stat(path).mode & 0o777) == 0o600, "private-key tempfile mode is not 0600")
+  assert(File.binread(path) == raw_pem, "private-key tempfile content changed")
+  assert(
+    File.expand_path(path).start_with?("#{File.expand_path(Dir.tmpdir)}/"),
+    "private-key tempfile is outside TMPDIR"
+  )
+end
+assert(!File.exist?(private_path), "successful private-key block left its tempfile")
+
+assert_deleted_after_failure do |capture|
+  ASCCredentials.with_private_key_tempfile(raw_pem) do |path|
+    capture.call(path)
+    raise "injected failure"
+  end
+end
+
+api_key = {
+  key_id: "NEWKEY1234",
+  issuer_id: "issuer-for-test",
+  key: raw_pem
+}
+json_path = nil
+ASCCredentials.with_api_key_json_tempfile(api_key) do |path|
+  json_path = path
+  assert(File.exist?(path), "API-key JSON tempfile was not created")
+  assert((File.stat(path).mode & 0o777) == 0o600, "API-key JSON tempfile mode is not 0600")
+  assert(
+    JSON.parse(File.binread(path)) == {
+      "key_id" => "NEWKEY1234",
+      "issuer_id" => "issuer-for-test",
+      "key" => raw_pem
+    },
+    "API-key JSON tempfile did not preserve the hash"
+  )
+  assert(
+    File.expand_path(path).start_with?("#{File.expand_path(Dir.tmpdir)}/"),
+    "API-key JSON tempfile is outside TMPDIR"
+  )
+end
+assert(!File.exist?(json_path), "successful API-key JSON block left its tempfile")
+
+assert_deleted_after_failure do |capture|
+  ASCCredentials.with_api_key_json_tempfile(api_key) do |path|
+    capture.call(path)
+    raise "injected failure"
+  end
+end
+
+puts "PASS: ASC credential decode and tempfile lifecycle"

--- a/scripts/test-asc-credentials.rb
+++ b/scripts/test-asc-credentials.rb
@@ -1,11 +1,13 @@
-require "base64"
-require "json"
-require "openssl"
-require "tmpdir"
+# frozen_string_literal: true
 
-helper_path = File.expand_path("../fastlane/asc_credentials.rb", __dir__)
+require 'base64'
+require 'json'
+require 'openssl'
+require 'tmpdir'
+
+helper_path = File.expand_path('../fastlane/asc_credentials.rb', __dir__)
 unless File.exist?(helper_path)
-  warn "FAIL: fastlane/asc_credentials.rb is missing"
+  warn 'FAIL: fastlane/asc_credentials.rb is missing'
   exit 1
 end
 
@@ -21,80 +23,78 @@ end
 def assert_deleted_after_failure
   yielded_path = nil
   begin
-    yield(lambda { |path| yielded_path = path })
-    assert(false, "injected tempfile failure did not propagate")
-  rescue RuntimeError => error
-    raise unless error.message == "injected failure"
+    yield(->(path) { yielded_path = path })
+    assert(false, 'injected tempfile failure did not propagate')
+  rescue RuntimeError => e
+    raise unless e.message == 'injected failure'
   end
   assert(!File.exist?(yielded_path), "failed tempfile block left #{yielded_path}")
 end
 
-raw_pem = OpenSSL::PKey::EC.generate("prime256v1").to_pem
+raw_pem = OpenSSL::PKey::EC.generate('prime256v1').to_pem
 encoded = Base64.strict_encode64(raw_pem)
-assert(ASCCredentials.decode_private_key(encoded) == raw_pem, "strict decode changed the key")
+assert(ASCCredentials.decode_private_key(encoded) == raw_pem, 'strict decode changed the key')
 
 [
-  "not base64!",
-  Base64.strict_encode64("decoded, but not a key")
+  'not base64!',
+  Base64.strict_encode64('decoded, but not a key')
 ].each do |invalid_value|
-  begin
-    ASCCredentials.decode_private_key(invalid_value)
-    assert(false, "invalid encoded key material must fail closed")
-  rescue ASCCredentials::CredentialError => error
-    assert(!error.message.include?(invalid_value), "decode error exposed input material")
-  end
+  ASCCredentials.decode_private_key(invalid_value)
+  assert(false, 'invalid encoded key material must fail closed')
+rescue ASCCredentials::CredentialError => e
+  assert(!e.message.include?(invalid_value), 'decode error exposed input material')
 end
 
 private_path = nil
 ASCCredentials.with_private_key_tempfile(raw_pem) do |path|
   private_path = path
-  assert(File.exist?(path), "private-key tempfile was not created")
-  assert((File.stat(path).mode & 0o777) == 0o600, "private-key tempfile mode is not 0600")
-  assert(File.binread(path) == raw_pem, "private-key tempfile content changed")
+  assert(File.exist?(path), 'private-key tempfile was not created')
+  assert((File.stat(path).mode & 0o777) == 0o600, 'private-key tempfile mode is not 0600')
+  assert(File.binread(path) == raw_pem, 'private-key tempfile content changed')
   assert(
     File.expand_path(path).start_with?("#{File.expand_path(Dir.tmpdir)}/"),
-    "private-key tempfile is outside TMPDIR"
+    'private-key tempfile is outside TMPDIR'
   )
 end
-assert(!File.exist?(private_path), "successful private-key block left its tempfile")
+assert(!File.exist?(private_path), 'successful private-key block left its tempfile')
 
 assert_deleted_after_failure do |capture|
   ASCCredentials.with_private_key_tempfile(raw_pem) do |path|
     capture.call(path)
-    raise "injected failure"
+    raise 'injected failure'
   end
 end
 
 api_key = {
-  key_id: "NEWKEY1234",
-  issuer_id: "issuer-for-test",
+  key_id: 'NEWKEY1234',
+  issuer_id: 'issuer-for-test',
   key: raw_pem
 }
 json_path = nil
 ASCCredentials.with_api_key_json_tempfile(api_key) do |path|
   json_path = path
-  assert(File.exist?(path), "API-key JSON tempfile was not created")
-  assert((File.stat(path).mode & 0o777) == 0o600, "API-key JSON tempfile mode is not 0600")
+  assert(File.exist?(path), 'API-key JSON tempfile was not created')
+  assert((File.stat(path).mode & 0o777) == 0o600, 'API-key JSON tempfile mode is not 0600')
   assert(
     JSON.parse(File.binread(path)) == {
-      "key_id" => "NEWKEY1234",
-      "issuer_id" => "issuer-for-test",
-      "key" => raw_pem
+      'key_id' => 'NEWKEY1234',
+      'issuer_id' => 'issuer-for-test',
+      'key' => raw_pem
     },
-    "API-key JSON tempfile did not preserve the hash"
+    'API-key JSON tempfile did not preserve the hash'
   )
   assert(
     File.expand_path(path).start_with?("#{File.expand_path(Dir.tmpdir)}/"),
-    "API-key JSON tempfile is outside TMPDIR"
+    'API-key JSON tempfile is outside TMPDIR'
   )
 end
-assert(!File.exist?(json_path), "successful API-key JSON block left its tempfile")
+assert(!File.exist?(json_path), 'successful API-key JSON block left its tempfile')
 
 assert_deleted_after_failure do |capture|
   ASCCredentials.with_api_key_json_tempfile(api_key) do |path|
     capture.call(path)
-    raise "injected failure"
+    raise 'injected failure'
   end
 end
 
-puts "PASS: ASC credential decode and tempfile lifecycle"
+puts 'PASS: ASC credential decode and tempfile lifecycle'

--- a/scripts/test-fastlane-asc-lane.rb
+++ b/scripts/test-fastlane-asc-lane.rb
@@ -1,0 +1,62 @@
+require "base64"
+require "open3"
+require "openssl"
+
+repo_root = File.expand_path("..", __dir__)
+raw_pem = OpenSSL::PKey::EC.generate("prime256v1").to_pem
+encoded = Base64.strict_encode64(raw_pem)
+key_id = "TSTKEY1234"
+issuer_id = "11111111-2222-3333-4444-555555555555"
+
+def redacted(output, secrets)
+  secrets.reduce(output) { |text, secret| text.gsub(secret, "[REDACTED]") }
+end
+
+env = {
+  "ASC_KEY_ID" => key_id,
+  "ASC_ISSUER_ID" => issuer_id,
+  "ASC_KEY_CONTENT_BASE64" => encoded,
+  "FASTLANE_SKIP_UPDATE_CHECK" => "1"
+}
+stdout, stderr, status = Open3.capture3(
+  env,
+  "bundle", "exec", "fastlane", "check_asc_key",
+  chdir: repo_root
+)
+output = stdout + stderr
+unless status.success?
+  warn "FAIL: namespaced in-memory ASC key did not load"
+  warn redacted(output, [raw_pem, encoded, issuer_id])
+  exit 1
+end
+
+unless output.include?("key_id=#{key_id}") &&
+    output.include?("issuer_present=true") &&
+    output.include?("key_present=true")
+  warn "FAIL: check_asc_key did not report the approved non-secret facts"
+  exit 1
+end
+if output.include?(raw_pem) || output.include?(encoded) || output.include?(issuer_id)
+  warn "FAIL: check_asc_key output exposed key or issuer material"
+  exit 1
+end
+
+bare_env = {
+  "ASC_KEY_ID" => nil,
+  "ASC_ISSUER_ID" => nil,
+  "ASC_KEY_CONTENT_BASE64" => nil,
+  "FASTLANE_SKIP_UPDATE_CHECK" => "1"
+}
+bare_stdout, bare_stderr, bare_status = Open3.capture3(
+  bare_env,
+  "bundle", "exec", "fastlane", "check_asc_key",
+  chdir: repo_root
+)
+bare_output = bare_stdout + bare_stderr
+if bare_status.success? || !bare_output.include?("ASC_KEY_CONTENT_BASE64")
+  warn "FAIL: bare check_asc_key must fail closed at the namespaced key-content fetch"
+  warn redacted(bare_output, [raw_pem, encoded, issuer_id])
+  exit 1
+end
+
+puts "PASS: check_asc_key uses namespaced in-memory credentials and fails closed when bare"

--- a/scripts/test-fastlane-asc-lane.rb
+++ b/scripts/test-fastlane-asc-lane.rb
@@ -41,20 +41,36 @@ if output.include?(raw_pem) || output.include?(encoded) || output.include?(issue
   exit 1
 end
 
-bare_env = {
-  "ASC_KEY_ID" => nil,
-  "ASC_ISSUER_ID" => nil,
-  "ASC_KEY_CONTENT_BASE64" => nil,
-  "FASTLANE_SKIP_UPDATE_CHECK" => "1"
-}
-bare_stdout, bare_stderr, bare_status = Open3.capture3(
-  bare_env,
-  "bundle", "exec", "fastlane", "check_asc_key",
-  chdir: repo_root
-)
-bare_output = bare_stdout + bare_stderr
+legacy_env_path = File.join(repo_root, "fastlane", ".env")
+created_legacy_fixture = false
+begin
+  unless File.exist?(legacy_env_path)
+    File.open(legacy_env_path, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |file|
+      created_legacy_fixture = true
+      file.puts("ASC_KEY_ID=LEGACYTEST")
+      file.puts("ASC_ISSUER_ID=legacy-issuer-for-test")
+      file.puts("ASC_KEY_PATH=/tmp/deleted-legacy-key.p8")
+    end
+  end
+
+  bare_env = {
+    "ASC_KEY_ID" => nil,
+    "ASC_ISSUER_ID" => nil,
+    "ASC_KEY_CONTENT_BASE64" => nil,
+    "FASTLANE_SKIP_UPDATE_CHECK" => "1"
+  }
+  bare_stdout, bare_stderr, bare_status = Open3.capture3(
+    bare_env,
+    "bundle", "exec", "fastlane", "check_asc_key",
+    chdir: repo_root
+  )
+  bare_output = bare_stdout + bare_stderr
+ensure
+  File.delete(legacy_env_path) if created_legacy_fixture && File.exist?(legacy_env_path)
+end
+
 if bare_status.success? || !bare_output.include?("ASC_KEY_CONTENT_BASE64")
-  warn "FAIL: bare check_asc_key must fail closed at the namespaced key-content fetch"
+  warn "FAIL: legacy .env must not let bare check_asc_key bypass the namespaced key-content fetch"
   warn redacted(bare_output, [raw_pem, encoded, issuer_id])
   exit 1
 end

--- a/scripts/test-fastlane-asc-lane.rb
+++ b/scripts/test-fastlane-asc-lane.rb
@@ -1,67 +1,69 @@
-require "base64"
-require "open3"
-require "openssl"
+# frozen_string_literal: true
 
-repo_root = File.expand_path("..", __dir__)
-raw_pem = OpenSSL::PKey::EC.generate("prime256v1").to_pem
+require 'base64'
+require 'open3'
+require 'openssl'
+
+repo_root = File.expand_path('..', __dir__)
+raw_pem = OpenSSL::PKey::EC.generate('prime256v1').to_pem
 encoded = Base64.strict_encode64(raw_pem)
-key_id = "TSTKEY1234"
-issuer_id = "11111111-2222-3333-4444-555555555555"
+key_id = 'TSTKEY1234'
+issuer_id = '11111111-2222-3333-4444-555555555555'
 
 def redacted(output, secrets)
-  secrets.reduce(output) { |text, secret| text.gsub(secret, "[REDACTED]") }
+  secrets.reduce(output) { |text, secret| text.gsub(secret, '[REDACTED]') }
 end
 
 env = {
-  "ASC_KEY_ID" => key_id,
-  "ASC_ISSUER_ID" => issuer_id,
-  "ASC_KEY_CONTENT_BASE64" => encoded,
-  "FASTLANE_SKIP_UPDATE_CHECK" => "1"
+  'ASC_KEY_ID' => key_id,
+  'ASC_ISSUER_ID' => issuer_id,
+  'ASC_KEY_CONTENT_BASE64' => encoded,
+  'FASTLANE_SKIP_UPDATE_CHECK' => '1'
 }
 stdout, stderr, status = Open3.capture3(
   env,
-  "bundle", "exec", "fastlane", "check_asc_key",
+  'bundle', 'exec', 'fastlane', 'check_asc_key',
   chdir: repo_root
 )
 output = stdout + stderr
 unless status.success?
-  warn "FAIL: namespaced in-memory ASC key did not load"
+  warn 'FAIL: namespaced in-memory ASC key did not load'
   warn redacted(output, [raw_pem, encoded, issuer_id])
   exit 1
 end
 
 unless output.include?("key_id=#{key_id}") &&
-    output.include?("issuer_present=true") &&
-    output.include?("key_present=true")
-  warn "FAIL: check_asc_key did not report the approved non-secret facts"
+       output.include?('issuer_present=true') &&
+       output.include?('key_present=true')
+  warn 'FAIL: check_asc_key did not report the approved non-secret facts'
   exit 1
 end
 if output.include?(raw_pem) || output.include?(encoded) || output.include?(issuer_id)
-  warn "FAIL: check_asc_key output exposed key or issuer material"
+  warn 'FAIL: check_asc_key output exposed key or issuer material'
   exit 1
 end
 
-legacy_env_path = File.join(repo_root, "fastlane", ".env")
+legacy_env_path = File.join(repo_root, 'fastlane', '.env')
 created_legacy_fixture = false
 begin
   unless File.exist?(legacy_env_path)
     File.open(legacy_env_path, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |file|
       created_legacy_fixture = true
-      file.puts("ASC_KEY_ID=LEGACYTEST")
-      file.puts("ASC_ISSUER_ID=legacy-issuer-for-test")
-      file.puts("ASC_KEY_PATH=/tmp/deleted-legacy-key.p8")
+      file.puts('ASC_KEY_ID=LEGACYTEST')
+      file.puts('ASC_ISSUER_ID=legacy-issuer-for-test')
+      file.puts('ASC_KEY_PATH=/tmp/deleted-legacy-key.p8')
     end
   end
 
   bare_env = {
-    "ASC_KEY_ID" => nil,
-    "ASC_ISSUER_ID" => nil,
-    "ASC_KEY_CONTENT_BASE64" => nil,
-    "FASTLANE_SKIP_UPDATE_CHECK" => "1"
+    'ASC_KEY_ID' => nil,
+    'ASC_ISSUER_ID' => nil,
+    'ASC_KEY_CONTENT_BASE64' => nil,
+    'FASTLANE_SKIP_UPDATE_CHECK' => '1'
   }
   bare_stdout, bare_stderr, bare_status = Open3.capture3(
     bare_env,
-    "bundle", "exec", "fastlane", "check_asc_key",
+    'bundle', 'exec', 'fastlane', 'check_asc_key',
     chdir: repo_root
   )
   bare_output = bare_stdout + bare_stderr
@@ -69,10 +71,10 @@ ensure
   File.delete(legacy_env_path) if created_legacy_fixture && File.exist?(legacy_env_path)
 end
 
-if bare_status.success? || !bare_output.include?("ASC_KEY_CONTENT_BASE64")
-  warn "FAIL: legacy .env must not let bare check_asc_key bypass the namespaced key-content fetch"
+if bare_status.success? || !bare_output.include?('ASC_KEY_CONTENT_BASE64')
+  warn 'FAIL: legacy .env must not let bare check_asc_key bypass the namespaced key-content fetch'
   warn redacted(bare_output, [raw_pem, encoded, issuer_id])
   exit 1
 end
 
-puts "PASS: check_asc_key uses namespaced in-memory credentials and fails closed when bare"
+puts 'PASS: check_asc_key uses namespaced in-memory credentials and fails closed when bare'

--- a/scripts/test-fastlane-credential-routing.sh
+++ b/scripts/test-fastlane-credential-routing.sh
@@ -36,7 +36,8 @@ if [[ "${REF_LINES[*]}" != "${EXPECTED_REFS[*]}" ]]; then
   exit 1
 fi
 
-mkdir -p "$TEST_ROOT/bootstrap" "$TEST_ROOT/ruby/bin" "$TEST_ROOT/no-op-ruby/bin"
+mkdir -p "$TEST_ROOT/bootstrap" "$TEST_ROOT/failing-brew" "$TEST_ROOT/ruby/bin" \
+  "$TEST_ROOT/no-op-ruby/bin"
 
 cat >"$TEST_ROOT/bootstrap/brew" <<EOF
 #!/bin/bash
@@ -45,6 +46,11 @@ if [[ "\${1:-}" != "--prefix" || "\${2:-}" != "ruby" ]]; then
   exit 64
 fi
 printf '%s\n' "\${FAKE_RUBY_PREFIX}"
+EOF
+
+cat >"$TEST_ROOT/failing-brew/brew" <<'EOF'
+#!/bin/bash
+exit 1
 EOF
 
 cat >"$TEST_ROOT/ruby/bin/op" <<'EOF'
@@ -62,8 +68,29 @@ printf '\n' >>"$COMMAND_LOG"
 EOF
 
 cp "$TEST_ROOT/ruby/bin/bundle" "$TEST_ROOT/no-op-ruby/bin/bundle"
-chmod +x "$TEST_ROOT/bootstrap/brew" "$TEST_ROOT/ruby/bin/op" \
+chmod +x "$TEST_ROOT/bootstrap/brew" "$TEST_ROOT/failing-brew/brew" "$TEST_ROOT/ruby/bin/op" \
   "$TEST_ROOT/ruby/bin/bundle" "$TEST_ROOT/no-op-ruby/bin/bundle"
+
+assert_ruby_prerequisite_failure() {
+  local test_name=$1
+  local test_path=$2
+  local output
+  local status
+
+  set +e
+  output=$(PATH="$test_path" "$WRAPPER" lanes 2>&1)
+  status=$?
+  set -e
+  if [[ "$status" -eq 0 || "$output" != *"brew install ruby"* ]]; then
+    echo "FAIL: $test_name must fail with the Homebrew Ruby prerequisite"
+    printf 'exit: %s\n%s\n' "$status" "$output"
+    exit 1
+  fi
+}
+
+assert_ruby_prerequisite_failure "missing brew" "/usr/bin:/bin"
+assert_ruby_prerequisite_failure \
+  "missing Homebrew Ruby formula" "$TEST_ROOT/failing-brew:/usr/bin:/bin"
 
 run_wrapper() {
   local ruby_prefix=$1

--- a/scripts/test-fastlane-credential-routing.sh
+++ b/scripts/test-fastlane-credential-routing.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WRAPPER="$REPO_ROOT/scripts/fastlane.sh"
+REFS_FILE="$REPO_ROOT/fastlane/asc.env"
+TEST_ROOT=$(mktemp -d)
+
+cleanup() {
+  if [[ -n "${TEST_ROOT:-}" && -d "$TEST_ROOT" ]]; then
+    rm -rf -- "$TEST_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+if [[ ! -x "$WRAPPER" ]]; then
+  echo "FAIL: scripts/fastlane.sh is missing or not executable"
+  exit 1
+fi
+if [[ ! -f "$REFS_FILE" ]]; then
+  echo "FAIL: fastlane/asc.env is missing"
+  exit 1
+fi
+
+mapfile -t REF_LINES < <(sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$REFS_FILE")
+EXPECTED_REFS=(
+  'ASC_KEY_ID=op://family-foqos/app_store_connect_key/ASC_KEY_ID_REF'
+  'ASC_ISSUER_ID=op://family-foqos/app_store_connect_key/ASC_ISSUER_ID_REF'
+  'ASC_KEY_CONTENT_BASE64=op://family-foqos/app_store_connect_key/ASC_KEY_CONTENT_BASE64_REF'
+)
+if [[ "${REF_LINES[*]}" != "${EXPECTED_REFS[*]}" ]]; then
+  echo "FAIL: fastlane/asc.env does not contain exactly the three approved mappings"
+  exit 1
+fi
+
+mkdir -p "$TEST_ROOT/bootstrap" "$TEST_ROOT/ruby/bin" "$TEST_ROOT/no-op-ruby/bin"
+
+cat >"$TEST_ROOT/bootstrap/brew" <<EOF
+#!/bin/bash
+if [[ "\${1:-}" != "--prefix" || "\${2:-}" != "ruby" ]]; then
+  echo "unexpected brew arguments: \$*" >&2
+  exit 64
+fi
+printf '%s\n' "\${FAKE_RUBY_PREFIX}"
+EOF
+
+cat >"$TEST_ROOT/ruby/bin/op" <<'EOF'
+#!/bin/bash
+printf 'op' >"$COMMAND_LOG"
+printf '\t%s' "$@" >>"$COMMAND_LOG"
+printf '\n' >>"$COMMAND_LOG"
+EOF
+
+cat >"$TEST_ROOT/ruby/bin/bundle" <<'EOF'
+#!/bin/bash
+printf 'bundle' >"$COMMAND_LOG"
+printf '\t%s' "$@" >>"$COMMAND_LOG"
+printf '\n' >>"$COMMAND_LOG"
+EOF
+
+cp "$TEST_ROOT/ruby/bin/bundle" "$TEST_ROOT/no-op-ruby/bin/bundle"
+chmod +x "$TEST_ROOT/bootstrap/brew" "$TEST_ROOT/ruby/bin/op" \
+  "$TEST_ROOT/ruby/bin/bundle" "$TEST_ROOT/no-op-ruby/bin/bundle"
+
+run_wrapper() {
+  local ruby_prefix=$1
+  shift
+  COMMAND_LOG="$TEST_ROOT/command.log" \
+    FAKE_RUBY_PREFIX="$ruby_prefix" \
+    PATH="$TEST_ROOT/bootstrap:/usr/bin:/bin" \
+    "$WRAPPER" "$@"
+}
+
+for lane in check_asc_key pull_metadata beta release; do
+  run_wrapper "$TEST_ROOT/ruby" "$lane" "argument with spaces"
+  printf -v expected 'op\trun\t--env-file\t%s\t--\tbundle\texec\tfastlane\t%s\targument with spaces' \
+    "$REPO_ROOT/scripts/../fastlane/asc.env" "$lane"
+  if [[ "$(<"$TEST_ROOT/command.log")" != "$expected" ]]; then
+    echo "FAIL: credential lane $lane was not routed through op run"
+    printf 'actual: %s\n' "$(<"$TEST_ROOT/command.log")"
+    exit 1
+  fi
+done
+
+for lane in screenshots lanes gates build_number; do
+  run_wrapper "$TEST_ROOT/ruby" "$lane" "argument with spaces"
+  printf -v expected 'bundle\texec\tfastlane\t%s\targument with spaces' "$lane"
+  if [[ "$(<"$TEST_ROOT/command.log")" != "$expected" ]]; then
+    echo "FAIL: non-credential lane $lane did not bypass op"
+    printf 'actual: %s\n' "$(<"$TEST_ROOT/command.log")"
+    exit 1
+  fi
+done
+
+set +e
+MISSING_OP_OUTPUT=$(run_wrapper "$TEST_ROOT/no-op-ruby" check_asc_key 2>&1)
+MISSING_OP_STATUS=$?
+set -e
+if [[ "$MISSING_OP_STATUS" -eq 0 || "$MISSING_OP_OUTPUT" != *"1Password CLI 'op' is required"* ]]; then
+  echo "FAIL: missing op must fail with a friendly error"
+  printf 'exit: %s\n%s\n' "$MISSING_OP_STATUS" "$MISSING_OP_OUTPUT"
+  exit 1
+fi
+
+echo "PASS: Fastlane credential routing and reference mappings"

--- a/scripts/test-fastlane-credential-routing.sh
+++ b/scripts/test-fastlane-credential-routing.sh
@@ -22,7 +22,10 @@ if [[ ! -f "$REFS_FILE" ]]; then
   exit 1
 fi
 
-mapfile -t REF_LINES < <(sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$REFS_FILE")
+REF_LINES=()
+while IFS= read -r line; do
+  REF_LINES+=("$line")
+done < <(sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$REFS_FILE")
 EXPECTED_REFS=(
   'ASC_KEY_ID=op://family-foqos/app_store_connect_key/ASC_KEY_ID_REF'
   'ASC_ISSUER_ID=op://family-foqos/app_store_connect_key/ASC_ISSUER_ID_REF'


### PR DESCRIPTION
## Summary

- route `beta`, `release`, `pull_metadata`, and `check_asc_key` through child-scoped `op run` references
- strictly decode the base64 private key in Ruby and pass raw `key_content` to Fastlane
- create mode-`0600` gym `.p8` and metadata JSON tempfiles with block-scoped cleanup on success and failure
- add reference-only direnv bootstrap files, remove the obsolete Fastlane env template, and retain the ignored local `fastlane/.env`
- add real-behavior harnesses for credential decoding, tempfile lifecycle, lane loading, legacy-env fail-closed behavior, and Bash-3.2-compatible wrapper routing

## Credential lifecycle

Project-created gym `.p8` and `pull_metadata` JSON tempfiles are explicitly mode `0600` and ensure-deleted. Fastlane Transporter verification may leave its own residue; the authoritative design accepts that limitation and intentionally adds no runtime scan of `~/.appstoreconnect`.

The replacement key ID is printed by `check_asc_key` because it is non-secret and lets the operator confirm rotation. The issuer ID and private key remain presence-only and are never printed.

## Verification

- `ruby scripts/test-asc-credentials.rb`
- `ruby scripts/test-fastlane-asc-lane.rb`
- `./scripts/test-fastlane-credential-routing.sh` under macOS `/bin/bash` 3.2
- `ruby scripts/test-archive-storage.rb`
- `bash scripts/test-check-prod-schema.sh`
- `bash scripts/test-fastlane-gates.sh`
- Ruby and Bash syntax checks
- `bundle exec fastlane lanes`
- legacy-path, base64-flag, credential-material, and `fastlane run` scans
- independent review cleared head `2219c0b`

No Xcode, simulator, upload, submission, `pilot`, or `deliver` operation was run.

## Cutover checklist

- [x] Legacy App Store Connect key revoked and local key file removed in #364
- [x] Reference-only 1Password and direnv bootstrap committed
- [x] Archive-only credential path covered by mode/cleanup harnesses
- [ ] Operator runs `direnv allow .` in the intended checkout
- [ ] Operator runs `./scripts/fastlane.sh check_asc_key` with the approved 1Password session; this agent process did not inherit `OP_SERVICE_ACCOUNT_TOKEN`

Implements the approved design at `0944afeb0e6dcdec150af9c0772f3b0f3a98c76d`.

Closes #365

## Summary by Sourcery

Wire Fastlane App Store Connect lanes to use 1Password-provided, in-memory credentials with secure tempfiles and a shell wrapper, replacing the legacy disk-based key path approach.

New Features:
- Introduce an ASCCredentials helper module to decode base64 App Store Connect keys and manage secure, auto-cleaned tempfiles for gym and metadata flows.
- Add a Fastlane shell wrapper and asc.env reference file to route credential-using lanes through child-scoped 1Password CLI sessions while keeping non-credential lanes unchanged.

Enhancements:
- Update Fastfile to consume raw PEM key content via ASCCredentials, centralize archive building in a private lane, and reduce check_asc_key output to non-secret presence indicators.
- Add Ruby and Bash test harnesses to verify credential decoding, tempfile lifecycle, Fastlane lane wiring, and fail-closed behavior when legacy environment files are present.

Documentation:
- Add a detailed implementation plan documenting the 1Password Fastlane wiring design, constraints, tasks, and verification steps.

Chores:
- Replace obsolete Fastlane environment templates with direnv-based bootstrap files and commit additional ignore rules for local dev tooling directories.