### PR TITLE
Add privacy manifests to every app bundle

### DIFF
--- a/Foqos/PrivacyInfo.xcprivacy
+++ b/Foqos/PrivacyInfo.xcprivacy
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/FoqosDeviceMonitor/PrivacyInfo.xcprivacy
+++ b/FoqosDeviceMonitor/PrivacyInfo.xcprivacy
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/FoqosShieldConfig/PrivacyInfo.xcprivacy
+++ b/FoqosShieldConfig/PrivacyInfo.xcprivacy
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/FoqosWidget/PrivacyInfo.xcprivacy
+++ b/FoqosWidget/PrivacyInfo.xcprivacy
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- add a dedicated `PrivacyInfo.xcprivacy` to the app and each of its three extension bundles
- declare only required-reason API access; do not declare collected data, tracking, or tracking domains
- rely on the filesystem-synchronized target groups so each target owns and embeds its manifest without a project-file edit

## Audit correction

Issue #345's original zero-file-timestamp assumption is incorrect. `Packages/FoqosShared/Sources/FoqosShared/Log.swift:128,136,139` reads `contentModificationDateKey` / `contentModificationDate`, and `FoqosShared` is linked into all four binaries. The built binaries independently confirm `Foundation.URLResourceValues.contentModificationDate.getter` and `_NSURLContentModificationDateKey`, so every bundle declares `FileTimestamp` with reason `C617.1`.

## Required-reason ratification

| Binary / bundle | Declared categories | Reason codes | Source evidence | Built-binary evidence |
| --- | --- | --- | --- | --- |
| `FamilyFoqos.app` | File timestamp; User defaults | `C617.1`; `CA92.1`, `1C8F.1` | Shared `Log.swift:128,136,139`; standard defaults in `AppMode.swift:53` and other app-only stores; App Group suite in `FoqosApp.swift:112` | `contentModificationDate` getter, `_NSURLContentModificationDateKey`, and `_OBJC_CLASS_$_NSUserDefaults` imports |
| `FoqosDeviceMonitor.appex` | File timestamp; User defaults | `C617.1`; `1C8F.1` | Shared `Log.swift:128,136,139`; App Group suite in `DeviceActivityMonitorExtension.swift:26` | same three API-family imports |
| `FoqosShieldConfig.appex` | File timestamp; User defaults | `C617.1`; `1C8F.1` | Shared `Log.swift:128,136,139`; App Group suite in `ShieldConfigurationExtension.swift:45` | same three API-family imports |
| `FoqosWidgetExtension.appex` | File timestamp; User defaults | `C617.1`; `1C8F.1` | Shared `Log.swift:128,136,139`; App Group suite in `FoqosWidgetBundle.swift:16` | same three API-family imports |

The source scan found no boot-time, disk-space, or active-keyboard required-reason APIs in the app targets, `FoqosShared`, or CodeScanner 2.5.2. CodeScanner has no matching source call sites and carries its own upstream privacy manifest declaring UserDefaults `CA92.1`; the statically linked app binary was still scanned as a whole.

## Validation

- recorded the pre-change failure: no manifest existed in any of the four built bundles
- `plutil -lint` passes for all source and built manifests
- each built bundle contains exactly one target-level manifest, byte-for-byte equal to its source manifest
- simulator Debug build succeeds for all targets on UUID `966A5E52-D795-4AB5-86A5-67D17B2D6413`
- full suite: 1,169 passed, 0 failed, 0 skipped
- `swift-format lint --recursive .`
- `./scripts/check-c2-guards.sh`
- `./scripts/check-sync-guards.sh`
- `git diff --check`

`./scripts/check-prod-schema.sh` still reports the five production record types tracked by #346 as missing. That pre-existing release gate is unrelated to these resource-only changes.

The definitive ITMS-91053 validation remains the first TestFlight/App Store Connect upload after this change.

Fixes #345
