### PR TITLE
Fix blank SwiftData previews (#193)

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -714,7 +714,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -735,7 +735,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -746,7 +746,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -894,7 +894,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -922,7 +922,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -948,7 +948,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -976,7 +976,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -998,12 +998,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1024,12 +1024,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1049,12 +1049,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1074,12 +1074,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1100,7 +1100,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1111,7 +1111,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1132,7 +1132,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1143,7 +1143,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1178,7 +1178,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1201,7 +1201,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1212,7 +1212,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.8;
+				MARKETING_VERSION = 2.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift
+++ b/Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift
@@ -1,4 +1,5 @@
 import FamilyControls
+import SwiftData
 import SwiftUI
 
 struct BlockedProfileCarousel: View {
@@ -265,62 +266,34 @@ struct BlockedProfileCarousel: View {
 
 }
 
-// Active preview
-#Preview {
-  let activeId = UUID()
+#if DEBUG
+  @MainActor
+  struct BlockedProfileCarouselPreview: View {
+    enum Scenario: CaseIterable {
+      case active
+      case inactive
+      case startingProfile
+    }
 
-  ZStack {
-    Color(.systemGroupedBackground).ignoresSafeArea()
+    let container: ModelContainer
+    let profiles: [BlockedProfiles]
+    let scenario: Scenario
 
-    BlockedProfileCarousel(
-      profiles: [
-        BlockedProfiles(
-          id: activeId,
-          name: "Work",
-          selectedActivity: FamilyActivitySelection(),
-          blockingStrategyId: NFCBlockingStrategy.id,
-          enableLiveActivity: true,
-          reminderTimeInSeconds: 3600
-        ),
-        BlockedProfiles(
-          id: UUID(),
-          name: "Gaming",
-          selectedActivity: FamilyActivitySelection(),
-          blockingStrategyId: QRCodeBlockingStrategy.id,
-          enableLiveActivity: false,
-          reminderTimeInSeconds: nil
-        ),
-        BlockedProfiles(
-          id: UUID(),
-          name: "Social Media",
-          selectedActivity: FamilyActivitySelection(),
-          blockingStrategyId: ManualBlockingStrategy.id,
-          enableLiveActivity: true,
-          reminderTimeInSeconds: 1800
-        ),
-      ],
-      isBlocking: true,
-      isBreakAvailable: true,
-      isBreakActive: false,
-      activeSessionProfileId: activeId,
-      elapsedTime: 1234,
-      onStartTapped: { _ in },
-      onStopTapped: { _ in },
-      onEditTapped: { _ in },
-      onStatsTapped: { _ in },
-      onBreakTapped: { _ in },
-      onManageTapped: {},
-      onEmergencyTapped: {}
-    )
-  }
-}
+    init(scenario: Scenario) {
+      let schema = Schema([BlockedProfiles.self])
+      let configuration = ModelConfiguration(
+        schema: schema,
+        isStoredInMemoryOnly: true,
+        cloudKitDatabase: .none
+      )
 
-#Preview {
-  ZStack {
-    Color(.systemGroupedBackground).ignoresSafeArea()
+      do {
+        container = try ModelContainer(for: schema, configurations: [configuration])
+      } catch {
+        fatalError("Failed to create carousel preview container: \(error)")
+      }
 
-    BlockedProfileCarousel(
-      profiles: [
+      profiles = [
         BlockedProfiles(
           id: UUID(),
           name: "Work",
@@ -345,70 +318,47 @@ struct BlockedProfileCarousel: View {
           enableLiveActivity: true,
           reminderTimeInSeconds: 1800
         ),
-      ],
-      isBlocking: false,
-      isBreakAvailable: false,
-      isBreakActive: false,
-      activeSessionProfileId: nil,
-      elapsedTime: 1234,
-      onStartTapped: { _ in },
-      onStopTapped: { _ in },
-      onEditTapped: { _ in },
-      onStatsTapped: { _ in },
-      onBreakTapped: { _ in },
-      onManageTapped: {},
-      onEmergencyTapped: {}
-    )
+      ]
+      self.scenario = scenario
+
+      for profile in profiles {
+        container.mainContext.insert(profile)
+      }
+    }
+
+    var body: some View {
+      ZStack {
+        Color(.systemGroupedBackground).ignoresSafeArea()
+
+        BlockedProfileCarousel(
+          profiles: profiles,
+          isBlocking: scenario == .active,
+          isBreakAvailable: scenario == .active,
+          isBreakActive: false,
+          activeSessionProfileId: scenario == .active ? profiles.first?.id : nil,
+          elapsedTime: 1234,
+          startingProfileId: scenario == .startingProfile ? profiles[safe: 1]?.id : nil,
+          onStartTapped: { _ in },
+          onStopTapped: { _ in },
+          onEditTapped: { _ in },
+          onStatsTapped: { _ in },
+          onBreakTapped: { _ in },
+          onManageTapped: {},
+          onEmergencyTapped: {}
+        )
+      }
+      .modelContainer(container)
+    }
   }
-}
-
-// Preview with startingProfileId set to "Gaming" (second profile)
-#Preview("Starting Profile - Gaming") {
-  let gamingProfileId = UUID()
-
-  ZStack {
-    Color(.systemGroupedBackground).ignoresSafeArea()
-
-    BlockedProfileCarousel(
-      profiles: [
-        BlockedProfiles(
-          id: UUID(),
-          name: "Work",
-          selectedActivity: FamilyActivitySelection(),
-          blockingStrategyId: NFCBlockingStrategy.id,
-          enableLiveActivity: true,
-          reminderTimeInSeconds: 3600
-        ),
-        BlockedProfiles(
-          id: gamingProfileId,
-          name: "Gaming",
-          selectedActivity: FamilyActivitySelection(),
-          blockingStrategyId: QRCodeBlockingStrategy.id,
-          enableLiveActivity: false,
-          reminderTimeInSeconds: nil
-        ),
-        BlockedProfiles(
-          id: UUID(),
-          name: "Social Media",
-          selectedActivity: FamilyActivitySelection(),
-          blockingStrategyId: ManualBlockingStrategy.id,
-          enableLiveActivity: true,
-          reminderTimeInSeconds: 1800
-        ),
-      ],
-      isBlocking: false,
-      isBreakAvailable: false,
-      isBreakActive: false,
-      activeSessionProfileId: nil,
-      elapsedTime: 1234,
-      startingProfileId: gamingProfileId,
-      onStartTapped: { _ in },
-      onStopTapped: { _ in },
-      onEditTapped: { _ in },
-      onStatsTapped: { _ in },
-      onBreakTapped: { _ in },
-      onManageTapped: {},
-      onEmergencyTapped: {}
-    )
+  #Preview("Active") {
+    BlockedProfileCarouselPreview(scenario: .active)
   }
-}
+
+  #Preview("Inactive") {
+    BlockedProfileCarouselPreview(scenario: .inactive)
+  }
+
+  #Preview("Starting Profile - Gaming") {
+    BlockedProfileCarouselPreview(scenario: .startingProfile)
+  }
+#endif

--- a/Foqos/Views/Child/ChildDashboardView.swift
+++ b/Foqos/Views/Child/ChildDashboardView.swift
@@ -680,4 +680,5 @@ struct ChildSettingsView: View {
 
 #Preview {
   ChildDashboardView()
+    .modelContainer(for: BlockedProfiles.self, inMemory: true)
 }

--- a/FoqosTests/BlockedProfileCarouselTests.swift
+++ b/FoqosTests/BlockedProfileCarouselTests.swift
@@ -3,6 +3,16 @@ import XCTest
 @testable import FamilyFoqos
 
 final class BlockedProfileCarouselTests: XCTestCase {
+  @MainActor
+  func testGivenCarouselPreviewScenarios_WhenConstructed_ThenAllProfilesAreRegistered() {
+    for scenario in BlockedProfileCarouselPreview.Scenario.allCases {
+      let preview = BlockedProfileCarouselPreview(scenario: scenario)
+
+      XCTAssertEqual(preview.profiles.count, 3)
+      XCTAssertTrue(preview.profiles.allSatisfy(\.isPersistentModelValid))
+    }
+  }
+
   func testGivenCurrentPageStillPresent_WhenProfilesChange_ThenCurrentPageKept() {
     let currentId = UUID()
     let nextId = UUID()

--- a/docs/superpowers/plans/2026-08-11-issue-193-safe-preview-context.md
+++ b/docs/superpowers/plans/2026-08-11-issue-193-safe-preview-context.md
@@ -1,0 +1,91 @@
+# Issue #193 Safe Preview Context Implementation Plan
+
+> **For implementers:** Follow the repository's TDD, serialized Xcode, versioning, review, and
+> verification requirements. Do not merge this PR; hand the green reviewed PR to the planner.
+
+**Goal:** Make the three carousel previews and the child dashboard preview render with valid
+SwiftData contexts while preserving production zombie-model protections.
+
+**Architecture:** A debug-only carousel preview fixture owns an in-memory `ModelContainer`, inserts
+its directly constructed profiles, and passes both the registered profiles and the same container
+to the preview hierarchy. The query-backed child dashboard preview receives an in-memory container
+directly. Production views and model-validation logic remain unchanged.
+
+**Tech stack:** SwiftUI previews, SwiftData, XCTest, Xcode project build settings.
+
+---
+
+## Task 1: Add the failing carousel preview registration test
+
+**Files:**
+
+- Modify: `FoqosTests/BlockedProfileCarouselTests.swift`
+
+1. Add a test that iterates every `BlockedProfileCarouselPreview.Scenario` and asserts that the
+   fixture supplies three profiles and every profile is `isPersistentModelValid`.
+2. Run the focused test through the serialized stream:
+
+   ```bash
+   set -o pipefail
+   scripts/xcode-stream.sh --agent build1 --session collab -- \
+     xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+     -only-testing:FoqosTests/BlockedProfileCarouselTests 2>&1 | bundle exec xcpretty
+   ```
+
+3. Confirm RED because `BlockedProfileCarouselPreview` does not exist yet. Do not continue if the
+   test unexpectedly passes.
+4. Commit the red test as a new commit.
+
+## Task 2: Implement the in-memory preview contexts
+
+**Files:**
+
+- Modify: `Foqos/Components/BlockedProfileCards/BlockedProfileCarousel.swift`
+- Modify: `Foqos/Views/Child/ChildDashboardView.swift`
+
+1. Import SwiftData in `BlockedProfileCarousel.swift`.
+2. Add a debug-only, main-actor `BlockedProfileCarouselPreview` fixture with `CaseIterable`
+   scenarios for active, inactive, and starting-profile previews.
+3. In the fixture initializer, create an in-memory `ModelContainer` for `BlockedProfiles`, build
+   the scenario's three profiles, insert them all into `container.mainContext`, and retain the
+   matching active/starting IDs.
+4. Render the existing carousel configuration from the fixture and attach `.modelContainer` using
+   that exact container.
+5. Replace the three duplicated preview bodies with the corresponding fixture scenarios.
+6. Attach `.modelContainer(for: BlockedProfiles.self, inMemory: true)` to the child dashboard
+   preview.
+7. Re-run the focused command from Task 1 and confirm GREEN.
+8. Commit the implementation as a new commit.
+
+## Task 3: Apply the strict version bump
+
+**Files:**
+
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+
+1. Update every target configuration from marketing version `2.0.8` to `2.0.9` and build version
+   `27` to `28`.
+2. Run the repository version-increment check against `main` and confirm it passes.
+3. Commit the version bump as a new commit.
+
+## Task 4: Verify the complete #193 change
+
+**Files:** none
+
+1. Run `swift-format lint --recursive .` and `git diff --check`.
+2. Run repository guard scripts relevant to all commits, including log privacy; no log-site floor
+   change is expected because #193 removes no log calls.
+3. Run the full unit test suite through `scripts/xcode-stream.sh` with caller `pipefail` and
+   `bundle exec xcpretty`.
+4. Run a Debug build through the same serialized stream to compile both preview declarations.
+5. Inspect the complete diff against `main` and confirm only the approved #193 design, test,
+   preview changes, and version bump are present.
+
+## Task 5: Review and publish
+
+1. Request independent code review before publication and address only verified findings in new
+   commits.
+2. Re-run affected verification after any review changes.
+3. Push `fix/193-safe-preview-context` and open an undrafted PR that closes #193.
+4. Wait for green CI, then report the PR and evidence to the planner for merge. Do not begin #248
+   until the planner confirms #193 is merged and `main` is updated.

--- a/docs/superpowers/specs/2026-08-11-issue-193-safe-preview-context-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-193-safe-preview-context-design.md
@@ -1,0 +1,47 @@
+# Issue #193 Safe Preview Context Design
+
+## Goal
+
+Restore the four remaining blank SwiftUI previews that render `BlockedProfiles` through
+`SafeModelView` or `@SafeQuery`, without weakening the production zombie-model safeguards.
+
+## Root cause
+
+`SafeModelView` and the `.valid` array extension intentionally reject a `PersistentModel` unless
+it is registered with a live `ModelContext`. The three `BlockedProfileCarousel` previews construct
+`BlockedProfiles` directly, so their models have no context and the carousel filters them out. A
+`.modelContainer` modifier alone does not retroactively insert those already-created objects.
+
+`ChildDashboardView` obtains its profiles through `@SafeQuery`. Its preview does not construct
+models directly, but the query has no model container to read from.
+
+## Design
+
+Introduce a debug-only carousel preview fixture that:
+
+- creates an in-memory `ModelContainer` for `BlockedProfiles`;
+- creates the profiles for each existing preview scenario;
+- inserts every profile into the container's main context before the view renders; and
+- attaches that exact container to the carousel view.
+
+Keep the existing active, inactive, and starting-profile scenarios. Centralizing their setup in
+one fixture avoids three subtly different container lifetimes and makes registration directly
+testable.
+
+For `ChildDashboardView`, attach an in-memory `BlockedProfiles` model container to the preview.
+Because `@SafeQuery` owns model retrieval there, no explicit seed insertion is required.
+
+Do not change `SafeModelView`, `.valid`, or production persistence behavior.
+
+## Verification
+
+Add a focused unit test that constructs each carousel preview scenario and proves every supplied
+profile is registered and valid. Run that test red before implementing the fixture, then green.
+Compile the app to validate both preview declarations. Finally run the project test suite and the
+repository checks through the serialized Xcode stream.
+
+## Delivery
+
+Ship #193 as its own branch and PR with a strict marketing/build version bump above `main`.
+Request independent code review and require green CI before handing the PR to the planner for
+merge.


### PR DESCRIPTION
## Summary

- create a debug-only carousel preview fixture backed by an in-memory SwiftData container
- insert all directly constructed preview profiles into that same container before rendering
- give the query-backed child dashboard preview its own in-memory model container
- cover every carousel preview scenario with a registration-validity regression test
- bump the app from 2.0.8 (27) to 2.0.9 (28)

## Root cause

`SafeModelView` and `.valid` reject a `PersistentModel` unless it remains registered with a live
`ModelContext`. The carousel previews constructed profiles directly, so a container modifier alone
would not attach those existing instances and the cards remained blank. The fixture now inserts the
profiles and supplies the exact same container to the rendered hierarchy.

`ChildDashboardView` is different: it obtains profiles through `@SafeQuery`, so attaching an
in-memory `BlockedProfiles` container is sufficient.

## Validation

- TDD red: focused test failed because `BlockedProfileCarouselPreview` did not exist
- focused tests: 4 passed, 0 failed
- full suite: 1,219 passed, 0 failed
- Debug build: succeeded
- `swift-format lint --recursive .`
- `scripts/check-c2-guards.sh`
- `scripts/check-sync-guards.sh`
- `ruby scripts/check-log-privacy.rb --root .` (503 sites)
- `scripts/check-version-increment.sh origin/main HEAD`
- independent review: ready to merge; no Critical or Important findings

Closes #193
