### PR TITLE
Fix launch crash when sync shuts down during startup

### DIFF
--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -73,6 +73,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
 
   #if DEBUG
     private var queueDrainDelayOverrideNanos: UInt64?
+    var beforeDeleteIntentRecoveryForTest: (() async -> Void)?
     func setQueueDrainDelayForTest(_ nanos: UInt64) {
       queueDrainDelayOverrideNanos = nanos
     }
@@ -456,6 +457,8 @@ final class SyncEngineController: SyncEngineDriverDelegate {
         seedZoneAndRecords()  // intent-first (I11)
         flushTask = Task { [weak self] in await self?.sessionSync.flushSessionCache() }
       case .purged:  // T6
+        namespaceGeneration += 1
+        startupTask?.cancel()
         store.purgeAllSystemFields()
         store.transaction { s in
           s.engineState = nil
@@ -1078,6 +1081,10 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   /// `changeTag` (not `record.recordChangeTag`) so the matching-tag ⇒ delete arm is
   /// deterministically testable.
   private func recoverDeleteIntents(generation: Int) async {
+    #if DEBUG
+      await beforeDeleteIntentRecoveryForTest?()
+    #endif
+    guard generation == namespaceGeneration, driver != nil else { return }
     let pending = pendingDeleteNames()
     for (name, tag) in store.deleteTombstones where !pending.contains(name) {
       guard generation == namespaceGeneration else { return }

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -5,6 +5,30 @@ import XCTest
 @testable import FamilyFoqos
 
 @MainActor
+private final class StartupRecoveryGate {
+  private var hasEntered = false
+  private var entryContinuation: CheckedContinuation<Void, Never>?
+  private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+  func suspend() async {
+    hasEntered = true
+    entryContinuation?.resume()
+    entryContinuation = nil
+    await withCheckedContinuation { releaseContinuation = $0 }
+  }
+
+  func waitUntilEntered() async {
+    guard !hasEntered else { return }
+    await withCheckedContinuation { entryContinuation = $0 }
+  }
+
+  func release() {
+    releaseContinuation?.resume()
+    releaseContinuation = nil
+  }
+}
+
+@MainActor
 final class SyncEngineControllerTests: XCTestCase {
   var suiteName: String!
   var defaults: UserDefaults!
@@ -1643,7 +1667,9 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertTrue(hasPendingZoneSave())
   }
 
-  func testGivenZonePurged_WhenHandled_ThenDisabledDiscardStateTombstonesIntact() {
+  func testGivenCancelledStartup_WhenZonePurgedBeforeItRuns_ThenStartupExitsWithoutDriverAccess()
+    async
+  {
     store.engineState = Data([0x1])
     store.resetIntent = ResetIntent(id: UUID(), clear: false, stage: .deleting, priorCommandId: nil)
     store.pendingSeedIntent = true
@@ -1655,6 +1681,7 @@ final class SyncEngineControllerTests: XCTestCase {
     controller.handle(
       .fetchedDatabaseChanges(
         modifiedZoneIDs: [], deletedZones: [(zoneID: zoneID, reason: .purged)]))
+    await controller.startupTask?.value
 
     XCTAssertEqual(controller.state, .purged, "T6")
     XCTAssertNil(store.engineState, "engine state discarded")
@@ -1663,6 +1690,25 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertNotNil(store.deleteTombstones["keep"], "tombstones survive (not consent-scoped)")
     XCTAssertFalse(SharedData.deviceSyncEnabled, "sync disabled")
     XCTAssertTrue(pendingSaveNames().isEmpty, "nothing enqueued")
+  }
+
+  func testGivenStartupPastInitialGuard_WhenZonePurgedDuringRecovery_ThenStartupExitsCleanly()
+    async
+  {
+    let gate = StartupRecoveryGate()
+    let controller = makeController()
+    controller.beforeDeleteIntentRecoveryForTest = { await gate.suspend() }
+    controller.start()
+    await gate.waitUntilEntered()
+
+    controller.handle(
+      .fetchedDatabaseChanges(
+        modifiedZoneIDs: [], deletedZones: [(zoneID: zoneID, reason: .purged)]))
+    gate.release()
+    await controller.startupTask?.value
+
+    XCTAssertEqual(controller.state, .purged)
+    XCTAssertFalse(controller.hasLiveDriver)
   }
 
   // MARK: - T7 accountChange (§7)


### PR DESCRIPTION
## Summary

- invalidate and cancel startup when a purged zone tears down the sync driver
- revalidate startup generation and driver lifetime before delete-intent recovery
- add deterministic regressions for teardown before startup runs and after its initial guard

`.purged` previously diverged from `stop()` and `prepareForAccountSwitch()` startup-task invalidation semantics; this deliberately aligns that lifecycle invariant across all three paths.

## Validation

- full simulator suite: 1,164 passed, 0 failed, 0 skipped
- both regression tests crash before the fix and pass after it
- `swift-format lint --recursive .`
- `./scripts/check-c2-guards.sh`
- `./scripts/check-sync-guards.sh`
- `./scripts/check-prod-schema.sh` remains blocked only by the known #346 production deployment of five record types

Fixes #373
