### PR TITLE
Fix V2 sync composition defects (#348, #349, #351, #352, #353)

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -686,7 +686,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -707,7 +707,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -718,7 +718,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -866,7 +866,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -894,7 +894,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -920,7 +920,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -948,7 +948,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -970,12 +970,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -996,12 +996,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1021,12 +1021,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1046,12 +1046,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1072,7 +1072,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1083,7 +1083,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1104,7 +1104,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1115,7 +1115,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1139,7 +1139,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1150,7 +1150,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1173,7 +1173,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1184,7 +1184,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -686,7 +686,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -707,7 +707,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -718,7 +718,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -866,7 +866,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -894,7 +894,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -920,7 +920,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -948,7 +948,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -970,12 +970,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -996,12 +996,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1021,12 +1021,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1046,12 +1046,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1072,7 +1072,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1083,7 +1083,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1104,7 +1104,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1115,7 +1115,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1139,7 +1139,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1150,7 +1150,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1173,7 +1173,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1184,7 +1184,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -790,7 +790,10 @@ class ProfileSyncManager: ObservableObject {
     }
     if isSyncReady { engineController.requestSync() }
   }
-  func enqueueProfileDelete(_ id: UUID) throws {
+  func enqueueProfileDelete(
+    _ id: UUID,
+    onDeleteCommitted: @escaping @MainActor () -> Void = {}
+  ) throws {
     defer { recomputeSyncStatus() }
     guard let engineController else {
       deferredDeleteRecordNames.insert(id.uuidString)
@@ -799,7 +802,10 @@ class ProfileSyncManager: ObservableObject {
       throw SyncEngineControllingError.notAttached
     }
     do {
-      try engineController.enqueueProfileDelete(id, requestSyncAfterPendingDelete: isSyncReady)
+      try engineController.enqueueProfileDelete(
+        id,
+        requestSyncAfterPendingDelete: isSyncReady,
+        onDeleteCommitted: onDeleteCommitted)
     } catch SyncEngineControllingError.notAttached {
       deferredDeleteRecordNames.insert(id.uuidString)
       PreAttachDeleteBuffer.add(

--- a/Foqos/CloudKit/ProfileSyncManager.swift
+++ b/Foqos/CloudKit/ProfileSyncManager.swift
@@ -477,6 +477,7 @@ class ProfileSyncManager: ObservableObject {
   func resolveConflictCombine() async {
     guard let conflict = accountChangeConflict else { return }
     cancelAccountResolutionRetry()
+    StrategyManager.shared.clearAllRemoteSessionActive()
     await reattachEngine(userRecordName: conflict.newUserRecordName, forceSeed: true)
     clearPause()
   }
@@ -495,6 +496,7 @@ class ProfileSyncManager: ObservableObject {
     guard let context = attachedModelContext else { throw SyncError.syncDisabled }
 
     let profiles = try context.fetch(FetchDescriptor<BlockedProfiles>())
+    StrategyManager.shared.forceClearEnforcementForSyncedDataWipe(context: context)
     for profile in profiles {
       try BlockedProfiles.deleteProfile(profile, in: context, cleanup: cleanup)
     }

--- a/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
+++ b/Foqos/CloudKit/SyncEngine/MutationFunnel.swift
@@ -172,6 +172,9 @@ final class MutationFunnel {
           store.clearTombstone(recordName: recordName)
           store.clearDeleteWatermark(recordName: recordName)
           modelContext.rollback()
+          if let restored = try? BlockedProfiles.findProfile(byID: profileId, in: modelContext) {
+            BlockedProfiles.updateSnapshot(for: restored)
+          }
           Log.error(
             "Deferred profile delete save failed for \(recordName): \(error.localizedDescription)",
             category: .sync

--- a/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncApplyService.swift
@@ -202,6 +202,9 @@ final class SyncApplyService {
           profileDeleteCommitObserver?(recordName)
         } catch {
           modelContext.rollback()
+          if let restored = try? BlockedProfiles.findProfile(byID: id, in: modelContext) {
+            BlockedProfiles.updateSnapshot(for: restored)
+          }
           store.clearDeleteWatermark(recordName: recordName)
           store.addFailedApply(
             FailedApply(

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController+Cutover.swift
@@ -49,13 +49,25 @@ extension SyncEngineController: SyncEngineControlling {
     try enqueueProfileDelete(id, requestSyncAfterPendingDelete: false)
   }
   func enqueueProfileDelete(_ id: UUID, requestSyncAfterPendingDelete: Bool) throws {
+    try enqueueProfileDelete(
+      id,
+      requestSyncAfterPendingDelete: requestSyncAfterPendingDelete,
+      onDeleteCommitted: {})
+  }
+
+  func enqueueProfileDelete(
+    _ id: UUID,
+    requestSyncAfterPendingDelete: Bool,
+    onDeleteCommitted: @escaping @MainActor () -> Void
+  ) throws {
     guard let funnel else { throw SyncEngineControllingError.notAttached }
-    let onPendingDeleteEnqueued: @MainActor () -> Void = { [weak self] in
+    let commitCallback: @MainActor () -> Void = { [weak self] in
       if requestSyncAfterPendingDelete { self?.requestSync() }
+      onDeleteCommitted()
     }
     try funnel.enqueueDelete(
       profileId: id,
-      onPendingDeleteEnqueued: onPendingDeleteEnqueued)
+      onPendingDeleteEnqueued: commitCallback)
   }
   func enqueueLocationSave(_ id: UUID) throws {
     guard let funnel else { throw SyncEngineControllingError.notAttached }

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -160,7 +160,10 @@ final class SyncEngineController: SyncEngineDriverDelegate {
     scheduleProfileDeleteCommit: @escaping (@escaping @MainActor () -> Void) -> Void =
       BlockedProfiles.scheduleProfileDeleteCommit,
     scheduleReconciler: @escaping (ModelContext) -> Void =
-      { PreActivationReminderScheduler.reconcileScheduleRegistrations(context: $0) }
+      {
+        PreActivationReminderScheduler.reconcileMissingSnapshots(context: $0)
+        PreActivationReminderScheduler.reconcileScheduleRegistrations(context: $0)
+      }
   ) {
     self.modelContext = modelContext
     self.store = store

--- a/Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineControlling.swift
@@ -20,6 +20,11 @@ protocol SyncEngineControlling: AnyObject {
   func enqueueProfileSave(_ id: UUID) throws
   func enqueueProfileDelete(_ id: UUID) throws
   func enqueueProfileDelete(_ id: UUID, requestSyncAfterPendingDelete: Bool) throws
+  func enqueueProfileDelete(
+    _ id: UUID,
+    requestSyncAfterPendingDelete: Bool,
+    onDeleteCommitted: @escaping @MainActor () -> Void
+  ) throws
   func enqueueLocationSave(_ id: UUID) throws
   func enqueueLocationDelete(_ id: UUID) throws
   func enqueueEmergencySettingsSave() throws

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -172,6 +172,8 @@ struct FoqosApp: App {
             if hasPerformedInitialSetup && !ScreenshotDemoMode.isActive {
               PreActivationReminderScheduler.mergeExtensionScheduleSuppression(
                 context: container.mainContext)
+              PreActivationReminderScheduler.reconcileMissingSnapshots(
+                context: container.mainContext)
               PreActivationReminderScheduler.reconcileScheduleRegistrations(
                 context: container.mainContext)
               PreActivationReminderScheduler.catchUpMissedScheduleStarts(context: container.mainContext)
@@ -299,6 +301,8 @@ struct FoqosApp: App {
           if !ScreenshotDemoMode.isActive {
             // Reschedule pre-activation reminders for today
             PreActivationReminderScheduler.mergeExtensionScheduleSuppression(
+              context: container.mainContext)
+            PreActivationReminderScheduler.reconcileMissingSnapshots(
               context: container.mainContext)
             PreActivationReminderScheduler.reconcileScheduleRegistrations(
               context: container.mainContext)

--- a/Foqos/Models/BlockedProfiles.swift
+++ b/Foqos/Models/BlockedProfiles.swift
@@ -501,6 +501,7 @@ class BlockedProfiles {
     let removeStartSchedule: (BlockedProfiles) -> Void
     let removeStopSchedule: (BlockedProfiles) -> Void
     let cancelPreActivationReminders: (UUID) -> Void
+    let cancelSessionAndBreakReminders: (UUID) -> Void
     let removeBreakBackstop: (UUID) -> Void
     let removeOneMoreMinuteBackstop: (UUID) -> Void
   }
@@ -510,6 +511,7 @@ class BlockedProfiles {
       removeStartSchedule: { DeviceActivityCenterUtil.removeScheduleTimerActivities(for: $0) },
       removeStopSchedule: { DeviceActivityCenterUtil.removeStopScheduleActivity(for: $0) },
       cancelPreActivationReminders: { TimersUtil.cancelAllPreActivationReminders(for: $0) },
+      cancelSessionAndBreakReminders: { TimersUtil.cancelOwnedReminders(for: $0) },
       removeBreakBackstop: { DeviceActivityCenterUtil.removeBreakBackstop(profileId: $0) },
       removeOneMoreMinuteBackstop: {
         DeviceActivityCenterUtil.removeOneMoreMinuteBackstop(profileId: $0)
@@ -543,6 +545,7 @@ class BlockedProfiles {
     cleanup.removeStartSchedule(profile)
     cleanup.removeStopSchedule(profile)
     cleanup.cancelPreActivationReminders(profile.id)
+    cleanup.cancelSessionAndBreakReminders(profile.id)
     cleanup.removeBreakBackstop(profile.id)
     cleanup.removeOneMoreMinuteBackstop(profile.id)
 

--- a/Foqos/Utils/PreActivationReminderScheduler.swift
+++ b/Foqos/Utils/PreActivationReminderScheduler.swift
@@ -44,6 +44,20 @@ enum PreActivationReminderScheduler {
     return hasActiveSchedule && !profile.needsAppSelection
   }
 
+  @MainActor
+  static func reconcileMissingSnapshots(context: ModelContext) {
+    do {
+      let profiles = try BlockedProfiles.fetchProfiles(in: context).valid
+      for profile in profiles where SharedData.snapshot(for: profile.id.uuidString) == nil {
+        BlockedProfiles.updateSnapshot(for: profile)
+      }
+    } catch {
+      Log.error(
+        "Failed to reconcile profile snapshots: \(error.localizedDescription)",
+        category: .timer)
+    }
+  }
+
   /// #301: register DeviceActivity schedules for eligible profiles independent of whether
   /// pre-activation reminders are enabled.
   /// Old reminder-gated name `rescheduleAllReminders` caused #301 by hiding registration.

--- a/Foqos/Utils/ProfileDeleteGate.swift
+++ b/Foqos/Utils/ProfileDeleteGate.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum ProfileDeleteGate {
+  enum DeleteBlockReason: Equatable {
+    case active
+    case remotelyActive
+    case locked
+  }
+
+  static func blockedReason(
+    hasLocalActiveSession: Bool,
+    isRemotelyActive: Bool,
+    isEditLocked: Bool
+  ) -> DeleteBlockReason? {
+    if hasLocalActiveSession { return .active }
+    if isRemotelyActive { return .remotelyActive }
+    if isEditLocked { return .locked }
+    return nil
+  }
+}

--- a/Foqos/Utils/ProfileStartArbiter.swift
+++ b/Foqos/Utils/ProfileStartArbiter.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+enum ProfileStartArbiter {
+  enum Decision: Equatable {
+    case start
+    case reject
+    case adopt
+  }
+
+  static func decide(
+    incomingStartTime: Date,
+    incomingProfileId: UUID,
+    existingStartTime: Date?,
+    existingProfileId: UUID?
+  ) -> Decision {
+    guard
+      let existingStartTime,
+      let existingProfileId,
+      existingProfileId != incomingProfileId
+    else {
+      return .start
+    }
+    if incomingStartTime > existingStartTime { return .adopt }
+    if incomingStartTime < existingStartTime { return .reject }
+    return incomingProfileId.uuidString > existingProfileId.uuidString ? .adopt : .reject
+  }
+}

--- a/Foqos/Utils/ProfileStartArbiter.swift
+++ b/Foqos/Utils/ProfileStartArbiter.swift
@@ -13,13 +13,10 @@ enum ProfileStartArbiter {
     existingStartTime: Date?,
     existingProfileId: UUID?
   ) -> Decision {
-    guard
-      let existingStartTime,
-      let existingProfileId,
-      existingProfileId != incomingProfileId
-    else {
+    guard let existingStartTime, let existingProfileId else {
       return .start
     }
+    guard existingProfileId != incomingProfileId else { return .reject }
     if incomingStartTime > existingStartTime { return .adopt }
     if incomingStartTime < existingStartTime { return .reject }
     return incomingProfileId.uuidString > existingProfileId.uuidString ? .adopt : .reject

--- a/Foqos/Utils/ProfileStartArbiter.swift
+++ b/Foqos/Utils/ProfileStartArbiter.swift
@@ -19,6 +19,7 @@ enum ProfileStartArbiter {
     guard existingProfileId != incomingProfileId else { return .reject }
     if incomingStartTime > existingStartTime { return .adopt }
     if incomingStartTime < existingStartTime { return .reject }
+    // Stable but arbitrary: profile UUID text is the only tie-break value shared by both devices.
     return incomingProfileId.uuidString > existingProfileId.uuidString ? .adopt : .reject
   }
 }

--- a/Foqos/Utils/RemotelyActiveStore.swift
+++ b/Foqos/Utils/RemotelyActiveStore.swift
@@ -12,4 +12,8 @@ enum RemotelyActiveStore {
   static func save(_ ids: Set<UUID>, defaults: UserDefaults = .standard) {
     defaults.set(ids.map(\.uuidString), forKey: defaultsKey)
   }
+
+  static func clear(defaults: UserDefaults = .standard) {
+    save([], defaults: defaults)
+  }
 }

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -1579,6 +1579,28 @@ class StrategyManager: ObservableObject {
         return
       }
 
+      // Arbitrate before activating this profile: ending an older local session deactivates
+      // restrictions globally, so doing this later would leave the incoming winner unblocked.
+      let existing = try BlockedProfileSession.mostRecentActiveSession(in: context)
+      switch ProfileStartArbiter.decide(
+        incomingStartTime: startTime,
+        incomingProfileId: profileId,
+        existingStartTime: existing?.startTime,
+        existingProfileId: existing?.blockedProfile.id
+      ) {
+      case .reject:
+        Log.info(
+          "Remote start for '\(profile.name)' is older than the active session; keeping local",
+          category: .strategy)
+        return
+      case .adopt:
+        if let existing {
+          endLocalSessionAndSyncStop(existing, context: context)
+        }
+      case .start:
+        break
+      }
+
       // Activate restrictions
       appBlocker.activateRestrictions(for: BlockedProfiles.getSnapshot(for: profile))
 
@@ -1602,6 +1624,20 @@ class StrategyManager: ObservableObject {
     } catch {
       Log.info("Error starting remote session - \(error)", category: .strategy)
     }
+  }
+
+  private func endLocalSessionAndSyncStop(
+    _ session: BlockedProfileSession,
+    context: ModelContext
+  ) {
+    let profileId = session.blockedProfile.id
+    let wasProcessingRemoteChange = processingRemoteChange
+    processingRemoteChange = false
+    _ = getStrategy(id: ManualBlockingStrategy.id).stopBlocking(
+      context: context,
+      session: session)
+    processingRemoteChange = wasProcessingRemoteChange
+    sessionStopOutbox.enqueue(profileId: profileId)
   }
 
   /// Stop a session triggered by remote device

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -83,6 +83,13 @@ class StrategyManager: ObservableObject {
     RemotelyActiveStore.save(remotelyActiveProfileIds, defaults: remoteActiveDefaults)
   }
 
+  func clearAllRemoteSessionActive() {
+    // Event-scoped to account transitions and synced-data wipes. Do not clear on relaunch:
+    // remote-active locks must survive until sync provides a newer session state.
+    remotelyActiveProfileIds = []
+    RemotelyActiveStore.clear(defaults: remoteActiveDefaults)
+  }
+
   var isBreakActive: Bool {
     return activeSession?.isBreakActive == true
   }
@@ -1519,8 +1526,7 @@ class StrategyManager: ObservableObject {
     elapsedTime = 0
     showCustomStrategyView = false
     customStrategyView = nil
-    remotelyActiveProfileIds.removeAll()
-    RemotelyActiveStore.save(remotelyActiveProfileIds, defaults: remoteActiveDefaults)
+    clearAllRemoteSessionActive()
     timersUtil.cancelAll()
 
     clearBlockingArtifacts(context: context)

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -878,6 +878,10 @@ class StrategyManager: ObservableObject {
     _ session: BlockedProfileSession,
     context: ModelContext? = nil
   ) {
+    // A new start supersedes any persisted stop intent for this profile. Otherwise a later
+    // foreground drain could stop the newly-started remote record instead of the old session.
+    sessionStopOutbox.remove(profileId: session.blockedProfile.id)
+
     // Cancel stale reminders/notifications from previous sessions
     timersUtil.cancelAll()
 
@@ -1590,7 +1594,7 @@ class StrategyManager: ObservableObject {
       ) {
       case .reject:
         Log.info(
-          "Remote start for '\(profile.name)' is older than the active session; keeping local",
+          "Remote start for '\(profile.name)' does not supersede the active session; keeping existing",
           category: .strategy)
         return
       case .adopt:

--- a/Foqos/Utils/TimersUtil.swift
+++ b/Foqos/Utils/TimersUtil.swift
@@ -200,6 +200,26 @@ final class TimersUtil: TimersUtilScheduling, @unchecked Sendable {  // SAFETY: 
     allReminderCleanupRange.map { preActivationReminderIdentifier(for: profileId, minutes: $0) }
   }
 
+  static func cancelOwnedReminders(for profileId: UUID) {
+    let identifiers = [
+      sessionReminderIdentifier(for: profileId),
+      breakReminderIdentifier(for: profileId),
+    ]
+    ownedReminderState.lock.lock()
+    var ownedIdentifiers = ownedReminderIdentifiers
+    for identifier in identifiers {
+      ownedIdentifiers.remove(identifier)
+      ownedReminderState.scheduleGenerations[identifier] =
+        (ownedReminderState.scheduleGenerations[identifier] ?? 0) &+ 1
+    }
+    ownedReminderIdentifiers = ownedIdentifiers
+    ownedReminderState.lock.unlock()
+
+    let center = UNUserNotificationCenter.current()
+    center.removePendingNotificationRequests(withIdentifiers: identifiers)
+    center.removeDeliveredNotifications(withIdentifiers: identifiers)
+  }
+
   static func cancelAllPreActivationReminders(for profileId: UUID) {
     let identifiers = allPreActivationReminderIdentifiers(for: profileId)
     UNUserNotificationCenter.current().removePendingNotificationRequests(

--- a/Foqos/Views/BlockedProfileListView.swift
+++ b/Foqos/Views/BlockedProfileListView.swift
@@ -199,7 +199,7 @@ struct BlockedProfileListView: View {
     // Delete the profiles and reorder
     do {
       var disabledDeletedRecordNames: [String] = []
-      var deletedProfileIds: [UUID] = []
+      var locallyCommittedProfileIds: [UUID] = []
       for index in offsets {
         let profile = profilesToDelete[index]
         let profileId = profile.id
@@ -214,12 +214,15 @@ struct BlockedProfileListView: View {
           // run BEFORE the reorder below, whose `context.save()` would otherwise commit
           // ahead of the funnel.
           do {
-            try profileSyncManager.enqueueProfileDelete(profileId)
+            try profileSyncManager.enqueueProfileDelete(profileId) {
+              strategyManager.setRemoteSessionActive(false, profileId: profileId)
+            }
           } catch SyncEngineControllingError.notAttached {
             // Engine isn't attached yet — the funnel can't own this delete, so delete
             // locally now instead of silently leaving the profile behind (review finding
             // #6). It will propagate once the engine attaches.
             try BlockedProfiles.deleteProfile(profile, in: context)
+            locallyCommittedProfileIds.append(profileId)
           }
         } else {
           // Sync disabled — the funnel would no-op (I2 is only reachable once the engine has
@@ -227,8 +230,8 @@ struct BlockedProfileListView: View {
           // the shared reorder save durably commits.
           try BlockedProfiles.deleteProfile(profile, in: context)
           disabledDeletedRecordNames.append(profileId.uuidString)
+          locallyCommittedProfileIds.append(profileId)
         }
-        deletedProfileIds.append(profileId)
       }
 
       BlockedProfiles.scheduleProfileDeleteCommit {
@@ -241,7 +244,7 @@ struct BlockedProfileListView: View {
           for recordName in disabledDeletedRecordNames {
             profileSyncManager.recordDisabledDeleteTombstone(recordName: recordName)
           }
-          for profileId in deletedProfileIds {
+          for profileId in locallyCommittedProfileIds {
             strategyManager.setRemoteSessionActive(false, profileId: profileId)
           }
           // The `order` field is synced state — bump syncVersion + enqueue a save for each

--- a/Foqos/Views/BlockedProfileListView.swift
+++ b/Foqos/Views/BlockedProfileListView.swift
@@ -6,6 +6,7 @@ struct BlockedProfileListView: View {
   @Environment(\.modelContext) private var context
   @Environment(\.dismiss) private var dismiss
   @EnvironmentObject private var profileSyncManager: ProfileSyncManager
+  @EnvironmentObject private var strategyManager: StrategyManager
   @ObservedObject private var appModeManager = AppModeManager.shared
   @ObservedObject private var lockCodeManager = LockCodeManager.shared
 
@@ -23,6 +24,7 @@ struct BlockedProfileListView: View {
 
   private enum DeleteError {
     case activeProfile
+    case remotelyActiveProfile
     case lockedProfile
     case fetchFailed
     case syncFailed(String)
@@ -30,6 +32,7 @@ struct BlockedProfileListView: View {
     var title: String {
       switch self {
       case .activeProfile: "Cannot Delete Active Profile"
+      case .remotelyActiveProfile: "Active on Another Device"
       case .lockedProfile: "Profile Locked"
       case .fetchFailed: "Unable to Delete"
       case .syncFailed: "Sync Error"
@@ -40,6 +43,8 @@ struct BlockedProfileListView: View {
       switch self {
       case .activeProfile:
         "You cannot delete a profile that is currently active. Please switch to a different profile first."
+      case .remotelyActiveProfile:
+        "This profile is currently blocking on another device. Stop it there before deleting."
       case .lockedProfile:
         "This profile is locked. Open the profile, enter the lock code, "
           + "then delete it from the profile screen."
@@ -168,16 +173,26 @@ struct BlockedProfileListView: View {
     }
     let profilesToDelete = profiles
 
-    // Check if any of the profiles to delete are active or locked
+    // Check if any of the profiles to delete are active or locked.
     for index in offsets {
       let profile = profilesToDelete[index]
-      if profile.id == activeSession?.blockedProfile.id {
+      let reason = ProfileDeleteGate.blockedReason(
+        hasLocalActiveSession: profile.id == activeSession?.blockedProfile.id,
+        isRemotelyActive: strategyManager.remotelyActiveProfileIds.contains(profile.id),
+        isEditLocked: lockCodeManager.isEditLocked(profile)
+      )
+      switch reason {
+      case .active:
         deleteError = .activeProfile
         return
-      }
-      if lockCodeManager.isEditLocked(profile) {
+      case .remotelyActive:
+        deleteError = .remotelyActiveProfile
+        return
+      case .locked:
         deleteError = .lockedProfile
         return
+      case nil:
+        break
       }
     }
 
@@ -269,5 +284,6 @@ struct BlockedProfileListView: View {
 #Preview {
   BlockedProfileListView()
     .environmentObject(ProfileSyncManager.shared)
+    .environmentObject(StrategyManager.shared)
     .modelContainer(for: BlockedProfiles.self, inMemory: true)
 }

--- a/Foqos/Views/BlockedProfileListView.swift
+++ b/Foqos/Views/BlockedProfileListView.swift
@@ -199,6 +199,7 @@ struct BlockedProfileListView: View {
     // Delete the profiles and reorder
     do {
       var disabledDeletedRecordNames: [String] = []
+      var deletedProfileIds: [UUID] = []
       for index in offsets {
         let profile = profilesToDelete[index]
         let profileId = profile.id
@@ -227,6 +228,7 @@ struct BlockedProfileListView: View {
           try BlockedProfiles.deleteProfile(profile, in: context)
           disabledDeletedRecordNames.append(profileId.uuidString)
         }
+        deletedProfileIds.append(profileId)
       }
 
       BlockedProfiles.scheduleProfileDeleteCommit {
@@ -238,6 +240,9 @@ struct BlockedProfileListView: View {
           // delete cannot leave a tombstone that could later kill a live record.
           for recordName in disabledDeletedRecordNames {
             profileSyncManager.recordDisabledDeleteTombstone(recordName: recordName)
+          }
+          for profileId in deletedProfileIds {
+            strategyManager.setRemoteSessionActive(false, profileId: profileId)
           }
           // The `order` field is synced state — bump syncVersion + enqueue a save for each
           // surviving profile so the gap-fix reaches other devices (I2).

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -826,6 +826,7 @@ struct BlockedProfileView: View {
                       // delete would never propagate to other devices.
                       do {
                         try profileSyncManager.enqueueProfileDelete(profileId)
+                        strategyManager.setRemoteSessionActive(false, profileId: profileId)
                       } catch SyncEngineControllingError.notAttached {
                         // Engine isn't attached yet — the funnel can't own this delete, so
                         // delete locally now instead of silently leaving the profile behind
@@ -834,6 +835,7 @@ struct BlockedProfileView: View {
                         BlockedProfiles.scheduleProfileDeleteCommit {
                           do {
                             try modelContext.save()
+                            strategyManager.setRemoteSessionActive(false, profileId: profileId)
                           } catch {
                             showError(message: error.localizedDescription)
                           }
@@ -849,6 +851,7 @@ struct BlockedProfileView: View {
                           try modelContext.save()
                           profileSyncManager.recordDisabledDeleteTombstone(
                             recordName: deletedRecordName)
+                          strategyManager.setRemoteSessionActive(false, profileId: profileId)
                         } catch {
                           showError(message: error.localizedDescription)
                         }

--- a/Foqos/Views/BlockedProfileView.swift
+++ b/Foqos/Views/BlockedProfileView.swift
@@ -825,8 +825,9 @@ struct BlockedProfileView: View {
                       // swallowing the tombstone with no `.deleteRecord` enqueued — the
                       // delete would never propagate to other devices.
                       do {
-                        try profileSyncManager.enqueueProfileDelete(profileId)
-                        strategyManager.setRemoteSessionActive(false, profileId: profileId)
+                        try profileSyncManager.enqueueProfileDelete(profileId) {
+                          strategyManager.setRemoteSessionActive(false, profileId: profileId)
+                        }
                       } catch SyncEngineControllingError.notAttached {
                         // Engine isn't attached yet — the funnel can't own this delete, so
                         // delete locally now instead of silently leaving the profile behind

--- a/FoqosTests/DeleteProfileCleanupTests.swift
+++ b/FoqosTests/DeleteProfileCleanupTests.swift
@@ -21,6 +21,10 @@ final class DeleteProfileCleanupTests: XCTestCase {
       cancelPreActivationReminders: { _ in
         cleanupActions.append("cancelPreActivationReminders")
       },
+      cancelSessionAndBreakReminders: { profileId in
+        XCTAssertEqual(profileId, profile.id)
+        cleanupActions.append("cancelSessionAndBreakReminders")
+      },
       removeBreakBackstop: { profileId in
         XCTAssertEqual(profileId, profile.id)
         cleanupActions.append("removeBreakBackstop")
@@ -37,7 +41,7 @@ final class DeleteProfileCleanupTests: XCTestCase {
       cleanupActions,
       [
         "removeStartSchedule", "removeStopSchedule", "cancelPreActivationReminders",
-        "removeBreakBackstop", "removeOneMoreMinuteBackstop",
+        "cancelSessionAndBreakReminders", "removeBreakBackstop", "removeOneMoreMinuteBackstop",
       ]
     )
     XCTAssertNil(try BlockedProfiles.findProfile(byID: profile.id, in: context))

--- a/FoqosTests/Mocks/MockSyncEngineControlling.swift
+++ b/FoqosTests/Mocks/MockSyncEngineControlling.swift
@@ -59,9 +59,20 @@ final class MockSyncEngineControlling: SyncEngineControlling {
     try enqueueProfileDelete(id, requestSyncAfterPendingDelete: false)
   }
   func enqueueProfileDelete(_ id: UUID, requestSyncAfterPendingDelete: Bool) throws {
+    try enqueueProfileDelete(
+      id,
+      requestSyncAfterPendingDelete: requestSyncAfterPendingDelete,
+      onDeleteCommitted: {})
+  }
+  func enqueueProfileDelete(
+    _ id: UUID,
+    requestSyncAfterPendingDelete: Bool,
+    onDeleteCommitted: @escaping @MainActor () -> Void
+  ) throws {
     if let errorToThrow { throw errorToThrow }
     enqueuedProfileDeletes.append(id)
     if requestSyncAfterPendingDelete { requestSync() }
+    onDeleteCommitted()
   }
   func enqueueLocationSave(_ id: UUID) throws {
     if let errorToThrow { throw errorToThrow }

--- a/FoqosTests/MutationFunnelTests.swift
+++ b/FoqosTests/MutationFunnelTests.swift
@@ -548,6 +548,32 @@ final class MutationFunnelTests: XCTestCase {
       "rollback restored the second profile, so it must not be enqueued for remote deletion")
   }
 
+  func testGivenDeleteCommitFailure_WhenRollbackRestoresProfile_ThenSnapshotRestored() throws {
+    struct BoomError: Error {}
+
+    let profileId = UUID()
+    let container = try TestModelContainer.create()
+    let context = ModelContext(container)
+    let profile = try insertProfile(
+      in: context, id: profileId, name: "Snapshot", syncVersion: 1)
+    BlockedProfiles.updateSnapshot(for: profile)
+    let scheduler = ManualProfileDeleteCommitScheduler()
+    let funnel = MutationFunnel(
+      modelContext: context,
+      store: makeStore(),
+      driver: MockSyncEngineDriver(),
+      deviceId: "device-A",
+      scheduleProfileDeleteCommit: scheduler.schedule)
+    funnel.saveOverride = { throw BoomError() }
+
+    try funnel.enqueueDelete(profileId: profileId)
+    XCTAssertNil(SharedData.snapshot(for: profileId.uuidString))
+    scheduler.runNext()
+
+    XCTAssertNotNil(try BlockedProfiles.findProfile(byID: profileId, in: context))
+    XCTAssertNotNil(SharedData.snapshot(for: profileId.uuidString))
+  }
+
   // MARK: - S-15: failed entity delete removes the tombstone before returning and enqueues nothing
 
   func testGivenFailedProfileDelete_WhenEnqueueDelete_ThenTombstoneRemovedRollbackAndNothingEnqueued()

--- a/FoqosTests/PreActivationReminderSchedulerTests.swift
+++ b/FoqosTests/PreActivationReminderSchedulerTests.swift
@@ -8,11 +8,44 @@ import XCTest
 final class PreActivationReminderSchedulerTests: XCTestCase {
   private var container: ModelContainer!
   private var context: ModelContext!
+  private var suiteName: String!
+  private var defaults: UserDefaults!
 
   override func setUp() async throws {
     try await super.setUp()
+    suiteName = "PreActivationReminderSchedulerTests-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+    SharedData.configure(suite: defaults)
     container = try TestModelContainer.create()
     context = container.mainContext
+  }
+
+  override func tearDown() async throws {
+    defaults.removePersistentDomain(forName: suiteName)
+    try await super.tearDown()
+  }
+
+  func testGivenProfileWithMissingSnapshot_WhenReconciling_ThenSnapshotRewritten() throws {
+    let profile = BlockedProfiles(name: "Focus")
+    context.insert(profile)
+    try context.save()
+    SharedData.removeSnapshot(for: profile.id.uuidString)
+
+    PreActivationReminderScheduler.reconcileMissingSnapshots(context: context)
+
+    XCTAssertNotNil(SharedData.snapshot(for: profile.id.uuidString))
+  }
+
+  func testGivenPendingDelete_WhenReconciling_ThenSnapshotNotResurrected() throws {
+    let profile = BlockedProfiles(name: "Focus")
+    context.insert(profile)
+    try context.save()
+    SharedData.removeSnapshot(for: profile.id.uuidString)
+    context.delete(profile)
+
+    PreActivationReminderScheduler.reconcileMissingSnapshots(context: context)
+
+    XCTAssertNil(SharedData.snapshot(for: profile.id.uuidString))
   }
 
   func testGivenScheduledAppSelectedProfileNoReminders_WhenEligibility_ThenTrue() throws {

--- a/FoqosTests/ProfileDeleteGateTests.swift
+++ b/FoqosTests/ProfileDeleteGateTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class ProfileDeleteGateTests: XCTestCase {
+  func testGivenRemotelyActive_WhenComputingGate_ThenBlockedRemotelyActive() {
+    XCTAssertEqual(
+      ProfileDeleteGate.blockedReason(
+        hasLocalActiveSession: false,
+        isRemotelyActive: true,
+        isEditLocked: false
+      ),
+      .remotelyActive
+    )
+  }
+
+  func testGivenLocalActive_WhenComputingGate_ThenBlockedActive() {
+    XCTAssertEqual(
+      ProfileDeleteGate.blockedReason(
+        hasLocalActiveSession: true,
+        isRemotelyActive: false,
+        isEditLocked: false
+      ),
+      .active
+    )
+  }
+
+  func testGivenEditLocked_WhenComputingGate_ThenBlockedLocked() {
+    XCTAssertEqual(
+      ProfileDeleteGate.blockedReason(
+        hasLocalActiveSession: false,
+        isRemotelyActive: false,
+        isEditLocked: true
+      ),
+      .locked
+    )
+  }
+
+  func testGivenNothing_WhenComputingGate_ThenNil() {
+    XCTAssertNil(
+      ProfileDeleteGate.blockedReason(
+        hasLocalActiveSession: false,
+        isRemotelyActive: false,
+        isEditLocked: false
+      )
+    )
+  }
+
+  func testGivenLocalAndRemoteActive_WhenComputingGate_ThenLocalActiveWins() {
+    XCTAssertEqual(
+      ProfileDeleteGate.blockedReason(
+        hasLocalActiveSession: true,
+        isRemotelyActive: true,
+        isEditLocked: false
+      ),
+      .active
+    )
+  }
+}

--- a/FoqosTests/ProfileStartArbiterTests.swift
+++ b/FoqosTests/ProfileStartArbiterTests.swift
@@ -18,7 +18,7 @@ final class ProfileStartArbiterTests: XCTestCase {
       .start)
   }
 
-  func testGivenSameProfileActive_WhenDeciding_ThenStart() {
+  func testGivenSameProfileActive_WhenDeciding_ThenRejectDuplicate() {
     let now = Date(timeIntervalSinceReferenceDate: 1_000)
 
     XCTAssertEqual(
@@ -27,7 +27,7 @@ final class ProfileStartArbiterTests: XCTestCase {
         incomingProfileId: idB,
         existingStartTime: now.addingTimeInterval(-1),
         existingProfileId: idB),
-      .start)
+      .reject)
   }
 
   func testGivenIncomingNewer_WhenDeciding_ThenAdopt() {

--- a/FoqosTests/ProfileStartArbiterTests.swift
+++ b/FoqosTests/ProfileStartArbiterTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class ProfileStartArbiterTests: XCTestCase {
+  private let idA = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+  private let idB = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+
+  func testGivenNoExistingSession_WhenDeciding_ThenStart() {
+    let now = Date(timeIntervalSinceReferenceDate: 1_000)
+
+    XCTAssertEqual(
+      ProfileStartArbiter.decide(
+        incomingStartTime: now,
+        incomingProfileId: idB,
+        existingStartTime: nil,
+        existingProfileId: nil),
+      .start)
+  }
+
+  func testGivenSameProfileActive_WhenDeciding_ThenStart() {
+    let now = Date(timeIntervalSinceReferenceDate: 1_000)
+
+    XCTAssertEqual(
+      ProfileStartArbiter.decide(
+        incomingStartTime: now,
+        incomingProfileId: idB,
+        existingStartTime: now.addingTimeInterval(-1),
+        existingProfileId: idB),
+      .start)
+  }
+
+  func testGivenIncomingNewer_WhenDeciding_ThenAdopt() {
+    let now = Date(timeIntervalSinceReferenceDate: 1_000)
+
+    XCTAssertEqual(
+      ProfileStartArbiter.decide(
+        incomingStartTime: now,
+        incomingProfileId: idB,
+        existingStartTime: now.addingTimeInterval(-60),
+        existingProfileId: idA),
+      .adopt)
+  }
+
+  func testGivenIncomingOlder_WhenDeciding_ThenReject() {
+    let now = Date(timeIntervalSinceReferenceDate: 1_000)
+
+    XCTAssertEqual(
+      ProfileStartArbiter.decide(
+        incomingStartTime: now.addingTimeInterval(-60),
+        incomingProfileId: idB,
+        existingStartTime: now,
+        existingProfileId: idA),
+      .reject)
+  }
+
+  func testGivenEqualStartTimes_WhenDeciding_ThenHigherProfileIdWins() {
+    let now = Date(timeIntervalSinceReferenceDate: 1_000)
+
+    XCTAssertEqual(
+      ProfileStartArbiter.decide(
+        incomingStartTime: now,
+        incomingProfileId: idB,
+        existingStartTime: now,
+        existingProfileId: idA),
+      .adopt)
+    XCTAssertEqual(
+      ProfileStartArbiter.decide(
+        incomingStartTime: now,
+        incomingProfileId: idA,
+        existingStartTime: now,
+        existingProfileId: idB),
+      .reject)
+  }
+}

--- a/FoqosTests/ProfileSyncAccountResolverTests.swift
+++ b/FoqosTests/ProfileSyncAccountResolverTests.swift
@@ -16,6 +16,7 @@ final class ProfileSyncAccountResolverTests: XCTestCase {
   var savedIsSyncReady = false
   var savedController: (any SyncEngineControlling)?
   var savedBufferDefaults: UserDefaults!
+  var savedRemoteActiveProfileIds: Set<UUID>!
   var emergencyManager: EmergencyUnblockManager!
   let recA = CKRecord.ID(recordName: "userA")
   let recB = CKRecord.ID(recordName: "userB")
@@ -33,6 +34,10 @@ final class ProfileSyncAccountResolverTests: XCTestCase {
     savedIsSyncReady = manager.isSyncReady
     savedController = manager.engineController
     savedBufferDefaults = manager.bufferDefaults
+    savedRemoteActiveProfileIds = StrategyManager.shared.remotelyActiveProfileIds
+    for profileId in savedRemoteActiveProfileIds {
+      StrategyManager.shared.setRemoteSessionActive(false, profileId: profileId)
+    }
     manager.bufferDefaults = bufferDefaults
     emergencyManager = EmergencyUnblockManager(defaults: defaults)
     manager.engineController = nil
@@ -47,6 +52,12 @@ final class ProfileSyncAccountResolverTests: XCTestCase {
     manager.isEnabled = savedEnabled
     manager.bufferDefaults = savedBufferDefaults
     manager.clearAccountChangeStateForTest()
+    for profileId in StrategyManager.shared.remotelyActiveProfileIds {
+      StrategyManager.shared.setRemoteSessionActive(false, profileId: profileId)
+    }
+    for profileId in savedRemoteActiveProfileIds {
+      StrategyManager.shared.setRemoteSessionActive(true, profileId: profileId)
+    }
     UserDefaults().removePersistentDomain(forName: bufferSuiteName)
     UserDefaults().removePersistentDomain(forName: suiteName)
     try await super.tearDown()
@@ -150,6 +161,17 @@ final class ProfileSyncAccountResolverTests: XCTestCase {
     XCTAssertNil(manager.accountChangeConflict)
   }
 
+  func testGivenRemoteActiveId_WhenCombine_ThenRemoteActiveSetCleared() async throws {
+    try await makeAttachedManager(namespace: "userA", isEnabled: true, engineState: .steady)
+    manager.resolveAccountChange(availability: .available(recB), newName: "userB")
+    let keptProfile = seedLocalProfiles(count: 1).first!
+    StrategyManager.shared.setRemoteSessionActive(true, profileId: keptProfile.id)
+
+    await manager.resolveConflictCombine()
+
+    XCTAssertTrue(StrategyManager.shared.remotelyActiveProfileIds.isEmpty)
+  }
+
   func testSwitchWipesLocalAndEmergencyThenReattaches() async throws {
     try await makeAttachedManager(namespace: "userA", isEnabled: true, engineState: .steady)
     manager.resolveAccountChange(availability: .available(recB), newName: "userB")
@@ -168,6 +190,17 @@ final class ProfileSyncAccountResolverTests: XCTestCase {
     XCTAssertEqual(try container.mainContext.fetch(FetchDescriptor<SavedLocation>()).count, 0)
     XCTAssertEqual(emergencyManager.getRemainingEmergencyUnblocks(), 3)
     XCTAssertNil(manager.accountChangeConflict)
+  }
+
+  func testGivenRemoteActiveId_WhenSwitch_ThenRemoteActiveSetCleared() async throws {
+    try await makeAttachedManager(namespace: "userA", isEnabled: true, engineState: .steady)
+    manager.resolveAccountChange(availability: .available(recB), newName: "userB")
+    let wipedProfile = seedLocalProfiles(count: 1).first!
+    StrategyManager.shared.setRemoteSessionActive(true, profileId: wipedProfile.id)
+
+    await manager.resolveConflictSwitchToCloud()
+
+    XCTAssertTrue(StrategyManager.shared.remotelyActiveProfileIds.isEmpty)
   }
 
   func testSwitchWipeFailureKeepsConflictWithoutReattachOrEmergencyReset() async throws {
@@ -412,6 +445,16 @@ final class ProfileSyncAccountResolverTests: XCTestCase {
 
     XCTAssertEqual(events, ["stop", "restrictions", "live-activity", "delete"])
     XCTAssertEqual(try container.mainContext.fetch(FetchDescriptor<BlockedProfiles>()).count, 0)
+  }
+
+  func testGivenRemoteActiveId_WhenGenerationWipe_ThenRemoteActiveSetCleared() async throws {
+    try await makeAttachedManager(namespace: "userA", isEnabled: true, engineState: .steady)
+    let wipedProfile = seedLocalProfiles(count: 1).first!
+    StrategyManager.shared.setRemoteSessionActive(true, profileId: wipedProfile.id)
+
+    try manager.wipeLocalSyncedEntitiesForGeneration()
+
+    XCTAssertTrue(StrategyManager.shared.remotelyActiveProfileIds.isEmpty)
   }
 
   func testOriginWipeFailureAfterEntityDeleteDoesNotAdvanceGeneration() async throws {

--- a/FoqosTests/ProfileSyncAccountResolverTests.swift
+++ b/FoqosTests/ProfileSyncAccountResolverTests.swift
@@ -234,10 +234,12 @@ final class ProfileSyncAccountResolverTests: XCTestCase {
     var removedStartSchedules: Set<UUID> = []
     var removedStopSchedules: Set<UUID> = []
     var canceledPreActivationReminders: Set<UUID> = []
+    var canceledSessionAndBreakReminders: Set<UUID> = []
     let cleanup = BlockedProfiles.DeleteCleanup(
       removeStartSchedule: { removedStartSchedules.insert($0.id) },
       removeStopSchedule: { removedStopSchedules.insert($0.id) },
       cancelPreActivationReminders: { canceledPreActivationReminders.insert($0) },
+      cancelSessionAndBreakReminders: { canceledSessionAndBreakReminders.insert($0) },
       removeBreakBackstop: { _ in },
       removeOneMoreMinuteBackstop: { _ in }
     )
@@ -248,6 +250,7 @@ final class ProfileSyncAccountResolverTests: XCTestCase {
     XCTAssertTrue(removedStartSchedules.contains(profile.id))
     XCTAssertTrue(removedStopSchedules.contains(profile.id))
     XCTAssertTrue(canceledPreActivationReminders.contains(profile.id))
+    XCTAssertTrue(canceledSessionAndBreakReminders.contains(profile.id))
     XCTAssertEqual(try container.mainContext.fetch(FetchDescriptor<BlockedProfiles>()).count, 0)
   }
 
@@ -431,6 +434,7 @@ final class ProfileSyncAccountResolverTests: XCTestCase {
       removeStartSchedule: { _ in events.append("delete") },
       removeStopSchedule: { _ in },
       cancelPreActivationReminders: { _ in },
+      cancelSessionAndBreakReminders: { _ in },
       removeBreakBackstop: { _ in },
       removeOneMoreMinuteBackstop: { _ in })
 

--- a/FoqosTests/RemotelyActiveProfilesTests.swift
+++ b/FoqosTests/RemotelyActiveProfilesTests.swift
@@ -36,4 +36,30 @@ final class RemotelyActiveProfilesTests: XCTestCase {
     XCTAssertFalse(
       StrategyManager(remoteActiveDefaults: defaults).remotelyActiveProfileIds.contains(profileId))
   }
+
+  func testGivenRemoteActiveIds_WhenClearAll_ThenSetEmptyAndPersistsEmpty() {
+    let idA = UUID()
+    let idB = UUID()
+    let manager = StrategyManager(remoteActiveDefaults: defaults)
+    manager.setRemoteSessionActive(true, profileId: idA)
+    manager.setRemoteSessionActive(true, profileId: idB)
+
+    manager.clearAllRemoteSessionActive()
+
+    XCTAssertTrue(manager.remotelyActiveProfileIds.isEmpty)
+    XCTAssertTrue(RemotelyActiveStore.load(defaults: defaults).isEmpty)
+  }
+
+  func testGivenTwoRemoteActiveIds_WhenClearingOne_ThenOtherRemains() {
+    let idA = UUID()
+    let idB = UUID()
+    let manager = StrategyManager(remoteActiveDefaults: defaults)
+    manager.setRemoteSessionActive(true, profileId: idA)
+    manager.setRemoteSessionActive(true, profileId: idB)
+
+    manager.setRemoteSessionActive(false, profileId: idA)
+
+    XCTAssertEqual(manager.remotelyActiveProfileIds, [idB])
+    XCTAssertEqual(RemotelyActiveStore.load(defaults: defaults), [idB])
+  }
 }

--- a/FoqosTests/StrategyManagerRemoteSessionTests.swift
+++ b/FoqosTests/StrategyManagerRemoteSessionTests.swift
@@ -8,6 +8,7 @@ final class StrategyManagerRemoteSessionTests: XCTestCase {
   private var container: ModelContainer!
   private var context: ModelContext!
   private var manager: StrategyManager!
+  private var appBlocker: RecordingRestrictionApplier!
   private var suiteName: String!
 
   override func setUp() async throws {
@@ -16,11 +17,14 @@ final class StrategyManagerRemoteSessionTests: XCTestCase {
     SharedData.configure(suite: UserDefaults(suiteName: suiteName)!)
     container = try TestModelContainer.create()
     context = container.mainContext
-    manager = StrategyManager()
+    appBlocker = RecordingRestrictionApplier()
+    manager = StrategyManager(appBlocker: appBlocker)
+    manager.sessionStopOutbox.clear()
   }
 
   override func tearDown() async throws {
     manager.stopTimer()
+    manager.sessionStopOutbox.clear()
     UserDefaults().removePersistentDomain(forName: suiteName)
     try await super.tearDown()
   }
@@ -79,5 +83,56 @@ final class StrategyManagerRemoteSessionTests: XCTestCase {
     XCTAssertNil(manager.activeSession, "real stopRemoteSession clears the active session (#203)")
     XCTAssertNil(manager.timerTask, "real stopRemoteSession stops the timer (#203)")
     XCTAssertNotNil(session.endTime, "the session is ended")
+  }
+
+  func testGivenLocalNewerSession_WhenRemoteOlderStart_ThenRemoteRejected() throws {
+    let now = Date(timeIntervalSinceReferenceDate: 1_000)
+    let profileA = BlockedProfiles(name: "Local Newer")
+    let profileB = BlockedProfiles(name: "Remote Older")
+    context.insert(profileA)
+    context.insert(profileB)
+    let sessionA = BlockedProfileSession(tag: "local", blockedProfile: profileA, startTime: now)
+    context.insert(sessionA)
+    try context.save()
+    manager.activeSession = sessionA
+
+    manager.startRemoteSession(
+      context: context,
+      profileId: profileB.id,
+      sessionId: UUID(),
+      startTime: now.addingTimeInterval(-60))
+
+    XCTAssertEqual(manager.activeSession?.blockedProfile.id, profileA.id)
+    XCTAssertEqual(try activeSessions().map(\.blockedProfile.id), [profileA.id])
+    XCTAssertTrue(appBlocker.calls.isEmpty)
+  }
+
+  func testGivenLocalOlderSession_WhenRemoteNewerStart_ThenLocalEndedAndRemoteAdopted() throws {
+    let now = Date(timeIntervalSinceReferenceDate: 1_000)
+    let profileA = BlockedProfiles(name: "Local Older")
+    let profileB = BlockedProfiles(name: "Remote Newer")
+    context.insert(profileA)
+    context.insert(profileB)
+    let sessionA = BlockedProfileSession(
+      tag: "local", blockedProfile: profileA, startTime: now.addingTimeInterval(-60))
+    context.insert(sessionA)
+    try context.save()
+    manager.activeSession = sessionA
+
+    manager.startRemoteSession(
+      context: context,
+      profileId: profileB.id,
+      sessionId: UUID(),
+      startTime: now)
+
+    XCTAssertEqual(manager.activeSession?.blockedProfile.id, profileB.id)
+    XCTAssertEqual(try activeSessions().map(\.blockedProfile.id), [profileB.id])
+    XCTAssertNotNil(sessionA.endTime)
+    XCTAssertEqual(manager.sessionStopOutbox.pending, [profileA.id])
+    XCTAssertEqual(appBlocker.calls, [.activate(profileId: profileB.id)])
+  }
+
+  private func activeSessions() throws -> [BlockedProfileSession] {
+    try context.fetch(FetchDescriptor<BlockedProfileSession>()).filter { $0.endTime == nil }
   }
 }

--- a/FoqosTests/StrategyManagerRemoteSessionTests.swift
+++ b/FoqosTests/StrategyManagerRemoteSessionTests.swift
@@ -132,6 +132,41 @@ final class StrategyManagerRemoteSessionTests: XCTestCase {
     XCTAssertEqual(appBlocker.calls, [.activate(profileId: profileB.id)])
   }
 
+  func testGivenPendingStopForProfile_WhenRemoteSessionStarts_ThenPendingStopCleared() throws {
+    let profile = BlockedProfiles(name: "Restarted")
+    context.insert(profile)
+    try context.save()
+    manager.sessionStopOutbox.enqueue(profileId: profile.id)
+
+    manager.startRemoteSession(
+      context: context,
+      profileId: profile.id,
+      sessionId: UUID(),
+      startTime: Date(timeIntervalSinceReferenceDate: 1_000))
+
+    XCTAssertFalse(manager.sessionStopOutbox.pending.contains(profile.id))
+  }
+
+  func testGivenSameProfileActiveInStoreOnly_WhenRemoteStart_ThenNoDuplicateSessionCreated() throws {
+    let now = Date(timeIntervalSinceReferenceDate: 1_000)
+    let profile = BlockedProfiles(name: "Stored")
+    context.insert(profile)
+    let existing = BlockedProfileSession(
+      tag: "local", blockedProfile: profile, startTime: now.addingTimeInterval(-60))
+    context.insert(existing)
+    try context.save()
+    manager.activeSession = nil
+
+    manager.startRemoteSession(
+      context: context,
+      profileId: profile.id,
+      sessionId: UUID(),
+      startTime: now)
+
+    XCTAssertEqual(try activeSessions().map(\.id), [existing.id])
+    XCTAssertTrue(appBlocker.calls.isEmpty)
+  }
+
   private func activeSessions() throws -> [BlockedProfileSession] {
     try context.fetch(FetchDescriptor<BlockedProfileSession>()).filter { $0.endTime == nil }
   }

--- a/FoqosTests/SyncApplyServiceTests.swift
+++ b/FoqosTests/SyncApplyServiceTests.swift
@@ -960,6 +960,7 @@ final class SyncApplyServiceTests: XCTestCase {
     let profile = BlockedProfiles(id: id, name: "RemoteDelete", syncVersion: 1)
     context.insert(profile)
     try context.save()
+    BlockedProfiles.updateSnapshot(for: profile)
     store.setSystemFields(Data("cached".utf8), for: id.uuidString)
     store.setTombstone(recordName: id.uuidString, changeTag: "tag-1")
 
@@ -974,6 +975,7 @@ final class SyncApplyServiceTests: XCTestCase {
         recordID: CKRecord.ID(recordName: id.uuidString, zoneID: zoneID),
         recordType: SyncedProfile.recordType),
       .deleted)
+    XCTAssertNil(SharedData.snapshot(for: id.uuidString))
 
     scheduler.runNext()
 
@@ -983,6 +985,7 @@ final class SyncApplyServiceTests: XCTestCase {
       "rollback must leave the remote-active lock intact for retry")
     XCTAssertNotNil(store.systemFields(for: id.uuidString), "failed commit keeps deletion bookkeeping")
     XCTAssertEqual(store.deleteTombstones[id.uuidString] ?? nil, "tag-1")
+    XCTAssertNotNil(SharedData.snapshot(for: id.uuidString))
   }
 
   func testGivenTwoRemoteProfileDeletions_WhenFirstDeferredCommitRollsBackSecond_ThenSecondBookkeepingIsRetained()

--- a/FoqosTests/SyncApplyServiceTests.swift
+++ b/FoqosTests/SyncApplyServiceTests.swift
@@ -615,6 +615,31 @@ final class SyncApplyServiceTests: XCTestCase {
     XCTAssertFalse(sessionController.stopRemoteSessionCalled)
   }
 
+  func testGivenDifferentLocalProfileActive_WhenRemoteStartApplied_ThenDelegatesArbitration() throws {
+    let now = Date(timeIntervalSinceReferenceDate: 1_000)
+    let profileA = BlockedProfiles(name: "Local")
+    let profileB = BlockedProfiles(name: "Remote")
+    context.insert(profileA)
+    context.insert(profileB)
+    try context.save()
+    sessionController.activeSession = BlockedProfileSession(
+      tag: "local", blockedProfile: profileA, startTime: now.addingTimeInterval(-60))
+    var remote = ProfileSessionRecord(profileId: profileB.id)
+    _ = remote.applyUpdate(
+      isActive: true,
+      sequenceNumber: 1,
+      deviceId: "device-B",
+      startTime: now)
+
+    XCTAssertEqual(
+      makeService().applyFetchedModification(
+        remote.toCKRecord(in: zoneID), isPendingDeleteOrTombstoned: noPendingDelete),
+      .applied)
+
+    XCTAssertTrue(sessionController.startRemoteSessionCalled)
+    XCTAssertEqual(sessionController.startRemoteSessionProfileId, profileB.id)
+  }
+
   func testGivenOwnSessionModification_WhenApplied_ThenSelfEchoFiltered() throws {
     let now = Date()
     let id = UUID()

--- a/FoqosTests/SyncEngineControllerCutoverTests.swift
+++ b/FoqosTests/SyncEngineControllerCutoverTests.swift
@@ -166,6 +166,41 @@ final class SyncEngineControllerCutoverTests: XCTestCase {
     XCTAssertEqual(driver.sendChangesCount, sendBefore + 1)
   }
 
+  func testGivenProfileDelete_WhenDeferredCommitSucceeds_ThenCommitCallbackRunsAfterSave() throws {
+    let now = Date()
+    let profile = makeProfile(now: now)
+    controller.start()
+    var didCommit = false
+
+    try controller.enqueueProfileDelete(
+      profile.id,
+      requestSyncAfterPendingDelete: false,
+      onDeleteCommitted: { didCommit = true })
+
+    XCTAssertFalse(didCommit)
+    profileDeleteCommitScheduler.runNext()
+    XCTAssertTrue(didCommit)
+  }
+
+  func testGivenProfileDelete_WhenDeferredCommitFails_ThenCommitCallbackDoesNotRun() throws {
+    struct BoomError: Error {}
+
+    let now = Date()
+    let profile = makeProfile(now: now)
+    controller.start()
+    controller.funnel?.saveOverride = { throw BoomError() }
+    var didCommit = false
+
+    try controller.enqueueProfileDelete(
+      profile.id,
+      requestSyncAfterPendingDelete: false,
+      onDeleteCommitted: { didCommit = true })
+    profileDeleteCommitScheduler.runNext()
+
+    XCTAssertFalse(didCommit)
+    XCTAssertNotNil(try BlockedProfiles.findProfile(byID: profile.id, in: context))
+  }
+
   // MARK: - Task 134b (CRA-4): ResetController + LegacyCleanupCoordinator wiring
 
   func testGivenFetchedForeignResetCommand_WhenHandled_ThenRoutedToResetControllerApplyCommand()

--- a/FoqosTests/TimersUtilTargetedCancelTests.swift
+++ b/FoqosTests/TimersUtilTargetedCancelTests.swift
@@ -100,6 +100,41 @@ final class TimersUtilTargetedCancelTests: XCTestCase {
       timers.isOwnedReminderScheduleCurrentForTesting(identifier, generation: generation))
   }
 
+  func testGivenProfileOwnedReminders_WhenTargetedCancel_ThenOnlyProfileOwnershipInvalidated() {
+    let timers = TimersUtil()
+    let profileId = UUID()
+    let otherProfileId = UUID()
+    let sessionId = TimersUtil.sessionReminderIdentifier(for: profileId)
+    let breakId = TimersUtil.breakReminderIdentifier(for: profileId)
+    let otherId = TimersUtil.sessionReminderIdentifier(for: otherProfileId)
+    for identifier in [sessionId, breakId, otherId] {
+      _ = timers.scheduleNotification(
+        title: "Reminder",
+        message: "Message",
+        seconds: 60,
+        identifier: identifier)
+    }
+    let sessionGeneration = try! XCTUnwrap(
+      timers.ownedReminderScheduleGenerationForTesting(sessionId))
+    let breakGeneration = try! XCTUnwrap(
+      timers.ownedReminderScheduleGenerationForTesting(breakId))
+    let otherGeneration = try! XCTUnwrap(
+      timers.ownedReminderScheduleGenerationForTesting(otherId))
+
+    TimersUtil.cancelOwnedReminders(for: profileId)
+
+    XCTAssertEqual(timers.ownedReminderIdentifiersForTesting, [otherId])
+    XCTAssertFalse(
+      timers.isOwnedReminderScheduleCurrentForTesting(
+        sessionId, generation: sessionGeneration))
+    XCTAssertFalse(
+      timers.isOwnedReminderScheduleCurrentForTesting(breakId, generation: breakGeneration))
+    XCTAssertTrue(
+      timers.isOwnedReminderScheduleCurrentForTesting(otherId, generation: otherGeneration))
+
+    timers.cancelAllNotifications()
+  }
+
   func testGivenOwnedReminderAddCompletesAfterCancel_WhenCheckingStaleGeneration_ThenRequestsRemoval() {
     let timers = TimersUtil()
     let identifier = TimersUtil.sessionReminderIdentifier(for: UUID())


### PR DESCRIPTION
## Summary

- block list swipe-deletion when a profile is active on another device
- clear and prune durable remote-active state during account transitions and profile reconciliation
- self-heal missing enforcement snapshots after interrupted deletes
- cancel only the deleted profile's owned session and break reminders
- arbitrate cross-profile remote starts with deterministic newest-wins behavior, immediately syncing the loser's stop
- bump all targets from 2.0.0 (19) to 2.0.1 (20) for the strict version gate

## Why

Several individually-correct sync and cleanup changes composed into stale locks, orphaned active sessions, missing enforcement snapshots, and notifications owned by deleted profiles. This bundle closes those seams while reusing the existing account-wipe, delete-cleanup, snapshot, and session-CAS paths.

For cross-device starts, the deterministic rule is newest `startTime` wins; equal timestamps use the shared profile UUID string as the tie-break. The losing local session is ended before winner restrictions are applied, and its stop is sent through the normal unsuppressed CAS path with the persisted outbox as a durability backstop.

## Validation

- focused TDD runs for each issue
- full unit suite: 1,191 tests, 0 failures
- `swift-format lint --recursive .`
- `git diff --check`
- serialized Debug build through `scripts/xcode-stream.sh`: succeeded

Closes #348
Closes #349
Closes #351
Closes #352
Closes #353

## Summary by Sourcery

Tighten cross-device sync and enforcement behavior by arbitrating remote session starts, hardening remote-active lock and snapshot lifecycle handling, and ensuring deletions and rollbacks correctly clean up or restore associated timers, locks, and snapshots.

New Features:
- Introduce deterministic arbitration for cross-profile remote session starts using start-time and profile ID tie-breaking.
- Block deletion of profiles that are active on another device and surface a dedicated user-facing error message.

Bug Fixes:
- Ensure remote-active locks and durable state are cleared during account switches and synced-data wipes.
- Restore enforcement snapshots when profile deletions are rolled back or when snapshots are missing after interrupted operations.
- Cancel session and break notifications owned by deleted profiles to prevent orphaned reminders.
- Keep remote-active locks intact and snapshots consistent across deferred delete commits and rollbacks.
- Persist and clear remotely active profile IDs reliably via a dedicated clear operation.

Enhancements:
- Delegate remote session start arbitration through a dedicated ProfileStartArbiter and reuse it from sync application and strategy management.
- Refine profile deletion gating logic via a reusable ProfileDeleteGate helper.
- Extend timers utility with targeted cancellation of owned reminders for a specific profile.
- Extend pre-activation reminder reconciliation to repair missing snapshots on app launch and sync reconciliation.
- Improve tests around remote session handling, account resolution, deletion cleanup, timers, and snapshot reconciliation.

Tests:
- Add unit coverage for profile start arbitration, delete gating, remotely active profile clearing, snapshot reconciliation, and targeted reminder cancellation.
- Extend existing sync, mutation funnel, strategy manager, and profile sync tests to cover rollback behavior, arbitration paths, and remote-active clearing semantics.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR composes several V2 synchronization and cleanup fixes around profile deletion, account transitions, snapshot repair, notification ownership, and cross-profile session arbitration.

- Adds durable remote-active deletion gating and account-transition pruning.
- Repairs missing enforcement snapshots after interrupted deletes.
- Targets session and reminder cleanup to the deleted profile.
- Adds deterministic newest-wins arbitration for conflicting remote starts.
- Bumps all targets to version 2.0.1 build 20.

<h3>Confidence Score: 4/5</h3>

The remote-active marker must be cleared only after the synchronized detail-view deletion commits successfully; otherwise a failed delete can restore an active profile without its deletion guard.

The detail deletion path returns before its fallible save runs but immediately clears durable remote-active state, while rollback restores only the profile and snapshot.

**Files Needing Attention:** Foqos/Views/BlockedProfileView.swift

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Foqos/Views/BlockedProfileView.swift | Clears remote-active state before the deferred synchronized delete is durable, leaving failed-delete rollback inconsistent. |
| Foqos/Views/BlockedProfileListView.swift | Adds remote-active swipe-deletion gating and defers marker cleanup until the shared delete/reorder commit succeeds. |
| Foqos/Utils/StrategyManager.swift | Adds durable remote-state clearing and deterministic cross-profile remote-start arbitration with stop-outbox fallback. |
| Foqos/CloudKit/SyncEngine/MutationFunnel.swift | Repairs a deleted profile's enforcement snapshot when a deferred local delete commit rolls back. |
| Foqos/CloudKit/SyncEngine/SyncApplyService.swift | Repairs snapshots when a remotely applied profile deletion fails and is rolled back. |
| Foqos/Utils/PreActivationReminderScheduler.swift | Recreates missing snapshots only for valid persisted profiles during startup, foreground, and sync reconciliation. |
| Foqos/Models/BlockedProfiles.swift | Extends profile deletion cleanup to cancel session and break reminders owned by the deleted profile. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Remote as Remote device
  participant Sync as Session sync
  participant Arbiter as ProfileStartArbiter
  participant Strategy as StrategyManager
  participant Outbox as Stop outbox
  Remote->>Sync: New profile start
  Sync->>Arbiter: Compare start time and profile UUID
  alt Incoming start wins
    Arbiter->>Strategy: Adopt incoming profile
    Strategy->>Strategy: End losing local session
    Strategy->>Outbox: Persist losing profile stop
    Strategy->>Strategy: Apply winner restrictions
  else Existing start wins
    Arbiter-->>Sync: Reject incoming start locally
  end
```

<sub>Reviews (1): Last reviewed commit: ["chore: bump version to 2.0.1 (20)"](https://github.com/mnbf9rca/family-foqos/commit/1593f181738fd56a1702e663f24944faba40013e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51849149)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->