### PR TITLE
Add opt-in diagnostic family roster export

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -675,7 +675,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -686,7 +686,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -707,7 +707,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -718,7 +718,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -866,7 +866,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -894,7 +894,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -920,7 +920,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -948,7 +948,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -970,12 +970,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -996,12 +996,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1021,12 +1021,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1046,12 +1046,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1072,7 +1072,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1083,7 +1083,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1104,7 +1104,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1115,7 +1115,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1139,7 +1139,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1150,7 +1150,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1173,7 +1173,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1184,7 +1184,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/Utils/FamilyRosterExport.swift
+++ b/Foqos/Utils/FamilyRosterExport.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+enum FamilyRosterExport {
+  static func content(
+    for members: [FamilyMember],
+    monitoredDevices: [MonitoredDevice]
+  ) -> String {
+    let devicesByMember = Dictionary(grouping: monitoredDevices, by: \.childUserRecordName)
+    let lines = members.sorted(by: memberComesBefore).flatMap { member -> [String] in
+      var fields = [member.redactedLogLabel, member.displayName, member.id.uuidString]
+      if !member.userRecordName.isEmpty {
+        fields.append(member.userRecordName)
+      }
+      if !member.isActive {
+        fields.append("(departed)")
+      }
+
+      let matchedDevices =
+        member.userRecordName.isEmpty ? [] : (devicesByMember[member.userRecordName] ?? [])
+      let deviceLines =
+        matchedDevices
+        .sorted(by: deviceComesBefore)
+        .map { device in
+          let heartbeatRecordName = DeviceHeartbeat.recordName(
+            childUserRecordName: device.childUserRecordName,
+            deviceIdentifier: device.deviceIdentifier
+          )
+          return "  device — \(device.deviceIdentifier) — \(heartbeatRecordName)"
+        }
+
+      return [fields.joined(separator: " — ")] + deviceLines
+    }
+
+    guard !lines.isEmpty else { return "" }
+    return lines.joined(separator: "\n") + "\n"
+  }
+
+  private static func memberComesBefore(_ lhs: FamilyMember, _ rhs: FamilyMember) -> Bool {
+    if lhs.role.rawValue != rhs.role.rawValue {
+      return lhs.role.rawValue < rhs.role.rawValue
+    }
+    if lhs.displayName != rhs.displayName {
+      return lhs.displayName < rhs.displayName
+    }
+    return lhs.id.uuidString < rhs.id.uuidString
+  }
+
+  private static func deviceComesBefore(_ lhs: MonitoredDevice, _ rhs: MonitoredDevice) -> Bool {
+    if lhs.deviceIdentifier != rhs.deviceIdentifier {
+      return lhs.deviceIdentifier < rhs.deviceIdentifier
+    }
+    return DeviceHeartbeat.recordName(
+      childUserRecordName: lhs.childUserRecordName,
+      deviceIdentifier: lhs.deviceIdentifier
+    )
+      < DeviceHeartbeat.recordName(
+        childUserRecordName: rhs.childUserRecordName,
+        deviceIdentifier: rhs.deviceIdentifier
+      )
+  }
+}

--- a/Foqos/Utils/FamilyRosterExport.swift
+++ b/Foqos/Utils/FamilyRosterExport.swift
@@ -31,7 +31,9 @@ enum FamilyRosterExport {
       return [fields.joined(separator: " — ")] + deviceLines
     }
 
-    guard !lines.isEmpty else { return "" }
+    guard !lines.isEmpty else {
+      return "No family members were cached on this device at export time.\n"
+    }
     return lines.joined(separator: "\n") + "\n"
   }
 

--- a/Foqos/Utils/LogExportManager.swift
+++ b/Foqos/Utils/LogExportManager.swift
@@ -14,7 +14,7 @@ final class LogExportManager {
 
   /// Create a zip archive of all log files
   /// Offloads heavy file I/O to a background thread to avoid blocking the UI
-  func createLogArchive() async throws -> URL {
+  func createLogArchive(familyRoster: String? = nil) async throws -> URL {
     // Capture values that need main actor access
     let deviceInfo = generateDeviceInfo()
     let timestamp = formattedTimestamp()
@@ -47,6 +47,8 @@ final class LogExportManager {
       guard !copiedFiles.isEmpty else {
         throw LogExportError.noLogsAvailable
       }
+
+      try Self.writeFamilyRoster(familyRoster, to: stagingDir, fileManager: fileManager)
 
       // Add device info file
       let deviceInfoURL = stagingDir.appendingPathComponent("device-info.txt")
@@ -95,6 +97,16 @@ final class LogExportManager {
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM-dd-HHmmss"
     return formatter.string(from: Date())
+  }
+
+  nonisolated static func writeFamilyRoster(
+    _ content: String?,
+    to stagingDirectory: URL,
+    fileManager: FileManager
+  ) throws {
+    guard let content else { return }
+    let rosterURL = stagingDirectory.appendingPathComponent("roster.txt")
+    try content.write(to: rosterURL, atomically: true, encoding: .utf8)
   }
 
   /// Create zip using Cocoa compression (static version for use in detached tasks)

--- a/Foqos/Views/LogExportView.swift
+++ b/Foqos/Views/LogExportView.swift
@@ -8,6 +8,7 @@ struct LogExportView: View {
   @State private var errorMessage: String?
   @State private var showingPreview = false
   @State private var logStats: LogStats = LogStats()
+  @State private var includeFamilyMemberNames = false
 
   struct LogStats {
     var fileCount: Int = 0
@@ -28,7 +29,9 @@ struct LogExportView: View {
             .foregroundColor(.secondary)
 
             Text(
-              "Logs may contain profile names, timestamps, and technical device or account identifiers. Passwords and lock codes are never logged."
+              includeFamilyMemberNames
+                ? "This export includes family member names, full identifiers, and CloudKit record names in roster.txt. Share it only with Family Foqos support."
+                : "Logs may contain profile names, timestamps, and technical device or account identifiers. Family member names, passwords, and lock codes are not included."
             )
             .font(.caption)
             .foregroundColor(.secondary)
@@ -39,6 +42,15 @@ struct LogExportView: View {
         Section("Log Statistics") {
           LabeledContent("Log Files", value: "\(logStats.fileCount)")
           LabeledContent("Total Size", value: logStats.totalSize)
+        }
+
+        Section("Support Options") {
+          Toggle("Include family member names", isOn: $includeFamilyMemberNames)
+          Text(
+            "Turn this on only when Family Foqos support asks. Adds roster.txt so support can match diagnostic identifiers to family members."
+          )
+          .font(.caption)
+          .foregroundColor(.secondary)
         }
 
         Section {
@@ -85,11 +97,16 @@ struct LogExportView: View {
           Label("CloudKit sync operations", systemImage: "cloud")
           Label("Session start/stop events", systemImage: "clock")
           Label("Device info (model, iOS version)", systemImage: "iphone")
+          if includeFamilyMemberNames {
+            Label("Family member roster for support", systemImage: "person.text.rectangle")
+          }
         }
 
         Section("Not Included") {
           Label("Passwords or lock codes", systemImage: "lock.slash")
-          Label("Personal identifiers", systemImage: "person.slash")
+          if !includeFamilyMemberNames {
+            Label("Family member names", systemImage: "person.slash")
+          }
           Label("Location coordinates", systemImage: "location.slash")
           Label("Blocked app names", systemImage: "app.badge.checkmark")
         }
@@ -145,7 +162,14 @@ struct LogExportView: View {
       do {
         // Use zip archive instead of plain text file
         // createLogArchive() is async and offloads file I/O to a background thread
-        let url = try await LogExportManager.shared.createLogArchive()
+        let familyRoster =
+          includeFamilyMemberNames
+          ? FamilyRosterExport.content(
+            for: CloudKitManager.shared.familyMembers,
+            monitoredDevices: HeartbeatManager.shared.monitoredDevices
+          )
+          : nil
+        let url = try await LogExportManager.shared.createLogArchive(familyRoster: familyRoster)
         shareURL = url
         showingShareSheet = true
       } catch {

--- a/Foqos/Views/LogExportView.swift
+++ b/Foqos/Views/LogExportView.swift
@@ -30,7 +30,7 @@ struct LogExportView: View {
 
             Text(
               includeFamilyMemberNames
-                ? "This export includes family member names, full identifiers, and CloudKit record names in roster.txt. Share it only with Family Foqos support."
+                ? "This export includes currently loaded family member names, full identifiers, and CloudKit record names in roster.txt. It does not refresh family data. Share it only with Family Foqos support."
                 : "Logs may contain profile names, timestamps, and technical device or account identifiers. Family member names, passwords, and lock codes are not included."
             )
             .font(.caption)
@@ -47,7 +47,7 @@ struct LogExportView: View {
         Section("Support Options") {
           Toggle("Include family member names", isOn: $includeFamilyMemberNames)
           Text(
-            "Turn this on only when Family Foqos support asks. Adds roster.txt so support can match diagnostic identifiers to family members."
+            "Turn this on only when Family Foqos support asks. Adds roster.txt from family information already loaded in the app, without refreshing CloudKit, so support can match diagnostic identifiers to family members."
           )
           .font(.caption)
           .foregroundColor(.secondary)

--- a/Foqos/Views/LogExportView.swift
+++ b/Foqos/Views/LogExportView.swift
@@ -30,7 +30,7 @@ struct LogExportView: View {
 
             Text(
               includeFamilyMemberNames
-                ? "This export includes currently loaded family member names, full identifiers, and CloudKit record names in roster.txt. It does not refresh family data. Share it only with Family Foqos support."
+                ? "This export includes family member names, full identifiers, and CloudKit record names in roster.txt. Family data refreshes in the background when this option is enabled, while Share Logs still works offline using available data. Share it only with Family Foqos support."
                 : "Logs may contain profile names, timestamps, and technical device or account identifiers. Family member names, passwords, and lock codes are not included."
             )
             .font(.caption)
@@ -47,7 +47,7 @@ struct LogExportView: View {
         Section("Support Options") {
           Toggle("Include family member names", isOn: $includeFamilyMemberNames)
           Text(
-            "Turn this on only when Family Foqos support asks. Adds roster.txt from family information already loaded in the app, without refreshing CloudKit, so support can match diagnostic identifiers to family members."
+            "Turn this on only when Family Foqos support asks. Adds roster.txt and refreshes family information in the background when possible so support can match diagnostic identifiers to family members."
           )
           .font(.caption)
           .foregroundColor(.secondary)
@@ -141,6 +141,13 @@ struct LogExportView: View {
       }
       .onAppear {
         refreshStats()
+      }
+      .onChange(of: includeFamilyMemberNames) { _, isEnabled in
+        guard isEnabled else { return }
+
+        Task {
+          _ = try? await CloudKitManager.shared.fetchFamilyMembers()
+        }
       }
     }
   }

--- a/FoqosTests/FamilyRosterExportTests.swift
+++ b/FoqosTests/FamilyRosterExportTests.swift
@@ -107,8 +107,11 @@ final class FamilyRosterExportTests: XCTestCase {
     )
   }
 
-  func testGivenNoMembers_WhenFormattingRoster_ThenReturnsEmptyContent() {
-    XCTAssertEqual(FamilyRosterExport.content(for: [], monitoredDevices: []), "")
+  func testGivenNoMembers_WhenFormattingRoster_ThenExplainsEmptyCache() {
+    XCTAssertEqual(
+      FamilyRosterExport.content(for: [], monitoredDevices: []),
+      "No family members were cached on this device at export time.\n"
+    )
   }
 
   private func monitoredDevice(identifier: String, childRecordName: String) -> MonitoredDevice {

--- a/FoqosTests/FamilyRosterExportTests.swift
+++ b/FoqosTests/FamilyRosterExportTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import XCTest
+
+@testable import FamilyFoqos
+
+final class FamilyRosterExportTests: XCTestCase {
+  func testGivenActiveMember_WhenFormattingRoster_ThenIncludesEveryLogIdentityToken() {
+    let member = FamilyMember(
+      id: UUID(uuidString: "3F2A9C1B-672E-4C4A-9039-FF6107FBCE91")!,
+      userRecordName: "_abc123",
+      displayName: "Emma",
+      role: .child
+    )
+
+    XCTAssertEqual(
+      FamilyRosterExport.content(for: [member], monitoredDevices: []),
+      "child·3F2A9C1B — Emma — 3F2A9C1B-672E-4C4A-9039-FF6107FBCE91 — _abc123\n"
+    )
+  }
+
+  func testGivenInactiveMember_WhenFormattingRoster_ThenAppendsDeparted() {
+    let member = FamilyMember(
+      id: UUID(uuidString: "81D45AA0-DB15-48E2-9E20-0BE031607A19")!,
+      userRecordName: "_def456",
+      displayName: "Dad",
+      role: .parent,
+      isActive: false
+    )
+
+    XCTAssertTrue(
+      FamilyRosterExport.content(for: [member], monitoredDevices: [])
+        .contains("_def456 — (departed)\n")
+    )
+  }
+
+  func testGivenMatchedCachedDevices_WhenFormattingRoster_ThenAddsSortedDeviceLines() {
+    let member = FamilyMember(
+      id: UUID(uuidString: "3F2A9C1B-672E-4C4A-9039-FF6107FBCE91")!,
+      userRecordName: "_abc123",
+      displayName: "Emma",
+      role: .child
+    )
+    let devices = [
+      monitoredDevice(identifier: "device-z", childRecordName: "_abc123"),
+      monitoredDevice(identifier: "device-a", childRecordName: "_abc123"),
+      monitoredDevice(identifier: "unmatched", childRecordName: "_missing"),
+    ]
+
+    XCTAssertEqual(
+      FamilyRosterExport.content(for: [member], monitoredDevices: devices),
+      """
+      child·3F2A9C1B — Emma — 3F2A9C1B-672E-4C4A-9039-FF6107FBCE91 — _abc123
+        device — device-a — heartbeat-_abc123-device-a
+        device — device-z — heartbeat-_abc123-device-z
+
+      """
+    )
+  }
+
+  func testGivenMembersOutOfOrder_WhenFormattingRoster_ThenSortsRoleNameAndUUID() {
+    let parent = FamilyMember(
+      id: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!,
+      userRecordName: "parent",
+      displayName: "Alex",
+      role: .parent
+    )
+    let laterChild = FamilyMember(
+      id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+      userRecordName: "child-b",
+      displayName: "Sam",
+      role: .child
+    )
+    let earlierChild = FamilyMember(
+      id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+      userRecordName: "child-a",
+      displayName: "Sam",
+      role: .child
+    )
+
+    let lines = FamilyRosterExport.content(
+      for: [parent, laterChild, earlierChild], monitoredDevices: []
+    ).split(separator: "\n")
+
+    XCTAssertEqual(
+      lines.map(String.init),
+      [
+        "child·00000000 — Sam — 00000000-0000-0000-0000-000000000001 — child-a",
+        "child·00000000 — Sam — 00000000-0000-0000-0000-000000000002 — child-b",
+        "parent·00000000 — Alex — 00000000-0000-0000-0000-000000000003 — parent",
+      ])
+  }
+
+  func testGivenEmptyRecordName_WhenFormatting_ThenOmitsBlankFieldAndDoesNotMatchDevices() {
+    let member = FamilyMember(
+      id: UUID(uuidString: "3F2A9C1B-672E-4C4A-9039-FF6107FBCE91")!,
+      userRecordName: "",
+      displayName: "Emma",
+      role: .child
+    )
+
+    XCTAssertEqual(
+      FamilyRosterExport.content(
+        for: [member],
+        monitoredDevices: [monitoredDevice(identifier: "device-a", childRecordName: "")]
+      ),
+      "child·3F2A9C1B — Emma — 3F2A9C1B-672E-4C4A-9039-FF6107FBCE91\n"
+    )
+  }
+
+  func testGivenNoMembers_WhenFormattingRoster_ThenReturnsEmptyContent() {
+    XCTAssertEqual(FamilyRosterExport.content(for: [], monitoredDevices: []), "")
+  }
+
+  private func monitoredDevice(identifier: String, childRecordName: String) -> MonitoredDevice {
+    MonitoredDevice(
+      deviceIdentifier: identifier,
+      deviceName: "Test Device",
+      childUserRecordName: childRecordName,
+      lastSeenAt: Date(timeIntervalSince1970: 1_700_000_000),
+      isSuppressed: false,
+      notificationIdentifier: nil
+    )
+  }
+}

--- a/FoqosTests/LogExportManagerRosterTests.swift
+++ b/FoqosTests/LogExportManagerRosterTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import XCTest
+
+@testable import FamilyFoqos
+
+final class LogExportManagerRosterTests: XCTestCase {
+  func testGivenNilRoster_WhenStaging_ThenDoesNotCreateRosterFile() throws {
+    let directory = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    try LogExportManager.writeFamilyRoster(nil, to: directory, fileManager: .default)
+
+    XCTAssertFalse(
+      FileManager.default.fileExists(atPath: directory.appendingPathComponent("roster.txt").path)
+    )
+  }
+
+  func testGivenRosterContent_WhenStaging_ThenWritesExactUTF8FileIncludingEmptyContent() throws {
+    for content in ["child·ABCDEF12 — Emma\n", ""] {
+      let directory = try makeTemporaryDirectory()
+      defer { try? FileManager.default.removeItem(at: directory) }
+
+      try LogExportManager.writeFamilyRoster(content, to: directory, fileManager: .default)
+
+      XCTAssertEqual(
+        try String(
+          contentsOf: directory.appendingPathComponent("roster.txt"), encoding: .utf8),
+        content
+      )
+    }
+  }
+
+  private func makeTemporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("RosterTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+  }
+}

--- a/docs/superpowers/plans/2026-08-11-diagnostic-roster-export.md
+++ b/docs/superpowers/plans/2026-08-11-diagnostic-roster-export.md
@@ -192,7 +192,7 @@ func testGivenMembersOutOfOrder_WhenFormattingRoster_ThenSortsRoleNameAndUUID() 
   ])
 }
 
-func testGivenEmptyRecordNameAndEmptyRoster_WhenFormatting_ThenOmitsBlankFieldAndReturnsEmpty() {
+func testGivenEmptyRecordName_WhenFormatting_ThenOmitsBlankFieldAndDoesNotMatchDevices() {
   let member = FamilyMember(
     id: UUID(uuidString: "3F2A9C1B-672E-4C4A-9039-FF6107FBCE91")!,
     userRecordName: "",
@@ -201,9 +201,15 @@ func testGivenEmptyRecordNameAndEmptyRoster_WhenFormatting_ThenOmitsBlankFieldAn
   )
 
   XCTAssertEqual(
-    FamilyRosterExport.content(for: [member], monitoredDevices: []),
+    FamilyRosterExport.content(
+      for: [member],
+      monitoredDevices: [monitoredDevice(identifier: "device-a", childRecordName: "")]
+    ),
     "child·3F2A9C1B — Emma — 3F2A9C1B-672E-4C4A-9039-FF6107FBCE91\n"
   )
+}
+
+func testGivenNoMembers_WhenFormattingRoster_ThenReturnsEmptyContent() {
   XCTAssertEqual(FamilyRosterExport.content(for: [], monitoredDevices: []), "")
 }
 
@@ -239,7 +245,9 @@ let lines = members.sorted(by: memberComesBefore).flatMap { member -> [String] i
     fields.append("(departed)")
   }
 
-  let deviceLines = (devicesByMember[member.userRecordName] ?? [])
+  let matchedDevices =
+    member.userRecordName.isEmpty ? [] : (devicesByMember[member.userRecordName] ?? [])
+  let deviceLines = matchedDevices
     .sorted(by: deviceComesBefore)
     .map { device in
       let heartbeatRecordName = DeviceHeartbeat.recordName(

--- a/docs/superpowers/plans/2026-08-11-diagnostic-roster-export.md
+++ b/docs/superpowers/plans/2026-08-11-diagnostic-roster-export.md
@@ -1,0 +1,610 @@
+# Diagnostic Roster Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a transient, explicitly opted-in `roster.txt` to diagnostic exports so support can decode family-member, CloudKit participant, and cached heartbeat-device identifiers without putting names into ordinary logs.
+
+**Architecture:** A pure `FamilyRosterExport` formatter turns main-actor snapshots of family members and monitored devices into deterministic text. `LogExportView` owns consent and dynamic disclosure, while `LogExportManager` receives only an optional preformatted string and stages it without reading CloudKit or UI state.
+
+**Tech Stack:** Swift 6, SwiftUI, Foundation file APIs, XCTest, the existing serialized iOS simulator gate, and the existing Xcode project version gate.
+
+## Global Constraints
+
+- The roster toggle is transient `@State`, starts off whenever `LogExportView` is created, and is never persisted.
+- With the toggle off, no `roster.txt` exists and family member names remain absent from the export.
+- A member line is `<redactedLogLabel> — <displayName> — <full UUID> — <CK recordName> [— (departed)]`.
+- A matched cached device line is `  device — <device identifier> — <heartbeat record name>` immediately below its member.
+- Member ordering is role, display name, then full UUID; device ordering is device identifier, then heartbeat record name.
+- Empty CloudKit record names and unmatched cached devices are omitted; names and identifiers are never logged.
+- Export uses only `CloudKitManager.shared.familyMembers` and `HeartbeatManager.shared.monitoredDevices`; it performs no CloudKit fetch.
+- Existing callers of `createLogArchive()` remain privacy-safe through a default `familyRoster: nil` argument.
+- The existing no-logs check runs before roster staging, and a roster write failure fails the export instead of silently omitting the requested file.
+- Marketing version must be exactly `2.0.7` and build number exactly `26` in all 12 target/configuration pairs.
+- Never add Child-mode diagnostics gating. Only Child mode is subject to lock checks elsewhere: `currentMode == .child`.
+- Run every Xcode test/build through `scripts/xcode-stream.sh --agent build2 --session collab --`; never pass a destination or DerivedData path.
+
+---
+
+### Task 1: Pure deterministic roster formatter
+
+**Files:**
+- Create: `Foqos/Utils/FamilyRosterExport.swift`
+- Create: `FoqosTests/FamilyRosterExportTests.swift`
+
+**Interfaces:**
+- Consumes: `FamilyMember`, `FamilyMember.redactedLogLabel`, `MonitoredDevice`, and `DeviceHeartbeat.recordName(childUserRecordName:deviceIdentifier:)`.
+- Produces: `FamilyRosterExport.content(for:monitoredDevices:) -> String` for the export UI.
+
+- [ ] **Step 1: Write the first failing formatter test**
+
+Create `FoqosTests/FamilyRosterExportTests.swift` with a fixed UUID and an exact active-member expectation:
+
+```swift
+import Foundation
+import XCTest
+
+@testable import FamilyFoqos
+
+final class FamilyRosterExportTests: XCTestCase {
+  func testGivenActiveMember_WhenFormattingRoster_ThenIncludesEveryLogIdentityToken() {
+    let member = FamilyMember(
+      id: UUID(uuidString: "3F2A9C1B-672E-4C4A-9039-FF6107FBCE91")!,
+      userRecordName: "_abc123",
+      displayName: "Emma",
+      role: .child
+    )
+
+    XCTAssertEqual(
+      FamilyRosterExport.content(for: [member], monitoredDevices: []),
+      "child·3F2A9C1B — Emma — 3F2A9C1B-672E-4C4A-9039-FF6107FBCE91 — _abc123\n"
+    )
+  }
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+scripts/xcode-stream.sh --agent build2 --session collab -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -only-testing:FoqosTests/FamilyRosterExportTests
+```
+
+Expected: build/test failure because `FamilyRosterExport` does not exist.
+
+- [ ] **Step 3: Implement the minimal member formatter**
+
+Create `Foqos/Utils/FamilyRosterExport.swift`:
+
+```swift
+import Foundation
+
+enum FamilyRosterExport {
+  static func content(
+    for members: [FamilyMember],
+    monitoredDevices: [MonitoredDevice]
+  ) -> String {
+    let lines = members.sorted(by: memberComesBefore).map { member in
+      var fields = [member.redactedLogLabel, member.displayName, member.id.uuidString]
+      if !member.userRecordName.isEmpty {
+        fields.append(member.userRecordName)
+      }
+      if !member.isActive {
+        fields.append("(departed)")
+      }
+      return fields.joined(separator: " — ")
+    }
+
+    guard !lines.isEmpty else { return "" }
+    return lines.joined(separator: "\n") + "\n"
+  }
+
+  private static func memberComesBefore(_ lhs: FamilyMember, _ rhs: FamilyMember) -> Bool {
+    if lhs.role.rawValue != rhs.role.rawValue {
+      return lhs.role.rawValue < rhs.role.rawValue
+    }
+    if lhs.displayName != rhs.displayName {
+      return lhs.displayName < rhs.displayName
+    }
+    return lhs.id.uuidString < rhs.id.uuidString
+  }
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the Step 2 command. Expected: 1 test, 0 failures.
+
+- [ ] **Step 5: Add failing edge, ordering, and device-mapping tests**
+
+Extend `FamilyRosterExportTests` with:
+
+```swift
+func testGivenInactiveMember_WhenFormattingRoster_ThenAppendsDeparted() {
+  let member = FamilyMember(
+    id: UUID(uuidString: "81D45AA0-DB15-48E2-9E20-0BE031607A19")!,
+    userRecordName: "_def456",
+    displayName: "Dad",
+    role: .parent,
+    isActive: false
+  )
+
+  XCTAssertTrue(
+    FamilyRosterExport.content(for: [member], monitoredDevices: [])
+      .contains("_def456 — (departed)\n")
+  )
+}
+
+func testGivenMatchedCachedDevices_WhenFormattingRoster_ThenAddsSortedDeviceLines() {
+  let member = FamilyMember(
+    id: UUID(uuidString: "3F2A9C1B-672E-4C4A-9039-FF6107FBCE91")!,
+    userRecordName: "_abc123",
+    displayName: "Emma",
+    role: .child
+  )
+  let devices = [
+    monitoredDevice(identifier: "device-z", childRecordName: "_abc123"),
+    monitoredDevice(identifier: "device-a", childRecordName: "_abc123"),
+    monitoredDevice(identifier: "unmatched", childRecordName: "_missing"),
+  ]
+
+  XCTAssertEqual(
+    FamilyRosterExport.content(for: [member], monitoredDevices: devices),
+    """
+    child·3F2A9C1B — Emma — 3F2A9C1B-672E-4C4A-9039-FF6107FBCE91 — _abc123
+      device — device-a — heartbeat-_abc123-device-a
+      device — device-z — heartbeat-_abc123-device-z
+
+    """
+  )
+}
+
+func testGivenMembersOutOfOrder_WhenFormattingRoster_ThenSortsRoleNameAndUUID() {
+  let parent = FamilyMember(
+    id: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!,
+    userRecordName: "parent",
+    displayName: "Alex",
+    role: .parent
+  )
+  let laterChild = FamilyMember(
+    id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+    userRecordName: "child-b",
+    displayName: "Sam",
+    role: .child
+  )
+  let earlierChild = FamilyMember(
+    id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+    userRecordName: "child-a",
+    displayName: "Sam",
+    role: .child
+  )
+
+  let lines = FamilyRosterExport.content(
+    for: [parent, laterChild, earlierChild], monitoredDevices: []
+  ).split(separator: "\n")
+
+  XCTAssertEqual(lines.map(String.init), [
+    "child·00000000 — Sam — 00000000-0000-0000-0000-000000000001 — child-a",
+    "child·00000000 — Sam — 00000000-0000-0000-0000-000000000002 — child-b",
+    "parent·00000000 — Alex — 00000000-0000-0000-0000-000000000003 — parent",
+  ])
+}
+
+func testGivenEmptyRecordNameAndEmptyRoster_WhenFormatting_ThenOmitsBlankFieldAndReturnsEmpty() {
+  let member = FamilyMember(
+    id: UUID(uuidString: "3F2A9C1B-672E-4C4A-9039-FF6107FBCE91")!,
+    userRecordName: "",
+    displayName: "Emma",
+    role: .child
+  )
+
+  XCTAssertEqual(
+    FamilyRosterExport.content(for: [member], monitoredDevices: []),
+    "child·3F2A9C1B — Emma — 3F2A9C1B-672E-4C4A-9039-FF6107FBCE91\n"
+  )
+  XCTAssertEqual(FamilyRosterExport.content(for: [], monitoredDevices: []), "")
+}
+
+private func monitoredDevice(identifier: String, childRecordName: String) -> MonitoredDevice {
+  MonitoredDevice(
+    deviceIdentifier: identifier,
+    deviceName: "Test Device",
+    childUserRecordName: childRecordName,
+    lastSeenAt: Date(timeIntervalSince1970: 1_700_000_000),
+    isSuppressed: false,
+    notificationIdentifier: nil
+  )
+}
+```
+
+- [ ] **Step 6: Run the focused test and verify RED**
+
+Run the Step 2 command. Expected: the matched-device test fails because device lines are absent.
+
+- [ ] **Step 7: Extend the formatter with cached device lines**
+
+Replace the member-only `lines` construction with `flatMap`, group devices by child record name,
+and add this helper:
+
+```swift
+let devicesByMember = Dictionary(grouping: monitoredDevices, by: \.childUserRecordName)
+let lines = members.sorted(by: memberComesBefore).flatMap { member -> [String] in
+  var fields = [member.redactedLogLabel, member.displayName, member.id.uuidString]
+  if !member.userRecordName.isEmpty {
+    fields.append(member.userRecordName)
+  }
+  if !member.isActive {
+    fields.append("(departed)")
+  }
+
+  let deviceLines = (devicesByMember[member.userRecordName] ?? [])
+    .sorted(by: deviceComesBefore)
+    .map { device in
+      let heartbeatRecordName = DeviceHeartbeat.recordName(
+        childUserRecordName: device.childUserRecordName,
+        deviceIdentifier: device.deviceIdentifier
+      )
+      return "  device — \(device.deviceIdentifier) — \(heartbeatRecordName)"
+    }
+
+  return [fields.joined(separator: " — ")] + deviceLines
+}
+
+private static func deviceComesBefore(_ lhs: MonitoredDevice, _ rhs: MonitoredDevice) -> Bool {
+  if lhs.deviceIdentifier != rhs.deviceIdentifier {
+    return lhs.deviceIdentifier < rhs.deviceIdentifier
+  }
+  return DeviceHeartbeat.recordName(
+    childUserRecordName: lhs.childUserRecordName,
+    deviceIdentifier: lhs.deviceIdentifier
+  ) < DeviceHeartbeat.recordName(
+    childUserRecordName: rhs.childUserRecordName,
+    deviceIdentifier: rhs.deviceIdentifier
+  )
+}
+```
+
+- [ ] **Step 8: Run focused tests and formatting checks**
+
+Run the Step 2 command, then:
+
+```bash
+swift-format lint Foqos/Utils/FamilyRosterExport.swift FoqosTests/FamilyRosterExportTests.swift
+git diff --check
+```
+
+Expected: all formatter tests pass; lint and diff checks exit 0.
+
+- [ ] **Step 9: Commit the formatter**
+
+```bash
+git add Foqos/Utils/FamilyRosterExport.swift FoqosTests/FamilyRosterExportTests.swift
+git commit -S -m "Format diagnostic family roster"
+```
+
+---
+
+### Task 2: Optional roster archive staging
+
+**Files:**
+- Modify: `Foqos/Utils/LogExportManager.swift`
+- Create: `FoqosTests/LogExportManagerRosterTests.swift`
+
+**Interfaces:**
+- Consumes: optional UTF-8 roster content from Task 1's UI integration.
+- Produces: `createLogArchive(familyRoster: String? = nil) async throws -> URL` and testable `writeFamilyRoster(_:to:fileManager:)` staging behavior.
+
+- [ ] **Step 1: Write failing nil/non-nil staging tests**
+
+Create `FoqosTests/LogExportManagerRosterTests.swift`:
+
+```swift
+import Foundation
+import XCTest
+
+@testable import FamilyFoqos
+
+final class LogExportManagerRosterTests: XCTestCase {
+  func testGivenNilRoster_WhenStaging_ThenDoesNotCreateRosterFile() throws {
+    let directory = try makeTemporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    try LogExportManager.writeFamilyRoster(nil, to: directory, fileManager: .default)
+
+    XCTAssertFalse(
+      FileManager.default.fileExists(atPath: directory.appendingPathComponent("roster.txt").path)
+    )
+  }
+
+  func testGivenRosterContent_WhenStaging_ThenWritesExactUTF8FileIncludingEmptyContent() throws {
+    for content in ["child·ABCDEF12 — Emma\n", ""] {
+      let directory = try makeTemporaryDirectory()
+      defer { try? FileManager.default.removeItem(at: directory) }
+
+      try LogExportManager.writeFamilyRoster(content, to: directory, fileManager: .default)
+
+      XCTAssertEqual(
+        try String(
+          contentsOf: directory.appendingPathComponent("roster.txt"), encoding: .utf8),
+        content
+      )
+    }
+  }
+
+  private func makeTemporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("RosterTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+  }
+}
+```
+
+- [ ] **Step 2: Run focused archive tests and verify RED**
+
+```bash
+scripts/xcode-stream.sh --agent build2 --session collab -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -only-testing:FoqosTests/LogExportManagerRosterTests
+```
+
+Expected: build/test failure because `writeFamilyRoster` does not exist.
+
+- [ ] **Step 3: Add the staging helper and archive argument**
+
+Change the archive entry point to:
+
+```swift
+func createLogArchive(familyRoster: String? = nil) async throws -> URL {
+```
+
+After the existing no-logs guard and before device-info staging, call:
+
+```swift
+try Self.writeFamilyRoster(familyRoster, to: stagingDir, fileManager: fileManager)
+```
+
+Add this internal helper next to the other nonisolated static staging helpers:
+
+```swift
+nonisolated static func writeFamilyRoster(
+  _ content: String?,
+  to stagingDirectory: URL,
+  fileManager: FileManager
+) throws {
+  guard let content else { return }
+  let rosterURL = stagingDirectory.appendingPathComponent("roster.txt")
+  try content.write(to: rosterURL, atomically: true, encoding: .utf8)
+}
+```
+
+- [ ] **Step 4: Run focused archive tests and verify GREEN**
+
+Run the Step 2 command. Expected: 2 tests, 0 failures.
+
+- [ ] **Step 5: Verify existing default callers and fallback behavior**
+
+```bash
+rg -n "createLogArchive\(" Foqos FoqosTests
+swift-format lint Foqos/Utils/LogExportManager.swift FoqosTests/LogExportManagerRosterTests.swift
+git diff --check
+```
+
+Confirm existing zero-argument calls compile through the default `nil`, and confirm
+`createCombinedLogFileSync` still enumerates every staging file so `roster.txt` is included in the
+text fallback.
+
+- [ ] **Step 6: Commit archive staging**
+
+```bash
+git add Foqos/Utils/LogExportManager.swift FoqosTests/LogExportManagerRosterTests.swift
+git commit -S -m "Stage optional roster in log exports"
+```
+
+---
+
+### Task 3: Consent UI and truthful disclosure
+
+**Files:**
+- Modify: `Foqos/Views/LogExportView.swift`
+
+**Interfaces:**
+- Consumes: `FamilyRosterExport.content(for:monitoredDevices:)` and `LogExportManager.createLogArchive(familyRoster:)`.
+- Produces: transient user consent, conditional disclosure, and main-actor snapshots passed into archive creation.
+
+- [ ] **Step 1: Add the transient opt-in state**
+
+Add beside the existing `@State` properties:
+
+```swift
+@State private var includeFamilyMemberNames = false
+```
+
+Do not use `@AppStorage` or `UserDefaults`.
+
+- [ ] **Step 2: Add the support-only toggle and dynamic disclosure**
+
+Replace the static privacy caption with:
+
+```swift
+Text(
+  includeFamilyMemberNames
+    ? "This export includes family member names, full identifiers, and CloudKit record names in roster.txt. Share it only with Family Foqos support."
+    : "Logs may contain profile names, timestamps, and technical device or account identifiers. Family member names, passwords, and lock codes are not included."
+)
+.font(.caption)
+.foregroundColor(.secondary)
+```
+
+Add this section before the action buttons:
+
+```swift
+Section("Support Options") {
+  Toggle("Include family member names", isOn: $includeFamilyMemberNames)
+  Text(
+    "Turn this on only when Family Foqos support asks. Adds roster.txt so support can match diagnostic identifiers to family members."
+  )
+  .font(.caption)
+  .foregroundColor(.secondary)
+}
+```
+
+In **What's Included**, conditionally add:
+
+```swift
+if includeFamilyMemberNames {
+  Label("Family member roster for support", systemImage: "person.text.rectangle")
+}
+```
+
+Replace `Label("Personal identifiers", ...)` in **Not Included** with:
+
+```swift
+if !includeFamilyMemberNames {
+  Label("Family member names", systemImage: "person.slash")
+}
+```
+
+- [ ] **Step 3: Generate the roster only at the Share Logs action**
+
+In `exportLogs()`, immediately before calling the archive manager, compute:
+
+```swift
+let familyRoster =
+  includeFamilyMemberNames
+  ? FamilyRosterExport.content(
+    for: CloudKitManager.shared.familyMembers,
+    monitoredDevices: HeartbeatManager.shared.monitoredDevices
+  )
+  : nil
+let url = try await LogExportManager.shared.createLogArchive(familyRoster: familyRoster)
+```
+
+Remove the old zero-argument `createLogArchive()` call from that method. Do not alter Preview Logs.
+
+- [ ] **Step 4: Format and compile the UI integration**
+
+```bash
+swift-format --in-place Foqos/Views/LogExportView.swift
+swift-format lint Foqos/Views/LogExportView.swift
+git diff --check
+scripts/xcode-stream.sh --agent build2 --session collab -- \
+  xcodebuild build -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -configuration Debug
+```
+
+Expected: formatter clean and `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 5: Run the two focused suites together**
+
+```bash
+scripts/xcode-stream.sh --agent build2 --session collab -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -only-testing:FoqosTests/FamilyRosterExportTests \
+  -only-testing:FoqosTests/LogExportManagerRosterTests
+```
+
+Expected: all focused tests pass with 0 failures.
+
+- [ ] **Step 6: Commit UI integration**
+
+```bash
+git add Foqos/Views/LogExportView.swift
+git commit -S -m "Add support roster export consent"
+```
+
+---
+
+### Task 4: Version bump and final verification
+
+**Files:**
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+- Consumes: merged-main baseline `2.0.6` build `25`.
+- Produces: consistent release metadata `2.0.7` build `26` across all 12 target/configuration pairs.
+
+- [ ] **Step 1: Establish the failing live-main version gate**
+
+```bash
+git fetch origin main
+scripts/check-version-increment.sh origin/main HEAD
+```
+
+Expected before the bump: failure stating marketing/build versions did not increase.
+
+- [ ] **Step 2: Update every target/configuration pair**
+
+Use `apply_patch` to replace every `MARKETING_VERSION = 2.0.6;` with
+`MARKETING_VERSION = 2.0.7;` and every `CURRENT_PROJECT_VERSION = 25;` with
+`CURRENT_PROJECT_VERSION = 26;` in `FamilyFoqos.xcodeproj/project.pbxproj`.
+
+- [ ] **Step 3: Verify the working-tree counts**
+
+```bash
+test "$(rg -c 'MARKETING_VERSION = 2\.0\.7;' FamilyFoqos.xcodeproj/project.pbxproj)" -eq 12
+test "$(rg -c 'CURRENT_PROJECT_VERSION = 26;' FamilyFoqos.xcodeproj/project.pbxproj)" -eq 12
+! rg -n 'MARKETING_VERSION = 2\.0\.6;|CURRENT_PROJECT_VERSION = 25;' \
+  FamilyFoqos.xcodeproj/project.pbxproj
+```
+
+Expected: 12/12 settings agree and no stale baseline setting remains.
+
+- [ ] **Step 4: Commit the version bump**
+
+```bash
+git add FamilyFoqos.xcodeproj/project.pbxproj
+git commit -S -m "Bump version to 2.0.7 build 26"
+```
+
+- [ ] **Step 5: Verify the committed version gate**
+
+```bash
+scripts/check-version-increment.sh origin/main HEAD
+```
+
+Expected: the gate reports `2.0.6 -> 2.0.7`, `25 -> 26`.
+
+- [ ] **Step 6: Run the full serialized test suite at the exact committed head**
+
+```bash
+scripts/xcode-stream.sh --agent build2 --session collab -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos
+```
+
+Expected: 0 failures (baseline was 1,200 tests; the roster tests increase the count).
+
+- [ ] **Step 7: Run the exact-head serialized Debug build**
+
+```bash
+scripts/xcode-stream.sh --agent build2 --session collab -- \
+  xcodebuild build -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -configuration Debug
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 8: Run final formatting, project, privacy, version, and signature checks**
+
+```bash
+swift-format lint --recursive .
+git diff --check origin/main...HEAD
+rg -n "FamilyRosterExport|familyRoster|roster\.txt|Include family member names" Foqos FoqosTests
+rg -n "Log\.(debug|info|warning|error).*displayName|Log\.(debug|info|warning|error).*deviceIdentifier" Foqos
+scripts/check-version-increment.sh origin/main HEAD
+git log --show-signature --format=fuller origin/main..HEAD
+git status --short
+```
+
+Expected: formatting and diff checks pass; the privacy scan finds no roster name/identifier logging;
+the version gate passes; every new commit has a good signature; the worktree is clean.
+
+- [ ] **Step 9: Push, open a draft PR, and request review**
+
+```bash
+git push -u origin HEAD
+```
+
+Open a draft PR targeting `main` with the approved spec, privacy behavior, cached heartbeat mapping,
+red-green evidence, exact test/build counts, and version evidence. Request review before any merge;
+the planner, not the implementer, performs the merge.

--- a/docs/superpowers/specs/2026-08-11-diagnostic-roster-export-design.md
+++ b/docs/superpowers/specs/2026-08-11-diagnostic-roster-export-design.md
@@ -13,7 +13,8 @@ user turns on the export-screen toggle for that export.
 Diagnostic logs now identify family members with either:
 
 - `FamilyMember.redactedLogLabel`, formatted as `role·first8StableUUID`; or
-- an opaque CloudKit user record name when only a share participant is available.
+- an opaque CloudKit user record name when only a share participant is available; or
+- a heartbeat device identifier, sometimes embedded in a `DeviceHeartbeat` record name.
 
 Those values protect names in logs but make support investigations harder. The roster is a
 deliberate decode table supplied only when the user is seeking support. Every identity token that
@@ -47,14 +48,15 @@ Logs, so names do not enter the log preview or the logging subsystem.
 
 ## Roster Format
 
-A new pure `FamilyRosterExport` formatter accepts `[FamilyMember]` and returns UTF-8 text. It has no
-singleton, UI, filesystem, or CloudKit dependencies.
+A new pure `FamilyRosterExport` formatter accepts `[FamilyMember]` and `[MonitoredDevice]` snapshots
+and returns UTF-8 text. It has no singleton, UI, filesystem, or CloudKit dependencies.
 
 The file is headerless and contains one line per member. Fields use an em dash surrounded by
 spaces. The grammar is:
 
 ```text
 <redactedLogLabel> — <displayName> — <full UUID> — <CK recordName> [— (departed)]
+  device — <device identifier> — <heartbeat record name>
 ```
 
 Rules:
@@ -65,6 +67,14 @@ Rules:
   If a future or malformed model has an empty record name, that field is omitted rather than
   emitting a meaningless blank token.
 - `— (departed)` is appended only when `isActive == false`.
+- Cached devices are matched to members by
+  `MonitoredDevice.childUserRecordName == FamilyMember.userRecordName`. Each matched device becomes
+  an indented line immediately after its member. It includes the verbatim `deviceIdentifier` and
+  the complete `DeviceHeartbeat.recordName`, covering both heartbeat identity forms that can
+  appear in logs.
+- Device lines sort by `deviceIdentifier`, then computed heartbeat record name. A cached device
+  that cannot be matched to a current family member is omitted because the cache contains no
+  reliable person mapping for it; the export never guesses a name.
 - Members sort by `role.rawValue`, then `displayName`, then full UUID, using Swift's stable string
   comparison. The UUID tie-breaker makes output deterministic when role and name match.
 - An opted-in export with no cached members contains an empty `roster.txt`. The file's presence
@@ -75,16 +85,18 @@ Example:
 
 ```text
 child·3F2A9C1B — Emma — 3F2A9C1B-672E-4C4A-9039-FF6107FBCE91 — _abc123
+  device — 17418220-FA9F-4E79-AF4E-DC030C6E8E12 — heartbeat-_abc123-17418220-FA9F-4E79-AF4E-DC030C6E8E12
 parent·81D45AA0 — Dad — 81D45AA0-DB15-48E2-9E20-0BE031607A19 — _def456 — (departed)
 ```
 
 ## Architecture and Data Flow
 
 1. When Share Logs is tapped, `LogExportView` snapshots
-   `CloudKitManager.shared.familyMembers` on the main actor.
+   `CloudKitManager.shared.familyMembers` and `HeartbeatManager.shared.monitoredDevices` on the
+   main actor.
 2. If the toggle is off, the view passes `nil` to the archive manager.
-3. If the toggle is on, `FamilyRosterExport.content(for:)` formats the snapshot on the main actor,
-   and the view passes the resulting `String` to the archive manager.
+3. If the toggle is on, `FamilyRosterExport.content(for:monitoredDevices:)` formats the snapshots
+   on the main actor, and the view passes the resulting `String` to the archive manager.
 4. `LogExportManager.createLogArchive(familyRoster:)` retains a default value of `nil`, preserving
    the privacy-safe behavior of existing callers.
 5. Inside the detached staging task, an internal static helper writes non-`nil` content to
@@ -93,13 +105,15 @@ parent·81D45AA0 — Dad — 81D45AA0-DB15-48E2-9E20-0BE031607A19 — _def456 �
    combined-text fallback includes it as a clearly named `=== roster.txt ===` section because it
    already combines every staging file.
 
-The archive manager never reads `CloudKitManager` or `FamilyMember`. Passing a preformatted,
-optional `String` avoids singleton coupling and avoids transferring non-Sendable app state into
-the detached task.
+The archive manager never reads `CloudKitManager`, `HeartbeatManager`, `FamilyMember`, or
+`MonitoredDevice`. Passing a preformatted, optional `String` avoids singleton coupling and avoids
+transferring non-Sendable app state into the detached task.
 
-The roster uses the current in-memory family-member cache. Export does not initiate a CloudKit
-fetch: support exports must remain usable offline, and a network failure must not block access to
-existing logs. Inactive cached entries remain useful and are marked `(departed)`.
+The roster uses the current in-memory family-member cache and the locally persisted monitored-device
+cache. Export does not initiate a CloudKit fetch: support exports must remain usable offline, and a
+network failure must not block access to existing logs. Device mappings may therefore be incomplete
+until a parent device has refreshed heartbeats, but every cached device that matches a cached member
+is included. Inactive cached member entries remain useful and are marked `(departed)`.
 
 ## Error Handling
 
@@ -120,6 +134,9 @@ Focused unit tests cover:
   record name;
 - `(departed)` only for inactive members;
 - deterministic role/name/UUID ordering;
+- matched cached-device sub-lines containing the device identifier and computed heartbeat record
+  name in deterministic order;
+- omission of cached devices that have no matching family member;
 - omission of an empty record-name field;
 - empty member input;
 - `nil` roster content creating no file in a temporary staging directory;

--- a/docs/superpowers/specs/2026-08-11-diagnostic-roster-export-design.md
+++ b/docs/superpowers/specs/2026-08-11-diagnostic-roster-export-design.md
@@ -1,0 +1,139 @@
+# Diagnostic Roster Export Design
+
+## Goal
+
+Add an explicitly opted-in `roster.txt` file to diagnostic exports so Family Foqos support can
+map privacy-safe identity tokens in logs back to the family members they describe.
+
+Ordinary exports remain unchanged: family member names and the roster file are absent unless the
+user turns on the export-screen toggle for that export.
+
+## Context
+
+Diagnostic logs now identify family members with either:
+
+- `FamilyMember.redactedLogLabel`, formatted as `role·first8StableUUID`; or
+- an opaque CloudKit user record name when only a share participant is available.
+
+Those values protect names in logs but make support investigations harder. The roster is a
+deliberate decode table supplied only when the user is seeking support. Every identity token that
+can appear in a family-member log line must be resolvable from it.
+
+## User Experience and Consent
+
+`LogExportView` gains a transient `@State` toggle labeled **Include family member names**. It starts
+off every time the export screen is created and is not stored in `UserDefaults`. A previous opt-in
+therefore cannot silently affect a later export.
+
+Support-framed help text appears with the toggle:
+
+> Turn this on only when Family Foqos support asks. Adds roster.txt so support can match diagnostic
+> identifiers to family members.
+
+The privacy disclosure changes immediately:
+
+- Toggle off: explain that logs can contain profile names, timestamps, and technical device or
+  account identifiers, while family member names are not included.
+- Toggle on: state that `roster.txt` includes family member names, full identifiers, and CloudKit
+  record names, and should be shared only with Family Foqos support.
+
+The **What's Included** section conditionally adds **Family member roster for support**. The
+existing generic **Personal identifiers** row in **Not Included** is replaced with the accurate,
+specific **Family member names** row when the toggle is off; that row disappears when the toggle
+is on. Passwords, lock codes, location coordinates, and blocked app names remain excluded.
+
+Preview Logs continues to preview logs only. The roster is created only when the user taps Share
+Logs, so names do not enter the log preview or the logging subsystem.
+
+## Roster Format
+
+A new pure `FamilyRosterExport` formatter accepts `[FamilyMember]` and returns UTF-8 text. It has no
+singleton, UI, filesystem, or CloudKit dependencies.
+
+The file is headerless and contains one line per member. Fields use an em dash surrounded by
+spaces. The grammar is:
+
+```text
+<redactedLogLabel> — <displayName> — <full UUID> — <CK recordName> [— (departed)]
+```
+
+Rules:
+
+- `redactedLogLabel` is copied verbatim so it joins directly to log lines.
+- The UUID uses the complete uppercase `UUID.uuidString` representation.
+- A non-empty `userRecordName` is included verbatim so opaque participant labels can be resolved.
+  If a future or malformed model has an empty record name, that field is omitted rather than
+  emitting a meaningless blank token.
+- `— (departed)` is appended only when `isActive == false`.
+- Members sort by `role.rawValue`, then `displayName`, then full UUID, using Swift's stable string
+  comparison. The UUID tie-breaker makes output deterministic when role and name match.
+- An opted-in export with no cached members contains an empty `roster.txt`. The file's presence
+  still records that the option was honored without inventing data.
+- A final newline is present when at least one member exists.
+
+Example:
+
+```text
+child·3F2A9C1B — Emma — 3F2A9C1B-672E-4C4A-9039-FF6107FBCE91 — _abc123
+parent·81D45AA0 — Dad — 81D45AA0-DB15-48E2-9E20-0BE031607A19 — _def456 — (departed)
+```
+
+## Architecture and Data Flow
+
+1. When Share Logs is tapped, `LogExportView` snapshots
+   `CloudKitManager.shared.familyMembers` on the main actor.
+2. If the toggle is off, the view passes `nil` to the archive manager.
+3. If the toggle is on, `FamilyRosterExport.content(for:)` formats the snapshot on the main actor,
+   and the view passes the resulting `String` to the archive manager.
+4. `LogExportManager.createLogArchive(familyRoster:)` retains a default value of `nil`, preserving
+   the privacy-safe behavior of existing callers.
+5. Inside the detached staging task, an internal static helper writes non-`nil` content to
+   `roster.txt` before compression. A `nil` value creates no roster file.
+6. The normal ZIP path contains `roster.txt`. If coordinated ZIP creation fails, the existing
+   combined-text fallback includes it as a clearly named `=== roster.txt ===` section because it
+   already combines every staging file.
+
+The archive manager never reads `CloudKitManager` or `FamilyMember`. Passing a preformatted,
+optional `String` avoids singleton coupling and avoids transferring non-Sendable app state into
+the detached task.
+
+The roster uses the current in-memory family-member cache. Export does not initiate a CloudKit
+fetch: support exports must remain usable offline, and a network failure must not block access to
+existing logs. Inactive cached entries remain useful and are marked `(departed)`.
+
+## Error Handling
+
+If roster formatting succeeds but writing `roster.txt` fails, archive creation fails and the UI
+shows the existing localized export error. The app must not silently produce an archive that the
+user explicitly requested to include the roster.
+
+The existing no-logs check remains before the device-info and roster additions, so the presence of
+an opted-in roster alone does not make an otherwise empty log export shareable.
+
+No roster value is logged while formatting, staging, failing, or sharing.
+
+## Testing
+
+Focused unit tests cover:
+
+- exact active-member line output, including the verbatim log label, display name, full UUID, and
+  record name;
+- `(departed)` only for inactive members;
+- deterministic role/name/UUID ordering;
+- omission of an empty record-name field;
+- empty member input;
+- `nil` roster content creating no file in a temporary staging directory;
+- non-`nil` roster content creating an exact UTF-8 `roster.txt` file.
+
+Implementation follows red-green TDD. After focused tests pass, run the full serialized test suite,
+a serialized Debug build, swift-format lint, project-file validation, the privacy scan, and the
+version-increment gate.
+
+## Versioning and Scope
+
+This PR bumps every target/configuration pair from marketing version `2.0.6` to `2.0.7` and build
+number `25` to `26`. All 12 target/configuration pairs must agree.
+
+This PR does not change log content, CloudKit fetching, family-member lifecycle, preview behavior,
+or Child-mode diagnostics access. The subsequent and separate final batch PR addresses issue #360
+by adding the build-phase lint.


### PR DESCRIPTION
## Summary

- add a transient, off-by-default support toggle for including family member names in diagnostic exports
- generate a deterministic `roster.txt` mapping every log-visible family identity token to the member name, full UUID, CloudKit record name, and departed status
- map locally cached heartbeat device identifiers and record names beneath the matching family member without fetching CloudKit
- stage the roster only when explicitly supplied, preserving privacy-safe behavior for all existing archive callers
- bump every target/configuration pair to version 2.0.7 build 26

## Privacy behavior

- ordinary exports do not contain `roster.txt` or family member names
- the consent state is transient `@State` and resets off whenever the export view is recreated
- disclosure text and included/not-included lists change with the toggle
- unmatched cached devices and empty CloudKit record names are omitted
- names and device identifiers are never logged

## Design and plan

- `docs/superpowers/specs/2026-08-11-diagnostic-roster-export-design.md`
- `docs/superpowers/plans/2026-08-11-diagnostic-roster-export.md`

## TDD evidence

- formatter RED: compile failure because `FamilyRosterExport` did not exist; GREEN: 1 test passed
- cached-device RED: 1 expected failure because device lines were absent; GREEN: all 6 formatter tests passed
- archive RED: compile failure because `writeFamilyRoster` did not exist; GREEN: both filesystem staging tests passed

## Validation

- full serialized test suite: 1,208 tests, 0 failures
- serialized Debug build: succeeded
- combined focused suites: 8 tests, 0 failures
- `swift-format lint --recursive .`: passed
- `git diff --check origin/main...HEAD`: passed
- version gate: `2.0.6 -> 2.0.7`, build `25 -> 26`
- all branch commits have good Git signatures
