### PR TITLE
Refresh CloudKit schema reference

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -686,7 +686,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -707,7 +707,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -718,7 +718,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -866,7 +866,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -894,7 +894,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -920,7 +920,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -948,7 +948,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -970,12 +970,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -996,12 +996,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1021,12 +1021,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1046,12 +1046,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1072,7 +1072,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1083,7 +1083,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1104,7 +1104,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1115,7 +1115,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1139,7 +1139,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1150,7 +1150,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1173,7 +1173,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1184,7 +1184,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -686,7 +686,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -707,7 +707,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -718,7 +718,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -866,7 +866,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -894,7 +894,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -920,7 +920,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -948,7 +948,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -970,12 +970,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -996,12 +996,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1021,12 +1021,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1046,12 +1046,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1072,7 +1072,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1083,7 +1083,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1104,7 +1104,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1115,7 +1115,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1139,7 +1139,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1150,7 +1150,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1173,7 +1173,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1184,7 +1184,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/CloudKit/cloudkit-schema.ckdb
+++ b/Foqos/CloudKit/cloudkit-schema.ckdb
@@ -96,6 +96,23 @@ DEFINE SCHEMA
         GRANT READ TO "_world"
     );
 
+    RECORD TYPE DeviceHeartbeat (
+        "___createTime"       TIMESTAMP QUERYABLE SORTABLE,
+        "___createdBy"        REFERENCE QUERYABLE,
+        "___etag"             STRING,
+        "___modTime"          TIMESTAMP QUERYABLE SORTABLE,
+        "___modifiedBy"       REFERENCE QUERYABLE,
+        "___recordID"         REFERENCE QUERYABLE,
+        childUserRecordName    STRING,
+        deviceIdentifier       STRING,
+        deviceName             STRING,
+        lastHeartbeatAt        TIMESTAMP,
+        authorizationStatus    STRING,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
     RECORD TYPE "cloudkit.share" (
         "___createTime"               TIMESTAMP QUERYABLE SORTABLE,
         "___createdBy"                REFERENCE QUERYABLE,
@@ -145,6 +162,7 @@ DEFINE SCHEMA
         disableBackgroundStops  INT64,
         isManaged               INT64 QUERYABLE,
         managedByChildId        STRING QUERYABLE,
+        generation              INT64,
         lastModified            TIMESTAMP QUERYABLE SORTABLE,
         originDeviceId          STRING QUERYABLE,
         version                 INT64 QUERYABLE SORTABLE,
@@ -220,7 +238,72 @@ DEFINE SCHEMA
         longitude             DOUBLE,
         defaultRadiusMeters   DOUBLE,
         isLocked              INT64 QUERYABLE,
+        generation            INT64,
         lastModified          TIMESTAMP QUERYABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_creator"
+    );
+
+    RECORD TYPE EmergencySettings (
+        "___createTime"     TIMESTAMP QUERYABLE SORTABLE,
+        "___createdBy"      REFERENCE QUERYABLE,
+        "___etag"           STRING,
+        "___modTime"        TIMESTAMP QUERYABLE SORTABLE,
+        "___modifiedBy"      REFERENCE QUERYABLE,
+        "___recordID"        REFERENCE QUERYABLE,
+        unblocksRemaining    INT64,
+        resetPeriodInDays    INT64,
+        lastResetDate        TIMESTAMP,
+        settingsLocked       INT64,
+        version              INT64,
+        lastModified         TIMESTAMP,
+        originDeviceId       STRING,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_creator"
+    );
+
+    RECORD TYPE EmergencyResetEpoch (
+        "___createTime" TIMESTAMP QUERYABLE SORTABLE,
+        "___createdBy"  REFERENCE QUERYABLE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP QUERYABLE SORTABLE,
+        "___modifiedBy" REFERENCE QUERYABLE,
+        "___recordID"   REFERENCE QUERYABLE,
+        epoch            INT64,
+        generation       INT64,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_creator"
+    );
+
+    RECORD TYPE SyncEstablishment (
+        "___createTime" TIMESTAMP QUERYABLE SORTABLE,
+        "___createdBy"  REFERENCE QUERYABLE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP QUERYABLE SORTABLE,
+        "___modifiedBy" REFERENCE QUERYABLE,
+        "___recordID"   REFERENCE QUERYABLE,
+        generation       INT64,
+        establishedAt    TIMESTAMP,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_creator"
+    );
+
+    RECORD TYPE EmergencyUnblockEvent (
+        "___createTime" TIMESTAMP QUERYABLE SORTABLE,
+        "___createdBy"  REFERENCE QUERYABLE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP QUERYABLE SORTABLE,
+        "___modifiedBy" REFERENCE QUERYABLE,
+        "___recordID"   REFERENCE QUERYABLE,
+        id               STRING,
+        deviceId         STRING,
+        consumedAt       TIMESTAMP,
+        resetEpoch       INT64,
+        generation       INT64,
         GRANT WRITE TO "_creator",
         GRANT CREATE TO "_icloud",
         GRANT READ TO "_creator"

--- a/docs/cloudkit-production-schema.md
+++ b/docs/cloudkit-production-schema.md
@@ -17,8 +17,10 @@ bash scripts/test-check-prod-schema.sh
 ```
 
 Review `Foqos/CloudKit/cloudkit-schema.ckdb` against the pending Development schema in CloudKit
-Console. The local checker proves record-type coverage against `fastlane/required-prod-schema.txt`;
-field review remains part of the Console promotion review.
+Console. The local checker proves that the `.ckdb` covers every record type and field listed in
+`fastlane/required-prod-schema.txt`. Keep that manifest aligned with the app's declared `FieldKey`
+and `RecordKey` values through the hand-reconciliation commands in its header. Field review remains
+part of the Console promotion review because the checker does not derive the manifest from code.
 
 ## Promote to Production — Maintainer Only
 

--- a/docs/cloudkit-production-schema.md
+++ b/docs/cloudkit-production-schema.md
@@ -1,0 +1,49 @@
+# CloudKit Production Schema Runbook
+
+Container: `iCloud.com.cynexia.family-foqos`
+
+CloudKit Production does not infer schema from app writes. TestFlight and App Store builds use the
+Production environment, so promote the final Development schema before uploading the first build
+that depends on it. Production schema changes are additive-only; never rename or remove a deployed
+record type or field.
+
+## Repository Preflight
+
+Run these checks after the final schema-touching pull request has merged:
+
+```bash
+bash scripts/check-cloudkit-schema-export.sh
+bash scripts/test-check-prod-schema.sh
+```
+
+Review `Foqos/CloudKit/cloudkit-schema.ckdb` against the pending Development schema in CloudKit
+Console. The local checker proves record-type coverage against `fastlane/required-prod-schema.txt`;
+field review remains part of the Console promotion review.
+
+## Promote to Production — Maintainer Only
+
+1. Sign in to [CloudKit Console](https://icloud.developer.apple.com/).
+2. Select `iCloud.com.cynexia.family-foqos` and its CloudKit Database.
+3. Confirm the Development schema contains the record types and fields in
+   `Foqos/CloudKit/cloudkit-schema.ckdb`.
+4. Review the pending schema changes and deploy them to Production.
+5. Confirm the deployment completes before creating the TestFlight archive.
+
+This Console deployment is a maintainer keystroke. Agents update and verify repository artifacts;
+they do not promote the Production schema.
+
+## Postflight
+
+With `cktool` authenticated for the container, verify the deployed Production record types:
+
+```bash
+bash scripts/check-prod-schema.sh
+```
+
+The command must print `Production schema OK.` before TestFlight upload. It checks required record
+types; also confirm the newly promoted fields in CloudKit Console.
+
+## Apple References
+
+- [Integrating a Text-Based Schema into Your Workflow](https://developer.apple.com/documentation/cloudkit/integrating-a-text-based-schema-into-your-workflow)
+- [Deploying an iCloud Container’s Schema](https://developer.apple.com/documentation/cloudkit/deploying-an-icloud-container-s-schema)

--- a/docs/superpowers/plans/2026-08-10-cloudkit-schema-refresh.md
+++ b/docs/superpowers/plans/2026-08-10-cloudkit-schema-refresh.md
@@ -1,0 +1,229 @@
+# CloudKit Schema Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reconcile the checked-in CloudKit schema with current code and the required Production manifest, with a terse maintainer deployment runbook and a zero-Xcode drift check.
+
+**Architecture:** A small repository check treats `fastlane/required-prod-schema.txt` as the required record-type set and verifies that the `.ckdb` contains every declaration while permitting deprecated extras. The `.ckdb` fields are refreshed from current `CKRecord` encoders, and a separate runbook keeps the irreversible Production promotion explicitly maintainer-owned.
+
+**Tech Stack:** Bash, CloudKit Schema Language, Markdown
+
+## Global Constraints
+
+- No CloudKit Console mutation or `cktool` install/deploy.
+- No GitHub Actions or other CI wiring.
+- No Xcode build or simulator test.
+- Preserve deprecated compatibility record types in the `.ckdb`.
+- If #321 lands first, add a new version-bump commit against updated `main`; never amend or force-push.
+
+---
+
+### Task 1: Local schema-manifest drift check
+
+**Files:**
+- Create: `scripts/check-cloudkit-schema-export.sh`
+- Create: `scripts/test-check-cloudkit-schema-export.sh`
+
+**Interfaces:**
+- Consumes: `fastlane/required-prod-schema.txt` and `Foqos/CloudKit/cloudkit-schema.ckdb`
+- Produces: exit 0 when every non-comment manifest declaration exists exactly in the `.ckdb`; exit 1 for missing types; exit 2 for empty/unreadable inputs
+
+- [ ] **Step 1: Write the failing fixture test**
+
+Create a disposable repository-shaped directory, copy the production checker into `scripts/`, and
+exercise these literal fixtures:
+
+```text
+# matching manifest (extra compatibility type is allowed)
+RECORD TYPE Required
+RECORD TYPE "cloudkit.share"
+
+# matching schema
+RECORD TYPE Required (
+RECORD TYPE "cloudkit.share" (
+RECORD TYPE DeprecatedExtra (
+```
+
+The test must also assert that a missing `Required`, a prefix-only `RequiredExtra`, and a
+comment-only manifest fail with the intended exit class.
+
+- [ ] **Step 2: Run the fixture test and observe RED**
+
+Run: `bash scripts/test-check-cloudkit-schema-export.sh`
+
+Expected: exit 1 with `FAIL: CloudKit schema export checker is missing`.
+
+- [ ] **Step 3: Implement the minimal checker**
+
+Use the same exact-declaration rule as the Production gate:
+
+```bash
+while IFS= read -r requirement; do
+  [[ -z "$requirement" || "$requirement" == \#* ]] && continue
+  if ! grep -qF "$requirement (" "$SCHEMA_FILE"; then
+    echo "MISSING from checked-in CloudKit schema: $requirement"
+    missing=1
+  fi
+done <"$REQUIRED_FILE"
+```
+
+Validate both files are readable and non-empty, require at least one non-comment manifest entry,
+and print `Checked-in CloudKit schema covers every required record type.` on success.
+
+- [ ] **Step 4: Run the fixture test and observe GREEN**
+
+Run: `bash scripts/test-check-cloudkit-schema-export.sh`
+
+Expected: `PASS: checked-in CloudKit schema gate cases`.
+
+- [ ] **Step 5: Run the checker against the current stale repository and observe RED**
+
+Run: `bash scripts/check-cloudkit-schema-export.sh`
+
+Expected: exit 1 listing exactly these missing declarations:
+
+```text
+RECORD TYPE DeviceHeartbeat
+RECORD TYPE EmergencyResetEpoch
+RECORD TYPE EmergencySettings
+RECORD TYPE EmergencyUnblockEvent
+RECORD TYPE SyncEstablishment
+```
+
+### Task 2: Refresh schema artifact and maintainer runbook
+
+**Files:**
+- Modify: `Foqos/CloudKit/cloudkit-schema.ckdb`
+- Create: `docs/cloudkit-production-schema.md`
+
+**Interfaces:**
+- Consumes: current record encoders in `SyncModels.swift` and `DeviceHeartbeat.swift`
+- Produces: a checked-in schema covering all 15 manifest types and a maintainer-only Production promotion checklist
+
+- [ ] **Step 1: Add the shared-family record declaration**
+
+Add `DeviceHeartbeat` after `FamilyCommand`, with the standard six system fields, shared-family
+grants, and these application fields:
+
+```text
+childUserRecordName STRING,
+deviceIdentifier   STRING,
+deviceName         STRING,
+lastHeartbeatAt    TIMESTAMP,
+authorizationStatus STRING
+```
+
+- [ ] **Step 2: Bring existing DeviceSync declarations current**
+
+Add exactly this non-indexed field to both existing record declarations:
+
+```text
+generation INT64,
+```
+
+Place it with sync metadata on `SyncedProfile` and before `lastModified` on `SyncedLocation`.
+
+- [ ] **Step 3: Add current emergency and establishment declarations**
+
+Add the standard six system fields and creator-only grants to each record type, with these exact
+application fields:
+
+```text
+RECORD TYPE EmergencySettings (
+  unblocksRemaining INT64,
+  resetPeriodInDays INT64,
+  lastResetDate TIMESTAMP,
+  settingsLocked INT64,
+  version INT64,
+  lastModified TIMESTAMP,
+  originDeviceId STRING
+);
+
+RECORD TYPE EmergencyResetEpoch (
+  epoch INT64,
+  generation INT64
+);
+
+RECORD TYPE SyncEstablishment (
+  generation INT64,
+  establishedAt TIMESTAMP
+);
+
+RECORD TYPE EmergencyUnblockEvent (
+  id STRING,
+  deviceId STRING,
+  consumedAt TIMESTAMP,
+  resetEpoch INT64,
+  generation INT64
+);
+```
+
+- [ ] **Step 4: Add the maintainer-only runbook**
+
+Create `docs/cloudkit-production-schema.md` with:
+
+```text
+Container: iCloud.com.cynexia.family-foqos
+Preflight: bash scripts/check-cloudkit-schema-export.sh
+Promotion owner: maintainer only, after the final schema-touching PR and before TestFlight
+Promotion tool: CloudKit Console, Development schema -> Deploy to Production
+Postflight: bash scripts/check-prod-schema.sh
+Safety: Production changes are additive-only; agents never perform the Console keystroke
+```
+
+Link Apple’s `Integrating a Text-Based Schema into Your Workflow` and
+`Deploying an iCloud Container’s Schema` documentation.
+
+- [ ] **Step 5: Run the real checker and existing gate tests**
+
+Run:
+
+```bash
+bash scripts/check-cloudkit-schema-export.sh
+bash scripts/test-check-cloudkit-schema-export.sh
+bash scripts/test-check-prod-schema.sh
+```
+
+Expected: all exit 0 with their PASS/success markers.
+
+### Task 3: Review-ready verification and publication
+
+**Files:**
+- Verify: `Foqos/CloudKit/cloudkit-schema.ckdb`
+- Verify: `fastlane/required-prod-schema.txt`
+- Verify: `scripts/check-cloudkit-schema-export.sh`
+- Verify: `scripts/test-check-cloudkit-schema-export.sh`
+- Verify: `docs/cloudkit-production-schema.md`
+
+**Interfaces:**
+- Consumes: completed Tasks 1-2
+- Produces: reviewed draft PR closing #346's repository-owned portion without claiming Production deployment
+
+- [ ] **Step 1: Run final zero-Xcode verification**
+
+Run:
+
+```bash
+bash -n scripts/check-cloudkit-schema-export.sh scripts/test-check-cloudkit-schema-export.sh
+shellcheck scripts/check-cloudkit-schema-export.sh scripts/test-check-cloudkit-schema-export.sh
+bash scripts/check-cloudkit-schema-export.sh
+bash scripts/test-check-cloudkit-schema-export.sh
+bash scripts/test-check-prod-schema.sh
+git diff --check
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 2: Commit without amend or force**
+
+```bash
+git add Foqos/CloudKit/cloudkit-schema.ckdb docs/cloudkit-production-schema.md \
+  scripts/check-cloudkit-schema-export.sh scripts/test-check-cloudkit-schema-export.sh \
+  docs/superpowers/plans/2026-08-10-cloudkit-schema-refresh.md
+git commit -m "Refresh CloudKit schema reference"
+```
+
+- [ ] **Step 3: Publish and request review**
+
+Open a draft PR describing the maintainer-only Production deployment boundary. Send the PR and the
+exact base/head range to `reviewer` via AMQ before merge. Report the PR on `milestone/4-then-2`.

--- a/docs/superpowers/plans/2026-08-10-cloudkit-schema-refresh.md
+++ b/docs/superpowers/plans/2026-08-10-cloudkit-schema-refresh.md
@@ -186,6 +186,78 @@ bash scripts/test-check-prod-schema.sh
 
 Expected: all exit 0 with their PASS/success markers.
 
+### Task 2A: Guard declared application fields
+
+**Files:**
+- Modify: `scripts/check-cloudkit-schema-export.sh`
+- Modify: `scripts/test-check-cloudkit-schema-export.sh`
+
+**Interfaces:**
+- Consumes: `FieldKey: String` declarations in `Foqos/CloudKit/SyncModels.swift` and
+  `Foqos/CloudKit/ProfileSessionRecord.swift`; resolved `RecordKey` string constants in the four
+  current family model files; matching record blocks in `cloudkit-schema.ckdb`
+- Produces: exit 1 with `MISSING from checked-in CloudKit schema: <RecordType>.<field>` when any
+  declared current code field is absent; success identifying exactly 100 fields across 12 types
+
+- [ ] **Step 1: Extend the disposable fixtures first**
+
+Add minimal Swift fixtures for both declaration idioms. The enum fixture includes an explicit raw
+value and a keyless record type before a later keyed type, proving the parser resolves the wire
+name and does not mispair the later enum. The constant fixture uses an identifier whose string
+value differs from the field name. Add failure cases that remove one enum field, remove one
+constant field, and put a required field only in a different record block.
+
+- [ ] **Step 2: Run the fixture test and observe RED**
+
+Run: `bash scripts/test-check-cloudkit-schema-export.sh`
+
+Expected: exit 1 with `FAIL: missing declared enum field must exit 1`; the existing type-only
+checker incorrectly accepts the schema.
+
+- [ ] **Step 3: Extract declared code fields**
+
+Extend the existing Bash checker with two small `awk` extractors:
+
+1. Pair `static let recordType = "..."` with a following `enum FieldKey: String` only when no
+   intervening record-type declaration occurs, then emit each case's raw string or identifier.
+2. Resolve `static let <identifier> = "<wireName>"` declarations inside `RecordKey` enums in
+   `DeviceHeartbeat.swift`, `FamilyCommand.swift`, `FamilyLockCode.swift`, and
+   `FamilyMember.swift`.
+
+Sort the emitted `<recordType><TAB><field>` pairs uniquely. Require the known-good per-type counts
+of 39, 10, 8, 7, 5, 4, 2, 2, 5, 5, 7, and 6 so a vacuous or one-idiom extractor fails closed.
+
+- [ ] **Step 4: Compare each code field to its record block**
+
+For each emitted pair, inspect only the matching active `RECORD TYPE ... (` block and require an
+exact first-token field match before that block's `);`. Do not compare schema fields in the reverse
+direction, and do not scan arbitrary `record["..."]` string subscripts.
+
+- [ ] **Step 5: Run the fixture and production checks GREEN**
+
+Run:
+
+```bash
+bash scripts/test-check-cloudkit-schema-export.sh
+bash scripts/check-cloudkit-schema-export.sh
+```
+
+Expected:
+
+```text
+PASS: checked-in CloudKit schema gate cases
+Checked-in CloudKit schema covers every required record type and 100 declared fields across 12 active record types.
+```
+
+- [ ] **Step 6: Commit without amend**
+
+```bash
+git add scripts/check-cloudkit-schema-export.sh scripts/test-check-cloudkit-schema-export.sh \
+  docs/superpowers/specs/2026-08-10-cloudkit-schema-refresh-design.md \
+  docs/superpowers/plans/2026-08-10-cloudkit-schema-refresh.md
+git commit -m "Guard CloudKit schema fields"
+```
+
 ### Task 3: Review-ready verification and publication
 
 **Files:**

--- a/docs/superpowers/plans/2026-08-10-cloudkit-schema-refresh.md
+++ b/docs/superpowers/plans/2026-08-10-cloudkit-schema-refresh.md
@@ -198,7 +198,7 @@ Expected: all exit 0 with their PASS/success markers.
 - Consumes: hand-reconciled `RECORD TYPE X` and `RECORD TYPE X.field` manifest entries plus matching
   record blocks in `cloudkit-schema.ckdb`
 - Produces: exit 1 with `MISSING from checked-in CloudKit schema: RECORD TYPE X.field` when any
-  manifest field is absent; success identifying exactly 100 fields across 12 active types
+  manifest field is absent; success identifying exactly 101 fields across 13 active types
 
 - [ ] **Step 1: Add the failing field fixture first**
 
@@ -228,7 +228,7 @@ fields and record types.
 
 - [ ] **Step 4: Add the hand-reconciled field inventory**
 
-Extend `fastlane/required-prod-schema.txt` with the reviewer-verified 100 fields across 12 active
+Extend `fastlane/required-prod-schema.txt` with the reviewer-verified 101 fields across 13 active
 types and update its reconciliation date and commands. Update the runbook to state precisely that
 the checker proves `.ckdb` coverage of the manifest, while manifest-to-code alignment remains a
 documented hand review.

--- a/docs/superpowers/plans/2026-08-10-cloudkit-schema-refresh.md
+++ b/docs/superpowers/plans/2026-08-10-cloudkit-schema-refresh.md
@@ -189,49 +189,49 @@ Expected: all exit 0 with their PASS/success markers.
 ### Task 2A: Guard declared application fields
 
 **Files:**
+- Modify: `fastlane/required-prod-schema.txt`
 - Modify: `scripts/check-cloudkit-schema-export.sh`
 - Modify: `scripts/test-check-cloudkit-schema-export.sh`
+- Modify: `docs/cloudkit-production-schema.md`
 
 **Interfaces:**
-- Consumes: `FieldKey: String` declarations in `Foqos/CloudKit/SyncModels.swift` and
-  `Foqos/CloudKit/ProfileSessionRecord.swift`; resolved `RecordKey` string constants in the four
-  current family model files; matching record blocks in `cloudkit-schema.ckdb`
-- Produces: exit 1 with `MISSING from checked-in CloudKit schema: <RecordType>.<field>` when any
-  declared current code field is absent; success identifying exactly 100 fields across 12 types
+- Consumes: hand-reconciled `RECORD TYPE X` and `RECORD TYPE X.field` manifest entries plus matching
+  record blocks in `cloudkit-schema.ckdb`
+- Produces: exit 1 with `MISSING from checked-in CloudKit schema: RECORD TYPE X.field` when any
+  manifest field is absent; success identifying exactly 100 fields across 12 active types
 
-- [ ] **Step 1: Extend the disposable fixtures first**
+- [ ] **Step 1: Add the failing field fixture first**
 
-Add minimal Swift fixtures for both declaration idioms. The enum fixture includes an explicit raw
-value and a keyless record type before a later keyed type, proving the parser resolves the wire
-name and does not mispair the later enum. The constant fixture uses an identifier whose string
-value differs from the field name. Add failure cases that remove one enum field, remove one
-constant field, and put a required field only in a different record block.
+Add `RECORD TYPE Required.requiredField` to the disposable manifest and `requiredField STRING` to
+the matching schema. Add a second schema fixture that retains `Required` but removes
+`requiredField`, and require exit 1 with the exact missing manifest entry.
 
 - [ ] **Step 2: Run the fixture test and observe RED**
 
 Run: `bash scripts/test-check-cloudkit-schema-export.sh`
 
-Expected: exit 1 with `FAIL: missing declared enum field must exit 1`; the existing type-only
-checker incorrectly accepts the schema.
+Expected: exit 1 because the existing type-only checker treats `Required.requiredField` as a record
+type and rejects the otherwise matching schema.
 
-- [ ] **Step 3: Extract declared code fields**
+- [ ] **Step 3: Normalize schema records and fields**
 
-Extend the existing Bash checker with two small `awk` extractors:
+Use one small `awk` pass over the `.ckdb` to emit exact normalized entries:
 
-1. Pair `static let recordType = "..."` with a following `enum FieldKey: String` only when no
-   intervening record-type declaration occurs, then emit each case's raw string or identifier.
-2. Resolve `static let <identifier> = "<wireName>"` declarations inside `RecordKey` enums in
-   `DeviceHeartbeat.swift`, `FamilyCommand.swift`, `FamilyLockCode.swift`, and
-   `FamilyMember.swift`.
+```text
+RECORD TYPE Required
+RECORD TYPE Required.requiredField
+```
 
-Sort the emitted `<recordType><TAB><field>` pairs uniquely. Require the known-good per-type counts
-of 39, 10, 8, 7, 5, 4, 2, 2, 5, 5, 7, and 6 so a vacuous or one-idiom extractor fails closed.
+Keep the existing fixed-string manifest loop, changing it to exact-line matching against the
+normalized entries. This scopes every field to its record block and still permits extra schema
+fields and record types.
 
-- [ ] **Step 4: Compare each code field to its record block**
+- [ ] **Step 4: Add the hand-reconciled field inventory**
 
-For each emitted pair, inspect only the matching active `RECORD TYPE ... (` block and require an
-exact first-token field match before that block's `);`. Do not compare schema fields in the reverse
-direction, and do not scan arbitrary `record["..."]` string subscripts.
+Extend `fastlane/required-prod-schema.txt` with the reviewer-verified 100 fields across 12 active
+types and update its reconciliation date and commands. Update the runbook to state precisely that
+the checker proves `.ckdb` coverage of the manifest, while manifest-to-code alignment remains a
+documented hand review.
 
 - [ ] **Step 5: Run the fixture and production checks GREEN**
 
@@ -246,13 +246,14 @@ Expected:
 
 ```text
 PASS: checked-in CloudKit schema gate cases
-Checked-in CloudKit schema covers every required record type and 100 declared fields across 12 active record types.
+Checked-in CloudKit schema covers every required record type and field.
 ```
 
 - [ ] **Step 6: Commit without amend**
 
 ```bash
-git add scripts/check-cloudkit-schema-export.sh scripts/test-check-cloudkit-schema-export.sh \
+git add fastlane/required-prod-schema.txt scripts/check-cloudkit-schema-export.sh \
+  scripts/test-check-cloudkit-schema-export.sh docs/cloudkit-production-schema.md \
   docs/superpowers/specs/2026-08-10-cloudkit-schema-refresh-design.md \
   docs/superpowers/plans/2026-08-10-cloudkit-schema-refresh.md
 git commit -m "Guard CloudKit schema fields"

--- a/docs/superpowers/specs/2026-08-10-cloudkit-schema-refresh-design.md
+++ b/docs/superpowers/specs/2026-08-10-cloudkit-schema-refresh-design.md
@@ -38,9 +38,32 @@ CloudKit dashboard to promote schema changes to Production:
 if either input is empty/unreadable or any required `RECORD TYPE` declaration is absent. It allows
 extra declarations such as deprecated `FamilyPolicy`.
 
+The same checker also derives the active application field inventory from the two CloudKit key
+idioms used by the app:
+
+- `FieldKey: String` enums paired with their preceding `static let recordType` declaration in
+  `SyncModels.swift` and `ProfileSessionRecord.swift`.
+- `RecordKey` constants whose string values are resolved in `DeviceHeartbeat.swift`,
+  `FamilyCommand.swift`, `FamilyLockCode.swift`, and `FamilyMember.swift`.
+
+Pairing stops when another record-type declaration appears before a `FieldKey` enum, so the
+deprecated keyless `SyncedSession` declaration cannot accidentally claim `SyncedLocation` fields.
+The checker compares declared code fields as a subset of each matching `.ckdb` record block. It
+does not require the reverse subset because CloudKit schemas are additive-only and retain system
+and deprecated fields. The two legacy V1 string-subscript fallbacks on `SyncedProfile` are
+deliberately outside the inventory: they are Production compatibility reads, not declared current
+field keys.
+
+The known-good baseline is 100 fields across 12 active types: `SyncedProfile` (39),
+`ProfileSession` (10), `SyncedLocation` (8), `EmergencySettings` (7),
+`EmergencyUnblockEvent` (5), `SyncResetRequest` (4), `EmergencyResetEpoch` (2),
+`SyncEstablishment` (2), `DeviceHeartbeat` (5), `FamilyCommand` (5), `FamilyLockCode` (7), and
+`FamilyMember` (6). `FamilyRoot`, deprecated `SyncedSession`, and built-in `cloudkit.share` remain
+type-checked but are not part of the declared-key field inventory.
+
 `scripts/test-check-cloudkit-schema-export.sh` exercises the real script against disposable
-fixtures and proves matching-with-extras passes while missing, prefix-only, and empty-manifest
-cases fail closed.
+fixtures and proves matching-with-extras passes while missing, prefix-only, removed enum field,
+removed resolved-constant field, cross-record field, and empty-manifest cases fail closed.
 
 ## Maintainer Runbook
 

--- a/docs/superpowers/specs/2026-08-10-cloudkit-schema-refresh-design.md
+++ b/docs/superpowers/specs/2026-08-10-cloudkit-schema-refresh-design.md
@@ -8,7 +8,8 @@ and add a small zero-Xcode drift check.
 
 ## Sources of Truth
 
-- `fastlane/required-prod-schema.txt` defines the record types the release gate requires.
+- `fastlane/required-prod-schema.txt` defines the record types and active fields the release gate
+  requires, reconciled by hand against code.
 - The `CKRecord` encoders in `Foqos/CloudKit/SyncModels.swift`,
   `Foqos/Models/DeviceHeartbeat.swift`, and `Foqos/Models/FamilyCommand.swift` define current fields
   and data types.
@@ -34,36 +35,28 @@ CloudKit dashboard to promote schema changes to Production:
 
 ## Drift Check
 
-`scripts/check-cloudkit-schema-export.sh` reads the manifest and the checked-in `.ckdb`, then fails
-if either input is empty/unreadable or any required `RECORD TYPE` declaration is absent. It allows
-extra declarations such as deprecated `FamilyPolicy`.
+`fastlane/required-prod-schema.txt` stores both required record declarations (`RECORD TYPE X`) and
+required active fields (`RECORD TYPE X.field`). Its header documents the hand-reconciliation ritual
+for the two key idioms used by the app: `FieldKey: String` enums and resolved `RecordKey` string
+constants. This deliberately keeps the zero-Xcode gate simple and makes the manifest reviewable;
+automatic code-to-schema drift detection belongs in a separate Swift test.
 
-The same checker also derives the active application field inventory from the two CloudKit key
-idioms used by the app:
-
-- `FieldKey: String` enums paired with their preceding `static let recordType` declaration in
-  `SyncModels.swift` and `ProfileSessionRecord.swift`.
-- `RecordKey` constants whose string values are resolved in `DeviceHeartbeat.swift`,
-  `FamilyCommand.swift`, `FamilyLockCode.swift`, and `FamilyMember.swift`.
-
-Pairing stops when another record-type declaration appears before a `FieldKey` enum, so the
-deprecated keyless `SyncedSession` declaration cannot accidentally claim `SyncedLocation` fields.
-The checker compares declared code fields as a subset of each matching `.ckdb` record block. It
-does not require the reverse subset because CloudKit schemas are additive-only and retain system
-and deprecated fields. The two legacy V1 string-subscript fallbacks on `SyncedProfile` are
-deliberately outside the inventory: they are Production compatibility reads, not declared current
-field keys.
+`scripts/check-cloudkit-schema-export.sh` normalizes the checked-in `.ckdb` into the same exact
+record and record-field entries, then fails when any non-comment manifest line is absent. Required
+fields are scoped to their record blocks, so a same-named field on another type cannot satisfy the
+check. The comparison remains one-way: extra schema declarations are allowed because Production
+is additive-only and retains CloudKit system fields and deprecated compatibility data.
 
 The known-good baseline is 100 fields across 12 active types: `SyncedProfile` (39),
 `ProfileSession` (10), `SyncedLocation` (8), `EmergencySettings` (7),
 `EmergencyUnblockEvent` (5), `SyncResetRequest` (4), `EmergencyResetEpoch` (2),
 `SyncEstablishment` (2), `DeviceHeartbeat` (5), `FamilyCommand` (5), `FamilyLockCode` (7), and
 `FamilyMember` (6). `FamilyRoot`, deprecated `SyncedSession`, and built-in `cloudkit.share` remain
-type-checked but are not part of the declared-key field inventory.
+type-checked but are not part of the manually reconciled active-field inventory.
 
 `scripts/test-check-cloudkit-schema-export.sh` exercises the real script against disposable
-fixtures and proves matching-with-extras passes while missing, prefix-only, removed enum field,
-removed resolved-constant field, cross-record field, and empty-manifest cases fail closed.
+fixtures and proves matching-with-extras passes while missing type, prefix-only type, missing field,
+and empty-manifest cases fail closed.
 
 ## Maintainer Runbook
 

--- a/docs/superpowers/specs/2026-08-10-cloudkit-schema-refresh-design.md
+++ b/docs/superpowers/specs/2026-08-10-cloudkit-schema-refresh-design.md
@@ -1,0 +1,59 @@
+# CloudKit Schema Refresh Design
+
+## Goal
+
+Refresh `Foqos/CloudKit/cloudkit-schema.ckdb` so the committed reference schema represents every
+CloudKit record type required by the current app, document the maintainer-only Production promotion,
+and add a small zero-Xcode drift check.
+
+## Sources of Truth
+
+- `fastlane/required-prod-schema.txt` defines the record types the release gate requires.
+- The `CKRecord` encoders in `Foqos/CloudKit/SyncModels.swift`,
+  `Foqos/Models/DeviceHeartbeat.swift`, and `Foqos/Models/FamilyCommand.swift` define current fields
+  and data types.
+- `Foqos/CloudKit/cloudkit-schema.ckdb` remains a checked-in reference artifact. Agents do not
+  install it or promote it to Production.
+
+The current manifest has 15 required types. The reference export is missing `DeviceHeartbeat`,
+`EmergencyResetEpoch`, `EmergencySettings`, `EmergencyUnblockEvent`, and `SyncEstablishment`.
+It also predates the `generation` field on `SyncedProfile` and `SyncedLocation`.
+
+## Schema Changes
+
+Add `DeviceHeartbeat` alongside the shared-family record types, with fields matching its record
+encoder. Add the four emergency/establishment record types alongside the private DeviceSync types,
+using the same creator-only grants as the existing same-user records. Add `generation INT64` to
+`SyncedProfile` and `SyncedLocation`.
+
+Existing deprecated record types remain in the artifact. Production CloudKit schemas are
+additive-only, so the consistency check requires every manifest type to exist but does not reject
+extra compatibility types. Apple recommends keeping a text schema in source control and using the
+CloudKit dashboard to promote schema changes to Production:
+[Integrating a Text-Based Schema into Your Workflow](https://developer.apple.com/documentation/cloudkit/integrating-a-text-based-schema-into-your-workflow).
+
+## Drift Check
+
+`scripts/check-cloudkit-schema-export.sh` reads the manifest and the checked-in `.ckdb`, then fails
+if either input is empty/unreadable or any required `RECORD TYPE` declaration is absent. It allows
+extra declarations such as deprecated `FamilyPolicy`.
+
+`scripts/test-check-cloudkit-schema-export.sh` exercises the real script against disposable
+fixtures and proves matching-with-extras passes while missing, prefix-only, and empty-manifest
+cases fail closed.
+
+## Maintainer Runbook
+
+Add `docs/cloudkit-production-schema.md` with the exact container identifier, the pre-promotion
+repository checks, the CloudKit Console promotion boundary, and post-promotion verification through
+`scripts/check-prod-schema.sh`. The note explicitly states that Production deployment is a
+maintainer action after the final schema-touching change and before TestFlight; this work does not
+perform that action.
+
+## Scope Boundaries
+
+- No CloudKit Console mutation or `cktool` install/deploy.
+- No GitHub Actions or other CI wiring.
+- No Xcode build or simulator test.
+- If the #321 version-gate PR lands first, adjust this branch with a new version-bump commit against
+  the updated `main`; never amend or force-push.

--- a/docs/superpowers/specs/2026-08-10-cloudkit-schema-refresh-design.md
+++ b/docs/superpowers/specs/2026-08-10-cloudkit-schema-refresh-design.md
@@ -47,12 +47,13 @@ fields are scoped to their record blocks, so a same-named field on another type 
 check. The comparison remains one-way: extra schema declarations are allowed because Production
 is additive-only and retains CloudKit system fields and deprecated compatibility data.
 
-The known-good baseline is 100 fields across 12 active types: `SyncedProfile` (39),
+The known-good baseline is 101 fields across 13 active types: `SyncedProfile` (39),
 `ProfileSession` (10), `SyncedLocation` (8), `EmergencySettings` (7),
 `EmergencyUnblockEvent` (5), `SyncResetRequest` (4), `EmergencyResetEpoch` (2),
 `SyncEstablishment` (2), `DeviceHeartbeat` (5), `FamilyCommand` (5), `FamilyLockCode` (7), and
-`FamilyMember` (6). `FamilyRoot`, deprecated `SyncedSession`, and built-in `cloudkit.share` remain
-type-checked but are not part of the manually reconciled active-field inventory.
+`FamilyMember` (6), plus the literal `FamilyRoot.createdAt` write (1). Deprecated `SyncedSession`
+and built-in `cloudkit.share` remain type-checked but are not part of the manually reconciled
+active-field inventory.
 
 `scripts/test-check-cloudkit-schema-export.sh` exercises the real script against disposable
 fixtures and proves matching-with-extras passes while missing type, prefix-only type, missing field,

--- a/fastlane/required-prod-schema.txt
+++ b/fastlane/required-prod-schema.txt
@@ -3,9 +3,10 @@
 # Repeat the type searches, review the results, and preserve built-ins and deprecated types:
 #   rg -n 'static let recordType\s*=\s*"[^"]+"' Foqos FoqosDeviceMonitor FoqosShieldConfig FoqosWidget
 #   rg -n 'CKRecord\(recordType:\s*"[^"]+"' Foqos FoqosDeviceMonitor FoqosShieldConfig FoqosWidget
-# Repeat both field searches and reconcile the 12 active types / 100 fields below:
+# Repeat the field searches and reconcile the 13 active types / 101 fields below:
 #   rg -n 'static let recordType|enum FieldKey: String|^[[:space:]]+case [[:alnum:]_]+( = "[^"]+")?$' Foqos/CloudKit/SyncModels.swift Foqos/CloudKit/ProfileSessionRecord.swift
 #   rg -n 'static let recordType|enum RecordKey|^[[:space:]]+static let [[:alnum:]_]+ = "[^"]+"' Foqos/Models/DeviceHeartbeat.swift Foqos/Models/FamilyCommand.swift Foqos/Models/FamilyLockCode.swift Foqos/Models/FamilyMember.swift
+#   rg -n 'rootRecord\["[^"]+"\]' Foqos/CloudKit/CloudKitNetworkService.swift Foqos/CloudKit/CloudKitNetworkService+Sharing.swift
 RECORD TYPE DeviceHeartbeat
 RECORD TYPE DeviceHeartbeat.childUserRecordName
 RECORD TYPE DeviceHeartbeat.deviceIdentifier
@@ -51,6 +52,7 @@ RECORD TYPE FamilyMember.role
 RECORD TYPE FamilyMember.enrolledAt
 RECORD TYPE FamilyMember.isActive
 RECORD TYPE FamilyRoot
+RECORD TYPE FamilyRoot.createdAt
 RECORD TYPE ProfileSession
 RECORD TYPE ProfileSession.profileId
 RECORD TYPE ProfileSession.isActive

--- a/fastlane/required-prod-schema.txt
+++ b/fastlane/required-prod-schema.txt
@@ -1,20 +1,123 @@
-# Source of truth: record types referenced by app/extension code, reconciled by hand.
-# Last reconciled: 2026-08-09.
-# Repeat both searches, review the results, and preserve required CloudKit built-ins:
+# Source of truth: record types and current declared fields, reconciled by hand.
+# Last reconciled: 2026-08-11.
+# Repeat the type searches, review the results, and preserve built-ins and deprecated types:
 #   rg -n 'static let recordType\s*=\s*"[^"]+"' Foqos FoqosDeviceMonitor FoqosShieldConfig FoqosWidget
 #   rg -n 'CKRecord\(recordType:\s*"[^"]+"' Foqos FoqosDeviceMonitor FoqosShieldConfig FoqosWidget
+# Repeat both field searches and reconcile the 12 active types / 100 fields below:
+#   rg -n 'static let recordType|enum FieldKey: String|^[[:space:]]+case [[:alnum:]_]+( = "[^"]+")?$' Foqos/CloudKit/SyncModels.swift Foqos/CloudKit/ProfileSessionRecord.swift
+#   rg -n 'static let recordType|enum RecordKey|^[[:space:]]+static let [[:alnum:]_]+ = "[^"]+"' Foqos/Models/DeviceHeartbeat.swift Foqos/Models/FamilyCommand.swift Foqos/Models/FamilyLockCode.swift Foqos/Models/FamilyMember.swift
 RECORD TYPE DeviceHeartbeat
+RECORD TYPE DeviceHeartbeat.childUserRecordName
+RECORD TYPE DeviceHeartbeat.deviceIdentifier
+RECORD TYPE DeviceHeartbeat.deviceName
+RECORD TYPE DeviceHeartbeat.lastHeartbeatAt
+RECORD TYPE DeviceHeartbeat.authorizationStatus
 RECORD TYPE EmergencyResetEpoch
+RECORD TYPE EmergencyResetEpoch.epoch
+RECORD TYPE EmergencyResetEpoch.generation
 RECORD TYPE EmergencySettings
+RECORD TYPE EmergencySettings.unblocksRemaining
+RECORD TYPE EmergencySettings.resetPeriodInDays
+RECORD TYPE EmergencySettings.lastResetDate
+RECORD TYPE EmergencySettings.settingsLocked
+RECORD TYPE EmergencySettings.version
+RECORD TYPE EmergencySettings.lastModified
+RECORD TYPE EmergencySettings.originDeviceId
 RECORD TYPE EmergencyUnblockEvent
+RECORD TYPE EmergencyUnblockEvent.id
+RECORD TYPE EmergencyUnblockEvent.deviceId
+RECORD TYPE EmergencyUnblockEvent.consumedAt
+RECORD TYPE EmergencyUnblockEvent.resetEpoch
+RECORD TYPE EmergencyUnblockEvent.generation
 RECORD TYPE FamilyCommand
+RECORD TYPE FamilyCommand.id
+RECORD TYPE FamilyCommand.commandType
+RECORD TYPE FamilyCommand.targetChildId
+RECORD TYPE FamilyCommand.createdAt
+RECORD TYPE FamilyCommand.createdBy
 RECORD TYPE FamilyLockCode
+RECORD TYPE FamilyLockCode.id
+RECORD TYPE FamilyLockCode.codeHash
+RECORD TYPE FamilyLockCode.codeSalt
+RECORD TYPE FamilyLockCode.scopeType
+RECORD TYPE FamilyLockCode.scopeChildId
+RECORD TYPE FamilyLockCode.createdAt
+RECORD TYPE FamilyLockCode.updatedAt
 RECORD TYPE FamilyMember
+RECORD TYPE FamilyMember.id
+RECORD TYPE FamilyMember.userRecordName
+RECORD TYPE FamilyMember.displayName
+RECORD TYPE FamilyMember.role
+RECORD TYPE FamilyMember.enrolledAt
+RECORD TYPE FamilyMember.isActive
 RECORD TYPE FamilyRoot
 RECORD TYPE ProfileSession
+RECORD TYPE ProfileSession.profileId
+RECORD TYPE ProfileSession.isActive
+RECORD TYPE ProfileSession.sequenceNumber
+RECORD TYPE ProfileSession.startTime
+RECORD TYPE ProfileSession.endTime
+RECORD TYPE ProfileSession.breakStartTime
+RECORD TYPE ProfileSession.breakEndTime
+RECORD TYPE ProfileSession.lastModifiedBy
+RECORD TYPE ProfileSession.sessionOriginDevice
+RECORD TYPE ProfileSession.lastModified
 RECORD TYPE SyncEstablishment
+RECORD TYPE SyncEstablishment.generation
+RECORD TYPE SyncEstablishment.establishedAt
 RECORD TYPE SyncResetRequest
+RECORD TYPE SyncResetRequest.requestId
+RECORD TYPE SyncResetRequest.clearRemoteAppSelections
+RECORD TYPE SyncResetRequest.requestedAt
+RECORD TYPE SyncResetRequest.originDeviceId
 RECORD TYPE SyncedLocation
+RECORD TYPE SyncedLocation.locationId
+RECORD TYPE SyncedLocation.name
+RECORD TYPE SyncedLocation.latitude
+RECORD TYPE SyncedLocation.longitude
+RECORD TYPE SyncedLocation.defaultRadiusMeters
+RECORD TYPE SyncedLocation.isLocked
+RECORD TYPE SyncedLocation.generation
+RECORD TYPE SyncedLocation.lastModified
 RECORD TYPE SyncedProfile
+RECORD TYPE SyncedProfile.profileId
+RECORD TYPE SyncedProfile.name
+RECORD TYPE SyncedProfile.createdAt
+RECORD TYPE SyncedProfile.updatedAt
+RECORD TYPE SyncedProfile.blockingStrategyId
+RECORD TYPE SyncedProfile.strategyData
+RECORD TYPE SyncedProfile.order
+RECORD TYPE SyncedProfile.enableLiveActivity
+RECORD TYPE SyncedProfile.reminderTimeInSeconds
+RECORD TYPE SyncedProfile.customReminderMessage
+RECORD TYPE SyncedProfile.enableBreaks
+RECORD TYPE SyncedProfile.breakTimeInMinutes
+RECORD TYPE SyncedProfile.enableStrictMode
+RECORD TYPE SyncedProfile.enableAllowMode
+RECORD TYPE SyncedProfile.enableAllowModeDomains
+RECORD TYPE SyncedProfile.enableSafariBlocking
+RECORD TYPE SyncedProfile.preActivationReminderTimesData
+RECORD TYPE SyncedProfile.physicalUnblockNFCTagId
+RECORD TYPE SyncedProfile.physicalUnblockQRCodeId
+RECORD TYPE SyncedProfile.domains
+RECORD TYPE SyncedProfile.scheduleData
+RECORD TYPE SyncedProfile.geofenceRuleData
+RECORD TYPE SyncedProfile.startTriggersData
+RECORD TYPE SyncedProfile.stopConditionsData
+RECORD TYPE SyncedProfile.startScheduleData
+RECORD TYPE SyncedProfile.stopScheduleData
+RECORD TYPE SyncedProfile.startNFCTagId
+RECORD TYPE SyncedProfile.startQRCodeId
+RECORD TYPE SyncedProfile.stopNFCTagId
+RECORD TYPE SyncedProfile.stopQRCodeId
+RECORD TYPE SyncedProfile.disableBackgroundStops
+RECORD TYPE SyncedProfile.isManaged
+RECORD TYPE SyncedProfile.managedByChildId
+RECORD TYPE SyncedProfile.generation
+RECORD TYPE SyncedProfile.lastModified
+RECORD TYPE SyncedProfile.originDeviceId
+RECORD TYPE SyncedProfile.version
+RECORD TYPE SyncedProfile.profileSchemaVersion
+RECORD TYPE SyncedProfile.scheduleLastStoppedAt
 RECORD TYPE SyncedSession
 RECORD TYPE "cloudkit.share"

--- a/scripts/check-cloudkit-schema-export.sh
+++ b/scripts/check-cloudkit-schema-export.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REQUIRED_FILE="$REPO_ROOT/fastlane/required-prod-schema.txt"
+SCHEMA_FILE="$REPO_ROOT/Foqos/CloudKit/cloudkit-schema.ckdb"
+
+if [[ ! -r "$REQUIRED_FILE" || ! -s "$REQUIRED_FILE" ]]; then
+  echo "Required schema file is empty or unreadable: $REQUIRED_FILE" >&2
+  exit 2
+fi
+if [[ ! -r "$SCHEMA_FILE" || ! -s "$SCHEMA_FILE" ]]; then
+  echo "Checked-in CloudKit schema is empty or unreadable: $SCHEMA_FILE" >&2
+  exit 2
+fi
+
+checked=0
+while IFS= read -r requirement; do
+  [[ -z "$requirement" || "$requirement" == \#* ]] && continue
+  checked=$((checked + 1))
+done <"$REQUIRED_FILE"
+
+if [[ "$checked" -eq 0 ]]; then
+  echo "Required schema file is empty or unreadable: $REQUIRED_FILE" >&2
+  exit 2
+fi
+
+missing=0
+while IFS= read -r requirement; do
+  [[ -z "$requirement" || "$requirement" == \#* ]] && continue
+  if ! grep -qF "$requirement (" "$SCHEMA_FILE"; then
+    echo "MISSING from checked-in CloudKit schema: $requirement"
+    missing=1
+  fi
+done <"$REQUIRED_FILE"
+
+if [[ "$missing" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "Checked-in CloudKit schema covers every required record type."

--- a/scripts/check-cloudkit-schema-export.sh
+++ b/scripts/check-cloudkit-schema-export.sh
@@ -14,6 +14,36 @@ if [[ ! -r "$SCHEMA_FILE" || ! -s "$SCHEMA_FILE" ]]; then
   exit 2
 fi
 
+SCHEMA_REQUIREMENTS=$(mktemp)
+cleanup() {
+  rm -f -- "$SCHEMA_REQUIREMENTS"
+}
+trap cleanup EXIT
+
+awk '
+  /^[[:space:]]*RECORD TYPE[[:space:]]+/ {
+    record_type = $0
+    sub(/^[[:space:]]*RECORD TYPE[[:space:]]+/, "", record_type)
+    sub(/[[:space:]]*\(.*/, "", record_type)
+    print "RECORD TYPE " record_type
+    in_record = 1
+    next
+  }
+  in_record && /^[[:space:]]*\);/ {
+    in_record = 0
+    next
+  }
+  in_record {
+    field = $0
+    sub(/^[[:space:]]*/, "", field)
+    if (field == "" || field ~ /^\/\// || field ~ /^GRANT[[:space:]]/) {
+      next
+    }
+    split(field, parts, /[[:space:]]+/)
+    print "RECORD TYPE " record_type "." parts[1]
+  }
+' "$SCHEMA_FILE" >"$SCHEMA_REQUIREMENTS"
+
 checked=0
 while IFS= read -r requirement; do
   [[ -z "$requirement" || "$requirement" == \#* ]] && continue
@@ -28,7 +58,7 @@ fi
 missing=0
 while IFS= read -r requirement; do
   [[ -z "$requirement" || "$requirement" == \#* ]] && continue
-  if ! grep -qF "$requirement (" "$SCHEMA_FILE"; then
+  if ! grep -qFx "$requirement" "$SCHEMA_REQUIREMENTS"; then
     echo "MISSING from checked-in CloudKit schema: $requirement"
     missing=1
   fi
@@ -38,4 +68,4 @@ if [[ "$missing" -ne 0 ]]; then
   exit 1
 fi
 
-echo "Checked-in CloudKit schema covers every required record type."
+echo "Checked-in CloudKit schema covers every required record type and field."

--- a/scripts/test-check-cloudkit-schema-export.sh
+++ b/scripts/test-check-cloudkit-schema-export.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CHECK_SCRIPT="$REPO_ROOT/scripts/check-cloudkit-schema-export.sh"
+TEST_ROOT=$(mktemp -d)
+
+cleanup() {
+  if [[ -n "${TEST_ROOT:-}" && -d "$TEST_ROOT" ]]; then
+    rm -rf -- "$TEST_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+if [[ ! -f "$CHECK_SCRIPT" ]]; then
+  echo "FAIL: CloudKit schema export checker is missing"
+  exit 1
+fi
+
+mkdir -p "$TEST_ROOT/scripts" "$TEST_ROOT/fastlane" "$TEST_ROOT/Foqos/CloudKit"
+cp "$CHECK_SCRIPT" "$TEST_ROOT/scripts/check-cloudkit-schema-export.sh"
+
+run_check() {
+  set +e
+  CHECK_OUTPUT=$(cd "$TEST_ROOT" && bash scripts/check-cloudkit-schema-export.sh 2>&1)
+  CHECK_STATUS=$?
+  set -e
+}
+
+printf '%s\n' \
+  '# Required record types' \
+  'RECORD TYPE Required' \
+  'RECORD TYPE "cloudkit.share"' \
+  >"$TEST_ROOT/fastlane/required-prod-schema.txt"
+printf '%s\n' \
+  'DEFINE SCHEMA' \
+  'RECORD TYPE Required (' \
+  ');' \
+  'RECORD TYPE "cloudkit.share" (' \
+  ');' \
+  'RECORD TYPE DeprecatedExtra (' \
+  ');' \
+  >"$TEST_ROOT/Foqos/CloudKit/cloudkit-schema.ckdb"
+run_check
+if [[ "$CHECK_STATUS" -ne 0 || "$CHECK_OUTPUT" != *"covers every required record type"* ]]; then
+  echo "FAIL: matching schema with compatibility extras must pass"
+  echo "$CHECK_OUTPUT"
+  exit 1
+fi
+
+printf '%s\n' 'DEFINE SCHEMA' 'RECORD TYPE Other (' ');' \
+  >"$TEST_ROOT/Foqos/CloudKit/cloudkit-schema.ckdb"
+run_check
+if [[ "$CHECK_STATUS" -ne 1 || "$CHECK_OUTPUT" != *"MISSING from checked-in CloudKit schema: RECORD TYPE Required"* ]]; then
+  echo "FAIL: missing required record type must exit 1"
+  echo "$CHECK_OUTPUT"
+  exit 1
+fi
+
+printf '%s\n' \
+  'DEFINE SCHEMA' \
+  'RECORD TYPE RequiredExtra (' \
+  ');' \
+  'RECORD TYPE "cloudkit.share" (' \
+  ');' \
+  >"$TEST_ROOT/Foqos/CloudKit/cloudkit-schema.ckdb"
+run_check
+if [[ "$CHECK_STATUS" -ne 1 || "$CHECK_OUTPUT" != *"MISSING from checked-in CloudKit schema: RECORD TYPE Required"* ]]; then
+  echo "FAIL: a prefixed record type must not satisfy an exact requirement"
+  echo "$CHECK_OUTPUT"
+  exit 1
+fi
+
+printf '%s\n' '# comments do not count' '' >"$TEST_ROOT/fastlane/required-prod-schema.txt"
+run_check
+if [[ "$CHECK_STATUS" -ne 2 || "$CHECK_OUTPUT" != *"empty or unreadable"* ]]; then
+  echo "FAIL: comment-only manifest must exit 2"
+  echo "$CHECK_OUTPUT"
+  exit 1
+fi
+
+echo "PASS: checked-in CloudKit schema gate cases"

--- a/scripts/test-check-cloudkit-schema-export.sh
+++ b/scripts/test-check-cloudkit-schema-export.sh
@@ -30,11 +30,13 @@ run_check() {
 printf '%s\n' \
   '# Required record types' \
   'RECORD TYPE Required' \
+  'RECORD TYPE Required.requiredField' \
   'RECORD TYPE "cloudkit.share"' \
   >"$TEST_ROOT/fastlane/required-prod-schema.txt"
 printf '%s\n' \
   'DEFINE SCHEMA' \
   'RECORD TYPE Required (' \
+  '  requiredField STRING' \
   ');' \
   'RECORD TYPE "cloudkit.share" (' \
   ');' \
@@ -44,6 +46,20 @@ printf '%s\n' \
 run_check
 if [[ "$CHECK_STATUS" -ne 0 || "$CHECK_OUTPUT" != *"covers every required record type"* ]]; then
   echo "FAIL: matching schema with compatibility extras must pass"
+  echo "$CHECK_OUTPUT"
+  exit 1
+fi
+
+printf '%s\n' \
+  'DEFINE SCHEMA' \
+  'RECORD TYPE Required (' \
+  ');' \
+  'RECORD TYPE "cloudkit.share" (' \
+  ');' \
+  >"$TEST_ROOT/Foqos/CloudKit/cloudkit-schema.ckdb"
+run_check
+if [[ "$CHECK_STATUS" -ne 1 || "$CHECK_OUTPUT" != *"MISSING from checked-in CloudKit schema: RECORD TYPE Required.requiredField"* ]]; then
+  echo "FAIL: missing required field must exit 1"
   echo "$CHECK_OUTPUT"
   exit 1
 fi


### PR DESCRIPTION
## Summary

- refresh the checked-in CloudKit schema for the five current record types missing from the required Production manifest
- add the current `generation` fields to `SyncedProfile` and `SyncedLocation`
- hand-reconcile 101 active fields across 13 record types in `fastlane/required-prod-schema.txt`, including the literal `FamilyRoot.createdAt` write
- extend the zero-Xcode schema checker to validate exact record-scoped field requirements, with a missing-field fixture
- document the maintainer-only Production promotion boundary and the manifest-to-code hand-reconciliation step
- bump all targets from `2.0.2/21` to `2.0.3/22` over current `main`

## Guarantee and follow-up

The local checker proves that the checked-in `.ckdb` covers every record type and field listed in the manifest. The manifest is reconciled against Swift by hand using the commands in its header; the checker does not claim to derive fields from code.

Issue #383 tracks the separate in-language Swift code-to-schema drift test with fail-loud and 13-type/101-field acceptance criteria.

## Deployment boundary

This PR updates and verifies repository-owned schema artifacts only. It does **not** deploy CloudKit Production. After the final schema-touching PR merges, a maintainer must review Development schema changes in CloudKit Console, deploy them to Production, and run the authenticated postflight check before TestFlight.

## Validation

- `bash -n scripts/check-cloudkit-schema-export.sh scripts/test-check-cloudkit-schema-export.sh`
- `shellcheck scripts/check-cloudkit-schema-export.sh scripts/test-check-cloudkit-schema-export.sh`
- `bash scripts/test-check-cloudkit-schema-export.sh`
- `bash scripts/check-cloudkit-schema-export.sh`
- per-type manifest count audit: 13 types / 101 fields at reviewer-verified counts
- `bash scripts/test-check-prod-schema.sh`
- `bash scripts/test-check-version-increment.sh`
- `bash scripts/check-version-increment.sh origin/main HEAD`
- `plutil -lint FamilyFoqos.xcodeproj/project.pbxproj`
- `git diff --check origin/main...HEAD`

Refs #346