### PR TITLE
Fix sync engine suspension races

### DIFF
--- a/Foqos/CloudKit/SyncEngine/ResetController.swift
+++ b/Foqos/CloudKit/SyncEngine/ResetController.swift
@@ -90,6 +90,7 @@ final class ResetController {
   private let fetcher: RecordFetching
   private let surfacer: ResetConflictSurfacing
   private let deviceId: String
+  private let isActive: () -> Bool
 
   init(
     store: SyncEngineStore,
@@ -97,7 +98,8 @@ final class ResetController {
     seeder: ResetSeeder,
     fetcher: RecordFetching,
     surfacer: ResetConflictSurfacing,
-    deviceId: String
+    deviceId: String,
+    isActive: @escaping () -> Bool = { true }
   ) {
     self.store = store
     self.outbox = outbox
@@ -105,6 +107,7 @@ final class ResetController {
     self.fetcher = fetcher
     self.surfacer = surfacer
     self.deviceId = deviceId
+    self.isActive = isActive
   }
 
   private var zoneID: CKRecordZone.ID {
@@ -141,8 +144,9 @@ final class ResetController {
 
   /// §8.1 step 3. Driven from §5.5 (deletedZoneIDs / failedZoneDeletes .zoneNotFound).
   func handleZoneDeleteConfirmed() async {
-    guard let intent = store.resetIntent, intent.stage == .deleting else { return }
+    guard isActive(), let intent = store.resetIntent, intent.stage == .deleting else { return }
     await seeder.performI6Purge()
+    guard isActive() else { return }
     store.resetIntent = ResetIntent(
       id: intent.id, clear: intent.clear, wipe: intent.wipe, stage: .recreating,
       priorCommandId: intent.priorCommandId)
@@ -185,7 +189,7 @@ final class ResetController {
 
   /// Applied on a fetched modification of the fixed-name command record.
   func applyCommand(_ record: CKRecord) async {
-    guard let command = SyncResetRequest(from: record) else {
+    guard isActive(), let command = SyncResetRequest(from: record) else {
       // Undecodable command (incl. no readable requestId): inert, dies with its zone (§5.1).
       return
     }
@@ -208,6 +212,7 @@ final class ResetController {
       try? seeder.clearAllProfileSelections()
     }
     await seeder.performI6Purge()
+    guard isActive() else { return }
     seeder.seedAll()
     // 3. mark processed + provenance (I4: after apply)
     store.transaction { s in
@@ -305,7 +310,7 @@ final class ResetController {
 
   /// Resume a persisted resetIntent from its stage. .deleting runs the gate first (Task 106).
   func resume() async {
-    guard let intent = store.resetIntent else { return }
+    guard isActive(), let intent = store.resetIntent else { return }
     switch intent.stage {
     case .deleting:
       await runDeletingGate(intent)
@@ -331,7 +336,7 @@ final class ResetController {
     }
     do {
       let record = try await fetcher.fetchRecord(commandRecordID)
-      guard isCurrentDeletingIntent(intent) else { return }
+      guard isActive(), isCurrentDeletingIntent(intent) else { return }
       guard let record else {
         reenqueueDeleting()  // no command (any snapshot) ⇒ resume
         return
@@ -348,7 +353,7 @@ final class ResetController {
         abandon(intent)  // foreign, different from both ⇒ superseded ⇒ abandon + surface
       }
     } catch let error as CKError where error.code == .zoneNotFound {
-      guard isCurrentDeletingIntent(intent) else { return }
+      guard isActive(), isCurrentDeletingIntent(intent) else { return }
       reenqueueDeleting()  // zone died / was T5-reseeded ⇒ resume (zone-CAS + N1)
     } catch {
       // Transient fetch error ⇒ keep the intent; retry at next start / §5.6 cadence.
@@ -358,7 +363,7 @@ final class ResetController {
   private func runWipeDeletingGate(_ intent: ResetIntent) async {
     do {
       let record = try await fetcher.fetchRecord(establishmentRecordID)
-      guard isCurrentDeletingIntent(intent) else { return }
+      guard isActive(), isCurrentDeletingIntent(intent) else { return }
       guard let record else {
         reenqueueDeleting()
         return
@@ -374,7 +379,7 @@ final class ResetController {
         reenqueueDeleting()
       }
     } catch let error as CKError where error.code == .zoneNotFound {
-      guard isCurrentDeletingIntent(intent) else { return }
+      guard isActive(), isCurrentDeletingIntent(intent) else { return }
       reenqueueDeleting()
     } catch {
       // Transient fetch error ⇒ keep the intent; retry later.

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController+Reset.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController+Reset.swift
@@ -7,10 +7,12 @@ import Foundation
 final class DriverResetOutbox: ResetOutbox {
   private let driver: SyncEngineDriver
   private let zoneID: CKRecordZone.ID
+  private let isActive: () -> Bool
 
-  init(driver: SyncEngineDriver, zoneID: CKRecordZone.ID) {
+  init(driver: SyncEngineDriver, zoneID: CKRecordZone.ID, isActive: @escaping () -> Bool = { true }) {
     self.driver = driver
     self.zoneID = zoneID
+    self.isActive = isActive
   }
 
   private var commandRecordID: CKRecord.ID {
@@ -21,38 +23,50 @@ final class DriverResetOutbox: ResetOutbox {
   }
 
   func enqueueZoneDelete() {
+    guard isActive() else { return }
     Log.info("Reset sync: enqueue zone delete", category: .sync)
     driver.add(pendingDatabaseChanges: [.deleteZone(zoneID)])
   }
   func enqueueZoneSave() {
+    guard isActive() else { return }
     Log.info("Reset sync: enqueue zone save", category: .sync)
     driver.add(pendingDatabaseChanges: [.saveZone(CKRecordZone(zoneID: zoneID))])
   }
   func removeResetZoneChanges() {
+    guard isActive() else { return }
     driver.remove(
       pendingDatabaseChanges: [.deleteZone(zoneID), .saveZone(CKRecordZone(zoneID: zoneID))])
   }
   func enqueueCommandSave() {
+    guard isActive() else { return }
     Log.info("Reset sync: enqueue reset command", category: .sync)
     driver.add(pendingRecordZoneChanges: [.saveRecord(commandRecordID)])
   }
   func enqueueEstablishmentSave() {
+    guard isActive() else { return }
     Log.info("Reset sync: enqueue establishment record", category: .sync)
     driver.add(pendingRecordZoneChanges: [.saveRecord(establishmentRecordID)])
   }
   func removeCommandSave() {
+    guard isActive() else { return }
     driver.remove(pendingRecordZoneChanges: [.saveRecord(commandRecordID)])
   }
   func removeEstablishmentSave() {
+    guard isActive() else { return }
     driver.remove(pendingRecordZoneChanges: [.saveRecord(establishmentRecordID)])
   }
   func requestSend() {
+    guard isActive() else { return }
     // The outer Task only defers to a later main-actor turn; the §1.1/task-local CKSyncEngine
     // boundary is inside the driver, where sendChanges() crosses Task.detached before awaiting.
     Log.debug("Reset sync: request send", category: .sync)
-    Task { @MainActor in self.driver.sendChanges() }
+    Task { @MainActor [weak self] in
+      guard let self, self.isActive() else { return }
+      self.driver.sendChanges()
+    }
   }
   func clearPendingChangesForReset() {
+    guard isActive() else { return }
     Log.info("Reset sync: clearing pending engine changes before zone reset", category: .sync)
     driver.remove(pendingRecordZoneChanges: driver.pendingRecordZoneChanges)
     driver.remove(pendingDatabaseChanges: driver.pendingDatabaseChanges)

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -64,6 +64,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   private(set) var startupTask: Task<Void, Never>?
   private(set) var flushTask: Task<Void, Never>?
   private(set) var fetchCycleSweepTask: Task<Void, Never>?
+  private(set) var resetTask: Task<Void, Never>?
   private var queueDrainTask: Task<Void, Never>?
   private var queueDrainAttempt = 0
   private var queueDrainNeedsSend = false
@@ -74,6 +75,8 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   #if DEBUG
     private var queueDrainDelayOverrideNanos: UInt64?
     var beforeDeleteIntentRecoveryForTest: (() async -> Void)?
+    var beforeFailedApplyRetryForTest: (() async -> Void)?
+    var beforeSeedDecisionForTest: (() async -> Void)?
     func setQueueDrainDelayForTest(_ nanos: UInt64) {
       queueDrainDelayOverrideNanos = nanos
     }
@@ -123,6 +126,8 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     startupTask?.cancel()
     flushTask?.cancel()
     fetchCycleSweepTask?.cancel()
+    resetTask?.cancel()
+    resetTask = nil
     queueDrainTask?.cancel()
     queueDrainTask = nil
     isSending = false
@@ -130,6 +135,9 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     lastSuccessfulSyncDate = nil
     driver?.shutdown()
     driver = nil
+    funnel = nil
+    reset = nil
+    legacyCleanup = nil
     endAccountResolution()
     state = .disabled
   }
@@ -190,12 +198,14 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       store.engineState = nil
       driver = driverFactory(nil)
     }
+    let generation = namespaceGeneration
+    let isActive = { [weak self] in self?.isGenerationActive(generation) == true }
     funnel = MutationFunnel(
       modelContext: modelContext, store: store, driver: driver, deviceId: deviceId,
       scheduleProfileDeleteCommit: scheduleProfileDeleteCommit)
     reset = ResetController(
       store: store,
-      outbox: DriverResetOutbox(driver: driver, zoneID: zoneID),
+      outbox: DriverResetOutbox(driver: driver, zoneID: zoneID, isActive: isActive),
       seeder: DefaultResetSeeder(
         store: store,
         flush: { [weak self] in await self?.sessionSync.flushSessionCache() },
@@ -206,13 +216,17 @@ final class SyncEngineController: SyncEngineDriverDelegate {
         clearSelections: { [weak self] in try self?.clearAllLocalProfileSelections() }),
       fetcher: DriverRecordFetcher(driver: driver),
       surfacer: ConflictManagerResetSurfacer(),
-      deviceId: deviceId)
+      deviceId: deviceId,
+      isActive: isActive)
     legacyCleanup = LegacyCleanupCoordinator(store: store, driver: driver)
     wireResetHooks()
     performStrip()
     state = .bootstrapping
-    let generation = namespaceGeneration
     startupTask = Task { [weak self] in await self?.runStartupSequence(generation: generation) }
+  }
+
+  private func isGenerationActive(_ generation: Int) -> Bool {
+    generation == namespaceGeneration && driver != nil
   }
 
   /// Phase F composition (CRA-4): connects the controller's reset hooks to the
@@ -222,12 +236,19 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   /// `ResetController` methods are scheduled via `Task`; the synchronous ones
   /// (`handleZoneSaveConfirmed`, `handleCommandSaveResult`) run inline.
   private func wireResetHooks() {
+    let generation = namespaceGeneration
     onFetchedResetCommand = { [weak self] record in
-      Task { await self?.reset?.applyCommand(record) }
+      self?.resetTask = Task { [weak self] in
+        guard let self, self.isGenerationActive(generation), let reset = self.reset else { return }
+        await reset.applyCommand(record)
+      }
     }
     onZoneChangeConfirmed = { [weak self] saved, deleted in
       if !deleted.isEmpty {
-        Task { await self?.reset?.handleZoneDeleteConfirmed() }
+        self?.resetTask = Task { [weak self] in
+          guard let self, self.isGenerationActive(generation), let reset = self.reset else { return }
+          await reset.handleZoneDeleteConfirmed()
+        }
       }
       if !saved.isEmpty { self?.reset?.handleZoneSaveConfirmed() }
     }
@@ -257,7 +278,12 @@ final class SyncEngineController: SyncEngineDriverDelegate {
         }
       }
     }
-    onResumeReset = { [weak self] _ in Task { await self?.reset?.resume() } }
+    onResumeReset = { [weak self] _ in
+      self?.resetTask = Task { [weak self] in
+        guard let self, self.isGenerationActive(generation), let reset = self.reset else { return }
+        await reset.resume()
+      }
+    }
     // T11 (Fix 7): dequeue a live resetIntent's pending zone/command changes BEFORE
     // stop()'s best-effort final sendChanges() — user-initiated disable, never surfaced
     // as a superseded-reset conflict (see ResetController.abandonForStop).
@@ -291,6 +317,8 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     startupTask?.cancel()
     flushTask?.cancel()
     fetchCycleSweepTask?.cancel()
+    resetTask?.cancel()
+    resetTask = nil
     queueDrainTask?.cancel()
     queueDrainTask = nil
     isSending = false
@@ -299,6 +327,9 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     store.engineState = nil  // pending unsent saves lost (N5); tombstones survive
     driver?.shutdown()
     driver = nil
+    funnel = nil
+    reset = nil
+    legacyCleanup = nil
     state = .disabled
   }
 
@@ -459,6 +490,8 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       case .purged:  // T6
         namespaceGeneration += 1
         startupTask?.cancel()
+        resetTask?.cancel()
+        resetTask = nil
         store.purgeAllSystemFields()
         store.transaction { s in
           s.engineState = nil
@@ -476,6 +509,9 @@ final class SyncEngineController: SyncEngineDriverDelegate {
         lastSuccessfulSyncDate = nil
         driver?.shutdown()
         driver = nil
+        funnel = nil
+        reset = nil
+        legacyCleanup = nil
         state = .purged
       }
     }
@@ -946,16 +982,16 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   // MARK: - Startup
 
   private func runStartupSequence(generation: Int) async {
-    guard generation == namespaceGeneration else { return }
+    guard isGenerationActive(generation) else { return }
     await recoverDeleteIntents(generation: generation)
-    guard generation == namespaceGeneration else { return }
+    guard isGenerationActive(generation) else { return }
     await retryFailedApplies(generation: generation)
-    guard generation == namespaceGeneration else { return }
+    guard isGenerationActive(generation) else { return }
     reEnqueueLegacyCleanup()
     if store.resetIntent == nil {
-      await applySeedDecision()
+      await applySeedDecision(generation: generation)
     }
-    guard generation == namespaceGeneration else { return }
+    guard isGenerationActive(generation) else { return }
     if let intent = store.resetIntent { onResumeReset?(intent) }  // §8.1 (Phase E)
     driver.fetchChanges()
   }
@@ -972,11 +1008,15 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   /// the entry regardless of which op originally failed (already handled inside
   /// `SyncApplyService`, which clears by name on every successful path).
   private func retryFailedApplies(generation: Int) async {
+    #if DEBUG
+      await beforeFailedApplyRetryForTest?()
+    #endif
+    guard isGenerationActive(generation) else { return }
     for entry in store.failedApplies {
-      guard generation == namespaceGeneration else { return }
+      guard isGenerationActive(generation) else { return }
       let id = recordID(entry.recordName)
       let result = await driver.fetchRecord(id)
-      guard generation == namespaceGeneration else { return }
+      guard isGenerationActive(generation) else { return }
       switch entry.op {
       case .upsert:
         switch result {
@@ -1015,6 +1055,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
         }
       }
     }
+    guard isGenerationActive(generation) else { return }
     for recordID in apply.drainReenqueues() {
       markQueueDrainNeeded()
       driver.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
@@ -1087,7 +1128,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     guard generation == namespaceGeneration, driver != nil else { return }
     let pending = pendingDeleteNames()
     for (name, tag) in store.deleteTombstones where !pending.contains(name) {
-      guard generation == namespaceGeneration else { return }
+      guard isGenerationActive(generation) else { return }
       if entityExists(recordName: name) {
         // Local delete never completed — fail-toward-keep (E-3).
         store.clearTombstone(recordName: name)
@@ -1096,7 +1137,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       }
       // Recovered intent ⇒ verify-before-delete.
       let result = await driver.fetchRecord(recordID(name))
-      guard generation == namespaceGeneration else { return }
+      guard isGenerationActive(generation) else { return }
       switch result {
       case .found(let record, let serverTag):
         if let tag, let serverTag, serverTag == tag {
@@ -1145,11 +1186,16 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   /// Exactly one of: first-bootstrap seed, crash-recovery purge+re-seed, or (ordinary
   /// relaunch) nothing — the restored `engineState` is authoritative for the queue, so an
   /// ordinary relaunch enqueues zero changes (S-19/I7).
-  private func applySeedDecision() async {  // at most one seed (T1)
+  private func applySeedDecision(generation: Int) async {  // at most one seed (T1)
+    #if DEBUG
+      await beforeSeedDecisionForTest?()
+    #endif
+    guard isGenerationActive(generation) else { return }
     if store.engineState == nil {
       seedZoneAndRecords()
     } else if store.pendingSeedIntent {
       await purgeBookkeeping()
+      guard isGenerationActive(generation) else { return }
       seedZoneAndRecords()
     }
     // else ordinary relaunch (I7): enqueue nothing.

--- a/FoqosTests/Mocks/MockSessionSyncFlushing.swift
+++ b/FoqosTests/Mocks/MockSessionSyncFlushing.swift
@@ -5,5 +5,10 @@ import Foundation
 @MainActor
 final class MockSessionSyncFlushing: SessionSyncFlushing {
   private(set) var flushCount = 0
-  func flushSessionCache() async { flushCount += 1 }
+  var beforeFlush: (() async -> Void)?
+
+  func flushSessionCache() async {
+    flushCount += 1
+    await beforeFlush?()
+  }
 }

--- a/FoqosTests/Mocks/MockSyncEngineDriver.swift
+++ b/FoqosTests/Mocks/MockSyncEngineDriver.swift
@@ -30,6 +30,7 @@ final class MockSyncEngineDriver: SyncEngineDriver {
 
   var fetchRecordResults: [String: FetchRecordResult] = [:]
   var defaultFetchRecordResult: FetchRecordResult = .notFound
+  var beforeFetchRecord: (() async -> Void)?
   private(set) var fetchedRecordIDs: [CKRecord.ID] = []
 
   init(
@@ -94,6 +95,7 @@ final class MockSyncEngineDriver: SyncEngineDriver {
 
   func fetchRecord(_ id: CKRecord.ID) async -> FetchRecordResult {
     fetchedRecordIDs.append(id)
+    await beforeFetchRecord?()
     return fetchRecordResults[id.recordName] ?? defaultFetchRecordResult
   }
 

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -460,6 +460,41 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertTrue(pendingSaveNames().contains(p.id.uuidString))
   }
 
+  func testGivenStartupPastInitialGuard_WhenTeardownBeforeSeedDecision_ThenStartupExitsCleanly()
+    async
+  {
+    store.engineState = nil
+    let gate = StartupRecoveryGate()
+    let controller = makeController()
+    controller.beforeSeedDecisionForTest = { await gate.suspend() }
+    controller.start()
+    await gate.waitUntilEntered()
+
+    controller.prepareForAccountSwitch()
+    gate.release()
+    await controller.startupTask?.value
+
+    XCTAssertEqual(controller.state, .disabled)
+    XCTAssertFalse(controller.hasLiveDriver)
+  }
+
+  func testGivenPendingSeedFlushSuspended_WhenTeardownOccurs_ThenStartupDoesNotSeed() async {
+    store.engineState = Data([0x01])
+    store.pendingSeedIntent = true
+    let gate = StartupRecoveryGate()
+    sessionSync.beforeFlush = { await gate.suspend() }
+    let controller = makeController()
+    controller.start()
+    await gate.waitUntilEntered()
+
+    controller.prepareForAccountSwitch()
+    gate.release()
+    await controller.startupTask?.value
+
+    XCTAssertEqual(controller.state, .disabled)
+    XCTAssertFalse(controller.hasLiveDriver)
+  }
+
   func testGivenResetIntentDeletingAndNilEngineState_WhenStart_ThenStartupDoesNotOwnSeedZone() async {
     store.engineState = nil
     store.resetIntent = ResetIntent(id: UUID(), clear: false, stage: .deleting, priorCommandId: nil)
@@ -900,6 +935,33 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertNotNil(try? fetchProfile(id), "recovered record applied by the post-cycle sweep")
   }
 
+  func testGivenPendingReenqueueAtRetryEntry_WhenTeardownOccurs_ThenTailDoesNotUseDriver() async {
+    store.engineState = Data([0x01])
+    let controller = makeController()
+    controller.start()
+    await controller.startupTask?.value
+
+    let id = UUID()
+    let local = BlockedProfiles(id: id, name: "Local", syncVersion: 5)
+    context.insert(local)
+    try? context.save()
+    let remote = makeProfileRecord(id: id, version: 5, name: "Remote")
+    remote[SyncedProfile.FieldKey.updatedAt.rawValue] = local.updatedAt.addingTimeInterval(-10)
+    _ = apply.applyFetchedModification(remote, isPendingDeleteOrTombstoned: { _ in false })
+
+    let gate = StartupRecoveryGate()
+    controller.beforeFailedApplyRetryForTest = { await gate.suspend() }
+    controller.handle(.didFetchChanges)
+    await gate.waitUntilEntered()
+
+    controller.prepareForAccountSwitch()
+    gate.release()
+    await controller.fetchCycleSweepTask?.value
+
+    XCTAssertEqual(controller.state, .disabled)
+    XCTAssertFalse(controller.hasLiveDriver)
+  }
+
   // MARK: - T3 fetchedRecordZoneChanges routing (§5.1/§5.2, S-1, S-32, CRA-1, CRA-2)
 
   func testGivenNoTombstone_WhenFetchedModification_ThenApplied() {
@@ -986,6 +1048,55 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertTrue(
       store.failedApplies.isEmpty,
       "no failedApplies bookkeeping created by a generic apply of the reset command")
+  }
+
+  func testGivenResetCommandSuspendedInPurge_WhenAccountSwitchTearsDown_ThenTaskExitsCleanly()
+    async
+  {
+    store.engineState = Data([0x01])
+    let controller = makeController()
+    controller.start()
+    await controller.startupTask?.value
+
+    let gate = StartupRecoveryGate()
+    sessionSync.beforeFlush = { await gate.suspend() }
+    let request = SyncResetRequest(clearRemoteAppSelections: false, originDeviceId: "device-B")
+    controller.handle(
+      .fetchedRecordZoneChanges(modifications: [request.toCKRecord(in: zoneID)], deletions: []))
+    await gate.waitUntilEntered()
+    let task = controller.resetTask
+
+    controller.prepareForAccountSwitch()
+    gate.release()
+    await task?.value
+
+    XCTAssertFalse(store.processedResetCommandIds.contains(request.requestId))
+    XCTAssertEqual(controller.state, .disabled)
+    XCTAssertFalse(controller.hasLiveDriver)
+  }
+
+  func testGivenResetResumeFetchSuspended_WhenAccountSwitchTearsDown_ThenOutboxStaysIdle()
+    async
+  {
+    store.engineState = Data([0x01])
+    store.resetIntent = ResetIntent(
+      id: UUID(), clear: false, stage: .deleting, priorCommandId: nil)
+    let gate = StartupRecoveryGate()
+    driver.beforeFetchRecord = { await gate.suspend() }
+    let controller = makeController()
+    controller.start()
+    await gate.waitUntilEntered()
+    let task = controller.resetTask
+
+    let operationCount = driver.operations.count
+    controller.prepareForAccountSwitch()
+    gate.release()
+    await task?.value
+
+    XCTAssertEqual(driver.operations.count, operationCount)
+    XCTAssertNil(controller.reset)
+    XCTAssertNil(controller.legacyCleanup)
+    XCTAssertNil(controller.funnel)
   }
 
   func testGivenFetchedEstablishment_WhenFetchedModification_ThenRoutedToHookNotGenericApply() {
@@ -1690,6 +1801,9 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertNotNil(store.deleteTombstones["keep"], "tombstones survive (not consent-scoped)")
     XCTAssertFalse(SharedData.deviceSyncEnabled, "sync disabled")
     XCTAssertTrue(pendingSaveNames().isEmpty, "nothing enqueued")
+    XCTAssertNil(controller.reset)
+    XCTAssertNil(controller.legacyCleanup)
+    XCTAssertNil(controller.funnel)
   }
 
   func testGivenStartupPastInitialGuard_WhenZonePurgedDuringRecovery_ThenStartupExitsCleanly()
@@ -1722,6 +1836,9 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertEqual(controller.state, .disabled)
     XCTAssertNotNil(store.systemFields(for: "keep"), "account change purges nothing (§7)")
     XCTAssertTrue(controller.startupTask?.isCancelled ?? true, "in-flight continuations invalidated")
+    XCTAssertNil(controller.reset)
+    XCTAssertNil(controller.legacyCleanup)
+    XCTAssertNil(controller.funnel)
   }
 
   // MARK: - T11 stop (N5)
@@ -1749,6 +1866,9 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertNotNil(store.deleteTombstones["keep"], "tombstones survive T11 (re-propagate via I12)")
     XCTAssertEqual(driver.sendChangesCount, 1, "best-effort final send")
     XCTAssertEqual(controller.state, .disabled)
+    XCTAssertNil(controller.reset)
+    XCTAssertNil(controller.legacyCleanup)
+    XCTAssertNil(controller.funnel)
   }
 
   /// Fix 7 (T11 contract violation): a `deleteZone` enqueued by a live `.deleting` reset


### PR DESCRIPTION
## Summary

Fix the sync-engine teardown races that allowed suspended startup and reset continuations to resume after their driver had been shut down.

## Root cause

Async startup and reset work captured controller collaborators across suspension points. Account switching, sync disable, or zone purge advanced the namespace and nilled the live driver, but several continuations did not revalidate both the namespace generation and driver lifecycle before resuming work. That could dereference the controller's implicitly unwrapped driver or send stale operations through retained reset adapters.

## Suspension-site disposition

- **Startup seed entry:** `runStartupSequence` and `applySeedDecision` now require the captured generation to remain active with a live driver at entry and after each await.
- **Pending-seed purge:** the seed path rechecks lifecycle immediately after bookkeeping/session-cache purge before enqueuing zone or record work.
- **Failed-apply retry:** retry is gated before entry, after each record fetch, and before draining the re-enqueue tail, including the empty-loop tail case.
- **Reset hooks:** reset tasks are generation-gated and cancelled during teardown; `ResetController` rechecks lifecycle after async purge/fetch operations; the driver-backed reset outbox rejects stale operations, including deferred sends; teardown releases reset, funnel, and legacy-cleanup adapters.

Deterministic suspension gates cover each reachable boundary and verify that teardown neither crashes nor mutates a shut-down driver.

## Validation

- Focused suspension/teardown suite: 8 passed, 0 failed
- Full iOS simulator suite: 1,169 passed, 0 failed
- `swift-format lint --recursive .`
- `./scripts/check-c2-guards.sh`
- `./scripts/check-sync-guards.sh`
- `git diff --check`

## Known infrastructure gap

`./scripts/check-prod-schema.sh` still reports the existing #346 production deployment gap for `DeviceHeartbeat`, `EmergencyResetEpoch`, `EmergencySettings`, `EmergencyUnblockEvent`, and `SyncEstablishment`. This PR makes no schema changes.

Fixes #375