### PR TITLE
Preserve formatted Xcode failures (#379)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,13 +58,10 @@ Always place `xcodebuild` directly after the wrapper's `--`; never mediate it th
 `env`, `bundle`, or a shell command.
 
 ```bash
-# Preserve xcodebuild's status when formatting output.
-set -o pipefail
-
-# Build from command line
-scripts/xcode-stream.sh --agent <agent> --session <session> -- \
+# Build from command line with wrapper-owned output formatting.
+scripts/xcode-stream.sh --agent <agent> --session <session> --xcpretty -- \
   xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
-  -configuration Debug build 2>&1 | bundle exec xcpretty
+  -configuration Debug build
 
 # Clean only this owner's gate-assigned DerivedData.
 scripts/xcode-stream.sh --agent <agent> --session <session> -- scripts/clean-build.sh
@@ -395,11 +392,11 @@ The wrong pattern blocks both Individual AND Child modes. Only Child mode should
 
 ## Build Output
 
-When formatting a gated xcodebuild, enable `pipefail` so the command retains xcodebuild's status:
+When formatting a gated xcodebuild, use the wrapper-owned option. This retains the exact child
+status without depending on caller shell options:
 
 ```bash
-set -o pipefail
-scripts/xcode-stream.sh --agent <agent> --session <session> -- \
+scripts/xcode-stream.sh --agent <agent> --session <session> --xcpretty -- \
   xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
-  -configuration Debug build 2>&1 | bundle exec xcpretty
+  -configuration Debug build
 ```

--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -714,7 +714,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.17;
+				MARKETING_VERSION = 2.0.18;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -735,7 +735,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -746,7 +746,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.17;
+				MARKETING_VERSION = 2.0.18;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -894,7 +894,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -922,7 +922,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.17;
+				MARKETING_VERSION = 2.0.18;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -948,7 +948,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -976,7 +976,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.17;
+				MARKETING_VERSION = 2.0.18;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -998,12 +998,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.17;
+				MARKETING_VERSION = 2.0.18;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1024,12 +1024,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.17;
+				MARKETING_VERSION = 2.0.18;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1049,12 +1049,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.17;
+				MARKETING_VERSION = 2.0.18;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1074,12 +1074,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.17;
+				MARKETING_VERSION = 2.0.18;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1100,7 +1100,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1111,7 +1111,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.17;
+				MARKETING_VERSION = 2.0.18;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1132,7 +1132,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1143,7 +1143,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.17;
+				MARKETING_VERSION = 2.0.18;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1178,7 +1178,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.17;
+				MARKETING_VERSION = 2.0.18;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1201,7 +1201,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1212,7 +1212,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.17;
+				MARKETING_VERSION = 2.0.18;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/docs/superpowers/plans/2026-08-11-issue-379-xcode-stream-formatting.md
+++ b/docs/superpowers/plans/2026-08-11-issue-379-xcode-stream-formatting.md
@@ -204,26 +204,13 @@ git commit -m "Own xcpretty status propagation for #379"
 **Files:**
 - Modify: `AGENTS.md`
 - Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
-- Test: `scripts/test-xcode-stream.sh`
 - Test: `scripts/test-check-version-increment.sh`
 
 **Interfaces:**
 - Consumes: the public `--xcpretty` syntax from Task 2.
 - Produces: one safe documented formatted invocation and release 2.0.18 (37) in every configuration.
 
-- [ ] **Step 1: Add and run the RED documentation policy regression**
-
-Extend the existing `policy_requirements` with `--xcpretty`, then reject the unsafe instructions:
-
-```bash
-assert_not_contains "$POLICY_FILE" "set -o pipefail"
-assert_not_contains "$POLICY_FILE" "2>&1 | bundle exec xcpretty"
-```
-
-Run `scripts/test-xcode-stream.sh` and require it to fail because `AGENTS.md` still contains the
-old caller-owned pipeline.
-
-- [ ] **Step 2: Replace both canonical formatted examples**
+- [ ] **Step 1: Replace both canonical formatted examples**
 
 Use this shape in Build & Test Commands and Build Output:
 
@@ -235,6 +222,12 @@ scripts/xcode-stream.sh --agent <agent> --session <session> --xcpretty -- \
 
 Remove the preceding `set -o pipefail`, trailing `2>&1 | bundle exec xcpretty`, and wording that
 assigns status preservation to the caller.
+
+- [ ] **Step 2: Remove the obsolete policy-text expectation**
+
+Delete `bundle exec xcpretty` from `scripts/test-xcode-stream.sh`'s `policy_requirements`. Do not
+replace it with a `--xcpretty` source-text assertion: the behavioral regressions in Tasks 1 and 2
+prove safe formatting, while human and independent review verify the documentation examples.
 
 - [ ] **Step 3: Bump every target configuration**
 
@@ -248,14 +241,17 @@ Run:
 ```bash
 scripts/test-xcode-stream.sh
 scripts/test-check-version-increment.sh
+rg -n 'set -o pipefail|2>&1 \| bundle exec xcpretty' AGENTS.md
 ```
 
-Expected: both return zero; the version gate reports 2.0.17 to 2.0.18 and 36 to 37.
+Expected: both scripts return zero; the version gate reports 2.0.17 to 2.0.18 and 36 to 37; the
+`rg` audit finds no obsolete caller-owned formatting instruction and therefore returns 1 with no
+matches.
 
 - [ ] **Step 5: Commit docs and version**
 
 ```bash
-git add AGENTS.md FamilyFoqos.xcodeproj/project.pbxproj
+git add AGENTS.md FamilyFoqos.xcodeproj/project.pbxproj scripts/test-xcode-stream.sh
 git commit -m "Document safe formatted builds for #379"
 ```
 

--- a/docs/superpowers/plans/2026-08-11-issue-379-xcode-stream-formatting.md
+++ b/docs/superpowers/plans/2026-08-11-issue-379-xcode-stream-formatting.md
@@ -1,0 +1,371 @@
+# Wrapper-Owned Xcode Formatting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the supported `xcpretty` invocation preserve exact wrapper and `xcodebuild` failures without caller-managed `pipefail`.
+
+**Architecture:** Add a narrow public `--xcpretty` option to `scripts/xcode-stream.sh` and forward it through the existing gate boundary to internal direct-`xcodebuild` execution. The internal Bash process owns the only formatter pipeline and returns the child's exact nonzero status first, falling back to the formatter status only after child success.
+
+**Tech Stack:** Bash 4+, zsh regression harness, `ios-sim-gate`, `xcodebuild`, Bundler, `xcpretty`.
+
+## Global Constraints
+
+- Work only on `fix/379-xcode-stream-xcpretty`, forked from `main@55351b8a731dbcd9ab82b6c0cdd04bb48a0b4005`.
+- Preserve the public wrapper's current `exec` into `ios-sim-gate` and every unformatted execution path.
+- Accept `--xcpretty` only for a direct `xcodebuild` command and reject invalid use before gate mutation.
+- Return the exact child status whenever the child fails; return the formatter status only when the child succeeds.
+- Keep clean-build and screenshot commands unformatted and unchanged.
+- Update canonical `AGENTS.md` examples in the same PR so callers never own the formatter pipeline.
+- Advance all 12 configurations from 2.0.17 (36) to 2.0.18 (37).
+- Do not start the upstream `mnbf9rca/ios-sim-gate` issue until the planner confirms this PR merged.
+- Do not run implementation tasks in parallel; this repository reserves Xcode and simulator work for one stream at a time.
+
+---
+
+### Task 1: Add RED formatter-status regressions
+
+**Files:**
+- Modify: `scripts/test-xcode-stream.sh`
+- Test: `scripts/test-xcode-stream.sh`
+
+**Interfaces:**
+- Consumes: existing `run_wrapper`, fake gate, fake simulator, and fake `xcodebuild` harnesses.
+- Produces: fake `bundle exec xcpretty` behavior controlled by `XCPRETTY_EXIT`, captured formatter input at `XCPRETTY_INPUT_LOG`, and failing acceptance cases for the future public `--xcpretty` option.
+
+- [ ] **Step 1: Extend the fakes without changing production code**
+
+Add controllable output to fake `xcodebuild`:
+
+```bash
+[[ -z "${XCODEBUILD_STDOUT:-}" ]] || printf '%s\n' "$XCODEBUILD_STDOUT"
+[[ -z "${XCODEBUILD_STDERR:-}" ]] || printf '%s\n' "$XCODEBUILD_STDERR" >&2
+exit "${XCODEBUILD_EXIT:-0}"
+```
+
+Add a fake formatter at `$TEST_ROOT/bin/bundle` so the wrapper resolves it through the existing
+test `PATH`:
+
+```bash
+#!/opt/homebrew/bin/bash
+set -euo pipefail
+[[ "$#" -eq 2 && "$1" == "exec" && "$2" == "xcpretty" ]] || exit 64
+cat >"$XCPRETTY_INPUT_LOG"
+exit "${XCPRETTY_EXIT:-0}"
+```
+
+In `reset_case`, truncate and export `$CASE_ROOT/xcpretty-input.log`, and unset
+`XCPRETTY_EXIT`, `XCODEBUILD_STDOUT`, `XCODEBUILD_STDERR`, and `GATE_STATUS_EXIT`. Teach fake gate
+`status` to exit `${GATE_STATUS_EXIT:-0}` after its existing status output.
+
+- [ ] **Step 2: Add the fresh-zsh preflight failure test**
+
+Use `zsh -f` so no startup file can enable `pipefail`, request the supported formatter option, and
+assert exact status `29`:
+
+```bash
+reset_case formatted-preflight-status
+set +e
+GATE_STATUS_EXIT=29 zsh -f -c '
+  PATH=$1:$PATH
+  "$2" --agent build2 --session collab --xcpretty -- xcodebuild test
+' _ "$TEST_ROOT/bin" "$WRAPPER"
+status=$?
+set -e
+[[ "$status" -eq 29 ]] || fail "expected formatted preflight exit 29, got $status"
+[[ ! -s "$XCPRETTY_INPUT_LOG" ]] || fail "formatter ran before gate preflight completed"
+```
+
+- [ ] **Step 3: Add exact pipeline-status and merged-output tests**
+
+Reuse one registered fake simulator for each case, call the not-yet-implemented option, and pin:
+
+```bash
+XCODEBUILD_EXIT=23 XCPRETTY_EXIT=0 run_wrapper \
+  --agent build2 --session collab --xcpretty -- xcodebuild test
+# captured status must equal 23
+
+XCODEBUILD_EXIT=0 XCPRETTY_EXIT=17 run_wrapper \
+  --agent build2 --session collab --xcpretty -- xcodebuild test
+# captured status must equal 17
+
+XCODEBUILD_STDOUT='stdout marker' XCODEBUILD_STDERR='stderr marker' run_wrapper \
+  --agent build2 --session collab --xcpretty -- xcodebuild test
+assert_contains "$XCPRETTY_INPUT_LOG" "stdout marker"
+assert_contains "$XCPRETTY_INPUT_LOG" "stderr marker"
+```
+
+Wrap the expected failures with the suite's existing `set +e`/capture/`set -e` pattern. Reset the
+case between status pairs so logs and registry state cannot leak.
+
+- [ ] **Step 4: Add the invalid-scope regression**
+
+Assert `--xcpretty -- /usr/bin/true` exits nonzero, identifies the direct-`xcodebuild` requirement,
+and records no `register` or `run` gate mutation.
+
+- [ ] **Step 5: Run the shell suite and verify RED for the intended reason**
+
+Run:
+
+```bash
+scripts/test-xcode-stream.sh
+```
+
+Expected: FAIL at the first `--xcpretty` case because the current public parser treats the new
+option as invalid usage. Existing pre-option cases must reach that point successfully.
+
+- [ ] **Step 6: Commit the RED tests**
+
+```bash
+git add scripts/test-xcode-stream.sh
+git commit -m "Add failing formatter status tests for #379"
+```
+
+### Task 2: Implement wrapper-owned formatting
+
+**Files:**
+- Modify: `scripts/xcode-stream.sh`
+- Test: `scripts/test-xcode-stream.sh`
+
+**Interfaces:**
+- Consumes: public `--xcpretty`, the existing `__execute` private mode, and direct `xcodebuild` argument injection.
+- Produces: an internal `run_xcodebuild_with_xcpretty` path that returns child status first and formatter status second.
+
+- [ ] **Step 1: Parse and validate the public option**
+
+Add `--xcpretty` beside `--agent` and `--session`, update usage, and store a boolean. After capturing
+the child command but before `gate status`, require `${command[0]##*/}` to equal `xcodebuild` when
+the boolean is set:
+
+```bash
+[[ "$use_xcpretty" != true || "${command[0]##*/}" == "xcodebuild" ]] ||
+  die "--xcpretty requires xcodebuild immediately after --"
+```
+
+- [ ] **Step 2: Forward a private formatting marker through the gate**
+
+Build the internal child vector explicitly so the public wrapper still ends with `exec`:
+
+```bash
+internal_command=("$BASH4_BIN" "$SELF" __execute)
+[[ "$use_xcpretty" != true ]] || internal_command+=(--xcpretty)
+internal_command+=(-- "${command[@]}")
+
+exec "$BASH4_BIN" "$GATE_BIN" run "${owner_args[@]}" --udid "$owned_uuid" -- \
+  "${internal_command[@]}"
+```
+
+Update private dispatch to consume only that optional marker before the required `--` and pass a
+boolean to `execute_internal`.
+
+- [ ] **Step 3: Own the formatted direct-xcodebuild pipeline**
+
+Keep existing validation and injected arguments, then branch at the final execution point. The
+formatted branch disables `errexit` only around the pipeline, captures `PIPESTATUS` immediately,
+restores `errexit`, and exits deterministically:
+
+```bash
+set +e
+"$@" \
+  -destination "$IOS_SIM_GATE_DESTINATION" \
+  -derivedDataPath "$IOS_SIM_GATE_DERIVED_DATA_PATH" \
+  -parallel-testing-enabled NO \
+  -disable-concurrent-destination-testing \
+  2>&1 | bundle exec xcpretty
+statuses=("${PIPESTATUS[@]}")
+set -e
+
+((statuses[0] == 0)) || exit "${statuses[0]}"
+exit "${statuses[1]}"
+```
+
+The unformatted branch retains the current `exec "$@" ...` statement byte-for-byte.
+
+- [ ] **Step 4: Run targeted GREEN verification**
+
+Run:
+
+```bash
+bash -n scripts/xcode-stream.sh scripts/test-xcode-stream.sh
+scripts/test-xcode-stream.sh
+```
+
+Expected: syntax checks return zero and the suite ends with its PASS banner; the new exact status,
+fresh-zsh, merged-output, invalid-scope, and policy cases all pass.
+
+- [ ] **Step 5: Commit the implementation**
+
+```bash
+git add scripts/xcode-stream.sh
+git commit -m "Own xcpretty status propagation for #379"
+```
+
+### Task 3: Canonicalize documentation and advance the version
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+- Test: `scripts/test-xcode-stream.sh`
+- Test: `scripts/test-check-version-increment.sh`
+
+**Interfaces:**
+- Consumes: the public `--xcpretty` syntax from Task 2.
+- Produces: one safe documented formatted invocation and release 2.0.18 (37) in every configuration.
+
+- [ ] **Step 1: Add and run the RED documentation policy regression**
+
+Extend the existing `policy_requirements` with `--xcpretty`, then reject the unsafe instructions:
+
+```bash
+assert_not_contains "$POLICY_FILE" "set -o pipefail"
+assert_not_contains "$POLICY_FILE" "2>&1 | bundle exec xcpretty"
+```
+
+Run `scripts/test-xcode-stream.sh` and require it to fail because `AGENTS.md` still contains the
+old caller-owned pipeline.
+
+- [ ] **Step 2: Replace both canonical formatted examples**
+
+Use this shape in Build & Test Commands and Build Output:
+
+```bash
+scripts/xcode-stream.sh --agent <agent> --session <session> --xcpretty -- \
+  xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -configuration Debug build
+```
+
+Remove the preceding `set -o pipefail`, trailing `2>&1 | bundle exec xcpretty`, and wording that
+assigns status preservation to the caller.
+
+- [ ] **Step 3: Bump every target configuration**
+
+Change all 12 `MARKETING_VERSION = 2.0.17;` entries to `2.0.18` and all 12
+`CURRENT_PROJECT_VERSION = 36;` entries to `37`. Do not change any other project setting.
+
+- [ ] **Step 4: Run documentation and version gates**
+
+Run:
+
+```bash
+scripts/test-xcode-stream.sh
+scripts/test-check-version-increment.sh
+```
+
+Expected: both return zero; the version gate reports 2.0.17 to 2.0.18 and 36 to 37.
+
+- [ ] **Step 5: Commit docs and version**
+
+```bash
+git add AGENTS.md FamilyFoqos.xcodeproj/project.pbxproj
+git commit -m "Document safe formatted builds for #379"
+```
+
+### Task 4: Verify the exact committed head
+
+**Files:**
+- Verify only: all changed files
+
+**Interfaces:**
+- Consumes: Tasks 1–3 exact committed head.
+- Produces: local evidence packet for independent review and PR publication.
+
+- [ ] **Step 1: Run static and shell verification**
+
+Run:
+
+```bash
+bash -n scripts/xcode-stream.sh scripts/test-xcode-stream.sh
+shellcheck scripts/xcode-stream.sh scripts/test-xcode-stream.sh
+for test_script in scripts/test-*.sh; do "$test_script"; done
+swift-format lint --recursive .
+scripts/check-c2-guards.sh
+scripts/check-sync-guards.sh
+scripts/check-version-increment.sh
+bundle exec ruby scripts/check-log-privacy.rb
+git diff --check origin/main...HEAD
+```
+
+Expected: every command returns zero. Record privacy file/site/annotation counts and confirm they
+match the live baseline rather than changing any baseline file.
+
+- [ ] **Step 2: Prove the real supported formatted build**
+
+Run through the serialized gate with no outer pipeline and no caller `pipefail`:
+
+```bash
+scripts/xcode-stream.sh --agent build1 --session collab --xcpretty -- \
+  xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -configuration Debug clean build
+```
+
+Expected: clean and build succeed; the generated app reports 2.0.18 (37).
+
+- [ ] **Step 3: Run the full gated tests through the supported form**
+
+```bash
+scripts/xcode-stream.sh --agent build1 --session collab --xcpretty -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos
+```
+
+Expected: the complete current suite passes with zero failures.
+
+- [ ] **Step 4: Freeze exact git evidence**
+
+Record `HEAD`, `origin/main`, ancestry, commit list, status, diff check, and diff stat. The worktree
+must be clean and `origin/main` must remain an ancestor.
+
+### Task 5: Review, publish, and hand off
+
+**Files:**
+- No source changes unless review finds an issue.
+
+**Interfaces:**
+- Consumes: exact verified head and its evidence packet.
+- Produces: one non-draft green PR closing #379 and an urgent planner merge handoff.
+
+- [ ] **Step 1: Request independent read-only AMQ review**
+
+Send the reviewer exact base/head SHAs, approved spec and plan paths, RED/GREEN evidence, exact
+status-pair results, static gates, real build/test results, version, and diff scope. Ask for
+Critical/Important/Minor findings and READY yes/no. The reviewer must not mutate files or run Xcode
+concurrently.
+
+- [ ] **Step 2: Address findings in new commits**
+
+Fix every Critical or Important finding, do not amend or force-push, rerun proportionate
+verification, and request review of the new exact head.
+
+- [ ] **Step 3: Push and open the ready PR**
+
+Refresh `origin/main`, confirm ancestry, push `fix/379-xcode-stream-xcpretty`, and open one
+non-draft PR titled `Preserve formatted Xcode failures (#379)`. Include `Closes #379`, the exact
+status contract, verification evidence, and version 2.0.18 (37).
+
+- [ ] **Step 4: Wait for GitHub checks and hand off**
+
+Require every check to complete successfully and verify the PR is OPEN, non-draft, MERGEABLE, and
+pinned to the reviewed head/base. Send an urgent AMQ todo to the planner with the PR URL and exact
+evidence. Do not merge it.
+
+### Task 6: Share the settled design upstream after merge
+
+**Files:**
+- No local changes.
+
+**Interfaces:**
+- Consumes: planner confirmation that the Family Foqos PR merged and its final PR URL.
+- Produces: exactly one issue on `mnbf9rca/ios-sim-gate`; no upstream code change or demand.
+
+- [ ] **Step 1: Wait for planner merge confirmation**
+
+Do not draft, preview, or file the upstream issue while the Family Foqos PR is open.
+
+- [ ] **Step 2: File one terse upstream issue**
+
+Use plain product language to describe how adopter-owned `| xcpretty` pipelines can mask a gate or
+build failure in shells without `pipefail`, summarize the adopted wrapper-owned formatter and
+exact-status rule, and link the merged Family Foqos PR as a reusable reference for adopters such
+as making-tracks. State that adoption is the gate repository's decision.
+
+- [ ] **Step 3: Report the upstream issue URL to the planner**
+
+Send one AMQ status message with the issue URL and confirm no other upstream action was taken.

--- a/docs/superpowers/specs/2026-08-11-issue-379-xcode-stream-formatting-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-379-xcode-stream-formatting-design.md
@@ -1,0 +1,107 @@
+# Issue #379: Wrapper-Owned Xcode Output Formatting
+
+## Goal
+
+Make the repository's supported formatted `xcodebuild` invocation preserve failures without
+requiring callers to configure shell-specific `pipefail` behavior.
+
+The current documented form leaves the pipeline in the caller:
+
+```bash
+scripts/xcode-stream.sh --agent build1 --session collab -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  2>&1 | bundle exec xcpretty
+```
+
+In a fresh zsh process, a wrapper failure returns nonzero by itself but the formatted pipeline
+returns `xcpretty`'s zero status. The wrapper's internal `set -o pipefail` cannot affect that outer
+pipeline.
+
+## Supported interface
+
+Add one narrow public option to the existing entrypoint:
+
+```bash
+scripts/xcode-stream.sh --agent <agent> [--session <session>] --xcpretty -- \
+  xcodebuild <arguments>
+```
+
+`--xcpretty` is valid only when the command immediately after `--` is `xcodebuild`. The wrapper
+rejects the option for clean-build, screenshots, and arbitrary commands before asking the
+simulator gate to allocate or mutate anything. Those paths retain their current unformatted
+behavior.
+
+`AGENTS.md` uses this form for every canonical formatted build example and removes the caller-side
+`set -o pipefail` instruction and external `| bundle exec xcpretty` pipeline. Unformatted test,
+clean-build, and screenshot commands remain unchanged.
+
+## Execution boundary
+
+The public wrapper keeps its current `exec` into `ios-sim-gate`. Preflight, registry, allocation,
+and gate failures therefore remain visible and preserve their exact status without passing
+through a formatter.
+
+The public option is forwarded as a private marker to `__execute`. After the gate has established
+the complete internal environment, the direct-`xcodebuild` branch appends the existing exact UUID,
+DerivedData, and no-clone arguments, then owns this pipeline:
+
+```text
+xcodebuild <caller arguments> <injected arguments> 2>&1 | bundle exec xcpretty
+```
+
+The unformatted direct-`xcodebuild` branch continues to `exec` as it does today. The formatted
+branch alone retains the internal Bash process to supervise the two pipeline children. The gate
+still owns the outer process tree and cleanup boundary.
+
+## Exit-status contract
+
+The formatted branch captures both Bash `PIPESTATUS` entries immediately after the pipeline:
+
+1. If `xcodebuild` returns nonzero, return that exact status.
+2. If the child succeeds, return `xcpretty`'s status, including its exact nonzero status.
+3. Return zero only when both processes succeed.
+
+This preserves the existing wrapper promise instead of weakening it to an unspecified nonzero.
+In particular, child/formatter pairs `23/0` and `0/17` must return `23` and `17`, respectively.
+
+## Validation and failure behavior
+
+- Existing agent, session, command-placement, and injected-argument validation stays unchanged.
+- `--xcpretty` with a non-`xcodebuild` child is a usage failure before gate mutation.
+- A missing formatter executable or formatter startup failure is reported as a formatter failure
+  when the child succeeds.
+- Output sent to both stdout and stderr by `xcodebuild` reaches `xcpretty`, matching the current
+  documented `2>&1` behavior.
+- No generic formatter protocol or second wrapper script is introduced.
+
+## Test strategy
+
+Extend `scripts/test-xcode-stream.sh` with fake `bundle`/`xcpretty` behavior and write the failing
+regressions before implementation. Pin all of these cases:
+
+- a fresh `zsh -f` caller with no `pipefail` receives the exact preflight/gate failure status from
+  a supported `--xcpretty` invocation;
+- child `23`, formatter `0` returns `23`;
+- child `0`, formatter `17` returns `17`;
+- merged stdout/stderr reaches the formatter;
+- `--xcpretty` on a non-`xcodebuild` command fails before any gate mutation;
+- the existing unformatted exact-status test remains green; and
+- `AGENTS.md` requires the new supported form and no longer documents the unsafe external
+  pipeline or caller-managed `pipefail` setup.
+
+Run the complete shell-script regression suite, shell syntax checks, repository policy gates, a
+real clean Debug build through `--xcpretty`, and the full gated test suite before review. The
+release advances from 2.0.17 (36) to 2.0.18 (37).
+
+## Rejected alternatives
+
+A separate formatting helper would make the implementation small but create a second supported
+entrypoint and leave the unsafe syntax easy to rediscover. A generic formatter command protocol
+would add nested argument grammar and validation complexity without a second formatter use case.
+
+## Post-merge sharing
+
+The implementation PR closes #379 and merges before any upstream outreach. After the planner
+confirms the merge, file one terse issue on `mnbf9rca/ios-sim-gate` describing the adopter-side
+pipefail-masking hazard and the wrapper-owned fix, linking the Family Foqos PR as a reference
+implementation. The upstream issue shares the settled design and does not demand adoption.

--- a/scripts/test-fastlane-sim-gate.sh
+++ b/scripts/test-fastlane-sim-gate.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+# Keep this list in sync whenever the suite starts invoking another external tool.
+required_commands=(cat dirname grep mktemp rg rm ruby)
+for required_command in "${required_commands[@]}"; do
+  command -v "$required_command" >/dev/null || {
+    echo "FAIL: required command not found: $required_command" >&2
+    exit 127
+  }
+done
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TEST_ROOT=$(mktemp -d)
 
@@ -94,6 +103,12 @@ if grep -nE 'XCTEST_DEVICES_DIR|created\.each|simctl.*--set|Clone [[:digit:]]' \
   "$REPO_ROOT/fastlane/Fastfile"; then
   echo "FAIL: Fastfile still contains run-created XCTestDevices cleanup" >&2
   exit 1
+else
+  grep_status=$?
+  if [[ "$grep_status" -ne 1 ]]; then
+    echo "FAIL: could not inspect fastlane/Fastfile (grep exit $grep_status)" >&2
+    exit "$grep_status"
+  fi
 fi
 
 rg -n 'SimulatorGate\.assert_registered_device!' "$REPO_ROOT/fastlane/Fastfile" >/dev/null || {

--- a/scripts/test-fastlane-sim-gate.sh
+++ b/scripts/test-fastlane-sim-gate.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Keep this list in sync whenever the suite starts invoking another external tool.
-required_commands=(cat dirname grep mktemp rg rm ruby)
+required_commands=(cat dirname grep mktemp rm ruby)
 for required_command in "${required_commands[@]}"; do
   command -v "$required_command" >/dev/null || {
     echo "FAIL: required command not found: $required_command" >&2
@@ -111,7 +111,7 @@ else
   fi
 fi
 
-rg -n 'SimulatorGate\.assert_registered_device!' "$REPO_ROOT/fastlane/Fastfile" >/dev/null || {
+grep -nE 'SimulatorGate\.assert_registered_device!' "$REPO_ROOT/fastlane/Fastfile" >/dev/null || {
   echo "FAIL: screenshots lane does not assert exact registered simulator lookup" >&2
   exit 1
 }

--- a/scripts/test-fastlane-sim-gate.sh
+++ b/scripts/test-fastlane-sim-gate.sh
@@ -90,7 +90,8 @@ RUBY
 
 REPO_ROOT="$REPO_ROOT" ruby "$TEST_ROOT/test.rb"
 
-if rg -n 'XCTEST_DEVICES_DIR|created\.each|simctl.*--set|Clone \\d' "$REPO_ROOT/fastlane/Fastfile"; then
+if grep -nE 'XCTEST_DEVICES_DIR|created\.each|simctl.*--set|Clone [[:digit:]]' \
+  "$REPO_ROOT/fastlane/Fastfile"; then
   echo "FAIL: Fastfile still contains run-created XCTestDevices cleanup" >&2
   exit 1
 fi

--- a/scripts/test-xcode-stream.sh
+++ b/scripts/test-xcode-stream.sh
@@ -1,6 +1,34 @@
 #!/opt/homebrew/bin/bash
 set -euo pipefail
 
+# Keep this list in sync whenever the suite starts invoking another external tool.
+required_commands=(
+  /opt/homebrew/bin/bash
+  /opt/homebrew/bin/jq
+  /usr/bin/true
+  basename
+  cat
+  chmod
+  cmp
+  dirname
+  grep
+  mkdir
+  mktemp
+  mv
+  rm
+  zsh
+)
+for required_command in "${required_commands[@]}"; do
+  command -v "$required_command" >/dev/null || {
+    echo "FAIL: required command not found: $required_command" >&2
+    exit 127
+  }
+done
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+  echo "FAIL: Bash 4+ is required" >&2
+  exit 127
+fi
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WRAPPER="$REPO_ROOT/scripts/xcode-stream.sh"
 ADAPTER="$REPO_ROOT/scripts/ios-sim-gate-bin/xcrun"
@@ -620,6 +648,9 @@ done
 assert_not_contains "$POLICY_FILE" "NO parallel development on the same machine"
 if grep -nE '^xcodebuild ' "$POLICY_FILE" >/dev/null; then
   fail "AGENTS.md still documents a raw xcodebuild entrypoint"
+else
+  grep_status=$?
+  [[ "$grep_status" -eq 1 ]] || fail "could not inspect AGENTS.md (grep exit $grep_status)"
 fi
 
 echo "PASS: xcode stream allocation, enforcement, adapter scoping, and exact exit propagation"

--- a/scripts/test-xcode-stream.sh
+++ b/scripts/test-xcode-stream.sh
@@ -71,6 +71,7 @@ parse_owner() {
 case "$command" in
   status)
     printf 'capacity slots=3 admission=free\n'
+    exit "${GATE_STATUS_EXIT:-0}"
     ;;
   reconcile)
     printf 'reconciled\n' >>"$GATE_LOG"
@@ -197,9 +198,22 @@ write_fake_xcodebuild() {
   cat >"$TEST_ROOT/bin/xcodebuild" <<'EOF'
 #!/opt/homebrew/bin/bash
 printf '%s\n' "$@" >"$XCODEBUILD_LOG"
+[[ -z "${XCODEBUILD_STDOUT:-}" ]] || printf '%s\n' "$XCODEBUILD_STDOUT"
+[[ -z "${XCODEBUILD_STDERR:-}" ]] || printf '%s\n' "$XCODEBUILD_STDERR" >&2
 exit "${XCODEBUILD_EXIT:-0}"
 EOF
   chmod +x "$TEST_ROOT/bin/xcodebuild"
+}
+
+write_fake_xcpretty() {
+  cat >"$TEST_ROOT/bin/bundle" <<'EOF'
+#!/opt/homebrew/bin/bash
+set -euo pipefail
+[[ "$#" -eq 2 && "$1" == "exec" && "$2" == "xcpretty" ]] || exit 64
+cat >"$XCPRETTY_INPUT_LOG"
+exit "${XCPRETTY_EXIT:-0}"
+EOF
+  chmod +x "$TEST_ROOT/bin/bundle"
 }
 
 write_fake_fastlane_dependencies() {
@@ -256,6 +270,7 @@ reset_case() {
   : >"$CASE_ROOT/gate.log"
   : >"$CASE_ROOT/simctl.log"
   : >"$CASE_ROOT/xcodebuild.log"
+  : >"$CASE_ROOT/xcpretty-input.log"
 
   export IOS_SIM_GATE_HOME="$CASE_ROOT/state"
   export IOS_SIM_GATE_CACHE_HOME="$CASE_ROOT/cache"
@@ -266,13 +281,14 @@ reset_case() {
   export GATE_LOG="$CASE_ROOT/gate.log"
   export SIMCTL_LOG="$CASE_ROOT/simctl.log"
   export XCODEBUILD_LOG="$CASE_ROOT/xcodebuild.log"
+  export XCPRETTY_INPUT_LOG="$CASE_ROOT/xcpretty-input.log"
   export DEVICES_JSON="$CASE_ROOT/devices.json"
   export DEVICE_TYPES_JSON="$TEST_ROOT/device-types.json"
   export RUNTIMES_JSON="$TEST_ROOT/runtimes.json"
   export NEXT_UUID_FILE="$CASE_ROOT/next-uuid"
   export JQ_BIN WINNER_UUID
   unset IOS_SIM_GATE_DEVICE_TYPE IOS_SIM_GATE_RUNTIME SIMULATE_REGISTER_RACE XCODEBUILD_EXIT \
-    INCOMPATIBLE_RUNTIME
+    XCODEBUILD_STDOUT XCODEBUILD_STDERR XCPRETTY_EXIT GATE_STATUS_EXIT INCOMPATIBLE_RUNTIME
 }
 
 add_device() {
@@ -319,6 +335,7 @@ run_wrapper() {
 write_fake_gate
 write_fake_simctl
 write_fake_xcodebuild
+write_fake_xcpretty
 write_fake_fastlane_dependencies
 write_inventory_files
 
@@ -454,6 +471,55 @@ XCODEBUILD_EXIT=23 run_wrapper --agent build2 --session collab -- xcodebuild tes
 status=$?
 set -e
 [[ "$status" -eq 23 ]] || fail "expected xcodebuild exit 23, got $status"
+
+reset_case formatted-preflight-status
+set +e
+GATE_STATUS_EXIT=29 zsh -f -c '
+  export PATH="$1:$PATH"
+  "$2" --agent build2 --session collab --xcpretty -- xcodebuild test
+' _ "$TEST_ROOT/bin" "$WRAPPER"
+status=$?
+set -e
+[[ "$status" -eq 29 ]] || fail "expected formatted preflight exit 29, got $status"
+[[ ! -s "$XCPRETTY_INPUT_LOG" ]] || fail "formatter ran before gate preflight completed"
+
+reset_case formatted-child-status
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 collab
+set +e
+XCODEBUILD_EXIT=23 XCPRETTY_EXIT=0 \
+  run_wrapper --agent build2 --session collab --xcpretty -- xcodebuild test
+status=$?
+set -e
+[[ "$status" -eq 23 ]] || fail "expected formatted xcodebuild exit 23, got $status"
+
+reset_case formatted-formatter-status
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 collab
+set +e
+XCODEBUILD_EXIT=0 XCPRETTY_EXIT=17 \
+  run_wrapper --agent build2 --session collab --xcpretty -- xcodebuild test
+status=$?
+set -e
+[[ "$status" -eq 17 ]] || fail "expected xcpretty exit 17 after xcodebuild success, got $status"
+
+reset_case formatted-merged-output
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 collab
+XCODEBUILD_STDOUT="stdout marker" XCODEBUILD_STDERR="stderr marker" \
+  run_wrapper --agent build2 --session collab --xcpretty -- xcodebuild test
+assert_contains "$XCPRETTY_INPUT_LOG" "stdout marker"
+assert_contains "$XCPRETTY_INPUT_LOG" "stderr marker"
+
+reset_case rejected-xcpretty-scope
+set +e
+output=$(run_wrapper --agent build2 --session collab --xcpretty -- /usr/bin/true 2>&1)
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"--xcpretty requires xcodebuild immediately after --"* ]]; then
+  fail "--xcpretty must reject a non-xcodebuild child before gate mutation"
+fi
+[[ ! -s "$GATE_LOG" ]] || fail "invalid --xcpretty use reached the gate"
 
 if [[ ! -x "$ADAPTER" ]]; then
   fail "scripts/ios-sim-gate-bin/xcrun is missing or not executable"

--- a/scripts/test-xcode-stream.sh
+++ b/scripts/test-xcode-stream.sh
@@ -611,7 +611,6 @@ policy_requirements=(
   "-disable-concurrent-destination-testing"
   "scripts/fastlane.sh screenshots"
   "scripts/clean-build.sh"
-  "bundle exec xcpretty"
   "Read-only work does not consume a gate slot"
   "Archive and upload lanes do not boot simulators"
 )

--- a/scripts/test-xcode-stream.sh
+++ b/scripts/test-xcode-stream.sh
@@ -618,7 +618,7 @@ for requirement in "${policy_requirements[@]}"; do
   assert_contains "$POLICY_FILE" "$requirement"
 done
 assert_not_contains "$POLICY_FILE" "NO parallel development on the same machine"
-if rg -n '^xcodebuild ' "$POLICY_FILE" >/dev/null; then
+if grep -nE '^xcodebuild ' "$POLICY_FILE" >/dev/null; then
   fail "AGENTS.md still documents a raw xcodebuild entrypoint"
 fi
 

--- a/scripts/xcode-stream.sh
+++ b/scripts/xcode-stream.sh
@@ -64,6 +64,8 @@ require_internal_gate_contract() {
 }
 
 execute_internal() {
+  local use_xcpretty=$1
+  shift
   [[ "${1:-}" == "--" ]] || die "internal execution requires -- before the command"
   shift
   (($#)) || die "internal execution requires a command"
@@ -105,6 +107,21 @@ execute_internal() {
     esac
   done
 
+  if [[ "$use_xcpretty" == true ]]; then
+    local -a pipeline_statuses
+    set +e
+    "$@" \
+      -destination "$IOS_SIM_GATE_DESTINATION" \
+      -derivedDataPath "$IOS_SIM_GATE_DERIVED_DATA_PATH" \
+      -parallel-testing-enabled NO \
+      -disable-concurrent-destination-testing \
+      2>&1 | bundle exec xcpretty
+    pipeline_statuses=("${PIPESTATUS[@]}")
+    set -e
+    ((pipeline_statuses[0] == 0)) || exit "${pipeline_statuses[0]}"
+    exit "${pipeline_statuses[1]}"
+  fi
+
   exec "$@" \
     -destination "$IOS_SIM_GATE_DESTINATION" \
     -derivedDataPath "$IOS_SIM_GATE_DERIVED_DATA_PATH" \
@@ -124,7 +141,12 @@ delete_internal() {
 case "${1:-}" in
   __execute)
     shift
-    execute_internal "$@"
+    use_xcpretty=false
+    if [[ "${1:-}" == "--xcpretty" ]]; then
+      use_xcpretty=true
+      shift
+    fi
+    execute_internal "$use_xcpretty" "$@"
     ;;
   __delete)
     shift
@@ -135,13 +157,14 @@ esac
 
 usage() {
   cat >&2 <<'EOF'
-Usage: scripts/xcode-stream.sh --agent NAME [--session NAME] -- COMMAND [ARG ...]
+Usage: scripts/xcode-stream.sh --agent NAME [--session NAME] [--xcpretty] -- COMMAND [ARG ...]
 EOF
   exit 2
 }
 
 agent=""
 session=""
+use_xcpretty=false
 while (($#)); do
   case "$1" in
     --agent)
@@ -153,6 +176,10 @@ while (($#)); do
       (($# >= 2)) || usage
       session=$2
       shift 2
+      ;;
+    --xcpretty)
+      use_xcpretty=true
+      shift
       ;;
     --)
       shift
@@ -178,6 +205,11 @@ else
 fi
 
 command=("$@")
+[[ "$use_xcpretty" != true || "${command[0]##*/}" == "xcodebuild" ]] ||
+  die "--xcpretty requires xcodebuild immediately after --"
+if [[ "$use_xcpretty" == true ]]; then
+  command -v bundle >/dev/null || die "bundle not found; --xcpretty requires bundle exec xcpretty"
+fi
 owner_args=(--project "$PROJECT" --agent "$agent")
 if [[ -n "$session" ]]; then
   owner_args+=(--session "$session")
@@ -342,5 +374,9 @@ IFS=$'\t' read -r IOS_SIM_GATE_DEVICE_NAME IOS_SIM_GATE_RUNTIME_VERSION <<<"$met
 [[ -n "$IOS_SIM_GATE_RUNTIME_VERSION" ]] || die "resolved simulator has no runtime version"
 export IOS_SIM_GATE_DEVICE_NAME IOS_SIM_GATE_RUNTIME_VERSION
 
+internal_command=("$BASH4_BIN" "$SELF" __execute)
+[[ "$use_xcpretty" != true ]] || internal_command+=(--xcpretty)
+internal_command+=(-- "${command[@]}")
+
 exec "$BASH4_BIN" "$GATE_BIN" run "${owner_args[@]}" --udid "$owned_uuid" -- \
-  "$BASH4_BIN" "$SELF" __execute -- "${command[@]}"
+  "${internal_command[@]}"


### PR DESCRIPTION
## Summary

- add wrapper-owned `--xcpretty` formatting so callers no longer need an outer pipeline or shell-specific `pipefail`
- preserve the exact `xcodebuild` status when it fails and return the formatter status only after child success
- reject formatted non-`xcodebuild` commands before simulator-gate mutation
- update canonical agent commands and advance the release to 2.0.18 (37)
- make the affected shell-policy guards fail closed on missing tools and inspection errors
- repair the Fastlane clone-name guard and remove its undocumented ripgrep dependency

## Root cause

The documented `xcode-stream | xcpretty` pipeline belonged to the caller shell. In a fresh zsh without `pipefail`, `xcpretty` could return zero after the wrapper or `xcodebuild` failed, masking the failure. The wrapper's own shell options cannot affect a caller-owned pipeline.

## Verification

- TDD RED: fresh `zsh -f` expected gate status 29 but the old wrapper rejected `--xcpretty` with usage status 2
- exact status cases: preflight 29 preserved; child/formatter 23/0 returns 23; 0/17 returns 17
- merged stdout/stderr reaches `xcpretty`; invalid formatter scope records no gate mutation
- Bash syntax and shellcheck pass
- every `scripts/test-*.sh` suite passes
- missing-tool probes exit 127 and name the missing dependency
- both affected negative guards distinguish no-match from grep errors
- Fastlane suite passes with a PATH containing only its six declared tools and no ripgrep
- Swift formatting, C2, sync, strict-version, privacy, and diff gates pass
- privacy baseline remains 232 files / 500 sites / 0 annotations
- real clean Debug build through `--xcpretty`: succeeded; generated app 2.0.18 (37)
- real full test suite through `--xcpretty`: 1,223 tests, 0 failures
- independent review at exact head `b028e67`: READY, no findings

Closes #379
