### PR TITLE
Adopt the machine-wide iOS simulator gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ Agents must not invoke raw `xcodebuild` for simulator work. Give every stream a 
 and optional session name, then use the wrapper. It allocates or reuses the registry-owned iPhone
 17 on the newest compatible installed iOS runtime. Set `IOS_SIM_GATE_DEVICE_TYPE` or
 `IOS_SIM_GATE_RUNTIME` only when the task requires an override.
+Always place `xcodebuild` directly after the wrapper's `--`; never mediate it through `xcrun`,
+`env`, `bundle`, or a shell command.
 
 ```bash
 # Preserve xcodebuild's status when formatting output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,51 +6,68 @@ This file provides guidelines for agentic coding assistants working on the Famil
 
   - **NEVER** force commit or amend commits. Ever. Always create new commits for fixes, and use Git's revert feature to undo changes if needed. This preserves the integrity of the commit history and allows for proper code review.
   - **ALWAYS request code review before merging any changes.** This ensures that all changes are vetted for quality, correctness, and adherence to project standards.
-  - **NO parallel development on the same machine.** Xcode and the iOS Simulator cannot handle
-    concurrent builds or test runs: only ONE implementation stream (anything that builds or
-    tests) may be active at a time per machine. Git-level isolation does NOT lift this —
-    worktrees and extra clones still share the same build/test toolchain, so the contention is
-    Xcode, not git. Always work on feature branches, one bundle/PR at a time, branching from
-    `main` after the previous PR merges. Read-only sessions (planning, investigation, code
-    review) MAY run in parallel from their own working copy — a git worktree or a separate
-    clone — never in the checkout an implementer is actively using, and never running builds
-    or tests while an implementation stream is active.
+  - **All simulator builds and tests use the machine-wide gate.** The host supports up to three
+    Xcode/simulator streams when every stream enters through `scripts/xcode-stream.sh`. The gate
+    assigns a distinct simulator UUID, DerivedData directory, and capacity slot to each exact
+    `(project, agent, session)` owner. UUID destinations only; device-name destinations are
+    forbidden. The wrapper injects `-parallel-testing-enabled NO` and
+    `-disable-concurrent-destination-testing` to prevent XCTestDevices clones. Writing streams
+    still use separate feature branches/worktrees and disjoint file sets.
+    Read-only work does not consume a gate slot and may run concurrently from its own working copy.
 
 ## Build & Test Commands
 
 ### Building
 
-Use `./scripts/clean-build.sh` to clean build output.
-
-Use `xcpretty` to simplify output.
+Agents must not invoke raw `xcodebuild` for simulator work. Give every stream a stable agent name
+and optional session name, then use the wrapper. It allocates or reuses the registry-owned iPhone
+17 on the newest compatible installed iOS runtime. Set `IOS_SIM_GATE_DEVICE_TYPE` or
+`IOS_SIM_GATE_RUNTIME` only when the task requires an override.
 
 ```bash
-# Open in Xcode
-open FamilyFoqos.xcodeproj
+# Preserve xcodebuild's status when formatting output.
+set -o pipefail
 
 # Build from command line
-xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -configuration Debug build | xcpretty
+scripts/xcode-stream.sh --agent <agent> --session <session> -- \
+  xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -configuration Debug build 2>&1 | bundle exec xcpretty
+
+# Clean only this owner's gate-assigned DerivedData.
+scripts/xcode-stream.sh --agent <agent> --session <session> -- scripts/clean-build.sh
 ```
+
+The screenshots lane also boots a simulator, so gate its entire process tree:
+
+```bash
+scripts/xcode-stream.sh --agent <agent> --session <session> -- \
+  scripts/fastlane.sh screenshots
+```
+
+Archive and upload lanes do not boot simulators and remain unchanged; run them through
+`scripts/fastlane.sh` without the simulator gate.
 
 ### Running Tests
 The project has unit tests in the `FoqosTests` target.
 
-**Never use device names in test destinations.** Using `-destination 'platform=iOS Simulator,name=iPhone 17'` clones a new simulator into `~/Library/Developer/XCTestDevices/` on every invocation, consuming
-  ~16GB each. Use the UUID instead - run tests using:
+**Never pass a destination or DerivedData path yourself.** The wrapper injects the exact registered
+UUID and owner-scoped DerivedData. A device-name destination can create a new simulator under
+`~/Library/Developer/XCTestDevices/` on every invocation, consuming about 16 GB each.
+
 ```bash
-# 1. Find and boot the simulator (do this ONCE per session)
-xcrun simctl list devices available | grep "iPhone 17"
-# Pick the iPhone 17 UUID from the output, e.g. B9E4A679-BDF3-4541-A59F-DA4BE21F80ED
-xcrun simctl boot <UUID>
+# Run all tests. The wrapper injects UUID destination, DerivedData, and no-clone flags.
+scripts/xcode-stream.sh --agent <agent> --session <session> -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos
 
-# 2. Run all tests using the UUID (NOT the device name — using the name clones a new simulator every time)
-xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=<UUID>' | xcpretty
-
-# 3. Run a single test class
-xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -destination 'platform=iOS Simulator,id=<UUID>' -only-testing:FoqosTests/ClassName | xcpretty
+# Run a single test class.
+scripts/xcode-stream.sh --agent <agent> --session <session> -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -only-testing:FoqosTests/ClassName
 ```
 
-**IMPORTANT:** Tests take 2-3 seconds, but starting a simulator takes 3-4 minutes. Always use the simulator UUID (not name) in the `-destination` flag to reuse the already-booted simulator. Using the device name causes xcodebuild to clone a new simulator instance each time. Boot the simulator once, then run tests as many times as needed.
+The first run may spend several minutes booting the simulator. Later runs with the same exact
+agent/session owner reuse its registered UUID. Do not boot, clone, erase, or delete that simulator
+outside the wrapper.
 
 ### Code Formatting
 The project uses swift-format to maintain consistent code style. Configuration is in `.swift-format` at the repo root. A pre-commit hook auto-formats staged Swift files.
@@ -345,7 +362,11 @@ The wrong pattern blocks both Individual AND Child modes. Only Child mode should
 
 ## Build Output
 
-When running xcodebuild commands, pipe output through xcpretty for cleaner build status:
+When formatting a gated xcodebuild, enable `pipefail` so the command retains xcodebuild's status:
+
 ```bash
-xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -configuration Debug build 2>&1 | xcpretty
+set -o pipefail
+scripts/xcode-stream.sh --agent <agent> --session <session> -- \
+  xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -configuration Debug build 2>&1 | bundle exec xcpretty
 ```

--- a/docs/superpowers/plans/2026-08-10-ios-sim-gate-adoption.md
+++ b/docs/superpowers/plans/2026-08-10-ios-sim-gate-adoption.md
@@ -1,0 +1,213 @@
+# iOS Simulator Gate Adoption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans. Execute tasks
+> sequentially in this worktree because Family Foqos permits only one build/test stream on this
+> machine during adoption.
+
+**Goal:** Make `scripts/xcode-stream.sh` the single Family Foqos entrypoint for simulator builds,
+tests, and screenshots, backed by the installed machine-wide `ios-sim-gate`.
+
+**Architecture:** A Bash shim resolves or creates the exact registry-owned CoreSimulator and then
+execs the child through `ios-sim-gate run`. Its internal dispatcher enforces direct xcodebuild
+arguments and supplies gate state to Fastlane. Fastlane snapshot uses the allocated device by a
+lookup-only display name and a process-local `xcrun` adapter scopes snapshot's one global shutdown
+to the gate UUID.
+
+**Tech stack:** Bash 4, jq, CoreSimulator `simctl`, `ios-sim-gate` 0.1.0, Ruby/Fastlane 2.237.0,
+Xcodebuild.
+
+**Authoritative design:**
+`docs/superpowers/specs/2026-08-10-ios-sim-gate-adoption-design.md` at commit `a8f38ac`.
+
+## Global constraints
+
+- Do not alter or reinstall `~/.local/bin/ios-sim-gate`.
+- Do not run Xcode or a simulator outside the new shim after it exists.
+- Never select registry ownership or cleanup targets by simulator display name.
+- The xcrun adapter may rewrite only the exact argv `simctl shutdown booted`; all other argv must
+  pass unchanged to `/usr/bin/xcrun`.
+- The adapter PATH is local to the screenshot child process tree and must not persist afterward.
+- Use simulator UUIDs, never device names, in xcodebuild destinations.
+- Run all tasks sequentially; no second build/test process may overlap.
+- Never force-push or amend. Request review before merge.
+
+---
+
+### Task 1: Specify shim allocation and xcodebuild enforcement
+
+**Files:**
+- Create: `scripts/test-xcode-stream.sh`
+- Create later: `scripts/xcode-stream.sh`
+
+**Interfaces:**
+- `scripts/xcode-stream.sh --agent NAME [--session NAME] -- COMMAND [ARG ...]`
+- Consumes optional `IOS_SIM_GATE_DEVICE_TYPE` and `IOS_SIM_GATE_RUNTIME`.
+- Uses `IOS_SIM_GATE_BIN` and test-only command-path overrides only where needed for hermetic tests.
+
+- [ ] Build a temporary fake home, registry, gate, `jq`, `xcrun`, and child recorder. Keep all
+  simulator fixtures UUID-shaped so production validation is exercised.
+- [ ] Assert an available registry UUID for the exact `(family-foqos, agent, session)` is reused
+  and another owner's UUID is ignored.
+- [ ] Assert no-session and named-session owners remain distinct.
+- [ ] Assert the default allocation asks for iPhone 17 and the newest available iOS runtime; assert
+  device/runtime overrides select their exact fixtures.
+- [ ] Assert a missing or unavailable owned UUID is deleted only inside a gate run, reconciled,
+  replaced, and registered.
+- [ ] Assert a registration race deletes only the just-created loser and reuses the winner.
+- [ ] In internal xcodebuild mode, assert caller destination/DerivedData/concurrency flags are
+  rejected. Assert the wrapper injects the exact gate destination/path and both no-clone flags.
+- [ ] Make the fake xcodebuild exit 23 and assert the public wrapper exits 23.
+- [ ] Run `bash scripts/test-xcode-stream.sh` and observe RED because the shim is absent.
+
+### Task 2: Implement the minimal registry-first shim
+
+**Files:**
+- Create: `scripts/xcode-stream.sh`
+- Test: `scripts/test-xcode-stream.sh`
+
+- [ ] Parse and validate public arguments, owner identifiers, command presence, and required
+  dependencies. Resolve repository and installed-gate paths absolutely.
+- [ ] Initialize/validate gate state, read only the exact owner tuple, and confirm reuse against
+  `simctl list devices available --json`.
+- [ ] For unusable ownership, run exact deletion under `ios-sim-gate run` and reconcile.
+- [ ] Resolve device types and available iOS runtimes by identifier/name/version. Try default
+  runtimes newest-first until `simctl create` succeeds; fail an explicit incompatible runtime.
+- [ ] Register the new UUID. On owner-race failure, delete only the created UUID, reread the exact
+  tuple, and reuse the winner; otherwise return the registration failure.
+- [ ] Export lookup-only name/runtime values to the gated child and invoke the gate's `run` command.
+- [ ] Implement internal mode validation and direct xcodebuild flag rejection/injection with
+  `exec` status propagation.
+- [ ] Run `bash -n scripts/xcode-stream.sh` and `bash scripts/test-xcode-stream.sh`; expect GREEN.
+
+### Task 3: Specify and implement the exact-only xcrun adapter
+
+**Files:**
+- Extend: `scripts/test-xcode-stream.sh`
+- Create: `scripts/ios-sim-gate-bin/xcrun`
+- Modify: `scripts/xcode-stream.sh`
+
+- [ ] Add RED cases with a recording real-xcrun substitute. Pin exactly one rewrite from
+  `simctl shutdown booted` to `simctl shutdown $IOS_SIM_GATE_UDID`.
+- [ ] Pin untouched negative cases: `simctl shutdown <other-uuid>`, `simctl list devices`, global
+  flags preceding `simctl`, and arguments containing spaces.
+- [ ] Pin failure when the gate UUID is missing.
+- [ ] Pin screenshot dispatch prepends the adapter directory only in the lane child. Record the
+  caller PATH before/after and assert byte equality.
+- [ ] Implement the adapter with an overridable absolute real-xcrun path for tests and
+  `/usr/bin/xcrun` in production. Use `exec` for both rewrite and pass-through.
+- [ ] In shim internal mode, recognize only the repo's `scripts/fastlane.sh screenshots` command
+  as the screenshot lane and prepend the adapter directory in that process environment.
+- [ ] Run the shim test and shell syntax checks; expect GREEN.
+
+### Task 4: Replace wildcard DerivedData cleanup
+
+**Files:**
+- Create: `scripts/test-clean-build.sh`
+- Modify: `scripts/clean-build.sh`
+
+- [ ] Write RED tests that create two fake owner directories. Assert the script deletes exactly
+  `IOS_SIM_GATE_DERIVED_DATA_PATH` and preserves the sibling.
+- [ ] Assert unset, relative, root-level, wrong-project, and traversal-like paths fail without
+  deleting anything.
+- [ ] Implement canonical absolute-prefix validation under
+  `~/Library/Caches/ios-sim-gate/DerivedData/family-foqos/<agent>/<session>` and exact deletion.
+- [ ] Run `bash scripts/test-clean-build.sh` and `bash -n scripts/clean-build.sh`; expect GREEN.
+
+### Task 5: Wire Fastlane snapshot to the gate contract
+
+**Files:**
+- Create: `scripts/test-fastlane-sim-gate.sh`
+- Modify: `fastlane/Snapfile`
+- Modify: `fastlane/Fastfile`
+- Verify: `scripts/test-fastlane-credential-routing.sh`
+
+- [ ] Write a structural/behavioral RED test that loads the snapshot configuration with fake gate
+  environment. Assert device name/runtime, DerivedData, and both no-clone xcargs come from the gate.
+- [ ] Assert the screenshots lane fails closed without the gate contract and verifies Fastlane's
+  name/runtime lookup resolves to `IOS_SIM_GATE_UDID`.
+- [ ] Assert the old XCTestDevices inventory, model matching, and deletion loop are absent.
+- [ ] Replace the fixed Snapfile device with required gate environment values. Add
+  `derived_data_path`, `ios_version`, and exact no-clone `xcargs`.
+- [ ] Replace the screenshot cleanup loop with a small gate-contract assertion before `snapshot`.
+  Leave framing/output behavior unchanged.
+- [ ] Run the new Fastlane gate test, credential routing test, `ruby -c fastlane/Fastfile`, and
+  RuboCop on the modified Ruby file; expect GREEN.
+
+### Task 6: Make agent policy and examples wrapper-only
+
+**Files:**
+- Extend: `scripts/test-xcode-stream.sh`
+- Modify: `AGENTS.md`
+
+- [ ] Add RED structural assertions for: three streams, wrapper-only simulator builds/tests,
+  UUID-only destinations, mandatory no-clone flags, gated screenshots, scoped clean-build, and
+  read-only work not consuming a slot.
+- [ ] Replace the stale no-parallel rule. Preserve the one-implementation-stream restriction only
+  for the current adoption session if necessary; the steady-state rule is gate capacity three.
+- [ ] Replace direct build/test examples with `scripts/xcode-stream.sh --agent ...` invocations,
+  including full-suite and single-test examples. Keep archive/upload lanes documented as unchanged.
+- [ ] Run the shim test and `git diff --check`; expect GREEN.
+
+### Task 7: Run all local verification before the real simulator smoke
+
+**Files:** none expected
+
+- [ ] Run all shell tests sequentially:
+
+  ```bash
+  scripts/test-check-prod-schema.sh
+  scripts/test-fastlane-credential-routing.sh
+  scripts/test-fastlane-gates.sh
+  scripts/test-xcode-stream.sh
+  scripts/test-clean-build.sh
+  scripts/test-fastlane-sim-gate.sh
+  ```
+
+- [ ] Run `shellcheck` on every modified shell script and `bundle exec rubocop fastlane/Fastfile`.
+- [ ] Run `ruby -c fastlane/Fastfile`, `git diff --check`, and inspect the complete diff.
+- [ ] Confirm the fake exit-23 case, exact adapter negatives, and caller-PATH equality are visibly
+  reported by the tests.
+
+### Task 8: Run the required real FoqosTests smoke through the shim
+
+**Files:** none expected
+
+- [ ] Capture `ios-sim-gate status`, the registry entry, normal simulator inventory, testing-device
+  inventory, and caller PATH before the run.
+- [ ] Run the full test suite sequentially through the new entrypoint, for example:
+
+  ```bash
+  scripts/xcode-stream.sh --agent build2 --session adoption-tests -- \
+    xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos
+  ```
+
+- [ ] Capture the wrapper exit code and post-run status/inventories. Confirm the owner maps to the
+  used UUID, all gate slots are free, and no new `Clone N of ...` testing device exists.
+
+### Task 9: Run the required real screenshots smoke through the shim
+
+**Files:** screenshot output may be regenerated but should remain within existing repository rules
+
+- [ ] With no overlapping Xcode process, capture the same gate/inventory/PATH baseline.
+- [ ] Run:
+
+  ```bash
+  scripts/xcode-stream.sh --agent build2 --session adoption-screenshots -- \
+    scripts/fastlane.sh screenshots
+  ```
+
+- [ ] Confirm exit zero, exact registry ownership, released slot, no new clone, and caller PATH
+  byte equality. Confirm logs show snapshot used the allocated UUID and scoped DerivedData.
+- [ ] If the xcrun adapter needs any behavior beyond the approved one rewrite, stop and report
+  instead of broadening it.
+
+### Task 10: Publish a ready PR and request review
+
+**Files:** none expected
+
+- [ ] Commit implementation as new signed commits; never amend.
+- [ ] Verify commit signatures and clean branch status.
+- [ ] Push `feat/362-sim-gate-adoption` and open a ready-for-review PR. The body must include
+  `Closes #362`, smoke evidence, and an explicit note that #363 is not included.
+- [ ] Request code review through AMQ thread `adopt/ios-sim-gate-review` before merge.
+- [ ] Reply to planner thread `adopt/ios-sim-gate` with PR number and exact smoke evidence.

--- a/docs/superpowers/plans/2026-08-10-ios-sim-gate-adoption.md
+++ b/docs/superpowers/plans/2026-08-10-ios-sim-gate-adoption.md
@@ -211,3 +211,40 @@ Xcodebuild.
   `Closes #362`, smoke evidence, and an explicit note that #363 is not included.
 - [ ] Request code review through AMQ thread `adopt/ios-sim-gate-review` before merge.
 - [ ] Reply to planner thread `adopt/ios-sim-gate` with PR number and exact smoke evidence.
+
+### Task 11: Close PR #378 simulator-isolation review findings
+
+**Files:**
+- Modify: `scripts/test-xcode-stream.sh`
+- Modify: `scripts/xcode-stream.sh`
+- Modify: `scripts/test-fastlane-sim-gate.sh`
+- Modify: `fastlane/simulator_gate.rb`
+- Modify: `scripts/test-clean-build.sh`
+- Modify: `scripts/clean-build.sh`
+- Modify: `AGENTS.md`
+
+- [ ] Add behavioral tests proving every internal child receives the scoped xcrun adapter PATH,
+  including a `bundle exec`-style command, while screenshot-only environment assertions remain
+  scoped to `scripts/fastlane.sh screenshots`. Run the test and observe the current conditional
+  adapter installation fail.
+- [ ] Install the adapter PATH unconditionally immediately after validating the internal gate
+  contract. Keep the exact three-argument adapter rewrite unchanged, then rerun the focused test.
+- [ ] Add a Fastlane test with two simulators sharing the configured name/runtime and observe that
+  the current first-match lookup accepts ambiguity. Require exactly one name/runtime match and
+  require its UUID to equal the gate UUID, then rerun the focused test.
+- [ ] Add a wrapper test with an unregistered simulator whose display name equals the exact planned
+  owner name and observe a second simulator being created. Refuse allocation before `simctl create`
+  when any simulator already has that display name, without deleting the orphan, then rerun the
+  focused test.
+- [ ] Add direct-mode tests for a later exact `xcodebuild` token, `OBJROOT=`, `SYMROOT=`,
+  `BUILD_DIR=`, and `-xcconfig`; observe acceptance, extend the existing rejection loop, and rerun
+  the focused test. Document that xcodebuild must be argv[0] after `--`, never mediated by
+  `xcrun`, `env`, or a shell.
+- [ ] Add a clean-build test whose cache root is supplied through `IOS_SIM_GATE_CACHE_HOME` and
+  differs from `$HOME/Library/Caches/ios-sim-gate`; observe refusal, derive the trusted project root
+  from that variable with the gate's existing default, and rerun the focused test.
+- [ ] Run all shell and Ruby verification, then sequentially rerun the full FoqosTests gate smoke
+  and screenshots gate smoke. Confirm exact exit status, released slots, unchanged XCTestDevices
+  clone inventory, and caller PATH equality.
+- [ ] Create a new signed commit, push without amend or force, request delta review on
+  `adopt/ios-sim-gate-review`, and reply on `adopt/ios-sim-gate` with the new head SHA and evidence.

--- a/docs/superpowers/specs/2026-08-10-ios-sim-gate-adoption-design.md
+++ b/docs/superpowers/specs/2026-08-10-ios-sim-gate-adoption-design.md
@@ -1,0 +1,215 @@
+# iOS Simulator Gate Adoption
+
+**Date:** 2026-08-10
+**Issue:** #362
+**Status:** Approved by the planner on `adopt/ios-sim-gate`
+**Scope:** Family Foqos simulator allocation, Xcode test/build entrypoints, Fastlane screenshots,
+DerivedData cleanup, and agent guidance
+
+## Problem
+
+Family Foqos still documents one Xcode implementation stream per machine and exposes raw
+`xcodebuild` commands. Its cleanup script deletes every matching DerivedData directory, and the
+screenshots lane inventories and deletes XCTestDevices clones by display name. Those conventions
+cannot safely support three concurrent Xcode/simulator streams.
+
+The machine-wide `ios-sim-gate` is now installed at `~/.local/bin/ios-sim-gate`. It already owns
+the three-slot semaphore, per-simulator locks, the registry, per-owner DerivedData paths, cleanup,
+and child exit propagation. The repository must adopt that contract without duplicating the gate.
+In particular, the repository still owns selecting or creating the simulator for an exact
+`(project, agent, session)` owner and ensuring every simulator-using project command actually
+consumes the environment exported by the gate.
+
+This design supersedes the proposed repository-local lock implementation in
+`2026-08-09-three-stream-concurrency.md`. That document remains useful historical context, but its
+custom Ruby semaphore, coordinator-assigned simulator table, and XCTestDevices clone cleanup are
+replaced by the standalone gate and this adoption shim.
+
+## Constraints
+
+- At most three Xcode/simulator streams run concurrently across the machine. The installed gate,
+  not this repository, enforces that capacity.
+- Every Family Foqos simulator build or test uses one repository entrypoint and one exact UUID.
+  Device display names never establish ownership.
+- The owner key is exactly `(project, agent, session)`, with project `family-foqos`. Reuse is only
+  from the gate registry entry for that exact tuple.
+- The default device type is `iPhone 17`; `IOS_SIM_GATE_DEVICE_TYPE` overrides it. The newest
+  compatible installed iOS runtime is selected unless `IOS_SIM_GATE_RUNTIME` overrides it.
+- Every direct `xcodebuild` receives the gate-exported UUID destination and DerivedData path plus
+  `-parallel-testing-enabled NO` and `-disable-concurrent-destination-testing`.
+- `scripts/fastlane.sh screenshots` is one gated unit for its entire process tree. Archive and
+  upload lanes remain unchanged because they do not boot a simulator.
+- Cleanup deletes only exact gate-owned paths or UUIDs. Wildcards and model/name-selected deletion
+  are forbidden.
+- Read-only work and read-only discovery do not consume a slot.
+- The adoption must preserve the child command's exact exit status.
+- The real acceptance run includes both the full `FoqosTests` suite and the screenshots lane.
+- Session Credential Warm-up (#363) is deliberately outside this change.
+
+## Options Considered
+
+### 1. One generic admission wrapper plus a thin Fastlane bridge — selected
+
+A shell entrypoint owns registry lookup/allocation and delegates the process tree to
+`ios-sim-gate run`. Its internal dispatcher enforces direct `xcodebuild` arguments and supplies
+the gate environment to the screenshot lane. This provides one documented path and one allocator
+without rebuilding the machine-wide lock implementation.
+
+Fastlane snapshot accepts an exact DerivedData path and xcodebuild arguments, but looks up a
+simulator by display name and unconditionally invokes `xcrun simctl shutdown booted`. The bridge
+therefore supplies a deterministic display name and exact runtime only as lookup keys. A tiny,
+process-local `xcrun` adapter rewrites exactly:
+
+```text
+simctl shutdown booted
+```
+
+to:
+
+```text
+simctl shutdown <IOS_SIM_GATE_UDID>
+```
+
+Every other argument vector is passed to `/usr/bin/xcrun` unchanged. The adapter directory is
+prepended to `PATH` only for the gated screenshot lane's process tree, so the caller's environment
+is unchanged when the wrapper exits. If the adapter needs any second rewrite, implementation stops
+for design review.
+
+### 2. Separate test and screenshot wrappers
+
+This makes each dispatcher smaller but duplicates registry resolution, allocation races, runtime
+selection, and stale-device replacement. The duplicated lifecycle is more dangerous than the
+small amount of command dispatch in option 1.
+
+### 3. Keep Fastlane independent and only document raw gate commands
+
+This produces the smallest diff, but it does not enforce one entrypoint, cannot guarantee snapshot
+uses gate-owned DerivedData or no-clone flags, and leaves the global `shutdown booted` hazard.
+
+## Design
+
+### Public entrypoint
+
+Add `scripts/xcode-stream.sh` with this interface:
+
+```bash
+scripts/xcode-stream.sh --agent <agent> [--session <session>] -- <command> [args...]
+```
+
+The wrapper uses absolute repository paths, a fixed project key of `family-foqos`, and Bash 4 to
+invoke the installed gate. `--agent`, optional `--session`, device/runtime overrides, and the child
+argument vector are validated before mutation. The public mode never accepts a caller-supplied
+UUID; ownership and reuse come from the registry.
+
+After resolution, public mode executes:
+
+```text
+ios-sim-gate run --project family-foqos --agent <agent> [--session <session>] \
+  --udid <resolved-uuid> -- scripts/xcode-stream.sh __execute -- <command> [args...]
+```
+
+The gate exports `IOS_SIM_GATE_UDID`, `IOS_SIM_GATE_DESTINATION`,
+`IOS_SIM_GATE_DERIVED_DATA_PATH`, `IOS_SIM_GATE_PROJECT`, `IOS_SIM_GATE_AGENT`, and optional
+`IOS_SIM_GATE_SESSION`. The internal mode refuses to run without that complete contract.
+
+For a direct `xcodebuild`, internal mode rejects any caller-provided `-destination`,
+`-derivedDataPath`, `-parallel-testing-enabled`, or
+`-disable-concurrent-destination-testing` argument. It then appends the exact gate values and both
+no-clone flags and uses `exec`, preserving the xcodebuild status.
+
+For `scripts/fastlane.sh screenshots`, internal mode exports the resolved simulator display name
+and runtime version, prepends the committed adapter directory to that child's `PATH`, and execs the
+lane. Other commands inherit the gate environment but receive no simulator-specific rewriting.
+The documented simulator-using commands are direct xcodebuild and the screenshots lane.
+
+### Registry-first allocation
+
+The wrapper asks the gate to initialize and validate state, then reads the registry under the
+gate's published registry format. It searches only for the exact project/agent/session tuple:
+
+1. If that tuple owns an available CoreSimulator UUID, reuse it.
+2. If it owns a missing or unavailable UUID, run exact-UUID deletion through
+   `ios-sim-gate run`, then call `ios-sim-gate reconcile` to prune the registry entry. This waits
+   for the simulator lock and cannot delete a sibling's device.
+3. If the tuple has no usable UUID, resolve the requested device type and installed iOS runtime,
+   create one simulator, and register its exact UUID.
+
+Default runtime selection considers available iOS runtimes newest first and selects the first one
+compatible with the requested device type. An explicit override resolves by exact identifier,
+name, or version and fails closed if unavailable or incompatible.
+
+Creation and registration are race-aware. If another invocation registers the same owner after
+this invocation's lookup, the loser deletes only the UUID it just created, rereads the registry,
+and reuses the winner. Any other registration failure also deletes only the newly created UUID and
+returns nonzero. Display names are deterministic for diagnostics and Fastlane lookup, but no
+ownership or cleanup decision reads the name.
+
+### Fastlane screenshots
+
+`Snapfile` and the screenshots lane fail closed unless the gate variables are present. They select
+the wrapper-resolved display name/runtime, set snapshot DerivedData to
+`IOS_SIM_GATE_DERIVED_DATA_PATH`, and pass both no-clone flags through `xcargs`. Snapshot's generated
+destination resolves to the registered UUID; the lane checks that lookup before the test starts.
+
+The old before/after XCTestDevices inventory and model-name deletion loop is removed. A compliant
+screenshot run must create no `Clone N of ...` testing device, so there is nothing for the
+repository to clean. Snapshot's one global `shutdown booted` call is constrained by the adapter to
+the gate UUID. Tests pin both the one allowed rewrite and a negative case such as
+`simctl shutdown <other-uuid>` passing through unchanged.
+
+### Scoped DerivedData cleanup
+
+`scripts/clean-build.sh` consumes `IOS_SIM_GATE_DERIVED_DATA_PATH`. It refuses an unset path, a
+relative path, the gate DerivedData root itself, and any path outside the Family Foqos subtree:
+
+```text
+~/Library/Caches/ios-sim-gate/DerivedData/family-foqos/<agent>/<session>
+```
+
+It removes exactly that validated path. It has no wildcard and cannot reach another owner's
+DerivedData.
+
+### Agent guidance
+
+`AGENTS.md` replaces the single-stream ban with these operational rules:
+
+- up to three simulator/Xcode streams may run, subject to the machine-wide gate;
+- all simulator builds/tests use `scripts/xcode-stream.sh` and UUID destinations;
+- the no-clone flags are mandatory and injected by the wrapper;
+- the screenshots lane uses the same wrapper around `scripts/fastlane.sh screenshots`;
+- archive/upload lanes remain outside the simulator gate;
+- read-only work is unrestricted, while writing streams still use disjoint worktrees/files; and
+- clean-build is called only inside a gate-owned process with its exact DerivedData environment.
+
+The Running Tests examples use the wrapper for the full suite and `-only-testing` selections.
+
+## Testing and Acceptance
+
+Shell tests use fake `ios-sim-gate`, `xcrun`, `xcodebuild`, and Fastlane commands to pin:
+
+- exact-tuple reuse and no cross-owner borrowing;
+- default and overridden device/runtime allocation;
+- stale/unavailable replacement through the gate;
+- registration-race cleanup of only the invocation-created UUID;
+- rejection and injection of direct xcodebuild arguments;
+- exact child status propagation;
+- exact-match-only xcrun rewriting, including untouched negative cases;
+- screenshot-only PATH scoping and Fastlane environment wiring; and
+- exact-path clean-build validation.
+
+Fastlane-focused tests verify the screenshot lane consumes the gate values and that the old clone
+cleanup is absent. Existing script tests, `shellcheck`, RuboCop, and `git diff --check` remain green.
+
+The real smoke records normal and XCTestDevices inventories before and after each run, then:
+
+1. runs all `FoqosTests` once through `scripts/xcode-stream.sh`;
+2. runs `scripts/fastlane.sh screenshots` once through the same entrypoint;
+3. confirms both commands return zero and a synthetic nonzero harness proves exact status
+   pass-through;
+4. confirms the registry maps the exact owner tuple to the used UUID;
+5. confirms the acquired slot is free after each process exits;
+6. confirms no new `Clone N of ...` simulator exists; and
+7. confirms the caller's `PATH` is byte-identical before and after the screenshot wrapper.
+
+The PR is ready for review, says `Closes #362`, and explicitly notes that #363 is not included.
+Review is requested through the AMQ thread `adopt/ios-sim-gate-review` before merge.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,6 +5,7 @@ require 'json'
 require 'shellwords'
 require File.expand_path('archive_storage', __dir__)
 require File.expand_path('asc_credentials', __dir__)
+require File.expand_path('simulator_gate', __dir__)
 
 # Runs under Homebrew Ruby via Bundler: export PATH="$(brew --prefix ruby)/bin:$PATH" && bundle exec fastlane <lane>
 default_platform(:ios)
@@ -14,8 +15,6 @@ SCHEME = 'FamilyFoqos'
 ARCHIVE_DIR = File.expand_path('~/Archives/family-foqos')
 REPO_ROOT = File.expand_path('..', __dir__)
 RELEASE_BLOCKING_LABEL = 'release-blocking'
-XCTEST_DEVICES_DIR = File.expand_path('~/Library/Developer/XCTestDevices')
-SNAPSHOT_DEVICE_NAME = 'iPhone 17 Pro Max'
 
 platform :ios do
   private_lane :preflight do
@@ -135,6 +134,13 @@ platform :ios do
     UI.success('Validated 3 framed en-GB screenshots')
   end
 
+  private_lane :assert_snapshot_gate do
+    SimulatorGate.assert_registered_device!(FastlaneCore::DeviceManager.simulators)
+    UI.message("Verified gate-owned screenshot simulator: #{ENV.fetch('IOS_SIM_GATE_UDID')}")
+  rescue SimulatorGate::GateError => e
+    UI.user_error!(e.message)
+  end
+
   def derived_build_number
     sh('git rev-list --count HEAD', log: false).strip
   end
@@ -214,49 +220,8 @@ platform :ios do
 
   desc 'Regenerate all App Store screenshots (demo mode + snapshot + frameit)'
   lane :screenshots do
-    before = Dir.exist?(XCTEST_DEVICES_DIR) ? Dir.children(XCTEST_DEVICES_DIR) : []
-    UI.message("XCTestDevices before snapshot: #{before.count}")
-
-    begin
-      snapshot
-    ensure
-      after = Dir.exist?(XCTEST_DEVICES_DIR) ? Dir.children(XCTEST_DEVICES_DIR) : []
-      created = after - before
-      UI.message("XCTestDevices after snapshot: #{after.count}; created this run: #{created.count}")
-
-      created.each do |udid|
-        unless udid.match?(/\A[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\z/)
-          UI.important("Refusing to delete unexpected XCTestDevices entry: #{udid}")
-          next
-        end
-
-        device_plist = File.join(XCTEST_DEVICES_DIR, udid, 'device.plist')
-        begin
-          device_name = sh(
-            'plutil', '-extract', 'name', 'raw', '-o', '-', device_plist, log: false
-          ).strip
-        rescue StandardError => e
-          UI.important("Preserving XCTestDevices entry #{udid}; name unavailable: #{e.message}")
-          next
-        end
-        expected_name = /\A(?:Clone \d+ of )?#{Regexp.escape(SNAPSHOT_DEVICE_NAME)}\z/
-        unless device_name.match?(expected_name)
-          UI.message("Preserving concurrent test simulator #{udid} named '#{device_name}'")
-          next
-        end
-
-        begin
-          sh('xcrun', 'simctl', '--set', XCTEST_DEVICES_DIR, 'shutdown', udid, log: false)
-        rescue StandardError => e
-          UI.message("Test simulator #{udid} was already stopped: #{e.message}")
-        end
-        sh('xcrun', 'simctl', '--set', XCTEST_DEVICES_DIR, 'delete', udid, log: false)
-        UI.message("Removed run-created test simulator #{udid}")
-      end
-
-      remaining = Dir.exist?(XCTEST_DEVICES_DIR) ? Dir.children(XCTEST_DEVICES_DIR) : []
-      UI.message("XCTestDevices after cleanup: #{remaining.count}")
-    end
+    assert_snapshot_gate
+    snapshot
 
     screenshots_directory = File.expand_path('screenshots', __dir__)
     background = File.join(screenshots_directory, 'background.png')

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,11 +1,20 @@
+unless defined?(SimulatorGate)
+  raise 'Run screenshots through scripts/xcode-stream.sh and scripts/fastlane.sh screenshots'
+end
+
+simulator_gate = SimulatorGate.snapshot_configuration
+
 devices([
-  "iPhone 17 Pro Max"
+  simulator_gate.fetch(:device_name)
 ])
 
 languages(["en-GB"])
 
 scheme("FoqosScreenshots")
 project("FamilyFoqos.xcodeproj")
+ios_version(simulator_gate.fetch(:runtime_version))
+derived_data_path(simulator_gate.fetch(:derived_data_path))
+xcargs(simulator_gate.fetch(:xcargs))
 app_identifier("com.cynexia.family-foqos")
 output_directory("./fastlane/screenshots")
 # Keep this true so the Fastfile's exactly-three framed check cannot pass on stale output.

--- a/fastlane/simulator_gate.rb
+++ b/fastlane/simulator_gate.rb
@@ -43,12 +43,14 @@ module SimulatorGate
 
   def self.assert_registered_device!(simulators, env: ENV)
     config = snapshot_configuration(env)
-    exact_device = simulators.find do |simulator|
+    matching_devices = simulators.select do |simulator|
       simulator.name.strip == config.fetch(:device_name).strip &&
-        simulator.os_version == config.fetch(:runtime_version) &&
-        simulator.udid == config.fetch(:uuid)
+        simulator.os_version == config.fetch(:runtime_version)
     end
-    return true if exact_device
+    unless matching_devices.one?
+      raise GateError, 'Fastlane simulator lookup must resolve exactly one name/runtime match'
+    end
+    return true if matching_devices.first.udid == config.fetch(:uuid)
 
     raise GateError, 'Fastlane simulator lookup does not resolve to the gate-owned UUID'
   end

--- a/fastlane/simulator_gate.rb
+++ b/fastlane/simulator_gate.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module SimulatorGate
+  class GateError < StandardError; end
+
+  REQUIRED_ENV = %w[
+    IOS_SIM_GATE_PROJECT
+    IOS_SIM_GATE_AGENT
+    IOS_SIM_GATE_UDID
+    IOS_SIM_GATE_DESTINATION
+    IOS_SIM_GATE_DERIVED_DATA_PATH
+    IOS_SIM_GATE_DEVICE_NAME
+    IOS_SIM_GATE_RUNTIME_VERSION
+  ].freeze
+  UUID_PATTERN = /\A[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\z/
+  XCODEBUILD_ARGUMENTS = '-parallel-testing-enabled NO ' \
+                         '-disable-concurrent-destination-testing'
+
+  def self.snapshot_configuration(env = ENV)
+    missing = REQUIRED_ENV.select { |key| env[key].to_s.empty? }
+    raise GateError, "Missing simulator gate environment: #{missing.join(', ')}" unless missing.empty?
+
+    uuid = env.fetch('IOS_SIM_GATE_UDID')
+    raise GateError, 'Invalid simulator gate UUID' unless uuid.match?(UUID_PATTERN)
+    raise GateError, 'Unexpected simulator gate project' unless env.fetch('IOS_SIM_GATE_PROJECT') == 'family-foqos'
+
+    destination = env.fetch('IOS_SIM_GATE_DESTINATION')
+    unless destination == "platform=iOS Simulator,id=#{uuid}"
+      raise GateError, 'Simulator gate destination does not match its UUID'
+    end
+
+    derived_data_path = env.fetch('IOS_SIM_GATE_DERIVED_DATA_PATH')
+    raise GateError, 'Simulator gate DerivedData path must be absolute' unless derived_data_path.start_with?('/')
+
+    {
+      uuid: uuid,
+      device_name: env.fetch('IOS_SIM_GATE_DEVICE_NAME'),
+      runtime_version: env.fetch('IOS_SIM_GATE_RUNTIME_VERSION'),
+      derived_data_path: derived_data_path,
+      xcargs: XCODEBUILD_ARGUMENTS
+    }
+  end
+
+  def self.assert_registered_device!(simulators, env: ENV)
+    config = snapshot_configuration(env)
+    exact_device = simulators.find do |simulator|
+      simulator.name.strip == config.fetch(:device_name).strip &&
+        simulator.os_version == config.fetch(:runtime_version) &&
+        simulator.udid == config.fetch(:uuid)
+    end
+    return true if exact_device
+
+    raise GateError, 'Fastlane simulator lookup does not resolve to the gate-owned UUID'
+  end
+end

--- a/scripts/clean-build.sh
+++ b/scripts/clean-build.sh
@@ -11,7 +11,8 @@ target="${IOS_SIM_GATE_DERIVED_DATA_PATH:-}"
   exit 1
 }
 
-project_root="$HOME/Library/Caches/ios-sim-gate/DerivedData/family-foqos"
+cache_root="${IOS_SIM_GATE_CACHE_HOME:-$HOME/Library/Caches/ios-sim-gate}"
+project_root="$cache_root/DerivedData/family-foqos"
 case "$target" in
   "$project_root"/*) ;;
   *)

--- a/scripts/clean-build.sh
+++ b/scripts/clean-build.sh
@@ -1,4 +1,60 @@
 #!/bin/bash
-# Clean Xcode derived data for FamilyFoqos project
-rm -rf "${HOME}/Library/Developer/Xcode/DerivedData/FamilyFoqos-"* 2>/dev/null
-echo "Cleaned FamilyFoqos derived data"
+set -euo pipefail
+
+target="${IOS_SIM_GATE_DERIVED_DATA_PATH:-}"
+[[ -n "$target" ]] || {
+  echo "clean-build: requires IOS_SIM_GATE_DERIVED_DATA_PATH from ios-sim-gate" >&2
+  exit 1
+}
+[[ "$target" == /* ]] || {
+  echo "clean-build: refusing relative DerivedData path: $target" >&2
+  exit 1
+}
+
+project_root="$HOME/Library/Caches/ios-sim-gate/DerivedData/family-foqos"
+case "$target" in
+  "$project_root"/*) ;;
+  *)
+    echo "clean-build: refusing path outside Family Foqos gate storage: $target" >&2
+    exit 1
+    ;;
+esac
+
+relative=${target#"$project_root"/}
+case "/$relative/" in
+  */../*|*/./*)
+    echo "clean-build: refusing traversal-like DerivedData path: $target" >&2
+    exit 1
+    ;;
+esac
+
+IFS=/ read -r agent owner_scope extra <<<"$relative"
+if [[ -z "$agent" || -z "$owner_scope" || -n "${extra:-}" ]]; then
+  echo "clean-build: refusing non-owner DerivedData path: $target" >&2
+  exit 1
+fi
+[[ "$agent" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]] || {
+  echo "clean-build: refusing invalid gate agent path: $target" >&2
+  exit 1
+}
+if [[ "$owner_scope" != "no-session" &&
+  ! "$owner_scope" =~ ^session-[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]]; then
+  echo "clean-build: refusing invalid gate session path: $target" >&2
+  exit 1
+fi
+
+if [[ ! -e "$target" && ! -L "$target" ]]; then
+  echo "DerivedData already absent: $target"
+  exit 0
+fi
+
+canonical_root=$(cd "$project_root" && pwd -P)
+canonical_parent=$(cd "$(dirname "$target")" && pwd -P)
+canonical_target="$canonical_parent/$(basename "$target")"
+[[ "$canonical_target" == "$canonical_root/$agent/$owner_scope" ]] || {
+  echo "clean-build: refusing path whose canonical parent escapes gate storage: $target" >&2
+  exit 1
+}
+
+rm -rf -- "$target"
+echo "Cleaned gate-owned DerivedData: $target"

--- a/scripts/ios-sim-gate-bin/xcrun
+++ b/scripts/ios-sim-gate-bin/xcrun
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+REAL_XCRUN="${IOS_SIM_GATE_REAL_XCRUN:-/usr/bin/xcrun}"
+[[ -x "$REAL_XCRUN" ]] || {
+  echo "ios-sim-gate xcrun adapter: real xcrun is not executable: $REAL_XCRUN" >&2
+  exit 127
+}
+
+if [[ "$#" -eq 3 && "$1" == "simctl" && "$2" == "shutdown" && "$3" == "booted" ]]; then
+  [[ -n "${IOS_SIM_GATE_UDID:-}" ]] || {
+    echo "ios-sim-gate xcrun adapter: IOS_SIM_GATE_UDID is required" >&2
+    exit 1
+  }
+  [[ "$IOS_SIM_GATE_UDID" =~ ^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$ ]] || {
+    echo "ios-sim-gate xcrun adapter: IOS_SIM_GATE_UDID is invalid" >&2
+    exit 1
+  }
+  exec "$REAL_XCRUN" simctl shutdown "$IOS_SIM_GATE_UDID"
+fi
+
+exec "$REAL_XCRUN" "$@"

--- a/scripts/test-clean-build.sh
+++ b/scripts/test-clean-build.sh
@@ -25,6 +25,20 @@ HOME="$FAKE_HOME" IOS_SIM_GATE_DERIVED_DATA_PATH="$GATE_ROOT/build2/session-a" \
 [[ ! -e "$GATE_ROOT/build2/session-a" ]] || fail "exact owner DerivedData was not removed"
 [[ -f "$GATE_ROOT/build2/session-b/sibling" ]] || fail "sibling DerivedData was removed"
 
+CUSTOM_CACHE_ROOT="$TEST_ROOT/custom-gate-cache"
+CUSTOM_PROJECT_ROOT="$CUSTOM_CACHE_ROOT/DerivedData/family-foqos"
+mkdir -p "$CUSTOM_PROJECT_ROOT/build3/session-custom" \
+  "$CUSTOM_PROJECT_ROOT/build3/session-sibling"
+touch "$CUSTOM_PROJECT_ROOT/build3/session-custom/owned" \
+  "$CUSTOM_PROJECT_ROOT/build3/session-sibling/sibling"
+HOME="$FAKE_HOME" IOS_SIM_GATE_CACHE_HOME="$CUSTOM_CACHE_ROOT" \
+  IOS_SIM_GATE_DERIVED_DATA_PATH="$CUSTOM_PROJECT_ROOT/build3/session-custom" \
+  "$CLEAN_SCRIPT"
+[[ ! -e "$CUSTOM_PROJECT_ROOT/build3/session-custom" ]] ||
+  fail "custom-cache owner DerivedData was not removed"
+[[ -f "$CUSTOM_PROJECT_ROOT/build3/session-sibling/sibling" ]] ||
+  fail "custom-cache sibling DerivedData was removed"
+
 assert_refused() {
   local description=$1
   local target=${2-__unset__}

--- a/scripts/test-clean-build.sh
+++ b/scripts/test-clean-build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLEAN_SCRIPT="$REPO_ROOT/scripts/clean-build.sh"
+TEST_ROOT=$(mktemp -d)
+FAKE_HOME="$TEST_ROOT/home"
+GATE_ROOT="$FAKE_HOME/Library/Caches/ios-sim-gate/DerivedData/family-foqos"
+
+cleanup() {
+  rm -rf -- "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+mkdir -p "$GATE_ROOT/build2/session-a" "$GATE_ROOT/build2/session-b"
+touch "$GATE_ROOT/build2/session-a/owned" "$GATE_ROOT/build2/session-b/sibling"
+
+HOME="$FAKE_HOME" IOS_SIM_GATE_DERIVED_DATA_PATH="$GATE_ROOT/build2/session-a" \
+  "$CLEAN_SCRIPT"
+[[ ! -e "$GATE_ROOT/build2/session-a" ]] || fail "exact owner DerivedData was not removed"
+[[ -f "$GATE_ROOT/build2/session-b/sibling" ]] || fail "sibling DerivedData was removed"
+
+assert_refused() {
+  local description=$1
+  local target=${2-__unset__}
+  local output
+  local status
+
+  mkdir -p "$GATE_ROOT/build2/session-b"
+  touch "$GATE_ROOT/build2/session-b/sibling"
+  set +e
+  if [[ "$target" == "__unset__" ]]; then
+    output=$(env -u IOS_SIM_GATE_DERIVED_DATA_PATH HOME="$FAKE_HOME" "$CLEAN_SCRIPT" 2>&1)
+    status=$?
+  else
+    output=$(HOME="$FAKE_HOME" IOS_SIM_GATE_DERIVED_DATA_PATH="$target" "$CLEAN_SCRIPT" 2>&1)
+    status=$?
+  fi
+  set -e
+
+  [[ "$status" -ne 0 ]] || fail "$description target was accepted"
+  [[ "$output" == *"refusing"* || "$output" == *"requires"* ]] ||
+    fail "$description failure was not explicit: $output"
+  [[ -f "$GATE_ROOT/build2/session-b/sibling" ]] ||
+    fail "$description failure removed sibling DerivedData"
+}
+
+assert_refused "unset"
+assert_refused "relative" "relative/DerivedData"
+assert_refused "gate project root" "$GATE_ROOT"
+assert_refused "wrong project" \
+  "$FAKE_HOME/Library/Caches/ios-sim-gate/DerivedData/other-project/build2/session-b"
+assert_refused "traversal-like" "$GATE_ROOT/build2/session-b/../../other-project/owned"
+
+echo "PASS: clean-build deletes only exact gate-owned Family Foqos DerivedData"

--- a/scripts/test-fastlane-sim-gate.sh
+++ b/scripts/test-fastlane-sim-gate.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_ROOT=$(mktemp -d)
+
+cleanup() {
+  rm -rf -- "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+cat >"$TEST_ROOT/test.rb" <<'RUBY'
+# frozen_string_literal: true
+
+require File.expand_path('fastlane/simulator_gate', ENV.fetch('REPO_ROOT'))
+
+UUID = '11111111-1111-1111-1111-111111111111'
+ENV['IOS_SIM_GATE_PROJECT'] = 'family-foqos'
+ENV['IOS_SIM_GATE_AGENT'] = 'build2'
+ENV['IOS_SIM_GATE_SESSION'] = 'screenshots'
+ENV['IOS_SIM_GATE_UDID'] = UUID
+ENV['IOS_SIM_GATE_DESTINATION'] = "platform=iOS Simulator,id=#{UUID}"
+ENV['IOS_SIM_GATE_DERIVED_DATA_PATH'] = '/tmp/gate-derived-data'
+ENV['IOS_SIM_GATE_DEVICE_NAME'] = 'Family Foqos - build2 - screenshots'
+ENV['IOS_SIM_GATE_RUNTIME_VERSION'] = '26.0'
+
+config = SimulatorGate.snapshot_configuration
+raise 'wrong device' unless config.fetch(:device_name) == ENV.fetch('IOS_SIM_GATE_DEVICE_NAME')
+raise 'wrong runtime' unless config.fetch(:runtime_version) == '26.0'
+raise 'wrong DerivedData' unless config.fetch(:derived_data_path) == '/tmp/gate-derived-data'
+expected_xcargs = '-parallel-testing-enabled NO -disable-concurrent-destination-testing'
+raise 'wrong xcargs' unless config.fetch(:xcargs) == expected_xcargs
+
+device = Struct.new(:name, :os_version, :udid)
+matching = device.new(ENV.fetch('IOS_SIM_GATE_DEVICE_NAME'), '26.0', UUID)
+SimulatorGate.assert_registered_device!([matching])
+
+wrong = device.new(ENV.fetch('IOS_SIM_GATE_DEVICE_NAME'), '26.0',
+                   '22222222-2222-2222-2222-222222222222')
+begin
+  SimulatorGate.assert_registered_device!([wrong])
+  raise 'wrong UUID was accepted'
+rescue SimulatorGate::GateError
+  # Expected.
+end
+
+saved = ENV.to_h
+SimulatorGate::REQUIRED_ENV.each { |key| ENV.delete(key) }
+begin
+  SimulatorGate.snapshot_configuration
+  raise 'missing gate environment was accepted'
+rescue SimulatorGate::GateError
+  # Expected.
+ensure
+  saved.each { |key, value| ENV[key] = value }
+end
+
+captured = {}
+receiver = TOPLEVEL_BINDING.receiver
+%i[
+  devices languages scheme project app_identifier output_directory clear_previous_screenshots
+  override_status_bar stop_after_first_error concurrent_simulators reinstall_app
+  xcodebuild_formatter ios_version derived_data_path xcargs
+].each do |name|
+  receiver.singleton_class.define_method(name) do |value|
+    captured[name] = value
+  end
+end
+snapfile_path = File.expand_path('fastlane/Snapfile', ENV.fetch('REPO_ROOT'))
+Dir.chdir(ENV.fetch('REPO_ROOT')) do
+  TOPLEVEL_BINDING.eval(File.read(snapfile_path, encoding: 'utf-8'))
+end
+
+raise 'Snapfile device mismatch' unless captured.fetch(:devices) == [config.fetch(:device_name)]
+raise 'Snapfile runtime mismatch' unless captured.fetch(:ios_version) == config.fetch(:runtime_version)
+unless captured.fetch(:derived_data_path) == config.fetch(:derived_data_path)
+  raise 'Snapfile DerivedData mismatch'
+end
+raise 'Snapfile xcargs mismatch' unless captured.fetch(:xcargs) == expected_xcargs
+
+puts 'PASS: Fastlane simulator gate environment and exact UUID lookup'
+RUBY
+
+REPO_ROOT="$REPO_ROOT" ruby "$TEST_ROOT/test.rb"
+
+if rg -n 'XCTEST_DEVICES_DIR|created\.each|simctl.*--set|Clone \\d' "$REPO_ROOT/fastlane/Fastfile"; then
+  echo "FAIL: Fastfile still contains run-created XCTestDevices cleanup" >&2
+  exit 1
+fi
+
+rg -n 'SimulatorGate\.assert_registered_device!' "$REPO_ROOT/fastlane/Fastfile" >/dev/null || {
+  echo "FAIL: screenshots lane does not assert exact registered simulator lookup" >&2
+  exit 1
+}
+
+echo "PASS: Fastlane screenshot lane has no clone cleanup"

--- a/scripts/test-fastlane-sim-gate.sh
+++ b/scripts/test-fastlane-sim-gate.sh
@@ -38,6 +38,13 @@ SimulatorGate.assert_registered_device!([matching])
 wrong = device.new(ENV.fetch('IOS_SIM_GATE_DEVICE_NAME'), '26.0',
                    '22222222-2222-2222-2222-222222222222')
 begin
+  SimulatorGate.assert_registered_device!([matching, wrong])
+  raise 'ambiguous name/runtime lookup was accepted'
+rescue SimulatorGate::GateError
+  # Expected.
+end
+
+begin
   SimulatorGate.assert_registered_device!([wrong])
   raise 'wrong UUID was accepted'
 rescue SimulatorGate::GateError

--- a/scripts/test-xcode-stream.sh
+++ b/scripts/test-xcode-stream.sh
@@ -358,6 +358,19 @@ run_wrapper --agent build2 -- xcodebuild test
 assert_contains "$GATE_LOG" "$REUSE_UUID"
 assert_not_contains "$GATE_LOG" "$SESSION_UUID"
 
+reset_case crash-window-orphan
+add_device "$OTHER_UUID" "Family Foqos - build2 - orphan" \
+  com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set +e
+orphan_output=$(run_wrapper --agent build2 --session orphan -- xcodebuild test 2>&1)
+orphan_status=$?
+set -e
+if [[ "$orphan_status" -eq 0 || "$orphan_output" != *"display name already exists"* ]]; then
+  fail "an unregistered same-name simulator must block allocation: $orphan_output"
+fi
+assert_not_contains "$SIMCTL_LOG" "create "
+assert_not_contains "$SIMCTL_LOG" "delete $OTHER_UUID"
+
 reset_case default-allocation
 run_wrapper --agent build2 --session new -- xcodebuild test
 assert_contains "$SIMCTL_LOG" \
@@ -410,7 +423,8 @@ reset_case rejected-flags
 add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
 set_owner "$REUSE_UUID" build2 collab
 for forbidden in -destination -derivedDataPath -parallel-testing-enabled \
-  -disable-concurrent-destination-testing; do
+  -disable-concurrent-destination-testing OBJROOT=/tmp/objects SYMROOT=/tmp/symbols \
+  BUILD_DIR=/tmp/build -xcconfig; do
   set +e
   output=$(run_wrapper --agent build2 --session collab -- xcodebuild test "$forbidden" bad 2>&1)
   status=$?
@@ -419,6 +433,18 @@ for forbidden in -destination -derivedDataPath -parallel-testing-enabled \
     fail "caller-supplied $forbidden must be rejected"
   fi
 done
+
+reset_case rejected-indirect-xcodebuild
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 collab
+set +e
+output=$(run_wrapper --agent build2 --session collab -- /usr/bin/true xcodebuild test 2>&1)
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"xcodebuild must be the command immediately after --"* ]]; then
+  fail "a later bare xcodebuild token must be rejected"
+fi
+run_wrapper --agent build2 --session collab -- /usr/bin/true xcodebuild-wrapper
 
 reset_case exit-status
 add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
@@ -480,6 +506,14 @@ FASTLANE_CHILD_PATH_LOG="$CASE_ROOT/fastlane-child-path.log"
 FASTLANE_ARGS_LOG="$CASE_ROOT/fastlane-args.log"
 FAKE_RUBY_PREFIX="$TEST_ROOT/ruby"
 export FASTLANE_ENTRY_PATH_LOG FASTLANE_CHILD_PATH_LOG FASTLANE_ARGS_LOG FAKE_RUBY_PREFIX
+set +e
+output=$(run_wrapper --agent build2 --session screenshots -- \
+  "$REPO_ROOT/scripts/fastlane.sh" screenshots xcodebuild 2>&1)
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"xcodebuild must be the command immediately after --"* ]]; then
+  fail "the screenshot branch must not bypass later-token xcodebuild rejection"
+fi
 caller_path=$PATH
 run_wrapper --agent build2 --session screenshots -- "$REPO_ROOT/scripts/fastlane.sh" screenshots
 [[ "$PATH" == "$caller_path" ]] || fail "screenshot wrapper changed the caller PATH"
@@ -487,6 +521,19 @@ entry_path=$(<"$FASTLANE_ENTRY_PATH_LOG")
 [[ "$entry_path" == "$REPO_ROOT/scripts/ios-sim-gate-bin:"* ]] ||
   fail "adapter PATH was not scoped to the screenshot lane process"
 assert_contains "$FASTLANE_ARGS_LOG" "screenshots"
+
+reset_case non-screenshot-adapter-scope
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 bundle-exec
+FASTLANE_CHILD_PATH_LOG="$CASE_ROOT/bundle-child-path.log"
+FASTLANE_ARGS_LOG="$CASE_ROOT/bundle-args.log"
+export FASTLANE_CHILD_PATH_LOG FASTLANE_ARGS_LOG
+run_wrapper --agent build2 --session bundle-exec -- \
+  "$TEST_ROOT/ruby/bin/bundle" exec ruby -v
+bundle_child_path=$(<"$FASTLANE_CHILD_PATH_LOG")
+[[ "$bundle_child_path" == "$REPO_ROOT/scripts/ios-sim-gate-bin:"* ]] ||
+  fail "adapter PATH was not installed for a non-screenshot bundle exec child"
+assert_contains "$FASTLANE_ARGS_LOG" "exec"
 
 POLICY_FILE="$REPO_ROOT/AGENTS.md"
 policy_requirements=(

--- a/scripts/test-xcode-stream.sh
+++ b/scripts/test-xcode-stream.sh
@@ -1,0 +1,513 @@
+#!/opt/homebrew/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WRAPPER="$REPO_ROOT/scripts/xcode-stream.sh"
+ADAPTER="$REPO_ROOT/scripts/ios-sim-gate-bin/xcrun"
+JQ_BIN=/opt/homebrew/bin/jq
+TEST_ROOT=$(mktemp -d)
+mkdir -p "$TEST_ROOT/bin"
+
+REUSE_UUID=11111111-1111-1111-1111-111111111111
+SESSION_UUID=22222222-2222-2222-2222-222222222222
+OTHER_UUID=33333333-3333-3333-3333-333333333333
+CREATED_UUID=44444444-4444-4444-4444-444444444444
+WINNER_UUID=55555555-5555-5555-5555-555555555555
+STALE_UUID=66666666-6666-6666-6666-666666666666
+
+cleanup() {
+  rm -rf -- "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local path=$1
+  local expected=$2
+  grep -F -- "$expected" "$path" >/dev/null ||
+    fail "$path does not contain: $expected"
+}
+
+assert_not_contains() {
+  local path=$1
+  local unexpected=$2
+  if grep -F -- "$unexpected" "$path" >/dev/null; then
+    fail "$path unexpectedly contains: $unexpected"
+  fi
+}
+
+write_fake_gate() {
+  cat >"$TEST_ROOT/bin/ios-sim-gate" <<'EOF'
+#!/opt/homebrew/bin/bash
+set -euo pipefail
+
+registry="$IOS_SIM_GATE_HOME/registry.json"
+mkdir -p "$IOS_SIM_GATE_HOME"
+[[ -f "$registry" ]] || printf '{}\n' >"$registry"
+command=$1
+shift
+
+parse_owner() {
+  project=""
+  agent=""
+  session=""
+  uuid=""
+  while (($#)); do
+    case "$1" in
+      --project) project=$2; shift 2 ;;
+      --agent) agent=$2; shift 2 ;;
+      --session) session=$2; shift 2 ;;
+      --udid) uuid=$2; shift 2 ;;
+      --) shift; child=("$@"); break ;;
+      *) echo "unexpected gate argument: $1" >&2; exit 64 ;;
+    esac
+  done
+}
+
+case "$command" in
+  status)
+    printf 'capacity slots=3 admission=free\n'
+    ;;
+  reconcile)
+    printf 'reconciled\n' >>"$GATE_LOG"
+    temporary="$registry.tmp"
+    "$JQ_BIN" --slurpfile devices "$DEVICES_JSON" '
+      with_entries(
+        select(.key as $uuid | any($devices[0].devices[]?[]?; .udid == $uuid))
+      )
+    ' "$registry" >"$temporary"
+    mv "$temporary" "$registry"
+    ;;
+  register)
+    parse_owner "$@"
+    printf 'register\t%s\t%s\t%s\t%s\n' "$project" "$agent" "$session" "$uuid" \
+      >>"$GATE_LOG"
+    if [[ "${SIMULATE_REGISTER_RACE:-0}" == 1 ]]; then
+      temporary="$registry.tmp"
+      "$JQ_BIN" --arg uuid "$WINNER_UUID" --arg project "$project" --arg agent "$agent" \
+        --arg session "$session" \
+        '. + {($uuid): {project: $project, agent: $agent, session: $session,
+          lastupdated: "2026-08-10T00:00:00Z"}}' "$registry" >"$temporary"
+      mv "$temporary" "$registry"
+      echo "owner already registered" >&2
+      exit 1
+    fi
+    temporary="$registry.tmp"
+    "$JQ_BIN" --arg uuid "$uuid" --arg project "$project" --arg agent "$agent" \
+      --arg session "$session" \
+      '. + {($uuid): {project: $project, agent: $agent, session: $session,
+        lastupdated: "2026-08-10T00:00:00Z"}}' "$registry" >"$temporary"
+    mv "$temporary" "$registry"
+    ;;
+  run)
+    child=()
+    parse_owner "$@"
+    printf 'run\t%s\t%s\t%s\t%s\n' "$project" "$agent" "$session" "$uuid" >>"$GATE_LOG"
+    export IOS_SIM_GATE_UDID="$uuid"
+    export IOS_SIM_GATE_DESTINATION="platform=iOS Simulator,id=$uuid"
+    export IOS_SIM_GATE_DERIVED_DATA_PATH="$IOS_SIM_GATE_CACHE_HOME/DerivedData/$project/$agent/${session:-no-session}"
+    export IOS_SIM_GATE_PROJECT="$project"
+    export IOS_SIM_GATE_AGENT="$agent"
+    if [[ -n "$session" ]]; then
+      export IOS_SIM_GATE_SESSION="$session"
+    else
+      unset IOS_SIM_GATE_SESSION || true
+    fi
+    mkdir -p "$IOS_SIM_GATE_DERIVED_DATA_PATH"
+    exec "${child[@]}"
+    ;;
+  *)
+    echo "unexpected gate command: $command" >&2
+    exit 64
+    ;;
+esac
+EOF
+  chmod +x "$TEST_ROOT/bin/ios-sim-gate"
+}
+
+write_fake_simctl() {
+  cat >"$TEST_ROOT/bin/simctl" <<'EOF'
+#!/opt/homebrew/bin/bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$SIMCTL_LOG"
+case "$1 $2 ${3:-}" in
+  "list devices available")
+    "$JQ_BIN" '
+      .devices |= with_entries(.value |= map(select(.isAvailable != false)))
+    ' "$DEVICES_JSON"
+    ;;
+  "list devices --json")
+    cat "$DEVICES_JSON"
+    ;;
+  "list devicetypes --json")
+    cat "$DEVICE_TYPES_JSON"
+    ;;
+  "list runtimes available")
+    cat "$RUNTIMES_JSON"
+    ;;
+  "create "*)
+    name=$2
+    device_type=$3
+    runtime=$4
+    if [[ -n "${INCOMPATIBLE_RUNTIME:-}" && "$runtime" == "$INCOMPATIBLE_RUNTIME" ]]; then
+      echo "incompatible runtime" >&2
+      exit 1
+    fi
+    uuid=$(<"$NEXT_UUID_FILE")
+    temporary="$DEVICES_JSON.tmp"
+    "$JQ_BIN" --arg uuid "$uuid" --arg name "$name" --arg runtime "$runtime" \
+      --arg device_type "$device_type" '
+      .devices[$runtime] = ((.devices[$runtime] // []) + [{
+        udid: $uuid,
+        name: $name,
+        state: "Shutdown",
+        isAvailable: true,
+        dataPathSize: 0,
+        deviceTypeIdentifier: $device_type
+      }])
+    ' "$DEVICES_JSON" >"$temporary"
+    mv "$temporary" "$DEVICES_JSON"
+    printf '%s\n' "$uuid"
+    ;;
+  "shutdown "*)
+    ;;
+  "delete "*)
+    uuid=$2
+    temporary="$DEVICES_JSON.tmp"
+    "$JQ_BIN" --arg uuid "$uuid" '
+      .devices |= with_entries(.value |= map(select(.udid != $uuid)))
+    ' "$DEVICES_JSON" >"$temporary"
+    mv "$temporary" "$DEVICES_JSON"
+    ;;
+  *)
+    echo "unexpected simctl arguments: $*" >&2
+    exit 64
+    ;;
+esac
+EOF
+  chmod +x "$TEST_ROOT/bin/simctl"
+}
+
+write_fake_xcodebuild() {
+  cat >"$TEST_ROOT/bin/xcodebuild" <<'EOF'
+#!/opt/homebrew/bin/bash
+printf '%s\n' "$@" >"$XCODEBUILD_LOG"
+exit "${XCODEBUILD_EXIT:-0}"
+EOF
+  chmod +x "$TEST_ROOT/bin/xcodebuild"
+}
+
+write_fake_fastlane_dependencies() {
+  mkdir -p "$TEST_ROOT/ruby/bin"
+  cat >"$TEST_ROOT/bin/brew" <<'EOF'
+#!/opt/homebrew/bin/bash
+set -euo pipefail
+[[ "$*" == "--prefix ruby" ]] || exit 64
+printf '%s\n' "$PATH" >"$FASTLANE_ENTRY_PATH_LOG"
+printf '%s\n' "$FAKE_RUBY_PREFIX"
+EOF
+  cat >"$TEST_ROOT/ruby/bin/bundle" <<'EOF'
+#!/opt/homebrew/bin/bash
+set -euo pipefail
+printf '%s\n' "$PATH" >"$FASTLANE_CHILD_PATH_LOG"
+printf '%s\n' "$@" >"$FASTLANE_ARGS_LOG"
+EOF
+  cat >"$TEST_ROOT/bin/real-xcrun" <<'EOF'
+#!/opt/homebrew/bin/bash
+set -euo pipefail
+printf '<%s>\n' "$@" >"$REAL_XCRUN_LOG"
+EOF
+  chmod +x "$TEST_ROOT/bin/brew" "$TEST_ROOT/ruby/bin/bundle" "$TEST_ROOT/bin/real-xcrun"
+}
+
+write_inventory_files() {
+  cat >"$TEST_ROOT/device-types.json" <<'EOF'
+{
+  "devicetypes": [
+    {"name":"iPhone 17","identifier":"com.apple.CoreSimulator.SimDeviceType.iPhone-17"},
+    {"name":"iPhone 17 Pro Max","identifier":"com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro-Max"}
+  ]
+}
+EOF
+  cat >"$TEST_ROOT/runtimes.json" <<'EOF'
+{
+  "runtimes": [
+    {"identifier":"com.apple.CoreSimulator.SimRuntime.iOS-18-0","name":"iOS 18.0","version":"18.0","isAvailable":true},
+    {"identifier":"com.apple.CoreSimulator.SimRuntime.iOS-26-0","name":"iOS 26.0","version":"26.0","isAvailable":true},
+    {"identifier":"com.apple.CoreSimulator.SimRuntime.watchOS-26-0","name":"watchOS 26.0","version":"26.0","isAvailable":true}
+  ]
+}
+EOF
+}
+
+reset_case() {
+  local name=$1
+  CASE_ROOT="$TEST_ROOT/$name"
+  rm -rf -- "$CASE_ROOT"
+  mkdir -p "$CASE_ROOT/state" "$CASE_ROOT/cache"
+  printf '{}\n' >"$CASE_ROOT/state/registry.json"
+  printf '{"devices":{}}\n' >"$CASE_ROOT/devices.json"
+  printf '%s\n' "$CREATED_UUID" >"$CASE_ROOT/next-uuid"
+  : >"$CASE_ROOT/gate.log"
+  : >"$CASE_ROOT/simctl.log"
+  : >"$CASE_ROOT/xcodebuild.log"
+
+  export IOS_SIM_GATE_HOME="$CASE_ROOT/state"
+  export IOS_SIM_GATE_CACHE_HOME="$CASE_ROOT/cache"
+  export IOS_SIM_GATE_BIN="$TEST_ROOT/bin/ios-sim-gate"
+  export IOS_SIM_GATE_BASH_BIN=/opt/homebrew/bin/bash
+  export IOS_SIM_GATE_JQ_BIN="$JQ_BIN"
+  export IOS_SIM_GATE_SIMCTL_BIN="$TEST_ROOT/bin/simctl"
+  export GATE_LOG="$CASE_ROOT/gate.log"
+  export SIMCTL_LOG="$CASE_ROOT/simctl.log"
+  export XCODEBUILD_LOG="$CASE_ROOT/xcodebuild.log"
+  export DEVICES_JSON="$CASE_ROOT/devices.json"
+  export DEVICE_TYPES_JSON="$TEST_ROOT/device-types.json"
+  export RUNTIMES_JSON="$TEST_ROOT/runtimes.json"
+  export NEXT_UUID_FILE="$CASE_ROOT/next-uuid"
+  export JQ_BIN WINNER_UUID
+  unset IOS_SIM_GATE_DEVICE_TYPE IOS_SIM_GATE_RUNTIME SIMULATE_REGISTER_RACE XCODEBUILD_EXIT \
+    INCOMPATIBLE_RUNTIME
+}
+
+add_device() {
+  local uuid=$1
+  local name=$2
+  local runtime=$3
+  local available=${4:-true}
+  local temporary="$DEVICES_JSON.tmp"
+  # shellcheck disable=SC2016 # jq expressions intentionally use jq variables.
+  "$JQ_BIN" --arg uuid "$uuid" --arg name "$name" --arg runtime "$runtime" \
+    --argjson available "$available" '
+    .devices[$runtime] = ((.devices[$runtime] // []) + [{
+      udid: $uuid,
+      name: $name,
+      state: "Shutdown",
+      isAvailable: $available,
+      dataPathSize: 0
+    }])
+  ' "$DEVICES_JSON" >"$temporary"
+  mv "$temporary" "$DEVICES_JSON"
+}
+
+set_owner() {
+  local uuid=$1
+  local agent=$2
+  local session=$3
+  local temporary="$IOS_SIM_GATE_HOME/registry.json.tmp"
+  # shellcheck disable=SC2016 # jq expressions intentionally use jq variables.
+  "$JQ_BIN" --arg uuid "$uuid" --arg agent "$agent" --arg session "$session" '
+    . + {($uuid): {
+      project: "family-foqos",
+      agent: $agent,
+      session: $session,
+      lastupdated: "2026-08-10T00:00:00Z"
+    }}
+  ' "$IOS_SIM_GATE_HOME/registry.json" >"$temporary"
+  mv "$temporary" "$IOS_SIM_GATE_HOME/registry.json"
+}
+
+run_wrapper() {
+  PATH="$TEST_ROOT/bin:$PATH" "$WRAPPER" "$@"
+}
+
+write_fake_gate
+write_fake_simctl
+write_fake_xcodebuild
+write_fake_fastlane_dependencies
+write_inventory_files
+
+if [[ ! -x "$WRAPPER" ]]; then
+  fail "scripts/xcode-stream.sh is missing or not executable"
+fi
+
+reset_case exact-reuse
+add_device "$OTHER_UUID" "Other owner" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$OTHER_UUID" build1 collab
+set_owner "$REUSE_UUID" build2 collab
+run_wrapper --agent build2 --session collab -- xcodebuild test -project FamilyFoqos.xcodeproj
+assert_contains "$GATE_LOG" $'run\tfamily-foqos\tbuild2\tcollab\t11111111-1111-1111-1111-111111111111'
+assert_not_contains "$SIMCTL_LOG" "create "
+assert_contains "$XCODEBUILD_LOG" "platform=iOS Simulator,id=$REUSE_UUID"
+assert_contains "$XCODEBUILD_LOG" "$CASE_ROOT/cache/DerivedData/family-foqos/build2/collab"
+assert_contains "$XCODEBUILD_LOG" "-parallel-testing-enabled"
+assert_contains "$XCODEBUILD_LOG" "NO"
+assert_contains "$XCODEBUILD_LOG" "-disable-concurrent-destination-testing"
+
+reset_case session-isolation
+add_device "$REUSE_UUID" "No session" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+add_device "$SESSION_UUID" "Named session" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 ""
+set_owner "$SESSION_UUID" build2 collab
+run_wrapper --agent build2 --session collab -- xcodebuild test
+assert_contains "$GATE_LOG" "$SESSION_UUID"
+assert_not_contains "$GATE_LOG" "$REUSE_UUID"
+
+reset_case no-session-reuse
+add_device "$REUSE_UUID" "No session" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+add_device "$SESSION_UUID" "Named session" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 ""
+set_owner "$SESSION_UUID" build2 collab
+run_wrapper --agent build2 -- xcodebuild test
+assert_contains "$GATE_LOG" "$REUSE_UUID"
+assert_not_contains "$GATE_LOG" "$SESSION_UUID"
+
+reset_case default-allocation
+run_wrapper --agent build2 --session new -- xcodebuild test
+assert_contains "$SIMCTL_LOG" \
+  "create Family Foqos - build2 - new com.apple.CoreSimulator.SimDeviceType.iPhone-17 com.apple.CoreSimulator.SimRuntime.iOS-26-0"
+assert_contains "$GATE_LOG" $'register\tfamily-foqos\tbuild2\tnew\t44444444-4444-4444-4444-444444444444'
+
+reset_case override-allocation
+IOS_SIM_GATE_DEVICE_TYPE="iPhone 17 Pro Max" IOS_SIM_GATE_RUNTIME="18.0" \
+  run_wrapper --agent build2 --session overrides -- xcodebuild test
+assert_contains "$SIMCTL_LOG" \
+  "create Family Foqos - build2 - overrides com.apple.CoreSimulator.SimDeviceType.iPhone-17-Pro-Max com.apple.CoreSimulator.SimRuntime.iOS-18-0"
+
+reset_case compatible-runtime-fallback
+INCOMPATIBLE_RUNTIME=com.apple.CoreSimulator.SimRuntime.iOS-26-0 \
+  run_wrapper --agent build2 --session fallback -- xcodebuild test
+assert_contains "$SIMCTL_LOG" \
+  "create Family Foqos - build2 - fallback com.apple.CoreSimulator.SimDeviceType.iPhone-17 com.apple.CoreSimulator.SimRuntime.iOS-26-0"
+assert_contains "$SIMCTL_LOG" \
+  "create Family Foqos - build2 - fallback com.apple.CoreSimulator.SimDeviceType.iPhone-17 com.apple.CoreSimulator.SimRuntime.iOS-18-0"
+
+reset_case explicit-incompatible-runtime
+set +e
+incompatible_output=$(INCOMPATIBLE_RUNTIME=com.apple.CoreSimulator.SimRuntime.iOS-26-0 \
+  IOS_SIM_GATE_RUNTIME=26.0 \
+  run_wrapper --agent build2 --session incompatible -- xcodebuild test 2>&1)
+incompatible_status=$?
+set -e
+if [[ "$incompatible_status" -eq 0 || "$incompatible_output" != *"incompatible"* ]]; then
+  fail "explicit incompatible runtime must fail closed"
+fi
+assert_not_contains "$GATE_LOG" $'register\tfamily-foqos\tbuild2\tincompatible'
+
+reset_case stale-replacement
+add_device "$STALE_UUID" "Unavailable" com.apple.CoreSimulator.SimRuntime.iOS-18-0 false
+set_owner "$STALE_UUID" build2 stale
+run_wrapper --agent build2 --session stale -- xcodebuild test
+assert_contains "$GATE_LOG" $'run\tfamily-foqos\tbuild2\tstale\t66666666-6666-6666-6666-666666666666'
+assert_contains "$SIMCTL_LOG" "delete $STALE_UUID"
+assert_contains "$GATE_LOG" "reconciled"
+assert_contains "$GATE_LOG" $'register\tfamily-foqos\tbuild2\tstale\t44444444-4444-4444-4444-444444444444'
+
+reset_case registration-race
+add_device "$WINNER_UUID" "Race winner" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+SIMULATE_REGISTER_RACE=1 run_wrapper --agent build2 --session race -- xcodebuild test
+assert_contains "$SIMCTL_LOG" "delete $CREATED_UUID"
+assert_not_contains "$SIMCTL_LOG" "delete $WINNER_UUID"
+assert_contains "$GATE_LOG" $'run\tfamily-foqos\tbuild2\trace\t55555555-5555-5555-5555-555555555555'
+
+reset_case rejected-flags
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 collab
+for forbidden in -destination -derivedDataPath -parallel-testing-enabled \
+  -disable-concurrent-destination-testing; do
+  set +e
+  output=$(run_wrapper --agent build2 --session collab -- xcodebuild test "$forbidden" bad 2>&1)
+  status=$?
+  set -e
+  if [[ "$status" -eq 0 || "$output" != *"must not supply $forbidden"* ]]; then
+    fail "caller-supplied $forbidden must be rejected"
+  fi
+done
+
+reset_case exit-status
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 collab
+set +e
+XCODEBUILD_EXIT=23 run_wrapper --agent build2 --session collab -- xcodebuild test
+status=$?
+set -e
+[[ "$status" -eq 23 ]] || fail "expected xcodebuild exit 23, got $status"
+
+if [[ ! -x "$ADAPTER" ]]; then
+  fail "scripts/ios-sim-gate-bin/xcrun is missing or not executable"
+fi
+
+REAL_XCRUN_LOG="$TEST_ROOT/real-xcrun.log"
+export REAL_XCRUN_LOG
+IOS_SIM_GATE_REAL_XCRUN="$TEST_ROOT/bin/real-xcrun" \
+  IOS_SIM_GATE_UDID="$REUSE_UUID" \
+  "$ADAPTER" simctl shutdown booted
+printf '<simctl>\n<shutdown>\n<%s>\n' "$REUSE_UUID" >"$TEST_ROOT/expected-xcrun.log"
+cmp -s "$REAL_XCRUN_LOG" "$TEST_ROOT/expected-xcrun.log" ||
+  fail "adapter did not rewrite the exact shutdown-booted invocation"
+
+negative_cases=(
+  "simctl|shutdown|$OTHER_UUID"
+  "simctl|list|devices"
+  "--sdk|iphonesimulator|simctl|shutdown|booted"
+  "simctl|spawn|$REUSE_UUID|argument with spaces"
+)
+for encoded_case in "${negative_cases[@]}"; do
+  IFS='|' read -r -a arguments <<<"$encoded_case"
+  IOS_SIM_GATE_REAL_XCRUN="$TEST_ROOT/bin/real-xcrun" \
+    IOS_SIM_GATE_UDID="$REUSE_UUID" \
+    "$ADAPTER" "${arguments[@]}"
+  : >"$TEST_ROOT/expected-xcrun.log"
+  for argument in "${arguments[@]}"; do
+    printf '<%s>\n' "$argument" >>"$TEST_ROOT/expected-xcrun.log"
+  done
+  cmp -s "$REAL_XCRUN_LOG" "$TEST_ROOT/expected-xcrun.log" ||
+    fail "adapter changed negative case: $encoded_case"
+done
+
+: >"$REAL_XCRUN_LOG"
+set +e
+missing_uuid_output=$(IOS_SIM_GATE_REAL_XCRUN="$TEST_ROOT/bin/real-xcrun" \
+  "$ADAPTER" simctl shutdown booted 2>&1)
+missing_uuid_status=$?
+set -e
+if [[ "$missing_uuid_status" -eq 0 || "$missing_uuid_output" != *"IOS_SIM_GATE_UDID"* ]]; then
+  fail "adapter must fail closed when the exact rewrite lacks a gate UUID"
+fi
+[[ ! -s "$REAL_XCRUN_LOG" ]] || fail "adapter called real xcrun after missing-UUID failure"
+
+reset_case screenshot-path-scope
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 screenshots
+FASTLANE_ENTRY_PATH_LOG="$CASE_ROOT/fastlane-entry-path.log"
+FASTLANE_CHILD_PATH_LOG="$CASE_ROOT/fastlane-child-path.log"
+FASTLANE_ARGS_LOG="$CASE_ROOT/fastlane-args.log"
+FAKE_RUBY_PREFIX="$TEST_ROOT/ruby"
+export FASTLANE_ENTRY_PATH_LOG FASTLANE_CHILD_PATH_LOG FASTLANE_ARGS_LOG FAKE_RUBY_PREFIX
+caller_path=$PATH
+run_wrapper --agent build2 --session screenshots -- "$REPO_ROOT/scripts/fastlane.sh" screenshots
+[[ "$PATH" == "$caller_path" ]] || fail "screenshot wrapper changed the caller PATH"
+entry_path=$(<"$FASTLANE_ENTRY_PATH_LOG")
+[[ "$entry_path" == "$REPO_ROOT/scripts/ios-sim-gate-bin:"* ]] ||
+  fail "adapter PATH was not scoped to the screenshot lane process"
+assert_contains "$FASTLANE_ARGS_LOG" "screenshots"
+
+POLICY_FILE="$REPO_ROOT/AGENTS.md"
+policy_requirements=(
+  "up to three"
+  "Xcode/simulator streams"
+  "scripts/xcode-stream.sh --agent"
+  "UUID destinations only"
+  "-parallel-testing-enabled NO"
+  "-disable-concurrent-destination-testing"
+  "scripts/fastlane.sh screenshots"
+  "scripts/clean-build.sh"
+  "bundle exec xcpretty"
+  "Read-only work does not consume a gate slot"
+  "Archive and upload lanes do not boot simulators"
+)
+for requirement in "${policy_requirements[@]}"; do
+  assert_contains "$POLICY_FILE" "$requirement"
+done
+assert_not_contains "$POLICY_FILE" "NO parallel development on the same machine"
+if rg -n '^xcodebuild ' "$POLICY_FILE" >/dev/null; then
+  fail "AGENTS.md still documents a raw xcodebuild entrypoint"
+fi
+
+echo "PASS: xcode stream allocation, enforcement, adapter scoping, and exact exit propagation"

--- a/scripts/xcode-stream.sh
+++ b/scripts/xcode-stream.sh
@@ -1,0 +1,329 @@
+#!/bin/bash
+
+BASH4_BIN="${IOS_SIM_GATE_BASH_BIN:-/opt/homebrew/bin/bash}"
+if [[ "${BASH_VERSINFO[0]:-0}" -lt 4 ]]; then
+  if [[ ! -x "$BASH4_BIN" ]]; then
+    echo "xcode-stream: Bash 4+ is required; expected $BASH4_BIN" >&2
+    exit 127
+  fi
+  exec "$BASH4_BIN" "$0" "$@"
+fi
+
+set -euo pipefail
+
+PROJECT=family-foqos
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SELF="$REPO_ROOT/scripts/xcode-stream.sh"
+GATE_BIN="${IOS_SIM_GATE_BIN:-$HOME/.local/bin/ios-sim-gate}"
+JQ_BIN="${IOS_SIM_GATE_JQ_BIN:-/opt/homebrew/bin/jq}"
+STATE_ROOT="${IOS_SIM_GATE_HOME:-$HOME/Library/Application Support/ios-sim-gate}"
+REGISTRY="$STATE_ROOT/registry.json"
+DEFAULT_DEVICE_TYPE="iPhone 17"
+
+die() {
+  echo "xcode-stream: $*" >&2
+  exit 1
+}
+
+validate_identifier() {
+  local label=$1
+  local value=$2
+  [[ "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]] ||
+    die "invalid $label: $value"
+}
+
+validate_uuid() {
+  [[ "$1" =~ ^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$ ]] ||
+    die "invalid simulator UUID: $1"
+}
+
+simctl() {
+  if [[ -n "${IOS_SIM_GATE_SIMCTL_BIN:-}" ]]; then
+    "$IOS_SIM_GATE_SIMCTL_BIN" "$@"
+  else
+    /usr/bin/xcrun simctl "$@"
+  fi
+}
+
+gate() {
+  "$BASH4_BIN" "$GATE_BIN" "$@"
+}
+
+require_internal_gate_contract() {
+  [[ "${IOS_SIM_GATE_PROJECT:-}" == "$PROJECT" ]] ||
+    die "internal execution requires IOS_SIM_GATE_PROJECT=$PROJECT"
+  [[ -n "${IOS_SIM_GATE_AGENT:-}" ]] || die "internal execution requires IOS_SIM_GATE_AGENT"
+  [[ -n "${IOS_SIM_GATE_UDID:-}" ]] || die "internal execution requires IOS_SIM_GATE_UDID"
+  [[ -n "${IOS_SIM_GATE_DESTINATION:-}" ]] ||
+    die "internal execution requires IOS_SIM_GATE_DESTINATION"
+  [[ -n "${IOS_SIM_GATE_DERIVED_DATA_PATH:-}" ]] ||
+    die "internal execution requires IOS_SIM_GATE_DERIVED_DATA_PATH"
+  validate_uuid "$IOS_SIM_GATE_UDID"
+  [[ "$IOS_SIM_GATE_DESTINATION" == "platform=iOS Simulator,id=$IOS_SIM_GATE_UDID" ]] ||
+    die "gate destination does not match gate UUID"
+}
+
+execute_internal() {
+  [[ "${1:-}" == "--" ]] || die "internal execution requires -- before the command"
+  shift
+  (($#)) || die "internal execution requires a command"
+  require_internal_gate_contract
+
+  local command_name=${1##*/}
+  local command_path=""
+  if [[ "$1" == */* && -e "$1" ]]; then
+    command_path="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+  fi
+  if [[ "$command_path" == "$REPO_ROOT/scripts/fastlane.sh" && "${2:-}" == "screenshots" ]]; then
+    [[ -n "${IOS_SIM_GATE_DEVICE_NAME:-}" ]] ||
+      die "screenshot execution requires IOS_SIM_GATE_DEVICE_NAME"
+    [[ -n "${IOS_SIM_GATE_RUNTIME_VERSION:-}" ]] ||
+      die "screenshot execution requires IOS_SIM_GATE_RUNTIME_VERSION"
+    PATH="$REPO_ROOT/scripts/ios-sim-gate-bin:$PATH" exec "$@"
+  fi
+  if [[ "$command_name" != "xcodebuild" ]]; then
+    exec "$@"
+  fi
+
+  local argument
+  for argument in "$@"; do
+    case "$argument" in
+      -destination|-destination=*|-derivedDataPath|-derivedDataPath=*|\
+      -parallel-testing-enabled|-parallel-testing-enabled=*|\
+      -disable-concurrent-destination-testing|-disable-concurrent-destination-testing=*)
+        die "callers must not supply $argument; xcode-stream injects simulator isolation flags"
+        ;;
+    esac
+  done
+
+  exec "$@" \
+    -destination "$IOS_SIM_GATE_DESTINATION" \
+    -derivedDataPath "$IOS_SIM_GATE_DERIVED_DATA_PATH" \
+    -parallel-testing-enabled NO \
+    -disable-concurrent-destination-testing
+}
+
+delete_internal() {
+  [[ "$#" -eq 1 ]] || die "internal delete requires one UUID"
+  require_internal_gate_contract
+  validate_uuid "$1"
+  [[ "$1" == "$IOS_SIM_GATE_UDID" ]] || die "internal delete UUID does not match gate UUID"
+  simctl shutdown "$1" >/dev/null 2>&1 || true
+  simctl delete "$1" >/dev/null
+}
+
+case "${1:-}" in
+  __execute)
+    shift
+    execute_internal "$@"
+    ;;
+  __delete)
+    shift
+    delete_internal "$@"
+    exit 0
+    ;;
+esac
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/xcode-stream.sh --agent NAME [--session NAME] -- COMMAND [ARG ...]
+EOF
+  exit 2
+}
+
+agent=""
+session=""
+while (($#)); do
+  case "$1" in
+    --agent)
+      (($# >= 2)) || usage
+      agent=$2
+      shift 2
+      ;;
+    --session)
+      (($# >= 2)) || usage
+      session=$2
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+[[ -n "$agent" ]] || usage
+(($#)) || usage
+validate_identifier agent "$agent"
+[[ -z "$session" ]] || validate_identifier session "$session"
+[[ -x "$BASH4_BIN" ]] || die "Bash 4+ executable not found: $BASH4_BIN"
+[[ -f "$GATE_BIN" ]] || die "ios-sim-gate not found: $GATE_BIN"
+[[ -x "$JQ_BIN" ]] || die "jq not found: $JQ_BIN"
+if [[ -n "${IOS_SIM_GATE_SIMCTL_BIN:-}" ]]; then
+  [[ -x "$IOS_SIM_GATE_SIMCTL_BIN" ]] || die "simctl adapter not executable: $IOS_SIM_GATE_SIMCTL_BIN"
+else
+  [[ -x /usr/bin/xcrun ]] || die "xcrun not found: /usr/bin/xcrun"
+fi
+
+command=("$@")
+owner_args=(--project "$PROJECT" --agent "$agent")
+if [[ -n "$session" ]]; then
+  owner_args+=(--session "$session")
+fi
+
+gate status >/dev/null
+[[ -f "$REGISTRY" ]] || die "gate registry was not initialized: $REGISTRY"
+
+lookup_owned_uuid() {
+  # shellcheck disable=SC2016 # jq expressions intentionally use jq variables.
+  "$JQ_BIN" -r \
+    --arg project "$PROJECT" \
+    --arg agent "$agent" \
+    --arg session "$session" '
+      first(
+        to_entries[] |
+        select(
+          .value.project == $project and
+          .value.agent == $agent and
+          (.value.session // "") == $session
+        ) |
+        .key
+      ) // ""
+    ' "$REGISTRY"
+}
+
+available_inventory=$(simctl list devices available --json)
+runtimes_inventory=$(simctl list runtimes available --json)
+
+device_metadata() {
+  local uuid=$1
+  # shellcheck disable=SC2016 # jq expressions intentionally use jq variables.
+  "$JQ_BIN" -rn \
+    --arg uuid "$uuid" \
+    --argjson devices "$available_inventory" \
+    --argjson runtimes "$runtimes_inventory" '
+      first(
+        $devices.devices | to_entries[] |
+        .key as $runtime |
+        .value[] |
+        select(.udid == $uuid and ((.isAvailable // true) == true)) |
+        . as $device |
+        ($runtimes.runtimes[] | select(.identifier == $runtime)) as $runtime_record |
+        [$device.name, $runtime_record.version] | @tsv
+      ) // ""
+    '
+}
+
+owned_uuid=$(lookup_owned_uuid)
+metadata=""
+if [[ -n "$owned_uuid" ]]; then
+  validate_uuid "$owned_uuid"
+  metadata=$(device_metadata "$owned_uuid")
+fi
+
+if [[ -n "$owned_uuid" && -z "$metadata" ]]; then
+  delete_status=0
+  gate run "${owner_args[@]}" --udid "$owned_uuid" -- \
+    "$BASH4_BIN" "$SELF" __delete "$owned_uuid" || delete_status=$?
+  gate reconcile >/dev/null
+  remaining_uuid=$(lookup_owned_uuid)
+  if [[ -n "$remaining_uuid" ]]; then
+    die "unusable simulator $owned_uuid remains registered after gated delete (status $delete_status)"
+  fi
+  owned_uuid=""
+fi
+
+resolve_device_type() {
+  local selector=$1
+  local inventory
+  inventory=$(simctl list devicetypes --json)
+  # shellcheck disable=SC2016 # jq expressions intentionally use jq variables.
+  "$JQ_BIN" -r --arg selector "$selector" '
+    first(
+      .devicetypes[] |
+      select(.identifier == $selector or .name == $selector) |
+      .identifier
+    ) // ""
+  ' <<<"$inventory"
+}
+
+runtime_candidates() {
+  local selector=$1
+  # shellcheck disable=SC2016 # jq expressions intentionally use jq variables.
+  "$JQ_BIN" -r --arg selector "$selector" '
+    .runtimes |
+    map(select(
+      (.isAvailable // false) == true and
+      (.identifier | startswith("com.apple.CoreSimulator.SimRuntime.iOS-")) and
+      ($selector == "" or .identifier == $selector or .name == $selector or .version == $selector)
+    )) |
+    sort_by(.version | split(".") | map(tonumber)) |
+    reverse[] |
+    [.identifier, .version] | @tsv
+  ' <<<"$runtimes_inventory"
+}
+
+if [[ -z "$owned_uuid" ]]; then
+  device_selector="${IOS_SIM_GATE_DEVICE_TYPE:-$DEFAULT_DEVICE_TYPE}"
+  runtime_selector="${IOS_SIM_GATE_RUNTIME:-}"
+  device_type=$(resolve_device_type "$device_selector")
+  [[ -n "$device_type" ]] || die "no available simulator device type matches: $device_selector"
+
+  display_name="Family Foqos - $agent${session:+ - $session}"
+  created_uuid=""
+  created_runtime_version=""
+  candidate_count=0
+  while IFS=$'\t' read -r runtime_id runtime_version; do
+    [[ -n "$runtime_id" ]] || continue
+    ((candidate_count += 1))
+    create_status=0
+    created_uuid=$(simctl create "$display_name" "$device_type" "$runtime_id") || create_status=$?
+    if [[ "$create_status" -eq 0 && -n "$created_uuid" ]]; then
+      validate_uuid "$created_uuid"
+      created_runtime_version=$runtime_version
+      break
+    fi
+    created_uuid=""
+    if [[ -n "$runtime_selector" ]]; then
+      die "device type $device_selector is incompatible with runtime $runtime_selector"
+    fi
+  done < <(runtime_candidates "$runtime_selector")
+
+  ((candidate_count > 0)) || die "no available iOS runtime matches: ${runtime_selector:-newest}"
+  [[ -n "$created_uuid" ]] ||
+    die "could not create $device_selector on any compatible installed iOS runtime"
+
+  register_output=""
+  register_status=0
+  register_output=$(gate register "${owner_args[@]}" --udid "$created_uuid" 2>&1) ||
+    register_status=$?
+  if [[ "$register_status" -eq 0 ]]; then
+    owned_uuid=$created_uuid
+    metadata=$(printf '%s\t%s\n' "$display_name" "$created_runtime_version")
+  else
+    simctl shutdown "$created_uuid" >/dev/null 2>&1 || true
+    simctl delete "$created_uuid" >/dev/null || true
+    owned_uuid=$(lookup_owned_uuid)
+    if [[ -n "$owned_uuid" ]]; then
+      validate_uuid "$owned_uuid"
+      available_inventory=$(simctl list devices available --json)
+      metadata=$(device_metadata "$owned_uuid")
+    fi
+    if [[ -z "$owned_uuid" || -z "$metadata" ]]; then
+      [[ -z "$register_output" ]] || echo "$register_output" >&2
+      exit "$register_status"
+    fi
+  fi
+fi
+
+[[ -n "$metadata" ]] || die "could not resolve metadata for simulator $owned_uuid"
+IFS=$'\t' read -r IOS_SIM_GATE_DEVICE_NAME IOS_SIM_GATE_RUNTIME_VERSION <<<"$metadata"
+[[ -n "$IOS_SIM_GATE_DEVICE_NAME" ]] || die "resolved simulator has no display name"
+[[ -n "$IOS_SIM_GATE_RUNTIME_VERSION" ]] || die "resolved simulator has no runtime version"
+export IOS_SIM_GATE_DEVICE_NAME IOS_SIM_GATE_RUNTIME_VERSION
+
+exec "$BASH4_BIN" "$GATE_BIN" run "${owner_args[@]}" --udid "$owned_uuid" -- \
+  "$BASH4_BIN" "$SELF" __execute -- "${command[@]}"

--- a/scripts/xcode-stream.sh
+++ b/scripts/xcode-stream.sh
@@ -69,17 +69,25 @@ execute_internal() {
   (($#)) || die "internal execution requires a command"
   require_internal_gate_contract
 
+  export PATH="$REPO_ROOT/scripts/ios-sim-gate-bin:$PATH"
+
   local command_name=${1##*/}
   local command_path=""
+  local arguments=("$@")
+  local index
   if [[ "$1" == */* && -e "$1" ]]; then
     command_path="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
   fi
+  for ((index = 1; index < ${#arguments[@]}; index++)); do
+    [[ "${arguments[index]}" != "xcodebuild" ]] ||
+      die "xcodebuild must be the command immediately after --"
+  done
   if [[ "$command_path" == "$REPO_ROOT/scripts/fastlane.sh" && "${2:-}" == "screenshots" ]]; then
     [[ -n "${IOS_SIM_GATE_DEVICE_NAME:-}" ]] ||
       die "screenshot execution requires IOS_SIM_GATE_DEVICE_NAME"
     [[ -n "${IOS_SIM_GATE_RUNTIME_VERSION:-}" ]] ||
       die "screenshot execution requires IOS_SIM_GATE_RUNTIME_VERSION"
-    PATH="$REPO_ROOT/scripts/ios-sim-gate-bin:$PATH" exec "$@"
+    exec "$@"
   fi
   if [[ "$command_name" != "xcodebuild" ]]; then
     exec "$@"
@@ -90,7 +98,8 @@ execute_internal() {
     case "$argument" in
       -destination|-destination=*|-derivedDataPath|-derivedDataPath=*|\
       -parallel-testing-enabled|-parallel-testing-enabled=*|\
-      -disable-concurrent-destination-testing|-disable-concurrent-destination-testing=*)
+      -disable-concurrent-destination-testing|-disable-concurrent-destination-testing=*|\
+      OBJROOT=*|SYMROOT=*|BUILD_DIR=*|-xcconfig|-xcconfig=*)
         die "callers must not supply $argument; xcode-stream injects simulator isolation flags"
         ;;
     esac
@@ -273,6 +282,14 @@ if [[ -z "$owned_uuid" ]]; then
   [[ -n "$device_type" ]] || die "no available simulator device type matches: $device_selector"
 
   display_name="Family Foqos - $agent${session:+ - $session}"
+  all_devices_inventory=$(simctl list devices --json)
+  # shellcheck disable=SC2016 # jq expression intentionally uses a jq variable.
+  conflicting_uuid=$("$JQ_BIN" -r --arg display_name "$display_name" '
+    first(.devices[]?[]? | select(.name == $display_name) | .udid) // ""
+  ' <<<"$all_devices_inventory")
+  [[ -z "$conflicting_uuid" ]] ||
+    die "simulator display name already exists outside exact gate ownership: $display_name ($conflicting_uuid)"
+
   created_uuid=""
   created_runtime_version=""
   candidate_count=0


### PR DESCRIPTION
## Summary

- add `scripts/xcode-stream.sh` as the single registry-first entrypoint for simulator builds, tests, and screenshots
- enforce exact UUID destinations, owner-scoped DerivedData, and both no-clone xcodebuild flags
- route the whole Fastlane screenshots lane through the gate, constrain snapshot's global shutdown to its registered UUID, and remove model-name XCTestDevices cleanup
- make `clean-build.sh` delete only the exact gate-owned DerivedData path
- update `AGENTS.md` for up to three gated Xcode/simulator streams and wrapper-only examples
- add hermetic shell/Ruby coverage for allocation, races, status propagation, adapter scoping, Fastlane lookup, and cleanup safety

## Why

The previous one-stream policy, raw xcodebuild examples, wildcard DerivedData cleanup, and model-name clone cleanup could not safely support three concurrent agents. The installed machine-wide `ios-sim-gate` now owns capacity and locking; this PR supplies the repository-side allocation and plumbing contract.

## Verification

- all repository shell tests pass
- ShellCheck passes for every changed shell script
- RuboCop reports 2 files inspected, 0 offenses
- Ruby and Bash syntax checks pass
- full gated `FoqosTests`: **1,169 tests, 0 failures**, `Test Succeeded`
  - registered UUID: `B5D1468E-B0D5-49F1-AD20-7894AE095AFE`
  - all three gate slots free after exit
- full gated `scripts/fastlane.sh screenshots`: **3 UI tests, 0 failures**, 3 framed screenshots, lane successful
  - registered UUID: `51C4409F-987D-455C-ACD5-253AB766BDC2`
  - generated xcodebuild used the exact UUID, gate DerivedData, `-parallel-testing-enabled NO`, and `-disable-concurrent-destination-testing`
  - all three gate slots free after exit
- XCTestDevices clone UUID set unchanged across both smokes: 46 pre-existing clones, before/after SHA-256 `9691f8e3fdd56cdd06dde267e6fb981f73404ae024a655f600428b7bf67a9940`
- caller PATH unchanged across screenshot smoke: before/after SHA-256 `73e869d21c4ef4048d253f9590714dca85f5ce961e5a1ddc2a4e8ba94a2d1556`
- wrapper harness verifies exact child exit-code propagation with exit 23

## Scope

Session Credential Warm-up (#363) is deliberately not included.

Closes #362