### PR TITLE
Clean up Swift warning noise (#293, #179)

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -714,7 +714,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.15;
+				MARKETING_VERSION = 2.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -735,7 +735,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -746,7 +746,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.15;
+				MARKETING_VERSION = 2.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -894,7 +894,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -922,7 +922,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.15;
+				MARKETING_VERSION = 2.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -948,7 +948,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -976,7 +976,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.15;
+				MARKETING_VERSION = 2.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -998,12 +998,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.15;
+				MARKETING_VERSION = 2.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1024,12 +1024,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.15;
+				MARKETING_VERSION = 2.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1049,12 +1049,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.15;
+				MARKETING_VERSION = 2.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1074,12 +1074,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.15;
+				MARKETING_VERSION = 2.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1100,7 +1100,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1111,7 +1111,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.15;
+				MARKETING_VERSION = 2.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1132,7 +1132,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1143,7 +1143,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.15;
+				MARKETING_VERSION = 2.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1178,7 +1178,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.15;
+				MARKETING_VERSION = 2.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1201,7 +1201,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 34;
+				CURRENT_PROJECT_VERSION = 35;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1212,7 +1212,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.15;
+				MARKETING_VERSION = 2.0.16;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/Utils/RatingManager.swift
+++ b/Foqos/Utils/RatingManager.swift
@@ -39,6 +39,6 @@ class RatingManager: ObservableObject {
       return
     }
 
-    SKStoreReviewController.requestReview(in: scene)
+    AppStore.requestReview(in: scene)
   }
 }

--- a/FoqosTests/EstablishmentGenerationGateTests.swift
+++ b/FoqosTests/EstablishmentGenerationGateTests.swift
@@ -7,18 +7,18 @@ final class EstablishmentGenerationGateTests: XCTestCase {
   private var suiteName: String!
   private var defaults: UserDefaults!
 
-  override func setUp() {
-    super.setUp()
+  override func setUp() async throws {
+    try await super.setUp()
     suiteName = "establishment-generation-\(UUID().uuidString)"
     defaults = UserDefaults(suiteName: suiteName)!
     SharedData.configure(suite: defaults)
   }
 
-  override func tearDown() {
+  override func tearDown() async throws {
     defaults.removePersistentDomain(forName: suiteName)
     defaults = nil
     suiteName = nil
-    super.tearDown()
+    try await super.tearDown()
   }
 
   private func makeStore(userRecordName: String = "user-A") -> SyncEngineStore {

--- a/FoqosTests/MutationFunnelTests.swift
+++ b/FoqosTests/MutationFunnelTests.swift
@@ -12,18 +12,18 @@ final class MutationFunnelTests: XCTestCase {
   private var defaults: UserDefaults!
   private let userRecordName = "phaseC-user"
 
-  override func setUp() {
-    super.setUp()
+  override func setUp() async throws {
+    try await super.setUp()
     suiteName = "MutationFunnelTests-\(UUID().uuidString)"
     defaults = UserDefaults(suiteName: suiteName)!
     SharedData.configure(suite: defaults)
   }
 
-  override func tearDown() {
+  override func tearDown() async throws {
     defaults.removePersistentDomain(forName: suiteName)
     defaults = nil
     suiteName = nil
-    super.tearDown()
+    try await super.tearDown()
   }
 
   // MARK: - Helpers

--- a/FoqosTests/ResetSeederTests.swift
+++ b/FoqosTests/ResetSeederTests.swift
@@ -10,18 +10,18 @@ final class ResetSeederTests: XCTestCase {
   private var defaults: UserDefaults!
   private var store: SyncEngineStore!
 
-  override func setUp() {
-    super.setUp()
+  override func setUp() async throws {
+    try await super.setUp()
     suiteName = "reset-seeder-\(UUID().uuidString)"
     defaults = UserDefaults(suiteName: suiteName)!
     SharedData.configure(suite: defaults)
     store = SyncEngineStore(userRecordName: "user-A", defaults: defaults)
   }
 
-  override func tearDown() {
+  override func tearDown() async throws {
     defaults.removePersistentDomain(forName: suiteName)
     defaults = nil
-    super.tearDown()
+    try await super.tearDown()
   }
 
   func testGivenSeeder_WhenPerformI6Purge_ThenPurgesSystemFieldsAndFlushesSessionCache() async {

--- a/FoqosTests/SessionStopOutboxTests.swift
+++ b/FoqosTests/SessionStopOutboxTests.swift
@@ -11,16 +11,16 @@ final class SessionStopOutboxTests: XCTestCase {
   private var suiteName: String!
   private var defaults: UserDefaults!
 
-  override func setUp() {
-    super.setUp()
+  override func setUp() async throws {
+    try await super.setUp()
     suiteName = "stop-outbox-\(UUID().uuidString)"
     defaults = UserDefaults(suiteName: suiteName)!
   }
 
-  override func tearDown() {
+  override func tearDown() async throws {
     defaults.removePersistentDomain(forName: suiteName)
     defaults = nil
-    super.tearDown()
+    try await super.tearDown()
   }
 
   func testGivenEnqueue_WhenReloaded_ThenPersistsAndDeduplicates() {

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -634,7 +634,9 @@ final class SyncEngineControllerTests: XCTestCase {
     controller.start()
     await controller.startupTask?.value
 
-    XCTAssertNil(store.deleteTombstones[id.uuidString], "entity present ⇒ abort, clear tombstone")
+    XCTAssertFalse(
+      store.deleteTombstones.keys.contains(id.uuidString),
+      "entity present ⇒ abort, clear tombstone")
     XCTAssertNil(store.deleteWatermark(for: id.uuidString), "entity present ⇒ abort, clear watermark")
     XCTAssertTrue(pendingDeleteNames().isEmpty, "no delete enqueued")
   }
@@ -649,7 +651,9 @@ final class SyncEngineControllerTests: XCTestCase {
     controller.start()
     await controller.startupTask?.value
 
-    XCTAssertNil(store.deleteTombstones[id.uuidString], "absent ⇒ already complete, cleared")
+    XCTAssertFalse(
+      store.deleteTombstones.keys.contains(id.uuidString),
+      "absent ⇒ already complete, cleared")
     XCTAssertFalse(pendingDeleteNames().contains(id.uuidString))
   }
 
@@ -669,8 +673,9 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertTrue(
       pendingDeleteNames().contains(id.uuidString),
       "matching tag ⇒ delete enqueued (CRA-5)")
-    XCTAssertNotNil(
-      store.deleteTombstones[id.uuidString], "tombstone retained until delete confirmed")
+    XCTAssertTrue(
+      store.deleteTombstones.keys.contains(id.uuidString),
+      "tombstone retained until delete confirmed")
   }
 
   // #302 acceptance: a tombstone written while sync is disabled enters the existing I12
@@ -709,7 +714,9 @@ final class SyncEngineControllerTests: XCTestCase {
     controller.start()
     await controller.startupTask?.value
 
-    XCTAssertNil(store.deleteTombstones[id.uuidString], "different tag ⇒ re-adopted, cleared")
+    XCTAssertFalse(
+      store.deleteTombstones.keys.contains(id.uuidString),
+      "different tag ⇒ re-adopted, cleared")
     XCTAssertFalse(pendingDeleteNames().contains(id.uuidString), "no delete")
     XCTAssertNotNil(SyncConflictManager.shared.conflictedProfiles[id], "conflict surfaced")
   }
@@ -724,7 +731,9 @@ final class SyncEngineControllerTests: XCTestCase {
     controller.start()
     await controller.startupTask?.value
 
-    XCTAssertNotNil(store.deleteTombstones[id.uuidString], "transient ⇒ keep, retry later")
+    XCTAssertTrue(
+      store.deleteTombstones.keys.contains(id.uuidString),
+      "transient ⇒ keep, retry later")
     XCTAssertFalse(pendingDeleteNames().contains(id.uuidString))
   }
 
@@ -741,8 +750,9 @@ final class SyncEngineControllerTests: XCTestCase {
     controller.start()
     await controller.startupTask?.value
 
-    XCTAssertNotNil(
-      store.deleteTombstones[id.uuidString], "zoneNotFound ⇒ keep, §5.6 re-verifies (Fix 3)")
+    XCTAssertTrue(
+      store.deleteTombstones.keys.contains(id.uuidString),
+      "zoneNotFound ⇒ keep, §5.6 re-verifies (Fix 3)")
     XCTAssertFalse(pendingDeleteNames().contains(id.uuidString))
   }
 
@@ -858,8 +868,8 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertNil(
       store.failedApplies.first { $0.recordName == id.uuidString },
       "verified-present retry drops the stale remote failed apply")
-    XCTAssertNotNil(
-      store.deleteTombstones[id.uuidString],
+    XCTAssertTrue(
+      store.deleteTombstones.keys.contains(id.uuidString),
       "newer local delete tombstone must survive the remote failed-apply cleanup")
     XCTAssertNotNil(
       store.systemFields(for: id.uuidString),
@@ -1008,13 +1018,17 @@ final class SyncEngineControllerTests: XCTestCase {
         deletions: [(recordID: recordID(id.uuidString), recordType: SyncedProfile.recordType)]))
 
     XCTAssertNil(try? fetchProfile(id), "local profile deleted (§5.2)")
-    XCTAssertNotNil(store.deleteTombstones[id.uuidString], "tombstone retained until durable delete")
+    XCTAssertTrue(
+      store.deleteTombstones.keys.contains(id.uuidString),
+      "tombstone retained until durable delete")
     XCTAssertNotNil(store.systemFields(for: id.uuidString))
     XCTAssertTrue(pendingDeleteNames().contains(id.uuidString), "pending delete retained until commit")
 
     profileDeleteCommitScheduler.runNext()
 
-    XCTAssertNil(store.deleteTombstones[id.uuidString], "tombstone cleared (I12)")
+    XCTAssertFalse(
+      store.deleteTombstones.keys.contains(id.uuidString),
+      "tombstone cleared (I12)")
     XCTAssertNil(store.systemFields(for: id.uuidString))
     XCTAssertFalse(pendingDeleteNames().contains(id.uuidString), "pending .deleteRecord removed (§5.2)")
   }
@@ -1337,7 +1351,9 @@ final class SyncEngineControllerTests: XCTestCase {
           (recordID: recordID(id.uuidString), error: makeCKError(.unknownItem))
         ]))
 
-    XCTAssertNil(store.deleteTombstones[id.uuidString], "U-delete clears the tombstone")
+    XCTAssertFalse(
+      store.deleteTombstones.keys.contains(id.uuidString),
+      "U-delete clears the tombstone")
     XCTAssertNil(store.systemFields(for: id.uuidString), "U-delete drops the system-fields entry")
   }
 
@@ -1354,7 +1370,9 @@ final class SyncEngineControllerTests: XCTestCase {
         savedRecords: [], failedRecordSaves: [],
         deletedRecordIDs: [recordID(id.uuidString)], failedRecordDeletes: []))
 
-    XCTAssertNil(store.deleteTombstones[id.uuidString], "confirmed delete clears tombstone (I12)")
+    XCTAssertFalse(
+      store.deleteTombstones.keys.contains(id.uuidString),
+      "confirmed delete clears tombstone (I12)")
     XCTAssertNil(store.systemFields(for: id.uuidString))
     XCTAssertTrue(apply.recentlyConfirmedDeletes.contains(id.uuidString), "echo guard populated")
   }
@@ -1798,7 +1816,9 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertNil(store.engineState, "engine state discarded")
     XCTAssertNil(store.resetIntent)
     XCTAssertFalse(store.pendingSeedIntent)
-    XCTAssertNotNil(store.deleteTombstones["keep"], "tombstones survive (not consent-scoped)")
+    XCTAssertTrue(
+      store.deleteTombstones.keys.contains("keep"),
+      "tombstones survive (not consent-scoped)")
     XCTAssertFalse(SharedData.deviceSyncEnabled, "sync disabled")
     XCTAssertTrue(pendingSaveNames().isEmpty, "nothing enqueued")
     XCTAssertNil(controller.reset)
@@ -1863,7 +1883,9 @@ final class SyncEngineControllerTests: XCTestCase {
     XCTAssertTrue(stopResetCalled, "reset dequeue hook invoked first (T11)")
     XCTAssertFalse(store.pendingSeedIntent)
     XCTAssertNil(store.engineState, "engine state discarded (N5 saves lost)")
-    XCTAssertNotNil(store.deleteTombstones["keep"], "tombstones survive T11 (re-propagate via I12)")
+    XCTAssertTrue(
+      store.deleteTombstones.keys.contains("keep"),
+      "tombstones survive T11 (re-propagate via I12)")
     XCTAssertEqual(driver.sendChangesCount, 1, "best-effort final send")
     XCTAssertEqual(controller.state, .disabled)
     XCTAssertNil(controller.reset)

--- a/FoqosTests/SyncEngineResetTests.swift
+++ b/FoqosTests/SyncEngineResetTests.swift
@@ -13,18 +13,18 @@ final class SyncEngineResetTests: XCTestCase {
   private let zoneID = CKRecordZone.ID(
     zoneName: CloudKitConstants.syncZoneName, ownerName: CKCurrentUserDefaultName)
 
-  override func setUp() {
-    super.setUp()
+  override func setUp() async throws {
+    try await super.setUp()
     suiteName = "reset-tests-\(UUID().uuidString)"
     defaults = UserDefaults(suiteName: suiteName)!
     SharedData.configure(suite: defaults)
     store = SyncEngineStore(userRecordName: "user-A", defaults: defaults)
   }
 
-  override func tearDown() {
+  override func tearDown() async throws {
     defaults.removePersistentDomain(forName: suiteName)
     defaults = nil
-    super.tearDown()
+    try await super.tearDown()
   }
 
   // MARK: - Helpers

--- a/FoqosTests/TimerDurationSnapTests.swift
+++ b/FoqosTests/TimerDurationSnapTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import FamilyFoqos
 
+@MainActor
 final class TimerDurationSnapTests: XCTestCase {
 
   // Mirrors the production snapPoints after the 1440 entry is removed.

--- a/docs/superpowers/plans/2026-08-11-issues-293-179-warning-cleanup.md
+++ b/docs/superpowers/plans/2026-08-11-issues-293-179-warning-cleanup.md
@@ -1,0 +1,65 @@
+# Issues #293 and #179 Implementation Plan
+
+**Goal:** Eliminate the settled tree's known warning noise with behavior-neutral code and test changes.
+
+**Architecture:** Correct actor isolation at test boundaries, express tombstone assertions as key-membership checks, adopt the supported StoreKit API, and narrowly quiet Xcode's App Intents metadata processor.
+
+**Tech stack:** Swift 6, XCTest, StoreKit, Xcode build settings.
+
+## Task 1: Correct XCTest actor isolation
+
+**Files:**
+
+- `FoqosTests/EstablishmentGenerationGateTests.swift`
+- `FoqosTests/MutationFunnelTests.swift`
+- `FoqosTests/ResetSeederTests.swift`
+- `FoqosTests/SessionStopOutboxTests.swift`
+- `FoqosTests/SyncEngineResetTests.swift`
+- `FoqosTests/TimerDurationSnapTests.swift`
+
+1. Convert synchronous lifecycle overrides in the five `@MainActor` classes to async throwing overrides.
+2. Preserve setup/teardown statement order.
+3. Mark `TimerDurationSnapTests` as `@MainActor`.
+4. Run the six focused test classes and inspect the raw warning stream.
+
+## Task 2: Correct tombstone assertions
+
+**File:** `FoqosTests/SyncEngineControllerTests.swift`
+
+1. Replace all 13 warned nested-optional assertions with explicit key membership assertions.
+2. Preserve each assertion message and presence/absence expectation.
+3. Run `SyncEngineControllerTests` and inspect the raw warning stream.
+
+## Task 3: Adopt supported StoreKit API and quiet metadata notices
+
+**Files:**
+
+- `Foqos/Utils/RatingManager.swift`
+- `FamilyFoqos.xcodeproj/project.pbxproj`
+
+1. Replace the deprecated review request call with `AppStore.requestReview(in:)`.
+2. Add `LM_FILTER_WARNINGS = YES` to project Debug and Release configurations only.
+3. Run a clean Debug build and require zero raw warning lines.
+
+## Task 4: Advance the strict release version
+
+**File:** `FamilyFoqos.xcodeproj/project.pbxproj`
+
+1. Change all 12 `MARKETING_VERSION` values from 2.0.15 to 2.0.16.
+2. Change all 12 `CURRENT_PROJECT_VERSION` values from 34 to 35.
+3. Run the strict version gate against `origin/main`.
+
+## Task 5: Full verification and review
+
+1. Run swift-format lint and repository policy gates.
+2. Run a clean serialized full test while capturing raw output.
+3. Require 1,223 passing tests and zero raw warning lines.
+4. Run a clean serialized Debug build and require zero raw warning lines.
+5. Request independent read-only review of the exact head.
+
+## Task 6: Publish
+
+1. Refresh live `origin/main` and confirm ancestry.
+2. Push the exact reviewed head and open one non-draft PR closing #293 and #179.
+3. Wait for all GitHub checks.
+4. Hand the green PR to the planner for merge; do not merge it directly.

--- a/docs/superpowers/plans/2026-08-11-issues-293-179-warning-cleanup.md
+++ b/docs/superpowers/plans/2026-08-11-issues-293-179-warning-cleanup.md
@@ -2,9 +2,9 @@
 
 **Goal:** Eliminate the settled tree's known warning noise with behavior-neutral code and test changes.
 
-**Architecture:** Correct actor isolation at test boundaries, express tombstone assertions as key-membership checks, adopt the supported StoreKit API, and narrowly quiet Xcode's App Intents metadata processor.
+**Architecture:** Correct actor isolation at test boundaries, express tombstone assertions as key-membership checks, adopt the supported StoreKit API, and explicitly classify the two irreducible Xcode metadata notices.
 
-**Tech stack:** Swift 6, XCTest, StoreKit, Xcode build settings.
+**Tech stack:** Swift 6, XCTest, StoreKit, Xcode.
 
 ## Task 1: Correct XCTest actor isolation
 
@@ -30,16 +30,15 @@
 2. Preserve each assertion message and presence/absence expectation.
 3. Run `SyncEngineControllerTests` and inspect the raw warning stream.
 
-## Task 3: Adopt supported StoreKit API and quiet metadata notices
+## Task 3: Adopt supported StoreKit API and classify metadata notices
 
 **Files:**
 
 - `Foqos/Utils/RatingManager.swift`
-- `FamilyFoqos.xcodeproj/project.pbxproj`
 
 1. Replace the deprecated review request call with `AppStore.requestReview(in:)`.
-2. Add `LM_FILTER_WARNINGS = YES` to project Debug and Release configurations only.
-3. Run a clean Debug build and require zero raw warning lines.
+2. Retain no ineffective metadata filter or extraction-disabling project setting.
+3. Run a clean Debug build and require zero project-source warnings plus exactly the allowlisted ShieldConfig metadata notice.
 
 ## Task 4: Advance the strict release version
 
@@ -53,8 +52,8 @@
 
 1. Run swift-format lint and repository policy gates.
 2. Run a clean serialized full test while capturing raw output.
-3. Require 1,223 passing tests and zero raw warning lines.
-4. Run a clean serialized Debug build and require zero raw warning lines.
+3. Require 1,223 passing tests, zero project-source warnings, and exactly the two allowlisted Xcode metadata notices.
+4. Run a clean serialized Debug build and require zero project-source warnings plus exactly the one allowlisted ShieldConfig notice.
 5. Request independent read-only review of the exact head.
 
 ## Task 6: Publish

--- a/docs/superpowers/specs/2026-08-11-issues-293-179-warning-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-11-issues-293-179-warning-cleanup-design.md
@@ -22,6 +22,11 @@ The `HeartbeatManager` exhaustiveness warning named in #293 is absent from the s
 
 Five `@MainActor` test classes override synchronous `setUp()` and `tearDown()`. XCTest declares those synchronous overrides nonisolated, so they cannot safely access main-actor state. Convert only those overrides to the established async-throwing lifecycle pattern used by clean neighboring tests:
 
+Scope is based on warning sites measured in the clean baseline, not on the class annotation alone.
+`ScreenshotDemoScheduleTests`, `FamilyCommandApplyTests`, and `LockCodeThrottleTests` have the
+same synchronous lifecycle shape but emitted no lifecycle warning, so they remain unchanged until
+compiler output demonstrates a problem.
+
 ```swift
 override func setUp() async throws {
   try await super.setUp()

--- a/docs/superpowers/specs/2026-08-11-issues-293-179-warning-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-11-issues-293-179-warning-cleanup-design.md
@@ -45,14 +45,14 @@ The installed iOS SDK declares `AppStore.requestReview(in:)` as the direct iOS 1
 
 ### Xcode metadata notices
 
-Two targets without App Intents dependencies emit tool-owned metadata-extraction notices. Xcode's installed `AppIntentsMetadata.xcspec` defines `LM_FILTER_WARNINGS = YES` as `--quiet-warnings` for that processor only. Set it in the project's Debug and Release configurations so metadata-extractor notices are quiet while Swift compiler warnings remain visible.
+Two targets without App Intents dependencies emit tool-owned metadata-extraction notices. Experiments against Xcode's installed `AppIntentsMetadata.xcspec` show that `LM_FILTER_WARNINGS = YES` adds `--quiet-warnings` but does not suppress the ShieldConfig notice. Disabling extraction produces more warnings and would break real App Intents metadata in the app and widget; forcing metadata output also leaves the notice. Retain no ineffective or behavior-changing build setting. Instead, narrow verification to an exact allowlist: one ShieldConfig notice in a clean build and the same notice plus one UI-test notice in a clean full test. Every project-source warning must be absent.
 
 ## Verification
 
 - Run focused tests for all edited test classes.
 - Run a clean serialized full test and capture the raw stream.
-- Require zero `warning:` lines in the captured stream.
-- Run a clean serialized Debug build and require zero `warning:` lines.
+- Require zero project-source warning lines and exactly the two allowlisted Xcode metadata notices in the captured test stream.
+- Run a clean serialized Debug build and require zero project-source warning lines plus exactly the one allowlisted ShieldConfig notice.
 - Run formatting, diff, C2, sync, strict-version, and privacy gates.
 - Obtain independent review of the exact verified head.
 

--- a/docs/superpowers/specs/2026-08-11-issues-293-179-warning-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-11-issues-293-179-warning-cleanup-design.md
@@ -1,0 +1,59 @@
+# Issues #293 and #179: Swift Warning Cleanup
+
+## Goal
+
+Remove the settled tree's known Swift 6 test/build warning noise without changing app behavior. Close #293 and #179 in one final hygiene PR.
+
+## Settled-tree baseline
+
+The full serialized test run at `50e849a` passes 1,223 tests with zero failures and emits 167 raw `warning:` lines:
+
+- 117 emissions from 13 nested-optional tombstone assertion sites compiled in nine passes;
+- 42 XCTest lifecycle actor-isolation warnings across five `@MainActor` test classes;
+- four main-actor call warnings in `TimerDurationSnapTests`;
+- two StoreKit deprecation warnings in `RatingManager`;
+- two Xcode App Intents metadata notices from targets without App Intents dependencies.
+
+The `HeartbeatManager` exhaustiveness warning named in #293 is absent from the settled tree, so no Heartbeat change is justified.
+
+## Root causes and design
+
+### XCTest lifecycle isolation
+
+Five `@MainActor` test classes override synchronous `setUp()` and `tearDown()`. XCTest declares those synchronous overrides nonisolated, so they cannot safely access main-actor state. Convert only those overrides to the established async-throwing lifecycle pattern used by clean neighboring tests:
+
+```swift
+override func setUp() async throws {
+  try await super.setUp()
+  // existing setup, unchanged
+}
+```
+
+Teardown retains its existing ordering and calls `try await super.tearDown()` last.
+
+### Timer snap tests
+
+`TimerDurationView` is main-actor isolated through SwiftUI, while its tests are not. Mark the test class `@MainActor`; do not change the production function or its isolation contract.
+
+### Nested optional assertions
+
+`deleteTombstones` is `[String: String?]`: dictionary lookup produces `String??` because a present tombstone may intentionally carry a nil change tag. The affected tests intend to assert durable key presence or absence, not inspect the change tag. Replace `XCTAssertNil`/`XCTAssertNotNil` on the nested optional with `deleteTombstones.keys.contains(recordName)`. This removes coercion and makes the assertions match their stated contract.
+
+### StoreKit deprecation
+
+The installed iOS SDK declares `AppStore.requestReview(in:)` as the direct iOS 16+ replacement for `SKStoreReviewController.requestReview(in:)`. The project deploys to iOS 18.6, so replace the call directly while preserving the existing foreground-scene selection.
+
+### Xcode metadata notices
+
+Two targets without App Intents dependencies emit tool-owned metadata-extraction notices. Xcode's installed `AppIntentsMetadata.xcspec` defines `LM_FILTER_WARNINGS = YES` as `--quiet-warnings` for that processor only. Set it in the project's Debug and Release configurations so metadata-extractor notices are quiet while Swift compiler warnings remain visible.
+
+## Verification
+
+- Run focused tests for all edited test classes.
+- Run a clean serialized full test and capture the raw stream.
+- Require zero `warning:` lines in the captured stream.
+- Run a clean serialized Debug build and require zero `warning:` lines.
+- Run formatting, diff, C2, sync, strict-version, and privacy gates.
+- Obtain independent review of the exact verified head.
+
+The release advances from 2.0.15 (34) to 2.0.16 (35). Privacy baselines remain unchanged.


### PR DESCRIPTION
## Summary

- fix Swift 6 XCTest actor-isolation warnings at the measured warning sites while preserving lifecycle ordering
- replace ambiguous nested-optional tombstone presence assertions with explicit key-membership checks
- adopt `AppStore.requestReview(in:)` without changing foreground-scene selection
- document the exact allowlist for Xcode-owned App Intents metadata notices
- advance the release from 2.0.15 (34) to 2.0.16 (35)

## Verification

- clean full test: 1,223 tests, 0 failures
- raw test warnings: 2 total, 0 Swift source warnings; both are allowlisted Xcode metadata notices for `FoqosShieldConfig` and `FoqosUITests`
- independent reviewer clean full test at exact head: same 1,223/0 result and same 2/0 warning classification
- clean Debug build: succeeded with 0 Swift source warnings and the single allowlisted `FoqosShieldConfig` metadata notice
- focused actor/timer tests: 71 tests, 0 failures
- focused `SyncEngineControllerTests`: 79 tests, 0 failures, 0 raw warnings
- swift-format, concurrency, sync, strict-version, privacy, and diff gates pass
- generated app version: 2.0.16 (35)
- independent review: READY, no Critical or Important findings

Closes #293
Closes #179
