### PR TITLE
chore: zero legacy RuboCop offenses + lint staged shell/Ruby in pre-commit (#371)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -19,6 +19,40 @@ if ! scripts/check-c2-guards.sh; then
   exit 1
 fi
 
+# --- Lint staged shell files ---
+STAGED_SHELL=$(git diff --cached --name-only --diff-filter=ACMR -- '*.sh')
+if [ -n "$STAGED_SHELL" ]; then
+  if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "WARNING: shellcheck is unavailable; run: brew install shellcheck. Skipping staged shell lint."
+  else
+    while IFS= read -r file; do
+      if ! shellcheck "$file"; then
+        echo "ERROR: shellcheck failed on $file"
+        exit 1
+      fi
+    done <<EOF
+$STAGED_SHELL
+EOF
+  fi
+fi
+
+# --- Lint staged Ruby files ---
+STAGED_RUBY=$(git diff --cached --name-only --diff-filter=ACMR -- '*.rb' 'fastlane/Fastfile')
+if [ -n "$STAGED_RUBY" ]; then
+  if ! command -v bundle >/dev/null 2>&1 || ! bundle exec rubocop --version >/dev/null 2>&1; then
+    echo "WARNING: RuboCop is unavailable; run: bundle install. Skipping staged Ruby lint."
+  else
+    while IFS= read -r file; do
+      if ! bundle exec rubocop "$file"; then
+        echo "ERROR: RuboCop failed on $file"
+        exit 1
+      fi
+    done <<EOF
+$STAGED_RUBY
+EOF
+  fi
+fi
+
 # --- Auto-format staged Swift files ---
 STAGED_SWIFT=$(git diff --cached --name-only --diff-filter=ACMR -- '*.swift')
 if [ -n "$STAGED_SWIFT" ]; then

--- a/fastlane/archive_storage.rb
+++ b/fastlane/archive_storage.rb
@@ -1,5 +1,7 @@
-require "fileutils"
-require "securerandom"
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'securerandom'
 
 module ArchiveStorage
   def self.replace_directory(source:, destination:, logger: ->(message) { warn(message) })
@@ -24,7 +26,7 @@ module ArchiveStorage
       end
       File.rename(temporary, destination)
       FileUtils.rm_rf(backup)
-    rescue Exception
+    rescue Exception # rubocop:disable Lint/RescueException -- Archive recovery must also run for Interrupt.
       if File.exist?(backup) && !File.exist?(destination)
         File.rename(backup, destination)
         logger.call("Archive backup restored: #{backup}")
@@ -36,14 +38,14 @@ module ArchiveStorage
   end
 
   def self.upload_dsyms(tag:, prerelease:, title:, notes:, asset:)
-    create_args = ["gh", "release", "create", tag]
-    create_args << "--prerelease" if prerelease
-    create_args += ["--title", title, "--notes", notes, asset]
+    create_args = ['gh', 'release', 'create', tag]
+    create_args << '--prerelease' if prerelease
+    create_args += ['--title', title, '--notes', notes, asset]
 
     begin
       yield(create_args)
-    rescue
-      yield(["gh", "release", "upload", tag, asset, "--clobber"])
+    rescue StandardError
+      yield(['gh', 'release', 'upload', tag, asset, '--clobber'])
     end
   end
 end

--- a/scripts/test-archive-storage.rb
+++ b/scripts/test-archive-storage.rb
@@ -1,26 +1,28 @@
-require "fileutils"
-require "tmpdir"
+# frozen_string_literal: true
 
-helper_path = File.expand_path("../fastlane/archive_storage.rb", __dir__)
+require 'fileutils'
+require 'tmpdir'
+
+helper_path = File.expand_path('../fastlane/archive_storage.rb', __dir__)
 unless File.exist?(helper_path)
-  warn "FAIL: fastlane/archive_storage.rb is missing"
+  warn 'FAIL: fastlane/archive_storage.rb is missing'
   exit 1
 end
 
 require helper_path
 
 unless ArchiveStorage.respond_to?(:upload_dsyms)
-  warn "FAIL: ArchiveStorage.upload_dsyms is missing"
+  warn 'FAIL: ArchiveStorage.upload_dsyms is missing'
   exit 1
 end
 
 Dir.mktmpdir do |root|
-  source = File.join(root, "source.xcarchive")
-  destination = File.join(root, "stored.xcarchive")
+  source = File.join(root, 'source.xcarchive')
+  destination = File.join(root, 'stored.xcarchive')
   FileUtils.mkdir_p(source)
   FileUtils.mkdir_p(destination)
-  File.write(File.join(source, "marker"), "new")
-  File.write(File.join(destination, "marker"), "old")
+  File.write(File.join(source, 'marker'), 'new')
+  File.write(File.join(destination, 'marker'), 'old')
   FileUtils.mkdir_p("#{destination}.tmp-stale")
   FileUtils.mkdir_p("#{destination}.backup-stale")
 
@@ -31,33 +33,33 @@ Dir.mktmpdir do |root|
     logger: ->(message) { messages << message }
   )
 
-  unless File.read(File.join(destination, "marker")) == "new"
-    warn "FAIL: completed copy did not replace the destination"
+  unless File.read(File.join(destination, 'marker')) == 'new'
+    warn 'FAIL: completed copy did not replace the destination'
     exit 1
   end
   unless messages.length == 1 && messages.first.include?("#{destination}.backup-")
-    warn "FAIL: archive replacement did not log the created backup path"
+    warn 'FAIL: archive replacement did not log the created backup path'
     exit 1
   end
   unless Dir.glob("#{destination}.{tmp,backup}-*").empty?
-    warn "FAIL: successful replacement left temporary or backup directories"
+    warn 'FAIL: successful replacement left temporary or backup directories'
     exit 1
   end
 
-  File.write(File.join(destination, "marker"), "known-good")
+  File.write(File.join(destination, 'marker'), 'known-good')
   begin
     ArchiveStorage.replace_directory(
-      source: File.join(root, "missing.xcarchive"),
+      source: File.join(root, 'missing.xcarchive'),
       destination: destination
     )
-    warn "FAIL: missing source should raise"
+    warn 'FAIL: missing source should raise'
     exit 1
   rescue Errno::ENOENT
     # Expected: copying fails before the known-good destination is moved.
   end
 
-  unless File.read(File.join(destination, "marker")) == "known-good"
-    warn "FAIL: failed replacement damaged the known-good destination"
+  unless File.read(File.join(destination, 'marker')) == 'known-good'
+    warn 'FAIL: failed replacement damaged the known-good destination'
     exit 1
   end
 
@@ -66,11 +68,12 @@ Dir.mktmpdir do |root|
   File.define_singleton_method(:rename) do |source_path, destination_path|
     rename_count += 1
     raise Errno::EIO if rename_count == 2
+
     rename.call(source_path, destination_path)
   end
   begin
     ArchiveStorage.replace_directory(source: source, destination: destination)
-    warn "FAIL: simulated swap failure should raise"
+    warn 'FAIL: simulated swap failure should raise'
     exit 1
   rescue Errno::EIO
     # Expected: the completed temporary copy fails to swap after backup creation.
@@ -78,8 +81,8 @@ Dir.mktmpdir do |root|
     File.define_singleton_method(:rename, rename)
   end
 
-  unless File.read(File.join(destination, "marker")) == "known-good"
-    warn "FAIL: swap failure did not restore the known-good backup"
+  unless File.read(File.join(destination, 'marker')) == 'known-good'
+    warn 'FAIL: swap failure did not restore the known-good backup'
     exit 1
   end
 
@@ -87,11 +90,12 @@ Dir.mktmpdir do |root|
   File.define_singleton_method(:rename) do |source_path, destination_path|
     rename_count += 1
     raise Interrupt if rename_count == 2
+
     rename.call(source_path, destination_path)
   end
   begin
     ArchiveStorage.replace_directory(source: source, destination: destination)
-    warn "FAIL: simulated interrupt should raise"
+    warn 'FAIL: simulated interrupt should raise'
     exit 1
   rescue Interrupt
     # Expected: Ctrl-C lands after backup creation but before the new archive swap.
@@ -99,8 +103,8 @@ Dir.mktmpdir do |root|
     File.define_singleton_method(:rename, rename)
   end
 
-  unless File.exist?(destination) && File.read(File.join(destination, "marker")) == "known-good"
-    warn "FAIL: interrupt did not restore the known-good backup to the expected path"
+  unless File.exist?(destination) && File.read(File.join(destination, 'marker')) == 'known-good'
+    warn 'FAIL: interrupt did not restore the known-good backup to the expected path'
     exit 1
   end
 
@@ -117,7 +121,7 @@ Dir.mktmpdir do |root|
       destination: destination,
       logger: ->(message) { interrupt_messages << message }
     )
-    warn "FAIL: interrupt immediately after backup rename should raise"
+    warn 'FAIL: interrupt immediately after backup rename should raise'
     exit 1
   rescue Interrupt
     # Expected: Ctrl-C lands after the destination moved but before the call returns.
@@ -125,50 +129,50 @@ Dir.mktmpdir do |root|
     File.define_singleton_method(:rename, rename)
   end
 
-  unless File.exist?(destination) && File.read(File.join(destination, "marker")) == "known-good"
-    warn "FAIL: post-rename interrupt did not restore the known-good backup"
+  unless File.exist?(destination) && File.read(File.join(destination, 'marker')) == 'known-good'
+    warn 'FAIL: post-rename interrupt did not restore the known-good backup'
     exit 1
   end
   unless interrupt_messages.any? { |message| message.include?("#{destination}.backup-") }
-    warn "FAIL: post-rename interrupt did not report the backup path"
+    warn 'FAIL: post-rename interrupt did not report the backup path'
     exit 1
   end
 
   FileUtils.rm_rf(destination)
   stale_backup = "#{destination}.backup-stale-recovery"
   FileUtils.mkdir_p(stale_backup)
-  File.write(File.join(stale_backup, "marker"), "recoverable")
+  File.write(File.join(stale_backup, 'marker'), 'recoverable')
   recovery_messages = []
   begin
     ArchiveStorage.replace_directory(
-      source: File.join(root, "still-missing.xcarchive"),
+      source: File.join(root, 'still-missing.xcarchive'),
       destination: destination,
       logger: ->(message) { recovery_messages << message }
     )
-    warn "FAIL: missing replacement source should raise after stale-backup recovery"
+    warn 'FAIL: missing replacement source should raise after stale-backup recovery'
     exit 1
   rescue Errno::ENOENT
     # Expected: replacement fails, but the stale known-good backup must survive.
   end
 
-  unless File.exist?(destination) && File.read(File.join(destination, "marker")) == "recoverable"
-    warn "FAIL: stale backup was not recovered before the failed replacement"
+  unless File.exist?(destination) && File.read(File.join(destination, 'marker')) == 'recoverable'
+    warn 'FAIL: stale backup was not recovered before the failed replacement'
     exit 1
   end
   unless recovery_messages.any? { |message| message.include?(stale_backup) }
-    warn "FAIL: stale-backup recovery did not report the discovered path"
+    warn 'FAIL: stale-backup recovery did not report the discovered path'
     exit 1
   end
 
   copy = FileUtils.method(:cp_r)
   FileUtils.define_singleton_method(:cp_r) do |_source_path, destination_path|
     FileUtils.mkdir_p(destination_path)
-    File.write(File.join(destination_path, "partial"), "incomplete")
+    File.write(File.join(destination_path, 'partial'), 'incomplete')
     raise Interrupt
   end
   begin
     ArchiveStorage.replace_directory(source: source, destination: destination)
-    warn "FAIL: interrupt during archive copy should raise"
+    warn 'FAIL: interrupt during archive copy should raise'
     exit 1
   rescue Interrupt
     # Expected: a partial temporary copy exists, but no complete copy has moved.
@@ -176,13 +180,13 @@ Dir.mktmpdir do |root|
     FileUtils.define_singleton_method(:cp_r, copy)
   end
 
-  unless File.read(File.join(source, "marker")) == "new" &&
-      File.read(File.join(destination, "marker")) == "recoverable"
-    warn "FAIL: copy interrupt damaged a complete source or stored archive"
+  unless File.read(File.join(source, 'marker')) == 'new' &&
+         File.read(File.join(destination, 'marker')) == 'recoverable'
+    warn 'FAIL: copy interrupt damaged a complete source or stored archive'
     exit 1
   end
   unless Dir.glob("#{destination}.tmp-*").empty?
-    warn "FAIL: copy interrupt left a partial temporary archive"
+    warn 'FAIL: copy interrupt left a partial temporary archive'
     exit 1
   end
 
@@ -193,7 +197,7 @@ Dir.mktmpdir do |root|
   end
   begin
     ArchiveStorage.replace_directory(source: source, destination: destination)
-    warn "FAIL: interrupt before the first rename should raise"
+    warn 'FAIL: interrupt before the first rename should raise'
     exit 1
   rescue Interrupt
     # Expected: the completed temporary copy never displaces the stored archive.
@@ -201,55 +205,55 @@ Dir.mktmpdir do |root|
     File.define_singleton_method(:rename, rename)
   end
 
-  unless File.read(File.join(source, "marker")) == "new" &&
-      File.read(File.join(destination, "marker")) == "recoverable"
-    warn "FAIL: pre-rename interrupt damaged a complete source or stored archive"
+  unless File.read(File.join(source, 'marker')) == 'new' &&
+         File.read(File.join(destination, 'marker')) == 'recoverable'
+    warn 'FAIL: pre-rename interrupt damaged a complete source or stored archive'
     exit 1
   end
 end
 
 create_calls = []
 ArchiveStorage.upload_dsyms(
-  tag: "build/12",
+  tag: 'build/12',
   prerelease: true,
-  title: "Title with spaces",
+  title: 'Title with spaces',
   notes: "Notes with an apostrophe: family's archive",
-  asset: "/tmp/path with spaces/dSYMs.zip"
+  asset: '/tmp/path with spaces/dSYMs.zip'
 ) { |args| create_calls << args }
 
 unless create_calls == [[
-  "gh", "release", "create", "build/12", "--prerelease",
-  "--title", "Title with spaces",
-  "--notes", "Notes with an apostrophe: family's archive",
-  "/tmp/path with spaces/dSYMs.zip",
+  'gh', 'release', 'create', 'build/12', '--prerelease',
+  '--title', 'Title with spaces',
+  '--notes', "Notes with an apostrophe: family's archive",
+  '/tmp/path with spaces/dSYMs.zip'
 ]]
-  warn "FAIL: release creation arguments were not preserved"
+  warn 'FAIL: release creation arguments were not preserved'
   exit 1
 end
 
 retry_calls = []
 ArchiveStorage.upload_dsyms(
-  tag: "v2.0.0",
+  tag: 'v2.0.0',
   prerelease: false,
-  title: "FamilyFoqos",
-  notes: "Retry",
-  asset: "/tmp/dSYMs.zip"
+  title: 'FamilyFoqos',
+  notes: 'Retry',
+  asset: '/tmp/dSYMs.zip'
 ) do |args|
   retry_calls << args
-  raise "release exists" if retry_calls.length == 1
+  raise 'release exists' if retry_calls.length == 1
 end
 
 unless retry_calls == [
   [
-    "gh", "release", "create", "v2.0.0",
-    "--title", "FamilyFoqos",
-    "--notes", "Retry",
-    "/tmp/dSYMs.zip",
+    'gh', 'release', 'create', 'v2.0.0',
+    '--title', 'FamilyFoqos',
+    '--notes', 'Retry',
+    '/tmp/dSYMs.zip'
   ],
-  ["gh", "release", "upload", "v2.0.0", "/tmp/dSYMs.zip", "--clobber"],
+  ['gh', 'release', 'upload', 'v2.0.0', '/tmp/dSYMs.zip', '--clobber']
 ]
-  warn "FAIL: existing release did not fall back to upload --clobber"
+  warn 'FAIL: existing release did not fall back to upload --clobber'
   exit 1
 end
 
-puts "PASS: archive replacement and GitHub retry are recoverable"
+puts 'PASS: archive replacement and GitHub retry are recoverable'


### PR DESCRIPTION
Closes #371.

- clears the 117 legacy RuboCop offenses while preserving archive interruption recovery
- lints staged shell and Ruby files in pre-commit, with install-and-skip warnings when tooling is unavailable
- leaves SwiftLint and CI out of scope

Verified with repo-wide RuboCop, ShellCheck over scripts and the hook, all four Ruby/shell harnesses, and alternate-index hook red/green probes.