### PR TITLE
Remove the Buy NFC Tags Settings link (#319)

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -714,7 +714,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.14;
+				MARKETING_VERSION = 2.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -735,7 +735,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -746,7 +746,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.14;
+				MARKETING_VERSION = 2.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -894,7 +894,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -922,7 +922,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.14;
+				MARKETING_VERSION = 2.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -948,7 +948,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -976,7 +976,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.14;
+				MARKETING_VERSION = 2.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -998,12 +998,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.14;
+				MARKETING_VERSION = 2.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1024,12 +1024,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.14;
+				MARKETING_VERSION = 2.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1049,12 +1049,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.14;
+				MARKETING_VERSION = 2.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1074,12 +1074,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.14;
+				MARKETING_VERSION = 2.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1100,7 +1100,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1111,7 +1111,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.14;
+				MARKETING_VERSION = 2.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1132,7 +1132,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1143,7 +1143,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.14;
+				MARKETING_VERSION = 2.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1178,7 +1178,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.14;
+				MARKETING_VERSION = 2.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1201,7 +1201,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1212,7 +1212,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.14;
+				MARKETING_VERSION = 2.0.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/Views/SettingsView.swift
+++ b/Foqos/Views/SettingsView.swift
@@ -2,8 +2,6 @@ import FamilyControls
 import SwiftData
 import SwiftUI
 
-let amznStoreLink = "https://amzn.to/4fbMuTM"
-
 struct SettingsView: View {
   enum WipeConfirmationAction: Equatable {
     case blocked
@@ -377,18 +375,6 @@ struct SettingsView: View {
             Text("Calgary AB 🇨🇦\nand London 🇬🇧")
               .foregroundStyle(.secondary)
               .multilineTextAlignment(.trailing)
-          }
-        }
-
-        Section("Buy NFC Tags") {
-          Link(destination: URL(string: amznStoreLink)!) {
-            HStack {
-              Text("Amazon (original author affiliate link)")
-                .foregroundColor(.primary)
-              Spacer()
-              Image(systemName: "arrow.up.right.square")
-                .foregroundColor(.secondary)
-            }
           }
         }
 

--- a/docs/superpowers/plans/2026-08-11-issue-319-remove-buy-nfc-tags-link.md
+++ b/docs/superpowers/plans/2026-08-11-issue-319-remove-buy-nfc-tags-link.md
@@ -1,0 +1,39 @@
+# Issue #319 Implementation Plan
+
+**Goal:** Remove the Buy NFC Tags affiliate link from Settings and remove its unused constant.
+
+**Architecture:** This is a local SwiftUI deletion in `SettingsView`. NFC strategy, scanner, writer, onboarding, and generic feature copy remain untouched.
+
+**Tech stack:** SwiftUI, Xcode project build settings, repository verification scripts.
+
+## Task 1: Remove the Settings purchase link
+
+**File:** `Foqos/Views/SettingsView.swift`
+
+1. Delete the file-level `amznStoreLink` constant.
+2. Delete the complete `Section("Buy NFC Tags")` block.
+3. Confirm the About section now flows directly to Help from the original author.
+4. Sweep for `amznStoreLink`, `Buy NFC Tags`, the affiliate label, and the exact URL; expect no matches.
+
+## Task 2: Advance the strict release version
+
+**File:** `FamilyFoqos.xcodeproj/project.pbxproj`
+
+1. Change every `MARKETING_VERSION` from 2.0.14 to 2.0.15.
+2. Change every `CURRENT_PROJECT_VERSION` from 33 to 34.
+3. Run the strict version gate against `origin/main`.
+
+## Task 3: Verify and review
+
+1. Run swift-format lint and `git diff --check`.
+2. Run C2, sync, version, and privacy gates.
+3. Run the existing test suite through the serialized Xcode wrapper.
+4. Run a serialized Debug build.
+5. Request independent read-only review of the exact head.
+
+## Task 4: Publish
+
+1. Refresh `origin/main` and verify it is still the branch base.
+2. Push the reviewed branch and open a non-draft PR closing only #319.
+3. Wait for all GitHub checks.
+4. Hand the green PR to the planner for merge; do not merge it directly.

--- a/docs/superpowers/specs/2026-08-11-issue-319-remove-buy-nfc-tags-link-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-319-remove-buy-nfc-tags-link-design.md
@@ -1,0 +1,31 @@
+# Issue #319: Remove the Buy NFC Tags Link
+
+## Goal
+
+Remove the affiliate purchase link from Settings without replacing it or changing the app's NFC functionality and explanatory copy elsewhere.
+
+## Audit
+
+- `Foqos/Views/SettingsView.swift` contains the only `Buy NFC Tags` section.
+- The section contains the only use of the file-level `amznStoreLink` constant.
+- The Amazon affiliate label occurs only inside that section.
+- No production code, tests, scripts, or project settings reference the constant or section text elsewhere.
+- Generic NFC feature descriptions and NFC scanning/writing behavior are unrelated to the purchase link and remain unchanged.
+
+## Design
+
+Delete the complete `Section("Buy NFC Tags")` block and delete the now-unused `amznStoreLink` constant. Add no replacement content.
+
+This is preferable to hiding the section behind a condition because the maintainer requested removal, and retaining dead affiliate-link code would leave the unwanted destination in the binary. It is also preferable to replacing the destination or label because the issue explicitly requests no replacement content.
+
+## Verification strategy
+
+There is no durable behavior seam for this static SwiftUI layout, and adding a source-text test would couple tests to formatting rather than user behavior. Verification therefore consists of:
+
+- an exact repository sweep proving the section, label, URL, and constant are absent;
+- a focused diff proving the surrounding About and Help sections are unchanged;
+- formatting and repository policy gates;
+- the existing test suite and a serialized Debug build;
+- independent review of the exact head.
+
+The release advances from 2.0.14 (33) to 2.0.15 (34). Privacy baselines remain unchanged.


### PR DESCRIPTION
## Summary

- remove the complete `Buy NFC Tags` section from Settings
- remove the now-unused module-visible `amznStoreLink` constant
- leave NFC behavior and generic NFC feature copy unchanged
- add the audit/design and implementation plan
- bump the release from 2.0.14 (33) to 2.0.15 (34)

## Verification

- full suite: 1,223 tests, 0 failures
- Debug build succeeded through the serialized Xcode wrapper
- exact repository sweep finds no affiliate URL, identifier, label, section text, or constant
- `SettingsView.swift` is a pure 14-line deletion with zero insertions; surrounding About, Help, and Diagnostics sections are unchanged
- generated app plist is valid at 2.0.15 (34)
- swift-format lint, diff check, C2, sync, strict-version, and privacy gates pass
- privacy baseline remains 232 files / 500 sites / 0 annotations
- independent review: READY at `2ad9cea`, no Critical, Important, or Minor findings
- planner ruling: publish the issue-defined removal as-is; any release-note messaging is separate product scope

Closes #319
