### PR TITLE
Unify device activity diagnostics across all timer kinds (#248)

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -714,7 +714,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -735,7 +735,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -746,7 +746,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -894,7 +894,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -922,7 +922,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -948,7 +948,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -976,7 +976,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -998,12 +998,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1024,12 +1024,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1049,12 +1049,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1074,12 +1074,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1100,7 +1100,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1111,7 +1111,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1132,7 +1132,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1143,7 +1143,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1178,7 +1178,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1201,7 +1201,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1212,7 +1212,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.9;
+				MARKETING_VERSION = 2.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/Components/Debug/DeviceActivitiesDebugCard.swift
+++ b/Foqos/Components/Debug/DeviceActivitiesDebugCard.swift
@@ -52,7 +52,9 @@ struct DeviceActivitiesDebugCard: View {
       DeviceActivityName(
         rawValue: "BreakScheduleActivity:550e8400-e29b-41d4-a716-446655440000"),
       DeviceActivityName(
-        rawValue: "ScheduleTimerActivity:550e8400-e29b-41d4-a716-446655440000"),
+        rawValue:
+          "\(OneMoreMinuteDeadlineBackstopActivity.id):550e8400-e29b-41d4-a716-446655440000"
+      ),
     ],
     profileId: UUID(uuidString: "550e8400-e29b-41d4-a716-446655440000")
   )

--- a/Foqos/Components/Debug/DeviceActivitiesDebugCard.swift
+++ b/Foqos/Components/Debug/DeviceActivitiesDebugCard.swift
@@ -17,6 +17,8 @@ struct DeviceActivitiesDebugCard: View {
         Divider()
 
         ForEach(Array(activities.enumerated()), id: \.element.rawValue) { index, activity in
+          let classification = DeviceActivityClassifier.classify(activity)
+
           VStack(alignment: .leading, spacing: 4) {
             Text("Activity \(index + 1)")
               .font(.caption)
@@ -24,12 +26,12 @@ struct DeviceActivitiesDebugCard: View {
               .bold()
 
             DebugRow(label: "Name", value: activity.rawValue)
-            DebugRow(label: "Type", value: activityType(for: activity))
+            DebugRow(label: "Type", value: classification.type)
 
-            if let profileId = profileId {
+            if let profileId {
               DebugRow(
                 label: "Matches Profile",
-                value: "\(isActivityForProfile(activity, profileId: profileId))"
+                value: "\(classification.matches(profileId: profileId))"
               )
             }
           }
@@ -40,42 +42,6 @@ struct DeviceActivitiesDebugCard: View {
         }
       }
     }
-  }
-
-  private func activityType(for activity: DeviceActivityName) -> String {
-    let rawValue = activity.rawValue
-
-    if rawValue.hasPrefix(BreakTimerActivity.id) {
-      return "Break Timer"
-    } else if rawValue.hasPrefix(ScheduleTimerActivity.id) {
-      return "Schedule Timer"
-    } else if rawValue.hasPrefix(StrategyTimerActivity.id) {
-      return "Strategy Timer"
-    } else {
-      // Check if it's a UUID (legacy schedule format)
-      if UUID(uuidString: rawValue) != nil {
-        return "Schedule Timer (Legacy)"
-      }
-      return "Unknown"
-    }
-  }
-
-  private func isActivityForProfile(_ activity: DeviceActivityName, profileId: UUID) -> Bool {
-    let rawValue = activity.rawValue
-    let profileIdString = profileId.uuidString
-
-    // Check if it's a break timer activity for this profile
-    if rawValue.hasPrefix(BreakTimerActivity.id) {
-      return rawValue.hasSuffix(profileIdString)
-    }
-
-    // Check if it's a strategy timer activity for this profile
-    if rawValue.hasPrefix(StrategyTimerActivity.id) {
-      return rawValue.hasSuffix(profileIdString)
-    }
-
-    // Check if it's a schedule timer activity or legacy format (just the UUID)
-    return rawValue == profileIdString
   }
 }
 

--- a/Foqos/Utils/DeviceActivityClassifier.swift
+++ b/Foqos/Utils/DeviceActivityClassifier.swift
@@ -1,0 +1,61 @@
+import DeviceActivity
+import Foundation
+
+enum DeviceActivityClassifier {
+  struct Classification {
+    let type: String
+    let profileId: UUID?
+
+    func matches(profileId: UUID) -> Bool {
+      self.profileId == profileId
+    }
+  }
+
+  static func classify(_ activity: DeviceActivityName) -> Classification {
+    let rawValue = activity.rawValue
+
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: BreakTimerActivity.id,
+      type: "Break Timer"
+    ) {
+      return result
+    }
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: StopScheduleTimerActivity.id,
+      type: "Stop Schedule Timer"
+    ) {
+      return result
+    }
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: ScheduleTimerActivity.id,
+      type: "Schedule Timer"
+    ) {
+      return result
+    }
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: StrategyTimerActivity.id,
+      type: "Strategy Timer"
+    ) {
+      return result
+    }
+    if let profileId = UUID(uuidString: rawValue) {
+      return Classification(type: "Schedule Timer (Legacy)", profileId: profileId)
+    }
+    return Classification(type: "Unknown", profileId: nil)
+  }
+
+  private static func classifyPrefixed(
+    _ rawValue: String,
+    activityId: String,
+    type: String
+  ) -> Classification? {
+    let prefix = "\(activityId):"
+    guard rawValue.hasPrefix(prefix) else { return nil }
+    let rawProfileId = String(rawValue.dropFirst(prefix.count))
+    return Classification(type: type, profileId: UUID(uuidString: rawProfileId))
+  }
+}

--- a/Foqos/Utils/DeviceActivityClassifier.swift
+++ b/Foqos/Utils/DeviceActivityClassifier.swift
@@ -56,6 +56,7 @@ enum DeviceActivityClassifier {
     let prefix = "\(activityId):"
     guard rawValue.hasPrefix(prefix) else { return nil }
     let rawProfileId = String(rawValue.dropFirst(prefix.count))
-    return Classification(type: type, profileId: UUID(uuidString: rawProfileId))
+    guard let profileId = UUID(uuidString: rawProfileId) else { return nil }
+    return Classification(type: type, profileId: profileId)
   }
 }

--- a/Foqos/Utils/DeviceActivityClassifier.swift
+++ b/Foqos/Utils/DeviceActivityClassifier.swift
@@ -14,10 +14,32 @@ enum DeviceActivityClassifier {
   static func classify(_ activity: DeviceActivityName) -> Classification {
     let rawValue = activity.rawValue
 
+    // Keep these cases aligned with TimerActivityUtil's runtime dispatch switch.
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: BreakDeadlineBackstopActivity.id,
+      type: "Break Deadline Backstop"
+    ) {
+      return result
+    }
     if let result = classifyPrefixed(
       rawValue,
       activityId: BreakTimerActivity.id,
       type: "Break Timer"
+    ) {
+      return result
+    }
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: OneMoreMinuteDeadlineBackstopActivity.id,
+      type: "One More Minute Deadline Backstop"
+    ) {
+      return result
+    }
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: OneMoreMinuteTimerActivity.id,
+      type: "One More Minute Timer"
     ) {
       return result
     }
@@ -30,20 +52,13 @@ enum DeviceActivityClassifier {
     }
     if let result = classifyPrefixed(
       rawValue,
-      activityId: ScheduleTimerActivity.id,
-      type: "Schedule Timer"
-    ) {
-      return result
-    }
-    if let result = classifyPrefixed(
-      rawValue,
       activityId: StrategyTimerActivity.id,
       type: "Strategy Timer"
     ) {
       return result
     }
     if let profileId = UUID(uuidString: rawValue) {
-      return Classification(type: "Schedule Timer (Legacy)", profileId: profileId)
+      return Classification(type: "Schedule Timer", profileId: profileId)
     }
     return Classification(type: "Unknown", profileId: nil)
   }
@@ -56,7 +71,6 @@ enum DeviceActivityClassifier {
     let prefix = "\(activityId):"
     guard rawValue.hasPrefix(prefix) else { return nil }
     let rawProfileId = String(rawValue.dropFirst(prefix.count))
-    guard let profileId = UUID(uuidString: rawProfileId) else { return nil }
-    return Classification(type: type, profileId: profileId)
+    return Classification(type: type, profileId: UUID(uuidString: rawProfileId))
   }
 }

--- a/Foqos/Views/DebugView.swift
+++ b/Foqos/Views/DebugView.swift
@@ -271,11 +271,12 @@ struct DebugView: View {
       markdown += "No device activities scheduled.\n\n"
     } else {
       for (index, activity) in deviceActivities.enumerated() {
+        let classification = DeviceActivityClassifier.classify(activity)
         markdown += "### Activity \(index + 1)\n"
         markdown += "- **Name:** \(activity.rawValue)\n"
-        markdown += "- **Type:** \(activityType(for: activity))\n"
+        markdown += "- **Type:** \(classification.type)\n"
         markdown +=
-          "- **Matches Profile:** \(isActivityForProfile(activity, profileId: profile.id) ? "Yes" : "No")\n"
+          "- **Matches Profile:** \(classification.matches(profileId: profile.id) ? "Yes" : "No")\n"
         markdown += "\n"
       }
     }
@@ -298,47 +299,6 @@ struct DebugView: View {
     // Copy to clipboard
     UIPasteboard.general.string = markdown
     showCopyConfirmation = true
-  }
-
-  private func activityType(for activity: DeviceActivityName) -> String {
-    let rawValue = activity.rawValue
-
-    if rawValue.hasPrefix(BreakTimerActivity.id) {
-      return "Break Timer"
-    } else if rawValue.hasPrefix(StopScheduleTimerActivity.id) {
-      return "Stop Schedule Timer"
-    } else if rawValue.hasPrefix(ScheduleTimerActivity.id) {
-      return "Schedule Timer"
-    } else {
-      // Check if it's a UUID (legacy schedule format)
-      if UUID(uuidString: rawValue) != nil {
-        return "Schedule Timer (Legacy)"
-      }
-      return "Unknown"
-    }
-  }
-
-  private func isActivityForProfile(_ activity: DeviceActivityName, profileId: UUID) -> Bool {
-    let rawValue = activity.rawValue
-    let profileIdString = profileId.uuidString
-
-    // Check if it's a break timer activity for this profile
-    if rawValue.hasPrefix(BreakTimerActivity.id) {
-      return rawValue.hasSuffix(profileIdString)
-    }
-
-    // Check if it's a stop schedule timer activity for this profile
-    if rawValue.hasPrefix(StopScheduleTimerActivity.id) {
-      return rawValue.hasSuffix(profileIdString)
-    }
-
-    // Check if it's a schedule timer activity for this profile
-    if rawValue.hasPrefix(ScheduleTimerActivity.id) {
-      return rawValue.hasSuffix(profileIdString)
-    }
-
-    // Check if it's a legacy schedule format (just the UUID)
-    return rawValue == profileIdString
   }
 }
 

--- a/FoqosTests/DeviceActivityClassifierTests.swift
+++ b/FoqosTests/DeviceActivityClassifierTests.swift
@@ -46,6 +46,15 @@ final class DeviceActivityClassifierTests: XCTestCase {
     XCTAssertFalse(classification.matches(profileId: profileId))
   }
 
+  func testGivenKnownPrefixWithInvalidUUID_WhenClassifying_ThenReturnsUnknown() {
+    let activity = DeviceActivityName(rawValue: "\(BreakTimerActivity.id):not-a-uuid")
+
+    let classification = DeviceActivityClassifier.classify(activity)
+
+    XCTAssertEqual(classification.type, "Unknown")
+    XCTAssertNil(classification.profileId)
+  }
+
   func testGivenDifferentProfile_WhenMatching_ThenReturnsFalse() {
     let activity = DeviceActivityName(
       rawValue: "\(StrategyTimerActivity.id):\(profileId.uuidString)")

--- a/FoqosTests/DeviceActivityClassifierTests.swift
+++ b/FoqosTests/DeviceActivityClassifierTests.swift
@@ -8,32 +8,59 @@ import XCTest
 final class DeviceActivityClassifierTests: XCTestCase {
   private let profileId = UUID(uuidString: "550e8400-e29b-41d4-a716-446655440000")!
 
-  func testGivenKnownPrefixedActivityNames_WhenClassifying_ThenReturnsTypeAndProfile() {
+  func testGivenEveryRuntimeActivityKind_WhenClassifying_ThenReturnsTypeAndProfile() {
+    // Keep this table aligned with TimerActivityUtil's exhaustive runtime dispatch switch.
     let cases = [
-      (BreakTimerActivity.id, "Break Timer"),
-      (StopScheduleTimerActivity.id, "Stop Schedule Timer"),
-      (ScheduleTimerActivity.id, "Schedule Timer"),
-      (StrategyTimerActivity.id, "Strategy Timer"),
+      (
+        BreakDeadlineBackstopActivity.id,
+        DeviceActivityName(
+          rawValue: "\(BreakDeadlineBackstopActivity.id):\(profileId.uuidString)"),
+        "Break Deadline Backstop"
+      ),
+      (
+        BreakTimerActivity.id,
+        DeviceActivityName(rawValue: "\(BreakTimerActivity.id):\(profileId.uuidString)"),
+        "Break Timer"
+      ),
+      (
+        OneMoreMinuteDeadlineBackstopActivity.id,
+        DeviceActivityName(
+          rawValue: "\(OneMoreMinuteDeadlineBackstopActivity.id):\(profileId.uuidString)"),
+        "One More Minute Deadline Backstop"
+      ),
+      (
+        OneMoreMinuteTimerActivity.id,
+        DeviceActivityName(
+          rawValue: "\(OneMoreMinuteTimerActivity.id):\(profileId.uuidString)"),
+        "One More Minute Timer"
+      ),
+      (
+        ScheduleTimerActivity.id,
+        DeviceActivityName(rawValue: profileId.uuidString),
+        "Schedule Timer"
+      ),
+      (
+        StopScheduleTimerActivity.id,
+        DeviceActivityName(
+          rawValue: "\(StopScheduleTimerActivity.id):\(profileId.uuidString)"),
+        "Stop Schedule Timer"
+      ),
+      (
+        StrategyTimerActivity.id,
+        DeviceActivityName(rawValue: "\(StrategyTimerActivity.id):\(profileId.uuidString)"),
+        "Strategy Timer"
+      ),
     ]
 
-    for (activityId, expectedType) in cases {
-      let activity = DeviceActivityName(rawValue: "\(activityId):\(profileId.uuidString)")
-
+    XCTAssertEqual(Set(cases.map(\.0)).count, 7)
+    for (_, activity, expectedType) in cases {
       let classification = DeviceActivityClassifier.classify(activity)
 
+      XCTAssertNotEqual(classification.type, "Unknown")
       XCTAssertEqual(classification.type, expectedType)
       XCTAssertEqual(classification.profileId, profileId)
       XCTAssertTrue(classification.matches(profileId: profileId))
     }
-  }
-
-  func testGivenLegacyBareUUID_WhenClassifying_ThenReturnsLegacyScheduleAndProfile() {
-    let activity = DeviceActivityName(rawValue: profileId.uuidString)
-
-    let classification = DeviceActivityClassifier.classify(activity)
-
-    XCTAssertEqual(classification.type, "Schedule Timer (Legacy)")
-    XCTAssertEqual(classification.profileId, profileId)
   }
 
   func testGivenUnknownName_WhenClassifying_ThenReturnsUnknownWithoutProfile() {
@@ -46,13 +73,14 @@ final class DeviceActivityClassifierTests: XCTestCase {
     XCTAssertFalse(classification.matches(profileId: profileId))
   }
 
-  func testGivenKnownPrefixWithInvalidUUID_WhenClassifying_ThenReturnsUnknown() {
+  func testGivenKnownPrefixWithInvalidUUID_WhenClassifying_ThenKeepsTypeWithoutProfile() {
     let activity = DeviceActivityName(rawValue: "\(BreakTimerActivity.id):not-a-uuid")
 
     let classification = DeviceActivityClassifier.classify(activity)
 
-    XCTAssertEqual(classification.type, "Unknown")
+    XCTAssertEqual(classification.type, "Break Timer")
     XCTAssertNil(classification.profileId)
+    XCTAssertFalse(classification.matches(profileId: profileId))
   }
 
   func testGivenDifferentProfile_WhenMatching_ThenReturnsFalse() {

--- a/FoqosTests/DeviceActivityClassifierTests.swift
+++ b/FoqosTests/DeviceActivityClassifierTests.swift
@@ -1,0 +1,58 @@
+import DeviceActivity
+import Foundation
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class DeviceActivityClassifierTests: XCTestCase {
+  private let profileId = UUID(uuidString: "550e8400-e29b-41d4-a716-446655440000")!
+
+  func testGivenKnownPrefixedActivityNames_WhenClassifying_ThenReturnsTypeAndProfile() {
+    let cases = [
+      (BreakTimerActivity.id, "Break Timer"),
+      (StopScheduleTimerActivity.id, "Stop Schedule Timer"),
+      (ScheduleTimerActivity.id, "Schedule Timer"),
+      (StrategyTimerActivity.id, "Strategy Timer"),
+    ]
+
+    for (activityId, expectedType) in cases {
+      let activity = DeviceActivityName(rawValue: "\(activityId):\(profileId.uuidString)")
+
+      let classification = DeviceActivityClassifier.classify(activity)
+
+      XCTAssertEqual(classification.type, expectedType)
+      XCTAssertEqual(classification.profileId, profileId)
+      XCTAssertTrue(classification.matches(profileId: profileId))
+    }
+  }
+
+  func testGivenLegacyBareUUID_WhenClassifying_ThenReturnsLegacyScheduleAndProfile() {
+    let activity = DeviceActivityName(rawValue: profileId.uuidString)
+
+    let classification = DeviceActivityClassifier.classify(activity)
+
+    XCTAssertEqual(classification.type, "Schedule Timer (Legacy)")
+    XCTAssertEqual(classification.profileId, profileId)
+  }
+
+  func testGivenUnknownName_WhenClassifying_ThenReturnsUnknownWithoutProfile() {
+    let activity = DeviceActivityName(rawValue: "OtherActivity:\(profileId.uuidString)")
+
+    let classification = DeviceActivityClassifier.classify(activity)
+
+    XCTAssertEqual(classification.type, "Unknown")
+    XCTAssertNil(classification.profileId)
+    XCTAssertFalse(classification.matches(profileId: profileId))
+  }
+
+  func testGivenDifferentProfile_WhenMatching_ThenReturnsFalse() {
+    let activity = DeviceActivityName(
+      rawValue: "\(StrategyTimerActivity.id):\(profileId.uuidString)")
+    let otherProfileId = UUID(uuidString: "8b688f50-28c9-49ae-938f-e54c43f74471")!
+
+    let classification = DeviceActivityClassifier.classify(activity)
+
+    XCTAssertFalse(classification.matches(profileId: otherProfileId))
+  }
+}

--- a/docs/superpowers/plans/2026-08-11-issue-248-device-activity-classifier.md
+++ b/docs/superpowers/plans/2026-08-11-issue-248-device-activity-classifier.md
@@ -1,0 +1,401 @@
+# Issue #248 Device Activity Classifier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the on-screen device-activity card and copied Markdown one tested classifier that
+recognizes break, stop-schedule, schedule, strategy, and legacy schedule activities consistently.
+
+**Architecture:** Add an app-level diagnostics utility that parses one `DeviceActivityName` into a
+display label and optional profile UUID. Both debug consumers use the same classification object
+for their type and profile-match output; timer dispatch in `FoqosShared` remains unchanged.
+
+**Tech Stack:** Swift, DeviceActivity, Foundation UUID parsing, SwiftUI, XCTest.
+
+## Global Constraints
+
+- One PR closes only #248.
+- Branch from merged `main` at version `2.0.9 (28)` and strictly bump above the live main version.
+- Recognize `BreakTimerActivity`, `StopScheduleTimerActivity`, `ScheduleTimerActivity`, and
+  `StrategyTimerActivity` IDs, checking stop-schedule before schedule.
+- Preserve bare-UUID legacy schedule recognition and unknown-name behavior.
+- Do not add other activity types or change timer scheduling, dispatch, sync, or session lifecycle.
+- Run all Xcode commands through `scripts/xcode-stream.sh --agent build1 --session collab --` with
+  caller `set -o pipefail` and `bundle exec xcpretty`.
+- Never amend or force-push; request independent code review before merge; planner owns merge.
+
+---
+
+### Task 1: Specify the classifier contract with failing tests
+
+**Files:**
+
+- Create: `FoqosTests/DeviceActivityClassifierTests.swift`
+
+**Interfaces:**
+
+- Consumes: the wished-for `DeviceActivityClassifier.classify(_:)` API.
+- Produces: executable expectations for all approved formats and profile matching.
+
+- [ ] **Step 1: Create the focused test file**
+
+```swift
+import DeviceActivity
+import Foundation
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class DeviceActivityClassifierTests: XCTestCase {
+  private let profileId = UUID(uuidString: "550e8400-e29b-41d4-a716-446655440000")!
+
+  func testGivenKnownPrefixedActivityNames_WhenClassifying_ThenReturnsTypeAndProfile() {
+    let cases = [
+      (BreakTimerActivity.id, "Break Timer"),
+      (StopScheduleTimerActivity.id, "Stop Schedule Timer"),
+      (ScheduleTimerActivity.id, "Schedule Timer"),
+      (StrategyTimerActivity.id, "Strategy Timer"),
+    ]
+
+    for (activityId, expectedType) in cases {
+      let activity = DeviceActivityName(rawValue: "\(activityId):\(profileId.uuidString)")
+
+      let classification = DeviceActivityClassifier.classify(activity)
+
+      XCTAssertEqual(classification.type, expectedType)
+      XCTAssertEqual(classification.profileId, profileId)
+      XCTAssertTrue(classification.matches(profileId: profileId))
+    }
+  }
+
+  func testGivenLegacyBareUUID_WhenClassifying_ThenReturnsLegacyScheduleAndProfile() {
+    let activity = DeviceActivityName(rawValue: profileId.uuidString)
+
+    let classification = DeviceActivityClassifier.classify(activity)
+
+    XCTAssertEqual(classification.type, "Schedule Timer (Legacy)")
+    XCTAssertEqual(classification.profileId, profileId)
+  }
+
+  func testGivenUnknownName_WhenClassifying_ThenReturnsUnknownWithoutProfile() {
+    let activity = DeviceActivityName(rawValue: "OtherActivity:\(profileId.uuidString)")
+
+    let classification = DeviceActivityClassifier.classify(activity)
+
+    XCTAssertEqual(classification.type, "Unknown")
+    XCTAssertNil(classification.profileId)
+    XCTAssertFalse(classification.matches(profileId: profileId))
+  }
+
+  func testGivenDifferentProfile_WhenMatching_ThenReturnsFalse() {
+    let activity = DeviceActivityName(
+      rawValue: "\(StrategyTimerActivity.id):\(profileId.uuidString)")
+    let otherProfileId = UUID(uuidString: "8b688f50-28c9-49ae-938f-e54c43f74471")!
+
+    let classification = DeviceActivityClassifier.classify(activity)
+
+    XCTAssertFalse(classification.matches(profileId: otherProfileId))
+  }
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+```bash
+set -o pipefail
+scripts/xcode-stream.sh --agent build1 --session collab -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -only-testing:FoqosTests/DeviceActivityClassifierTests 2>&1 | bundle exec xcpretty
+```
+
+Expected: compile failure because `DeviceActivityClassifier` does not exist. A different failure
+must be investigated before continuing.
+
+- [ ] **Step 3: Commit the proven RED test**
+
+```bash
+git add FoqosTests/DeviceActivityClassifierTests.swift
+git commit -m "Add failing device activity classifier tests for #248"
+```
+
+### Task 2: Implement the minimal shared classifier
+
+**Files:**
+
+- Create: `Foqos/Utils/DeviceActivityClassifier.swift`
+- Test: `FoqosTests/DeviceActivityClassifierTests.swift`
+
+**Interfaces:**
+
+- Consumes: canonical activity IDs exported by `FoqosShared`.
+- Produces: `DeviceActivityClassifier.classify(_:) -> Classification`, with `type`, `profileId`,
+  and `matches(profileId:)`.
+
+- [ ] **Step 1: Add the classifier implementation**
+
+```swift
+import DeviceActivity
+import Foundation
+
+enum DeviceActivityClassifier {
+  struct Classification {
+    let type: String
+    let profileId: UUID?
+
+    func matches(profileId: UUID) -> Bool {
+      self.profileId == profileId
+    }
+  }
+
+  static func classify(_ activity: DeviceActivityName) -> Classification {
+    let rawValue = activity.rawValue
+
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: BreakTimerActivity.id,
+      type: "Break Timer"
+    ) {
+      return result
+    }
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: StopScheduleTimerActivity.id,
+      type: "Stop Schedule Timer"
+    ) {
+      return result
+    }
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: ScheduleTimerActivity.id,
+      type: "Schedule Timer"
+    ) {
+      return result
+    }
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: StrategyTimerActivity.id,
+      type: "Strategy Timer"
+    ) {
+      return result
+    }
+    if let profileId = UUID(uuidString: rawValue) {
+      return Classification(type: "Schedule Timer (Legacy)", profileId: profileId)
+    }
+    return Classification(type: "Unknown", profileId: nil)
+  }
+
+  private static func classifyPrefixed(
+    _ rawValue: String,
+    activityId: String,
+    type: String
+  ) -> Classification? {
+    let prefix = "\(activityId):"
+    guard rawValue.hasPrefix(prefix) else { return nil }
+    let rawProfileId = String(rawValue.dropFirst(prefix.count))
+    return Classification(type: type, profileId: UUID(uuidString: rawProfileId))
+  }
+}
+```
+
+- [ ] **Step 2: Format the new Swift files**
+
+```bash
+swift-format --in-place \
+  Foqos/Utils/DeviceActivityClassifier.swift \
+  FoqosTests/DeviceActivityClassifierTests.swift
+```
+
+- [ ] **Step 3: Re-run the focused tests and verify GREEN**
+
+```bash
+set -o pipefail
+scripts/xcode-stream.sh --agent build1 --session collab -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -only-testing:FoqosTests/DeviceActivityClassifierTests 2>&1 | bundle exec xcpretty
+```
+
+Expected: four tests pass with zero failures and no new compiler warnings from these files.
+
+- [ ] **Step 4: Commit the classifier**
+
+```bash
+git add Foqos/Utils/DeviceActivityClassifier.swift
+git commit -m "Add shared device activity classifier for #248"
+```
+
+### Task 3: Route both diagnostics through the classifier
+
+**Files:**
+
+- Modify: `Foqos/Views/DebugView.swift:271-343`
+- Modify: `Foqos/Components/Debug/DeviceActivitiesDebugCard.swift:18-80`
+- Test: `FoqosTests/DeviceActivityClassifierTests.swift`
+
+**Interfaces:**
+
+- Consumes: `DeviceActivityClassifier.classify(_:)` from Task 2.
+- Produces: consistent type and profile-match output in both debug surfaces.
+
+- [ ] **Step 1: Replace DebugView's private copy**
+
+Inside the Markdown activity loop, classify once and use the returned values:
+
+```swift
+let classification = DeviceActivityClassifier.classify(activity)
+markdown += "### Activity \(index + 1)\n"
+markdown += "- **Name:** \(activity.rawValue)\n"
+markdown += "- **Type:** \(classification.type)\n"
+markdown +=
+  "- **Matches Profile:** \(classification.matches(profileId: profile.id) ? "Yes" : "No")\n"
+```
+
+Delete `DebugView.activityType(for:)` and `DebugView.isActivityForProfile(_:profileId:)`.
+
+- [ ] **Step 2: Replace DeviceActivitiesDebugCard's private copy**
+
+At the beginning of each `ForEach` row, classify once:
+
+```swift
+let classification = DeviceActivityClassifier.classify(activity)
+
+DebugRow(label: "Name", value: activity.rawValue)
+DebugRow(label: "Type", value: classification.type)
+
+if let profileId {
+  DebugRow(
+    label: "Matches Profile",
+    value: "\(classification.matches(profileId: profileId))"
+  )
+}
+```
+
+Use `classification.type` for the Type row and
+`classification.matches(profileId: profileId)` for Matches Profile. Delete the card's two private
+classification methods.
+
+- [ ] **Step 3: Format both consumers**
+
+```bash
+swift-format --in-place \
+  Foqos/Views/DebugView.swift \
+  Foqos/Components/Debug/DeviceActivitiesDebugCard.swift
+```
+
+- [ ] **Step 4: Re-run the focused tests**
+
+```bash
+set -o pipefail
+scripts/xcode-stream.sh --agent build1 --session collab -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -only-testing:FoqosTests/DeviceActivityClassifierTests 2>&1 | bundle exec xcpretty
+```
+
+Expected: all four tests pass.
+
+- [ ] **Step 5: Commit the consumer integration**
+
+```bash
+git add Foqos/Views/DebugView.swift Foqos/Components/Debug/DeviceActivitiesDebugCard.swift
+git commit -m "Use shared activity classification in diagnostics for #248"
+```
+
+### Task 4: Apply the strict version bump
+
+**Files:**
+
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+
+- Consumes: live `origin/main` version values.
+- Produces: one consistent marketing/build version across every target configuration.
+
+- [ ] **Step 1: Refresh main and confirm the version floor**
+
+```bash
+git fetch origin main
+git show origin/main:FamilyFoqos.xcodeproj/project.pbxproj \
+  | rg "MARKETING_VERSION =|CURRENT_PROJECT_VERSION =" \
+  | sort -u
+```
+
+If main remains `2.0.9 (28)`, change every configuration to `2.0.10 (29)`. If main advanced,
+rebase the branch and choose both values strictly above the new floor before editing.
+
+- [ ] **Step 2: Update all target configurations**
+
+Replace every `CURRENT_PROJECT_VERSION = 28;` with `CURRENT_PROJECT_VERSION = 29;` and every
+`MARKETING_VERSION = 2.0.9;` with `MARKETING_VERSION = 2.0.10;`.
+
+```bash
+ruby -pi -e \
+  'gsub(%q{CURRENT_PROJECT_VERSION = 28;}, %q{CURRENT_PROJECT_VERSION = 29;});
+   gsub(%q{MARKETING_VERSION = 2.0.9;}, %q{MARKETING_VERSION = 2.0.10;})' \
+  FamilyFoqos.xcodeproj/project.pbxproj
+```
+
+- [ ] **Step 3: Commit and run the ref-based gate**
+
+```bash
+git add FamilyFoqos.xcodeproj/project.pbxproj
+git commit -m "Bump version for #248 classifier fix"
+scripts/check-version-increment.sh origin/main HEAD
+```
+
+Expected: both version values increase.
+
+### Task 5: Verify, review, and publish
+
+**Files:** none
+
+**Interfaces:**
+
+- Consumes: the complete #248 branch.
+- Produces: an independently reviewed, undrafted, green PR handed to the planner.
+
+- [ ] **Step 1: Run static repository checks**
+
+```bash
+swift-format lint --recursive .
+git diff --check origin/main...HEAD
+scripts/check-version-increment.sh origin/main HEAD
+scripts/check-c2-guards.sh
+scripts/check-sync-guards.sh
+ruby scripts/check-log-privacy.rb --root .
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+set -o pipefail
+scripts/xcode-stream.sh --agent build1 --session collab -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  2>&1 | bundle exec xcpretty
+```
+
+Expected: all tests pass with zero failures.
+
+- [ ] **Step 3: Run the Debug build**
+
+```bash
+set -o pipefail
+scripts/xcode-stream.sh --agent build1 --session collab -- \
+  xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -configuration Debug build 2>&1 | bundle exec xcpretty
+```
+
+Expected: `Build Succeeded` with exit code zero.
+
+- [ ] **Step 4: Inspect scope and request independent review**
+
+Review `git diff origin/main...HEAD` and send the base SHA, head SHA, design, plan, and verification
+evidence to the read-only reviewer. Resolve every Critical or Important finding in new commits and
+rerun affected checks.
+
+- [ ] **Step 5: Publish and hand off**
+
+Push `fix/248-shared-device-activity-classifier`, open an undrafted PR that closes #248, wait for
+all CI checks to pass, and send the reviewed green PR to the planner. Do not merge it and do not
+begin #255 until the planner confirms this PR is merged and `main` is updated.

--- a/docs/superpowers/plans/2026-08-11-issue-248-device-activity-classifier.md
+++ b/docs/superpowers/plans/2026-08-11-issue-248-device-activity-classifier.md
@@ -5,11 +5,12 @@
 > checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Give the on-screen device-activity card and copied Markdown one tested classifier that
-recognizes break, stop-schedule, schedule, strategy, and legacy schedule activities consistently.
+recognizes all seven runtime-dispatched device activity kinds consistently.
 
 **Architecture:** Add an app-level diagnostics utility that parses one `DeviceActivityName` into a
-display label and optional profile UUID. Both debug consumers use the same classification object
-for their type and profile-match output; timer dispatch in `FoqosShared` remains unchanged.
+display label and optional profile UUID. It aligns with `TimerActivityUtil`, the runtime source of
+truth, by referencing all seven public activity ID constants without widening `FoqosShared`'s API.
+Both debug consumers use the same classification object; runtime dispatch remains unchanged.
 
 **Tech Stack:** Swift, DeviceActivity, Foundation UUID parsing, SwiftUI, XCTest.
 
@@ -17,10 +18,12 @@ for their type and profile-match output; timer dispatch in `FoqosShared` remains
 
 - One PR closes only #248.
 - Branch from merged `main` at version `2.0.9 (28)` and strictly bump above the live main version.
-- Recognize `BreakTimerActivity`, `StopScheduleTimerActivity`, `ScheduleTimerActivity`, and
-  `StrategyTimerActivity` IDs, checking stop-schedule before schedule.
-- Preserve bare-UUID legacy schedule recognition and unknown-name behavior.
-- Do not add other activity types or change timer scheduling, dispatch, sync, or session lifecycle.
+- Recognize the actual registered formats for every ID in `TimerActivityUtil`'s seven-kind switch.
+- Reference the public activity ID constants; do not duplicate their raw string values.
+- Treat a bare UUID as the current `Schedule Timer` format.
+- Treat a known prefix with an invalid UUID as the known type with no profile match.
+- Keep a source-of-truth comment naming `TimerActivityUtil`; do not widen `FoqosShared`'s API.
+- Do not change timer scheduling, dispatch, sync, or session lifecycle.
 - Run all Xcode commands through `scripts/xcode-stream.sh --agent build1 --session collab --` with
   caller `set -o pipefail` and `bundle exec xcpretty`.
 - Never amend or force-push; request independent code review before merge; planner owns merge.
@@ -51,32 +54,59 @@ import XCTest
 final class DeviceActivityClassifierTests: XCTestCase {
   private let profileId = UUID(uuidString: "550e8400-e29b-41d4-a716-446655440000")!
 
-  func testGivenKnownPrefixedActivityNames_WhenClassifying_ThenReturnsTypeAndProfile() {
+  func testGivenEveryRuntimeActivityKind_WhenClassifying_ThenReturnsTypeAndProfile() {
+    // Keep this table aligned with TimerActivityUtil's exhaustive runtime dispatch switch.
     let cases = [
-      (BreakTimerActivity.id, "Break Timer"),
-      (StopScheduleTimerActivity.id, "Stop Schedule Timer"),
-      (ScheduleTimerActivity.id, "Schedule Timer"),
-      (StrategyTimerActivity.id, "Strategy Timer"),
+      (
+        BreakDeadlineBackstopActivity.id,
+        DeviceActivityName(
+          rawValue: "\(BreakDeadlineBackstopActivity.id):\(profileId.uuidString)"),
+        "Break Deadline Backstop"
+      ),
+      (
+        BreakTimerActivity.id,
+        DeviceActivityName(rawValue: "\(BreakTimerActivity.id):\(profileId.uuidString)"),
+        "Break Timer"
+      ),
+      (
+        OneMoreMinuteDeadlineBackstopActivity.id,
+        DeviceActivityName(
+          rawValue: "\(OneMoreMinuteDeadlineBackstopActivity.id):\(profileId.uuidString)"),
+        "One More Minute Deadline Backstop"
+      ),
+      (
+        OneMoreMinuteTimerActivity.id,
+        DeviceActivityName(
+          rawValue: "\(OneMoreMinuteTimerActivity.id):\(profileId.uuidString)"),
+        "One More Minute Timer"
+      ),
+      (
+        ScheduleTimerActivity.id,
+        DeviceActivityName(rawValue: profileId.uuidString),
+        "Schedule Timer"
+      ),
+      (
+        StopScheduleTimerActivity.id,
+        DeviceActivityName(
+          rawValue: "\(StopScheduleTimerActivity.id):\(profileId.uuidString)"),
+        "Stop Schedule Timer"
+      ),
+      (
+        StrategyTimerActivity.id,
+        DeviceActivityName(rawValue: "\(StrategyTimerActivity.id):\(profileId.uuidString)"),
+        "Strategy Timer"
+      ),
     ]
 
-    for (activityId, expectedType) in cases {
-      let activity = DeviceActivityName(rawValue: "\(activityId):\(profileId.uuidString)")
-
+    XCTAssertEqual(Set(cases.map(\.0)).count, 7)
+    for (_, activity, expectedType) in cases {
       let classification = DeviceActivityClassifier.classify(activity)
 
+      XCTAssertNotEqual(classification.type, "Unknown")
       XCTAssertEqual(classification.type, expectedType)
       XCTAssertEqual(classification.profileId, profileId)
       XCTAssertTrue(classification.matches(profileId: profileId))
     }
-  }
-
-  func testGivenLegacyBareUUID_WhenClassifying_ThenReturnsLegacyScheduleAndProfile() {
-    let activity = DeviceActivityName(rawValue: profileId.uuidString)
-
-    let classification = DeviceActivityClassifier.classify(activity)
-
-    XCTAssertEqual(classification.type, "Schedule Timer (Legacy)")
-    XCTAssertEqual(classification.profileId, profileId)
   }
 
   func testGivenUnknownName_WhenClassifying_ThenReturnsUnknownWithoutProfile() {
@@ -85,6 +115,16 @@ final class DeviceActivityClassifierTests: XCTestCase {
     let classification = DeviceActivityClassifier.classify(activity)
 
     XCTAssertEqual(classification.type, "Unknown")
+    XCTAssertNil(classification.profileId)
+    XCTAssertFalse(classification.matches(profileId: profileId))
+  }
+
+  func testGivenKnownPrefixWithInvalidUUID_WhenClassifying_ThenKeepsTypeWithoutProfile() {
+    let activity = DeviceActivityName(rawValue: "\(BreakTimerActivity.id):not-a-uuid")
+
+    let classification = DeviceActivityClassifier.classify(activity)
+
+    XCTAssertEqual(classification.type, "Break Timer")
     XCTAssertNil(classification.profileId)
     XCTAssertFalse(classification.matches(profileId: profileId))
   }
@@ -110,8 +150,8 @@ scripts/xcode-stream.sh --agent build1 --session collab -- \
   -only-testing:FoqosTests/DeviceActivityClassifierTests 2>&1 | bundle exec xcpretty
 ```
 
-Expected: compile failure because `DeviceActivityClassifier` does not exist. A different failure
-must be investigated before continuing.
+Expected on initial implementation: missing classifier compile failure. Expected during review
+delta: three production kinds return `Unknown` and bare UUID returns `Schedule Timer (Legacy)`.
 
 - [ ] **Step 3: Commit the proven RED test**
 
@@ -152,10 +192,32 @@ enum DeviceActivityClassifier {
   static func classify(_ activity: DeviceActivityName) -> Classification {
     let rawValue = activity.rawValue
 
+    // Keep these cases aligned with TimerActivityUtil's runtime dispatch switch.
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: BreakDeadlineBackstopActivity.id,
+      type: "Break Deadline Backstop"
+    ) {
+      return result
+    }
     if let result = classifyPrefixed(
       rawValue,
       activityId: BreakTimerActivity.id,
       type: "Break Timer"
+    ) {
+      return result
+    }
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: OneMoreMinuteDeadlineBackstopActivity.id,
+      type: "One More Minute Deadline Backstop"
+    ) {
+      return result
+    }
+    if let result = classifyPrefixed(
+      rawValue,
+      activityId: OneMoreMinuteTimerActivity.id,
+      type: "One More Minute Timer"
     ) {
       return result
     }
@@ -168,20 +230,13 @@ enum DeviceActivityClassifier {
     }
     if let result = classifyPrefixed(
       rawValue,
-      activityId: ScheduleTimerActivity.id,
-      type: "Schedule Timer"
-    ) {
-      return result
-    }
-    if let result = classifyPrefixed(
-      rawValue,
       activityId: StrategyTimerActivity.id,
       type: "Strategy Timer"
     ) {
       return result
     }
     if let profileId = UUID(uuidString: rawValue) {
-      return Classification(type: "Schedule Timer (Legacy)", profileId: profileId)
+      return Classification(type: "Schedule Timer", profileId: profileId)
     }
     return Classification(type: "Unknown", profileId: nil)
   }
@@ -216,7 +271,7 @@ scripts/xcode-stream.sh --agent build1 --session collab -- \
   -only-testing:FoqosTests/DeviceActivityClassifierTests 2>&1 | bundle exec xcpretty
 ```
 
-Expected: four tests pass with zero failures and no new compiler warnings from these files.
+Expected: all focused tests pass with zero failures and no new compiler warnings from these files.
 
 - [ ] **Step 4: Commit the classifier**
 
@@ -292,7 +347,7 @@ scripts/xcode-stream.sh --agent build1 --session collab -- \
   -only-testing:FoqosTests/DeviceActivityClassifierTests 2>&1 | bundle exec xcpretty
 ```
 
-Expected: all four tests pass.
+Expected: all focused tests pass.
 
 - [ ] **Step 5: Commit the consumer integration**
 
@@ -390,12 +445,16 @@ Expected: `Build Succeeded` with exit code zero.
 
 - [ ] **Step 4: Inspect scope and request independent review**
 
-Review `git diff origin/main...HEAD` and send the base SHA, head SHA, design, plan, and verification
-evidence to the read-only reviewer. Resolve every Critical or Important finding in new commits and
-rerun affected checks.
+Review `git diff origin/main...HEAD` and send the base SHA, updated head SHA, revised design, plan,
+and verification evidence to the read-only reviewer. The delta review must confirm all seven
+runtime kinds, the current schedule label, malformed known-prefix semantics, and the source-of-truth
+comment. Resolve every Critical or Important finding in new commits and rerun affected checks.
 
 - [ ] **Step 5: Publish and hand off**
 
-Push `fix/248-shared-device-activity-classifier`, open an undrafted PR that closes #248, wait for
-all CI checks to pass, and send the reviewed green PR to the planner. Do not merge it and do not
-begin #255 until the planner confirms this PR is merged and `main` is updated.
+Push `fix/248-shared-device-activity-classifier`, open an undrafted PR that closes #248, and state
+that this intentionally changes both consumers: Markdown gains strategy classification and the
+card gains stop-schedule classification. Also document seven-kind coverage, the current bare-UUID
+schedule label, and malformed known-prefix semantics. Wait for all CI checks to pass and send the
+reviewed green PR to the planner. Do not merge it and do not begin #255 until the planner confirms
+this PR is merged and `main` is updated.

--- a/docs/superpowers/specs/2026-08-11-issue-248-device-activity-classifier-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-248-device-activity-classifier-design.md
@@ -10,9 +10,9 @@ activities and report profile matches consistently.
 `DebugView` and `DeviceActivitiesDebugCard` each implement private copies of the same string
 classification logic. The copies have drifted:
 
-- `DebugView` recognizes break, stop-schedule, schedule, and legacy schedule names but omits
+- `DebugView` recognizes break, stop-schedule, and bare-UUID schedule names but omits
   strategy timers.
-- `DeviceActivitiesDebugCard` recognizes break, schedule, strategy, and legacy schedule names but
+- `DeviceActivitiesDebugCard` recognizes break, bare-UUID schedule, and strategy names but
   omits stop-schedule timers.
 
 Both views consume the same `DeviceActivityCenter` names, so the same activity is reported
@@ -22,7 +22,10 @@ differently depending on whether the user reads the card or copies Markdown.
 
 Add an app-level `DeviceActivityClassifier` in `Foqos/Utils`. This is diagnostics presentation
 logic, so its display labels should not become public API in `FoqosShared` or affect the device
-monitor's timer dispatch.
+monitor's timer dispatch. `TimerActivityUtil` remains the runtime source of truth. The classifier
+aligns with its seven-kind switch by referencing the same public activity ID constants instead of
+duplicating identifier strings. A shared parser was considered and rejected for this hygiene PR
+because it would widen `FoqosShared`'s public API across four targets solely for diagnostics.
 
 The classifier returns one `Classification` containing:
 
@@ -33,27 +36,32 @@ The classifier returns one `Classification` containing:
 debug consumers will create one classification per activity and use it for both the type and match
 rows.
 
-Recognize the approved formats in this order:
+Recognize every activity kind dispatched by `TimerActivityUtil`:
 
-1. `BreakTimerActivity.id:<uuid>` as `Break Timer`;
-2. `StopScheduleTimerActivity.id:<uuid>` as `Stop Schedule Timer`;
-3. `ScheduleTimerActivity.id:<uuid>` as `Schedule Timer`;
-4. `StrategyTimerActivity.id:<uuid>` as `Strategy Timer`;
-5. a bare UUID as `Schedule Timer (Legacy)`; and
-6. everything else as `Unknown` with no profile match.
+1. `BreakDeadlineBackstopActivity.id:<uuid>` as `Break Deadline Backstop`;
+2. `BreakTimerActivity.id:<uuid>` as `Break Timer`;
+3. `OneMoreMinuteDeadlineBackstopActivity.id:<uuid>` as
+   `One More Minute Deadline Backstop`;
+4. `OneMoreMinuteTimerActivity.id:<uuid>` as `One More Minute Timer`;
+5. `StopScheduleTimerActivity.id:<uuid>` as `Stop Schedule Timer`;
+6. `StrategyTimerActivity.id:<uuid>` as `Strategy Timer`;
+7. a bare UUID as `Schedule Timer`; and
+8. everything else as `Unknown` with no profile match.
 
-Prefix recognition requires the colon delimiter and UUID parsing. This preserves all legitimate
-formats while avoiding suffix-based matches on malformed names. Stop-schedule remains before
-schedule as required by the issue contract.
+Prefix recognition requires the colon delimiter. A known prefix with an invalid UUID keeps its
+known type label but has no parsed profile and cannot match any profile. This preserves useful
+diagnostic information while making matching fail safe. A bare name must parse as a UUID to be a
+schedule timer. A prefixed `ScheduleTimerActivity.id:<uuid>` branch is intentionally absent because
+the current schedule registration format is the bare profile UUID.
 
-Do not classify additional timer/backstop types in this PR, change scheduling, or change any
-session lifecycle behavior.
+Do not change scheduling, runtime dispatch, sync, or session lifecycle behavior.
 
 ## Verification
 
-Add focused unit tests for all four prefixed formats, the legacy bare UUID, unknown input, and a
-different profile. Prove the new tests fail before the classifier exists, then make them pass with
-the minimal utility and consumer replacement.
+Add a focused table test covering every activity ID in `TimerActivityUtil`'s switch with its actual
+registered name format and proving none classifies as unknown, plus unknown input, malformed known
+input, and a different profile. Prove behavior changes fail before implementation, then make them
+pass with the minimal utility and consumer replacement.
 
 Run the focused classifier tests, the full suite, a Debug build, formatting, repository guards,
 log privacy lint, and the strict version gate. Obtain independent review before opening the

--- a/docs/superpowers/specs/2026-08-11-issue-248-device-activity-classifier-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-248-device-activity-classifier-design.md
@@ -1,0 +1,66 @@
+# Issue #248 Device Activity Classifier Design
+
+## Goal
+
+Make the on-screen device-activity diagnostics and copied Markdown classify the same live timer
+activities and report profile matches consistently.
+
+## Root cause
+
+`DebugView` and `DeviceActivitiesDebugCard` each implement private copies of the same string
+classification logic. The copies have drifted:
+
+- `DebugView` recognizes break, stop-schedule, schedule, and legacy schedule names but omits
+  strategy timers.
+- `DeviceActivitiesDebugCard` recognizes break, schedule, strategy, and legacy schedule names but
+  omits stop-schedule timers.
+
+Both views consume the same `DeviceActivityCenter` names, so the same activity is reported
+differently depending on whether the user reads the card or copies Markdown.
+
+## Design
+
+Add an app-level `DeviceActivityClassifier` in `Foqos/Utils`. This is diagnostics presentation
+logic, so its display labels should not become public API in `FoqosShared` or affect the device
+monitor's timer dispatch.
+
+The classifier returns one `Classification` containing:
+
+- the user-facing type label; and
+- the parsed profile UUID, when the name carries a valid UUID.
+
+`Classification.matches(profileId:)` compares the parsed UUID with the requested profile. Both
+debug consumers will create one classification per activity and use it for both the type and match
+rows.
+
+Recognize the approved formats in this order:
+
+1. `BreakTimerActivity.id:<uuid>` as `Break Timer`;
+2. `StopScheduleTimerActivity.id:<uuid>` as `Stop Schedule Timer`;
+3. `ScheduleTimerActivity.id:<uuid>` as `Schedule Timer`;
+4. `StrategyTimerActivity.id:<uuid>` as `Strategy Timer`;
+5. a bare UUID as `Schedule Timer (Legacy)`; and
+6. everything else as `Unknown` with no profile match.
+
+Prefix recognition requires the colon delimiter and UUID parsing. This preserves all legitimate
+formats while avoiding suffix-based matches on malformed names. Stop-schedule remains before
+schedule as required by the issue contract.
+
+Do not classify additional timer/backstop types in this PR, change scheduling, or change any
+session lifecycle behavior.
+
+## Verification
+
+Add focused unit tests for all four prefixed formats, the legacy bare UUID, unknown input, and a
+different profile. Prove the new tests fail before the classifier exists, then make them pass with
+the minimal utility and consumer replacement.
+
+Run the focused classifier tests, the full suite, a Debug build, formatting, repository guards,
+log privacy lint, and the strict version gate. Obtain independent review before opening the
+undrafted PR.
+
+## Delivery
+
+Ship #248 as one PR from merged `main`, bumping version `2.0.9 (28)` to `2.0.10 (29)` if `main`
+does not advance before publication. The planner owns merge and authorizes the next issue only
+after this PR lands.


### PR DESCRIPTION
Closes #248.

## Root cause

The device-activity card and copied Markdown each maintained a private classifier, and the copies
had drifted. Markdown did not recognize strategy timers, while the card did not recognize
stop-schedule timers. Both also omitted three production activity kinds dispatched by
`TimerActivityUtil`.

## What changed

- Added one app-level `DeviceActivityClassifier` used by both diagnostic consumers.
- Aligned its public ID constants with all seven kinds in `TimerActivityUtil` without widening the
  `FoqosShared` API.
- Added labels for break and one-more-minute deadline backstops and the one-more-minute timer.
- Labeled the current bare-UUID schedule format as `Schedule Timer`; removed the unreachable
  prefixed schedule branch.
- Preserved known type information for malformed known-prefix names while parsing no profile UUID,
  so profile matching fails safely.
- Added a table-driven test covering every runtime kind plus unknown, malformed, and mismatched
  profile behavior.
- Bumped the app from 2.0.9 (28) to 2.0.10 (29).

This intentionally changes both diagnostic surfaces: copied Markdown now identifies strategy
timers, and the on-screen card now identifies stop-schedule timers. It is therefore a behavior
correction as well as a deduplication.

## Validation

- Focused classifier tests: 4 passed, 0 failed
- Full XCTest suite: 1,223 passed, 0 failed
- Debug build: succeeded
- `swift-format lint --recursive .`
- `git diff --check origin/main...HEAD`
- strict version increment gate
- C2 and sync guards
- log privacy lint: 233 files, 503 sites, 0 annotations
- independent AMQ review and reviewer-requested delta fixes
