### PR TITLE
Delete bogus Supported plist key (#259)

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -714,7 +714,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.13;
+				MARKETING_VERSION = 2.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -735,7 +735,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -746,7 +746,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.13;
+				MARKETING_VERSION = 2.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -894,7 +894,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -922,7 +922,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.13;
+				MARKETING_VERSION = 2.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -948,7 +948,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -976,7 +976,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.13;
+				MARKETING_VERSION = 2.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -998,12 +998,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.13;
+				MARKETING_VERSION = 2.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1024,12 +1024,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.13;
+				MARKETING_VERSION = 2.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1049,12 +1049,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.13;
+				MARKETING_VERSION = 2.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1074,12 +1074,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.13;
+				MARKETING_VERSION = 2.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1100,7 +1100,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1111,7 +1111,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.13;
+				MARKETING_VERSION = 2.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1132,7 +1132,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1143,7 +1143,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.13;
+				MARKETING_VERSION = 2.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1178,7 +1178,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.13;
+				MARKETING_VERSION = 2.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1201,7 +1201,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 33;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1212,7 +1212,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.13;
+				MARKETING_VERSION = 2.0.14;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/Info.plist
+++ b/Foqos/Info.plist
@@ -14,8 +14,6 @@
 	</array>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
-	<key>Supported</key>
-	<false/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/docs/superpowers/plans/2026-08-11-issue-259-bogus-supported-plist-key-deletion.md
+++ b/docs/superpowers/plans/2026-08-11-issue-259-bogus-supported-plist-key-deletion.md
@@ -1,0 +1,55 @@
+# Issue #259 Bogus Supported Info.plist Key Deletion Implementation Plan
+
+> Execute in `fix/259-delete-bogus-supported-plist-keys`. Never amend or force-push. Serialize all
+> Xcode commands through `scripts/xcode-stream.sh` with `set -o pipefail` and `bundle exec xcpretty`.
+
+**Baseline:** `f7278df`, 2.0.13/32, privacy 232/500/0.
+
+## Task 1: Freeze evidence
+
+1. Inventory all four target plists and the fifth production root.
+2. Lint every source plist with `plutil`.
+3. Search all roots, tests, scripts, and project settings for exact key reads/configuration.
+4. Record commit `5ed7d75` as the actual introduction during Live Activities work.
+5. Confirm both real keys are build-setting-owned in Debug and Release.
+6. Inspect the baseline built main-app plist: expect Supported false, Live Activities true, and
+   non-exempt encryption false.
+
+## Task 2: Commit design and plan
+
+Commit the approved design and this executable plan before changing the plist.
+
+## Task 3: Delete and prove source configuration
+
+Use `apply_patch` to delete only the two `Supported` XML lines. Then:
+
+- run `plutil -lint` on all target plists;
+- require zero exact `Supported` source/build-setting/runtime-read hits;
+- run privacy lint and require unchanged 232/500/0; and
+- inspect the diff to require a pure two-line plist deletion.
+
+Commit the deletion. Do not edit either privacy baseline.
+
+## Task 4: Version bump
+
+Update all 12 configurations from MARKETING_VERSION 2.0.13 to 2.0.14 and
+CURRENT_PROJECT_VERSION 32 to 33. Commit separately and run the version gate.
+
+## Task 5: Exact-head verification
+
+Run formatting, diff, C2, sync, version, privacy, plist lint, and exact-key searches. Run the full
+1,223-test suite and serialized Debug build. Inspect the newly built main-app Info.plist:
+
+- extraction of `Supported` must fail because the key is absent;
+- `NSSupportsLiveActivities` must be true; and
+- `ITSAppUsesNonExemptEncryption` must be false.
+
+## Task 6: Review and publish
+
+Request read-only independent review with base/head, target inventory, runtime-read sweep, history
+correction, source/generated plist results, exact tests/build, privacy, and version evidence. The
+reviewer must not mutate files or run Xcode.
+
+Refresh main, push, and open a non-draft PR closing only #259. Monitor checks to green, verify the
+exact reviewed head is OPEN/non-draft/CLEAN, and request the planner-owned merge. Do not begin #319
+until merge confirmation.

--- a/docs/superpowers/specs/2026-08-11-issue-259-bogus-supported-plist-key-deletion-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-259-bogus-supported-plist-key-deletion-design.md
@@ -1,0 +1,71 @@
+# Issue #259 Bogus Supported Info.plist Key Deletion Design
+
+## Goal
+
+Delete the unrecognized `<key>Supported</key><false/>` pair from the main app Info.plist without
+changing any real target capability or duplicating build-setting-owned configuration.
+
+## Re-derived evidence
+
+The audit was repeated at `main` `f7278df`, version 2.0.13/32, privacy floor 500.
+
+### Target-plist inventory
+
+Four production target plists exist:
+
+- `Foqos/Info.plist` contains `Supported = false`.
+- `FoqosWidget/Info.plist` does not.
+- `FoqosDeviceMonitor/Info.plist` does not.
+- `FoqosShieldConfig/Info.plist` does not.
+
+`Packages/FoqosShared/Sources` is the fifth production root but has no target Info.plist. All four
+source plists pass `plutil -lint`.
+
+An exact sweep across all five production roots, tests, UI tests, scripts, and the Xcode project
+finds no string literal read of `Supported`, no `INFOPLIST_KEY_Supported`, and no generic runtime
+dependency on unknown keys. Existing bundle-dictionary reads request only explicit version/build
+metadata.
+
+### History correction
+
+Commit `5ed7d75` added the pair during the original Live Activities implementation. It was not left
+behind by a later encryption-key removal; the bogus pair predates that configuration. The history
+matters because the correct remediation is deletion, not restoring or renaming an encryption key.
+
+The actual settings are already owned by both main-target build configurations:
+
+- `INFOPLIST_KEY_NSSupportsLiveActivities = YES`
+- `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO`
+
+The baseline built main-app Info.plist proves all three generated results: Live Activities true,
+non-exempt encryption false, and bogus Supported false.
+
+## Approved approach
+
+Delete exactly these two source lines from `Foqos/Info.plist`:
+
+```xml
+<key>Supported</key>
+<false/>
+```
+
+Do not add a replacement source key. Keep real capability ownership in build settings. Bump all 12
+configurations from 2.0.13/32 to 2.0.14/33. The deletion removes no source file or `Log` call, so
+privacy must remain 232 files / 500 sites / 0 annotations and neither privacy baseline changes.
+
+## Rejected alternatives
+
+- Adding `NSSupportsLiveActivities` to the source plist was rejected because it already comes from
+  both build configurations; a second owner invites drift.
+- Adding a repository-text unit test was rejected as decorative. Plist parsing, generated-product
+  inspection, build, and the full suite are the relevant proof.
+
+## Verification contract
+
+- All four source plists pass `plutil -lint`.
+- Exact `Supported` key/configuration/runtime reads have zero repository hits.
+- Debug build succeeds.
+- The built main-app Info.plist has no `Supported` key, retains `NSSupportsLiveActivities = true`,
+  and retains `ITSAppUsesNonExemptEncryption = false`.
+- Version, privacy, formatting, C2, sync, diff, and full-suite checks pass.
+- Independent review has no unresolved Critical or Important findings.


### PR DESCRIPTION
## Summary

- remove the bogus root `Supported = false` entry from the main app plist
- retain the real generated settings for Live Activities and non-exempt encryption
- document the audit, corrected provenance, and implementation plan
- bump the release from 2.0.13 (32) to 2.0.14 (33)

## Verification

- full suite: 1,223 tests, 0 failures
- Debug build succeeded through the serialized Xcode wrapper
- generated app plist is valid and has no `Supported` key
- generated `NSSupportsLiveActivities` remains `true`
- generated `ITSAppUsesNonExemptEncryption` remains `false`
- whole-plist key/value comparison confirms `Supported = false` is the only semantic plist change; `CKSharingSupported` and neighboring capabilities are unchanged
- all source plists pass `plutil`
- swift-format lint, diff check, C2, sync, strict-version, and privacy gates pass
- privacy baseline remains 232 files / 500 sites / 0 annotations
- independent review: READY at `5eaac09`, no Critical, Important, or Minor findings

Closes #259
