### PR TITLE
Add CI version increment gate

### DIFF
--- a/.github/workflows/version-gate.yml
+++ b/.github/workflows/version-gate.yml
@@ -1,0 +1,25 @@
+name: Version gate
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  version-gate:
+    name: Version gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pull request history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require app and build version increments
+        run: |
+          scripts/check-version-increment.sh \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}"

--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -686,7 +686,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -707,7 +707,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -718,7 +718,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -866,7 +866,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -894,7 +894,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -920,7 +920,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -948,7 +948,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -970,12 +970,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -996,12 +996,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1021,12 +1021,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1046,12 +1046,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1072,7 +1072,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1083,7 +1083,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1104,7 +1104,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1115,7 +1115,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1139,7 +1139,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1150,7 +1150,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1173,7 +1173,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1184,7 +1184,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/docs/superpowers/plans/2026-08-10-ci-version-gate.md
+++ b/docs/superpowers/plans/2026-08-10-ci-version-gate.md
@@ -1,0 +1,134 @@
+# CI Version Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a tested pull-request check that requires both Xcode version settings to increase strictly from `main`.
+
+**Architecture:** A repository-local Bash script owns extraction, validation, and comparison. A minimal GitHub Actions workflow checks out complete history and invokes the script with the pull request base/head SHAs; a fixture Git repository tests the script without Xcode.
+
+**Tech Stack:** Bash, Git, GitHub Actions YAML, Xcode project text format
+
+## Global Constraints
+
+- Run no Xcode build or test for this zero-Xcode item.
+- Require `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` to be unique across all project configurations.
+- Require both head values to be strictly greater than their base values.
+- Set this pull request uniformly to `MARKETING_VERSION = 2.0.1` and `CURRENT_PROJECT_VERSION = 20`.
+- Do not add the optional sync guards or unit suite.
+- Leave branch-ruleset configuration to the maintainer and document that follow-up in the PR.
+
+---
+
+### Task 1: Executable version comparison
+
+**Files:**
+- Create: `scripts/check-version-increment.sh`
+- Create: `scripts/test-check-version-increment.sh`
+
+**Interfaces:**
+- Consumes: base Git ref as argument 1 and optional head Git ref as argument 2 (default `HEAD`)
+- Produces: exit 0 only when both version settings are valid, uniform, and strictly increased
+
+- [ ] **Step 1: Write the failing fixture test**
+
+Create a temporary repository containing a minimal `FamilyFoqos.xcodeproj/project.pbxproj`, commit
+base/head fixtures, invoke the production script, and assert pass/fail for increased, unchanged,
+decreased, multi-digit, malformed, and inconsistent values.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bash scripts/test-check-version-increment.sh`
+
+Expected: FAIL because `scripts/check-version-increment.sh` does not exist.
+
+- [ ] **Step 3: Implement the minimal comparison script**
+
+Implement helpers with these contracts:
+
+```bash
+unique_setting_value <ref> <MARKETING_VERSION|CURRENT_PROJECT_VERSION>
+version_is_greater <head-major.minor.patch> <base-major.minor.patch>
+```
+
+Read project contents with `git show "$ref:FamilyFoqos.xcodeproj/project.pbxproj"`, reject missing or
+non-unique settings, validate formats, and exit nonzero unless both comparisons are strictly greater.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bash scripts/test-check-version-increment.sh`
+
+Expected: `PASS: version increment gate cases`
+
+### Task 2: Pull-request workflow
+
+**Files:**
+- Create: `.github/workflows/version-gate.yml`
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+- Consumes: `github.event.pull_request.base.sha` and `github.event.pull_request.head.sha`
+- Produces: GitHub status check named `Version gate`
+
+- [ ] **Step 1: Add the minimal workflow**
+
+Use `pull_request` targeting `main`, `permissions: contents: read`, `actions/checkout@v4` with
+`fetch-depth: 0`, and invoke:
+
+```bash
+scripts/check-version-increment.sh \
+  "${{ github.event.pull_request.base.sha }}" \
+      "${{ github.event.pull_request.head.sha }}"
+```
+
+- [ ] **Step 2: Increment this pull request's project versions**
+
+Replace every project configuration's `MARKETING_VERSION = 2.0.0` with `2.0.1` and every
+`CURRENT_PROJECT_VERSION = 19` with `20`, then verify each setting has exactly one unique value.
+
+- [ ] **Step 3: Validate workflow structure and rerun script tests**
+
+Run:
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/version-gate.yml")'
+bash scripts/test-check-version-increment.sh
+```
+
+Expected: both commands exit 0 and the shell test prints its PASS marker.
+
+### Task 3: Review-ready verification
+
+**Files:**
+- Verify: `.github/workflows/version-gate.yml`
+- Verify: `scripts/check-version-increment.sh`
+- Verify: `scripts/test-check-version-increment.sh`
+
+**Interfaces:**
+- Consumes: completed Tasks 1-2
+- Produces: reviewable commit and draft pull request closing #321
+
+- [ ] **Step 1: Run final zero-Xcode verification**
+
+Run:
+
+```bash
+bash -n scripts/check-version-increment.sh scripts/test-check-version-increment.sh
+bash scripts/test-check-version-increment.sh
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/version-gate.yml")'
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Commit without amend/force**
+
+```bash
+git add .github/workflows/version-gate.yml scripts/check-version-increment.sh \
+  scripts/test-check-version-increment.sh docs/superpowers/specs/2026-08-10-ci-version-gate-design.md \
+  docs/superpowers/plans/2026-08-10-ci-version-gate.md
+git commit -m "Add CI version increment gate"
+```
+
+- [ ] **Step 3: Publish and request review**
+
+Open a draft PR that closes #321 and explicitly notes both the maintainer branch-ruleset follow-up
+and the omitted optional rider. Send the PR to `reviewer` via AMQ before any merge.

--- a/docs/superpowers/specs/2026-08-10-ci-version-gate-design.md
+++ b/docs/superpowers/specs/2026-08-10-ci-version-gate-design.md
@@ -1,0 +1,57 @@
+# CI Version Gate Design
+
+## Goal
+
+Add the repository's first GitHub Actions workflow and block pull requests to `main` unless both
+Xcode version settings increase strictly from the pull request base:
+
+- `MARKETING_VERSION` increases by numeric `major.minor.patch` comparison.
+- `CURRENT_PROJECT_VERSION` increases by integer comparison.
+
+## Scope
+
+The change contains one repository-local check script, one fixture-based shell test, one
+pull-request workflow, and the `2.0.1` / build `20` project-version increment required for this
+pull request to pass its own gate. The workflow deliberately omits the optional sync guards and
+Xcode unit suite; the approved board scope is the version gate only.
+
+After the pull request merges, the maintainer must add the workflow's `Version gate` check to the
+`main` branch ruleset. Repository ruleset configuration and any Xcode build are outside this
+change.
+
+## Design
+
+`scripts/check-version-increment.sh` accepts a base Git ref and an optional head Git ref. It reads
+`FamilyFoqos.xcodeproj/project.pbxproj` from both refs with `git show`, extracts every occurrence of
+the two version settings, and requires each setting to have one unique project-wide value. It
+validates `MARKETING_VERSION` as exactly three numeric components and
+`CURRENT_PROJECT_VERSION` as an unsigned integer before comparing them numerically.
+
+`.github/workflows/version-gate.yml` runs for pull requests targeting `main`, grants read-only
+repository access, checks out full history, and passes the pull request base/head SHAs to the
+script. Keeping comparison logic in the repository makes the behavior locally testable and avoids
+a third-party action dependency.
+
+Because every pull request must compare against the current `main`, concurrent pull requests can
+race on the same next version. A branch that becomes stale must add a new version-bump commit after
+rebasing or merging the updated base; existing commits are never amended.
+
+## Failure Behavior
+
+The gate fails closed when a ref or project file cannot be read, a setting is absent, target/build
+configurations disagree, a value is malformed, or either head value is less than or equal to its
+base value. Diagnostic output identifies the invalid setting or the required increase without
+printing unrelated project data.
+
+## Verification
+
+`scripts/test-check-version-increment.sh` creates a disposable Git repository and proves:
+
+- both values increasing passes;
+- unchanged marketing or build values fail;
+- decreased values fail;
+- numeric semantic comparison handles multi-digit components correctly;
+- malformed values fail;
+- inconsistent values across build configurations fail.
+
+The test is zero-Xcode and runs with standard macOS/GitHub runner shell and Git tools.

--- a/scripts/check-version-increment.sh
+++ b/scripts/check-version-increment.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_FILE="FamilyFoqos.xcodeproj/project.pbxproj"
+
+usage() {
+  echo "Usage: $0 <base-ref> [head-ref]" >&2
+}
+
+unique_setting_value() {
+  local ref=$1
+  local setting=$2
+  local project
+  local values
+  local count
+
+  if ! project=$(git show "$ref:$PROJECT_FILE"); then
+    echo "Unable to read $PROJECT_FILE at ref '$ref'." >&2
+    return 1
+  fi
+
+  values=$(
+    printf '%s\n' "$project" \
+      | sed -nE "s/^[[:space:]]*${setting}[[:space:]]*=[[:space:]]*([^;]+);.*/\\1/p" \
+      | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+      | sort -u
+  )
+  count=$(printf '%s\n' "$values" | awk 'NF { count += 1 } END { print count + 0 }')
+
+  if [[ "$count" -eq 0 ]]; then
+    echo "$setting is missing at ref '$ref'." >&2
+    return 1
+  fi
+  if [[ "$count" -ne 1 ]]; then
+    echo "$setting is inconsistent at ref '$ref':" >&2
+    printf '  %s\n' "$values" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$values"
+}
+
+decimal_compare() {
+  local left=$1
+  local right=$2
+
+  while [[ ${#left} -gt 1 && ${left:0:1} == "0" ]]; do
+    left=${left:1}
+  done
+  while [[ ${#right} -gt 1 && ${right:0:1} == "0" ]]; do
+    right=${right:1}
+  done
+
+  if [[ ${#left} -gt ${#right} ]]; then
+    echo 1
+  elif [[ ${#left} -lt ${#right} ]]; then
+    echo -1
+  elif [[ "$left" > "$right" ]]; then
+    echo 1
+  elif [[ "$left" < "$right" ]]; then
+    echo -1
+  else
+    echo 0
+  fi
+}
+
+version_is_greater() {
+  local head_version=$1
+  local base_version=$2
+  local head_parts
+  local base_parts
+  local index
+  local comparison
+
+  IFS=. read -r -a head_parts <<<"$head_version"
+  IFS=. read -r -a base_parts <<<"$base_version"
+
+  for index in 0 1 2; do
+    comparison=$(decimal_compare "${head_parts[$index]}" "${base_parts[$index]}")
+    if [[ "$comparison" -gt 0 ]]; then
+      return 0
+    fi
+    if [[ "$comparison" -lt 0 ]]; then
+      return 1
+    fi
+  done
+
+  return 1
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 2
+fi
+
+base_ref=$1
+head_ref=${2:-HEAD}
+
+base_marketing=$(unique_setting_value "$base_ref" MARKETING_VERSION)
+head_marketing=$(unique_setting_value "$head_ref" MARKETING_VERSION)
+base_build=$(unique_setting_value "$base_ref" CURRENT_PROJECT_VERSION)
+head_build=$(unique_setting_value "$head_ref" CURRENT_PROJECT_VERSION)
+
+if [[ ! "$base_marketing" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Invalid MARKETING_VERSION at ref '$base_ref': $base_marketing" >&2
+  exit 1
+fi
+if [[ ! "$head_marketing" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Invalid MARKETING_VERSION at ref '$head_ref': $head_marketing" >&2
+  exit 1
+fi
+if [[ ! "$base_build" =~ ^[0-9]+$ ]]; then
+  echo "Invalid CURRENT_PROJECT_VERSION at ref '$base_ref': $base_build" >&2
+  exit 1
+fi
+if [[ ! "$head_build" =~ ^[0-9]+$ ]]; then
+  echo "Invalid CURRENT_PROJECT_VERSION at ref '$head_ref': $head_build" >&2
+  exit 1
+fi
+
+failed=0
+if ! version_is_greater "$head_marketing" "$base_marketing"; then
+  echo "MARKETING_VERSION must increase (base: $base_marketing, head: $head_marketing)." >&2
+  failed=1
+fi
+if [[ $(decimal_compare "$head_build" "$base_build") -ne 1 ]]; then
+  echo "CURRENT_PROJECT_VERSION must increase (base: $base_build, head: $head_build)." >&2
+  failed=1
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "Version gate passed: MARKETING_VERSION $base_marketing -> $head_marketing; CURRENT_PROJECT_VERSION $base_build -> $head_build."

--- a/scripts/test-check-version-increment.sh
+++ b/scripts/test-check-version-increment.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GATE_SCRIPT="$REPO_ROOT/scripts/check-version-increment.sh"
+TEST_ROOT=$(mktemp -d)
+
+cleanup() {
+  if [[ -n "${TEST_ROOT:-}" && -d "$TEST_ROOT" ]]; then
+    rm -rf -- "$TEST_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+if [[ ! -f "$GATE_SCRIPT" ]]; then
+  echo "FAIL: version increment gate script is missing"
+  exit 1
+fi
+
+write_project() {
+  local marketing_version=$1
+  local build_version=$2
+  local second_marketing_version=${3:-$marketing_version}
+  local second_build_version=${4:-$build_version}
+
+  mkdir -p "$TEST_ROOT/FamilyFoqos.xcodeproj"
+  printf '%s\n' \
+    'buildSettings = {' \
+    "  CURRENT_PROJECT_VERSION = $build_version;" \
+    "  MARKETING_VERSION = $marketing_version;" \
+    '};' \
+    'buildSettings = {' \
+    "  CURRENT_PROJECT_VERSION = $second_build_version;" \
+    "  MARKETING_VERSION = $second_marketing_version;" \
+    '};' \
+    >"$TEST_ROOT/FamilyFoqos.xcodeproj/project.pbxproj"
+}
+
+commit_fixture() {
+  local marketing_version=$1
+  local build_version=$2
+  local second_marketing_version=${3:-$marketing_version}
+  local second_build_version=${4:-$build_version}
+
+  write_project \
+    "$marketing_version" \
+    "$build_version" \
+    "$second_marketing_version" \
+    "$second_build_version"
+  git -C "$TEST_ROOT" add FamilyFoqos.xcodeproj/project.pbxproj
+  git -C "$TEST_ROOT" commit -q -m "fixture $marketing_version ($build_version)"
+  git -C "$TEST_ROOT" rev-parse HEAD
+}
+
+run_gate() {
+  local head_ref=$1
+  set +e
+  GATE_OUTPUT=$(cd "$TEST_ROOT" && bash "$GATE_SCRIPT" "$BASE_REF" "$head_ref" 2>&1)
+  GATE_STATUS=$?
+  set -e
+}
+
+expect_pass() {
+  local description=$1
+  local head_ref=$2
+  run_gate "$head_ref"
+  if [[ "$GATE_STATUS" -ne 0 ]]; then
+    echo "FAIL: $description should pass"
+    echo "$GATE_OUTPUT"
+    exit 1
+  fi
+}
+
+expect_fail() {
+  local description=$1
+  local head_ref=$2
+  run_gate "$head_ref"
+  if [[ "$GATE_STATUS" -eq 0 ]]; then
+    echo "FAIL: $description should fail"
+    echo "$GATE_OUTPUT"
+    exit 1
+  fi
+}
+
+git -C "$TEST_ROOT" init -q
+git -C "$TEST_ROOT" config user.name "Version Gate Test"
+git -C "$TEST_ROOT" config user.email "version-gate@example.invalid"
+git -C "$TEST_ROOT" config commit.gpgsign false
+
+BASE_REF=$(commit_fixture 1.2.3 10)
+
+head_ref=$(commit_fixture 1.2.4 11)
+expect_pass "both versions increasing" "$head_ref"
+
+head_ref=$(commit_fixture 1.2.3 12)
+expect_fail "unchanged marketing version" "$head_ref"
+
+head_ref=$(commit_fixture 1.2.5 10)
+expect_fail "unchanged build version" "$head_ref"
+
+head_ref=$(commit_fixture 1.2.2 13)
+expect_fail "decreased marketing version" "$head_ref"
+
+head_ref=$(commit_fixture 1.2.6 9)
+expect_fail "decreased build version" "$head_ref"
+
+head_ref=$(commit_fixture 1.10.0 14)
+expect_pass "multi-digit semantic version increase" "$head_ref"
+
+head_ref=$(commit_fixture 1.2 15)
+expect_fail "malformed marketing version" "$head_ref"
+
+head_ref=$(commit_fixture 1.2.7 16 1.2.8 16)
+expect_fail "inconsistent project versions" "$head_ref"
+
+echo "PASS: version increment gate cases"


### PR DESCRIPTION
## Summary

- add the repository's first GitHub Actions workflow for pull requests to `main`
- require both `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` to increase strictly from the PR base
- fail closed for missing, malformed, or inconsistent Xcode version settings
- add a zero-Xcode fixture suite covering pass/fail boundaries and numeric semantic-version comparison
- bump all project configurations from `2.0.0` / build `19` to `2.0.1` / build `20` so this PR passes its own gate

## Scope decisions

The optional `check-sync-guards.sh` / `check-c2-guards.sh` / unit-suite rider was deliberately omitted. The approved scope for this first workflow is the version gate only.

The approved policy requires **both** `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` to increase on every PR to `main`, including docs- and CI-only changes.

After merge, the maintainer must update the `main` branch ruleset to:

1. add the `Version gate` status check; and
2. enable **Require branches to be up to date before merging**.

The up-to-date requirement makes the check rerun when `main` advances. Concurrent PRs that race on the same next version must add a new re-bump commit against updated `main`; never amend an existing commit.

## Validation

- `scripts/check-version-increment.sh 3dcca23 HEAD`
- `bash scripts/test-check-version-increment.sh`
- `shellcheck scripts/check-version-increment.sh scripts/test-check-version-increment.sh`
- `actionlint .github/workflows/version-gate.yml`
- `bash -n scripts/check-version-increment.sh scripts/test-check-version-increment.sh`
- Ruby YAML parse
- `git diff --check HEAD^ HEAD`

No Xcode build or test was run; this is a zero-Xcode item.

Closes #321