### PR TITLE
Detect XCTestDevices growth around gated runs

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -714,7 +714,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -735,7 +735,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -746,7 +746,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -894,7 +894,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -922,7 +922,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -948,7 +948,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -976,7 +976,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -998,12 +998,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1024,12 +1024,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1049,12 +1049,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1074,12 +1074,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1100,7 +1100,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1111,7 +1111,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1132,7 +1132,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1143,7 +1143,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1178,7 +1178,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1201,7 +1201,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1212,7 +1212,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/docs/superpowers/plans/2026-08-11-issue-400-xctestdevices-census.md
+++ b/docs/superpowers/plans/2026-08-11-issue-400-xctestdevices-census.md
@@ -1,0 +1,195 @@
+# XCTestDevices Growth Census Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect XCTestDevices growth around every gated child, fail when a new clone is attributable to the run's owned simulator, and warn on concurrent unattributed growth.
+
+**Architecture:** The outer `xcode-stream.sh` process will stop `exec`-replacing itself with the gate and instead own a before/after census lifecycle. A validated `simctl --set <root> list devices --json` snapshot is captured before launch; EXIT, INT, and TERM traps always capture the second snapshot, compare newly observed UUIDs, and preserve the child status unless attributable growth or census failure requires a hard failure.
+
+**Tech Stack:** Bash 4+, `xcrun simctl`, jq, the existing fake gate/simctl/xcodebuild shell harness.
+
+## Global Constraints
+
+- Run only one implementation/build/test stream on this machine.
+- Preserve the exact child exit status when both censuses succeed and no owned clone appears.
+- Run the after-census for success, failure, INT, and TERM exits.
+- Fail loudly if the XCTestDevices root is missing, simctl fails, or census JSON is malformed.
+- Match the full owned simulator display name as the terminal `of <owner>` chain segment so nested clones remain attributable without blaming a longer, prefixed session name.
+- Warn, but do not blame or fail, when another stream causes only unattributed growth.
+- Unit tests must use a fake XCTestDevices root and fake simctl inventory; they must not create real clones.
+- Increment MARKETING_VERSION from 2.0.19 to 2.0.20 and CURRENT_PROJECT_VERSION from 38 to 39.
+
+---
+
+### Task 1: Add fail-closed XCTestDevices census fixtures
+
+**Files:**
+- Modify: `scripts/test-xcode-stream.sh`
+
+**Interfaces:**
+- Consumes: the existing fake `simctl`, fake `xcodebuild`, `reset_case`, `add_device`, and `run_wrapper` harness.
+- Produces: fake `--set ROOT list devices --json` support and RED cases for owned, nested, unattributed, failed-child, interrupted-child, missing-root, simctl-error, and malformed-census behavior.
+
+- [ ] **Step 1: Extend the fake device set**
+
+Create `$CASE_ROOT/xctest-devices`, initialize `$CASE_ROOT/xctest-devices.json` to `{"devices":{}}`, and export:
+
+```bash
+IOS_SIM_GATE_XCTEST_DEVICES_ROOT="$CASE_ROOT/xctest-devices"
+XCTEST_DEVICES_JSON="$CASE_ROOT/xctest-devices.json"
+XCTEST_CENSUS_CALLS_FILE="$CASE_ROOT/xctest-census-calls"
+```
+
+Teach fake simctl to answer `--set "$IOS_SIM_GATE_XCTEST_DEVICES_ROOT" list devices --json`, increment the call counter, optionally fail on the requested call, and otherwise emit `$XCTEST_DEVICES_JSON`.
+
+- [ ] **Step 2: Let the fake child create test-only clone records**
+
+Before fake xcodebuild exits, when `XCODEBUILD_XCTEST_DEVICE_NAME` is set, append a record with `XCODEBUILD_XCTEST_DEVICE_UUID` and that name to `$XCTEST_DEVICES_JSON`. When `XCODEBUILD_INTERRUPT_PARENT=1`, send INT to `$PPID` after the record is written.
+
+- [ ] **Step 3: Write the RED attribution cases**
+
+Add cases asserting:
+
+```bash
+XCODEBUILD_XCTEST_DEVICE_NAME="Clone 1 of Family Foqos build2" \
+  run_wrapper --agent build2 -- xcodebuild test
+```
+
+fails with an owned-clone diagnostic, and that `Clone 2 of Clone 1 of Family Foqos build2` is also classified as owned.
+
+- [ ] **Step 4: Write RED failure and interrupt cases**
+
+Force the child to add an owned clone and exit 23; assert the wrapper still emits the census diagnostic and exits nonzero. Force the child to add the clone and signal INT to its parent; assert the same diagnostic appears. Add a no-growth INT case that preserves status 130 and records exactly two censuses, proving the INT path performed the after-census.
+
+- [ ] **Step 5: Write RED unattributed-growth and status-preservation cases**
+
+Add `Clone 1 of Another Stream` during a successful child; assert status 0 and a loud warning. Also run a child that exits 23 without growth; assert status 23 remains unchanged.
+
+- [ ] **Step 6: Write RED fail-loud census cases**
+
+Assert a missing fake set root, malformed before JSON, and a fake simctl error on the second census all return nonzero with a census failure diagnostic. For preflight failures, assert the gate log is empty.
+
+- [ ] **Step 7: Run the focused suite and record RED**
+
+Run:
+
+```bash
+bash scripts/test-xcode-stream.sh
+```
+
+Expected: FAIL at the first owned-clone fixture because the current wrapper does not census XCTestDevices.
+
+### Task 2: Implement the trapped census lifecycle
+
+**Files:**
+- Modify: `scripts/xcode-stream.sh`
+
+**Interfaces:**
+- Consumes: `IOS_SIM_GATE_XCTEST_DEVICES_ROOT`, `IOS_SIM_GATE_DEVICE_NAME`, the existing `simctl` adapter, and `$JQ_BIN`.
+- Produces: `xctest_devices_census`, `new_xctest_devices`, and `finish_xctest_devices_census`, with the final gate invocation running under EXIT/INT/TERM traps.
+
+- [ ] **Step 1: Add the configurable device-set root**
+
+Define:
+
+```bash
+XCTEST_DEVICES_ROOT="${IOS_SIM_GATE_XCTEST_DEVICES_ROOT:-$HOME/Library/Developer/XCTestDevices}"
+```
+
+- [ ] **Step 2: Implement a validated census**
+
+`xctest_devices_census` must require the root directory, call:
+
+```bash
+simctl --set "$XCTEST_DEVICES_ROOT" list devices --json
+```
+
+and use jq to reject anything except an object containing a `.devices` object whose values are arrays of records with string `udid` and `name` fields. Return a compact, UUID-sorted JSON array of `{udid,name}` records.
+
+- [ ] **Step 3: Implement UUID-based growth comparison**
+
+`new_xctest_devices BEFORE AFTER` must emit only after-records whose UUID did not occur in BEFORE. It must parse both snapshots using `--argjson` so malformed internal state fails rather than becoming an empty set.
+
+- [ ] **Step 4: Implement the exit finalizer**
+
+`finish_xctest_devices_census` must capture `$?` first, remove EXIT/INT/TERM traps, disable errexit for explicit handling, and obtain the after snapshot. It must classify an exact name or any clone chain ending in `of <full owner name>` as owned, while treating a longer prefixed session name as unrelated. It must:
+
+```text
+census failure -> print ERROR and exit 1
+unattributed growth -> print WARNING and preserve child status
+owned-name substring anywhere in new name -> print ERROR and exit 1
+no growth -> preserve child status
+```
+
+Every jq failure during comparison or classification must print a detector failure and exit 1.
+
+- [ ] **Step 5: Replace the final exec with trapped execution**
+
+Take the before snapshot immediately before the gate child, then install:
+
+```bash
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap finish_xctest_devices_census EXIT
+```
+
+Run the gate without `exec`, with errexit disabled around it, capture its status, restore errexit, and `exit "$child_status"` so the EXIT finalizer always runs.
+
+- [ ] **Step 6: Run the focused suite and record GREEN**
+
+Run:
+
+```bash
+bash scripts/test-xcode-stream.sh
+```
+
+Expected: PASS, including owned/nested attribution, warning, failure, interrupt, and fail-loud census cases.
+
+- [ ] **Step 7: Run static shell verification**
+
+Run:
+
+```bash
+shellcheck scripts/xcode-stream.sh scripts/test-xcode-stream.sh
+bash -n scripts/xcode-stream.sh scripts/test-xcode-stream.sh
+git diff --check
+```
+
+Expected: all exit 0 with no diagnostics.
+
+### Task 3: Version, review, and publish
+
+**Files:**
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+- Modify: `docs/superpowers/plans/2026-08-11-issue-400-xctestdevices-census.md` only to mark executed checkboxes if useful during handoff.
+
+**Interfaces:**
+- Consumes: the tested census implementation and origin/main at merge `52e6929`.
+- Produces: a signed, reviewed, merge-ready PR that closes #400.
+
+- [ ] **Step 1: Apply the required version increment**
+
+Replace every project setting value consistently:
+
+```text
+MARKETING_VERSION = 2.0.19 -> 2.0.20
+CURRENT_PROJECT_VERSION = 38 -> 39
+```
+
+- [ ] **Step 2: Re-run fresh verification**
+
+Run the focused suite, shellcheck, Bash syntax check, `git diff --check`, and:
+
+```bash
+scripts/check-version-increment.sh origin/main HEAD
+```
+
+after the signed commit exists. Expected version-gate output: 2.0.19 -> 2.0.20 and 38 -> 39.
+
+- [ ] **Step 3: Request independent review**
+
+Provide the reviewer base `52e6929`, head commit, this plan, the RED/GREEN evidence, and explicit attention points: EXIT/INT/TERM behavior, fail-closed errors, nested-name attribution, unrelated concurrent growth, and exact child-status preservation. Do not run Xcode builds in the reviewer stream.
+
+- [ ] **Step 4: Publish merge-ready and close the issue through the PR**
+
+Push the reviewed branch and open a ready PR whose body explains the effect-based invariant and includes `Closes #400`. Confirm all required GitHub checks pass, then hand the clean PR to the planner for merge.

--- a/scripts/test-xcode-stream.sh
+++ b/scripts/test-xcode-stream.sh
@@ -43,6 +43,8 @@ OTHER_UUID=33333333-3333-3333-3333-333333333333
 CREATED_UUID=44444444-4444-4444-4444-444444444444
 WINNER_UUID=55555555-5555-5555-5555-555555555555
 STALE_UUID=66666666-6666-6666-6666-666666666666
+XCTEST_OWN_UUID=77777777-7777-7777-7777-777777777777
+XCTEST_OTHER_UUID=88888888-8888-8888-8888-888888888888
 
 cleanup() {
   rm -rf -- "$TEST_ROOT"
@@ -165,6 +167,28 @@ write_fake_simctl() {
 set -euo pipefail
 
 printf '%s\n' "$*" >>"$SIMCTL_LOG"
+if [[ "${1:-}" == "--set" ]]; then
+  root=$2
+  shift 2
+  [[ "$root" == "$IOS_SIM_GATE_XCTEST_DEVICES_ROOT" ]] || {
+    echo "unexpected XCTestDevices root: $root" >&2
+    exit 64
+  }
+  [[ "$*" == "list devices --json" ]] || {
+    echo "unexpected XCTestDevices simctl arguments: $*" >&2
+    exit 64
+  }
+  calls=$(<"$XCTEST_CENSUS_CALLS_FILE")
+  ((calls += 1))
+  printf '%s\n' "$calls" >"$XCTEST_CENSUS_CALLS_FILE"
+  if [[ "${XCTEST_CENSUS_FAIL_CALL:-0}" -eq "$calls" ]]; then
+    echo "simulated XCTestDevices census failure" >&2
+    exit 75
+  fi
+  cat "$XCTEST_DEVICES_JSON"
+  exit 0
+fi
+
 case "$1 $2 ${3:-}" in
   "list devices available")
     "$JQ_BIN" '
@@ -229,6 +253,24 @@ write_fake_xcodebuild() {
 printf '%s\n' "$@" >"$XCODEBUILD_LOG"
 [[ -z "${XCODEBUILD_STDOUT:-}" ]] || printf '%s\n' "$XCODEBUILD_STDOUT"
 [[ -z "${XCODEBUILD_STDERR:-}" ]] || printf '%s\n' "$XCODEBUILD_STDERR" >&2
+if [[ -n "${XCODEBUILD_XCTEST_DEVICE_NAME:-}" ]]; then
+  temporary="$XCTEST_DEVICES_JSON.tmp"
+  "$JQ_BIN" --arg uuid "$XCODEBUILD_XCTEST_DEVICE_UUID" \
+    --arg name "$XCODEBUILD_XCTEST_DEVICE_NAME" '
+      .devices["com.apple.CoreSimulator.SimRuntime.iOS-26-0"] =
+        ((.devices["com.apple.CoreSimulator.SimRuntime.iOS-26-0"] // []) + [{
+          udid: $uuid,
+          name: $name,
+          state: "Shutdown",
+          isAvailable: true
+        }])
+    ' "$XCTEST_DEVICES_JSON" >"$temporary" || exit 74
+  mv "$temporary" "$XCTEST_DEVICES_JSON" || exit 74
+fi
+if [[ "${XCODEBUILD_INTERRUPT_CENSUS_PARENT:-0}" == 1 ]]; then
+  [[ -n "${IOS_SIM_GATE_CENSUS_PARENT_PID:-}" ]] || exit 86
+  kill -INT "$IOS_SIM_GATE_CENSUS_PARENT_PID" || exit 87
+fi
 exit "${XCODEBUILD_EXIT:-0}"
 EOF
   chmod +x "$TEST_ROOT/bin/xcodebuild"
@@ -292,9 +334,11 @@ reset_case() {
   local name=$1
   CASE_ROOT="$TEST_ROOT/$name"
   rm -rf -- "$CASE_ROOT"
-  mkdir -p "$CASE_ROOT/state" "$CASE_ROOT/cache"
+  mkdir -p "$CASE_ROOT/state" "$CASE_ROOT/cache" "$CASE_ROOT/xctest-devices"
   printf '{}\n' >"$CASE_ROOT/state/registry.json"
   printf '{"devices":{}}\n' >"$CASE_ROOT/devices.json"
+  printf '{"devices":{}}\n' >"$CASE_ROOT/xctest-devices.json"
+  printf '0\n' >"$CASE_ROOT/xctest-census-calls"
   printf '%s\n' "$CREATED_UUID" >"$CASE_ROOT/next-uuid"
   : >"$CASE_ROOT/gate.log"
   : >"$CASE_ROOT/simctl.log"
@@ -307,6 +351,7 @@ reset_case() {
   export IOS_SIM_GATE_BASH_BIN=/opt/homebrew/bin/bash
   export IOS_SIM_GATE_JQ_BIN="$JQ_BIN"
   export IOS_SIM_GATE_SIMCTL_BIN="$TEST_ROOT/bin/simctl"
+  export IOS_SIM_GATE_XCTEST_DEVICES_ROOT="$CASE_ROOT/xctest-devices"
   export GATE_LOG="$CASE_ROOT/gate.log"
   export SIMCTL_LOG="$CASE_ROOT/simctl.log"
   export XCODEBUILD_LOG="$CASE_ROOT/xcodebuild.log"
@@ -315,9 +360,13 @@ reset_case() {
   export DEVICE_TYPES_JSON="$TEST_ROOT/device-types.json"
   export RUNTIMES_JSON="$TEST_ROOT/runtimes.json"
   export NEXT_UUID_FILE="$CASE_ROOT/next-uuid"
+  export XCTEST_DEVICES_JSON="$CASE_ROOT/xctest-devices.json"
+  export XCTEST_CENSUS_CALLS_FILE="$CASE_ROOT/xctest-census-calls"
   export JQ_BIN WINNER_UUID
   unset IOS_SIM_GATE_DEVICE_TYPE IOS_SIM_GATE_RUNTIME SIMULATE_REGISTER_RACE XCODEBUILD_EXIT \
-    XCODEBUILD_STDOUT XCODEBUILD_STDERR XCPRETTY_EXIT GATE_STATUS_EXIT INCOMPATIBLE_RUNTIME
+    XCODEBUILD_STDOUT XCODEBUILD_STDERR XCODEBUILD_XCTEST_DEVICE_NAME \
+    XCODEBUILD_XCTEST_DEVICE_UUID XCODEBUILD_INTERRUPT_CENSUS_PARENT XCPRETTY_EXIT \
+    GATE_STATUS_EXIT INCOMPATIBLE_RUNTIME XCTEST_CENSUS_FAIL_CALL
 }
 
 add_device() {
@@ -385,6 +434,8 @@ assert_contains "$XCODEBUILD_LOG" "$CASE_ROOT/cache/DerivedData/family-foqos/bui
 assert_contains "$XCODEBUILD_LOG" "-parallel-testing-enabled"
 assert_contains "$XCODEBUILD_LOG" "NO"
 assert_contains "$XCODEBUILD_LOG" "-disable-concurrent-destination-testing"
+[[ $(<"$XCTEST_CENSUS_CALLS_FILE") -eq 2 ]] ||
+  fail "successful gated run must census XCTestDevices exactly twice"
 
 reset_case session-isolation
 add_device "$REUSE_UUID" "No session" com.apple.CoreSimulator.SimRuntime.iOS-26-0
@@ -521,6 +572,96 @@ run_wrapper --agent build2 --session collab -- bash -c 'exit 0'
 assert_contains "$GATE_LOG" \
   $'run\tfamily-foqos\tbuild2\tcollab\t11111111-1111-1111-1111-111111111111'
 
+reset_case owned-xctestdevices-growth
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 ""
+set +e
+output=$(XCODEBUILD_XCTEST_DEVICE_UUID="$XCTEST_OWN_UUID" \
+  XCODEBUILD_XCTEST_DEVICE_NAME="Clone 1 of Family Foqos build2" \
+  run_wrapper --agent build2 -- xcodebuild test 2>&1)
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"XCTestDevices clone appeared for owned simulator"* ]]; then
+  fail "owned XCTestDevices growth must fail the run: $output"
+fi
+
+reset_case nested-owned-xctestdevices-growth
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 ""
+set +e
+output=$(XCODEBUILD_XCTEST_DEVICE_UUID="$XCTEST_OWN_UUID" \
+  XCODEBUILD_XCTEST_DEVICE_NAME="Clone 2 of Clone 1 of Family Foqos build2" \
+  run_wrapper --agent build2 -- xcodebuild test 2>&1)
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"XCTestDevices clone appeared for owned simulator"* ]]; then
+  fail "nested owned XCTestDevices growth must fail the run: $output"
+fi
+
+reset_case failed-child-owned-xctestdevices-growth
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 ""
+set +e
+output=$(XCODEBUILD_EXIT=23 XCODEBUILD_XCTEST_DEVICE_UUID="$XCTEST_OWN_UUID" \
+  XCODEBUILD_XCTEST_DEVICE_NAME="Clone 1 of Family Foqos build2" \
+  run_wrapper --agent build2 -- xcodebuild test 2>&1)
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"XCTestDevices clone appeared for owned simulator"* ]]; then
+  fail "failed child must still run the owned-clone census: $output"
+fi
+
+reset_case interrupted-child-owned-xctestdevices-growth
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 ""
+set +e
+output=$(XCODEBUILD_INTERRUPT_CENSUS_PARENT=1 \
+  XCODEBUILD_XCTEST_DEVICE_UUID="$XCTEST_OWN_UUID" \
+  XCODEBUILD_XCTEST_DEVICE_NAME="Clone 1 of Family Foqos build2" \
+  run_wrapper --agent build2 -- xcodebuild test 2>&1)
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"XCTestDevices clone appeared for owned simulator"* ]]; then
+  fail "interrupted child must still run the owned-clone census: $output"
+fi
+
+reset_case interrupted-child-status
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 ""
+set +e
+XCODEBUILD_INTERRUPT_CENSUS_PARENT=1 run_wrapper --agent build2 -- xcodebuild test
+status=$?
+set -e
+[[ "$status" -eq 130 ]] || fail "INT must preserve shell status 130, got $status"
+[[ $(<"$XCTEST_CENSUS_CALLS_FILE") -eq 2 ]] ||
+  fail "interrupted gated run must census XCTestDevices exactly twice"
+
+reset_case unattributed-xctestdevices-growth
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 ""
+set +e
+output=$(XCODEBUILD_XCTEST_DEVICE_UUID="$XCTEST_OTHER_UUID" \
+  XCODEBUILD_XCTEST_DEVICE_NAME="Clone 1 of Another Stream" \
+  run_wrapper --agent build2 -- xcodebuild test 2>&1)
+status=$?
+set -e
+if [[ "$status" -ne 0 || "$output" != *"WARNING: XCTestDevices grew during gated run"* ]]; then
+  fail "unattributed XCTestDevices growth must warn without failing: $output"
+fi
+
+reset_case prefixed-owner-xctestdevices-growth
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 ""
+set +e
+output=$(XCODEBUILD_XCTEST_DEVICE_UUID="$XCTEST_OTHER_UUID" \
+  XCODEBUILD_XCTEST_DEVICE_NAME="Clone 1 of Family Foqos build2 - collab" \
+  run_wrapper --agent build2 -- xcodebuild test 2>&1)
+status=$?
+set -e
+if [[ "$status" -ne 0 || "$output" != *"WARNING: XCTestDevices grew during gated run"* ]]; then
+  fail "prefixed owner name must not be falsely attributed: $output"
+fi
+
 reset_case exit-status
 add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
 set_owner "$REUSE_UUID" build2 collab
@@ -529,6 +670,43 @@ XCODEBUILD_EXIT=23 run_wrapper --agent build2 --session collab -- xcodebuild tes
 status=$?
 set -e
 [[ "$status" -eq 23 ]] || fail "expected xcodebuild exit 23, got $status"
+
+reset_case missing-xctestdevices-root
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 ""
+rm -rf -- "$IOS_SIM_GATE_XCTEST_DEVICES_ROOT"
+set +e
+output=$(run_wrapper --agent build2 -- xcodebuild test 2>&1)
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"XCTestDevices census failed"* ]]; then
+  fail "missing XCTestDevices root must fail loudly: $output"
+fi
+[[ ! -s "$GATE_LOG" ]] || fail "missing XCTestDevices root reached the gate"
+
+reset_case malformed-xctestdevices-census
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 ""
+printf '{"devices":{"runtime":[{"udid":7}]}}\n' >"$XCTEST_DEVICES_JSON"
+set +e
+output=$(run_wrapper --agent build2 -- xcodebuild test 2>&1)
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"XCTestDevices census failed"* ]]; then
+  fail "malformed XCTestDevices inventory must fail loudly: $output"
+fi
+[[ ! -s "$GATE_LOG" ]] || fail "malformed XCTestDevices inventory reached the gate"
+
+reset_case failed-after-xctestdevices-census
+add_device "$REUSE_UUID" "Family Foqos build2" com.apple.CoreSimulator.SimRuntime.iOS-26-0
+set_owner "$REUSE_UUID" build2 ""
+set +e
+output=$(XCTEST_CENSUS_FAIL_CALL=2 run_wrapper --agent build2 -- xcodebuild test 2>&1)
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"XCTestDevices census failed"* ]]; then
+  fail "failed after-census must fail loudly: $output"
+fi
 
 reset_case formatted-preflight-status
 set +e

--- a/scripts/xcode-stream.sh
+++ b/scripts/xcode-stream.sh
@@ -18,6 +18,7 @@ GATE_BIN="${IOS_SIM_GATE_BIN:-$HOME/.local/bin/ios-sim-gate}"
 JQ_BIN="${IOS_SIM_GATE_JQ_BIN:-/opt/homebrew/bin/jq}"
 STATE_ROOT="${IOS_SIM_GATE_HOME:-$HOME/Library/Application Support/ios-sim-gate}"
 REGISTRY="$STATE_ROOT/registry.json"
+XCTEST_DEVICES_ROOT="${IOS_SIM_GATE_XCTEST_DEVICES_ROOT:-$HOME/Library/Developer/XCTestDevices}"
 DEFAULT_DEVICE_TYPE="iPhone 17"
 
 die() {
@@ -76,6 +77,99 @@ simctl() {
   else
     /usr/bin/xcrun simctl "$@"
   fi
+}
+
+xctest_devices_census() {
+  local inventory
+  local census
+
+  if [[ ! -d "$XCTEST_DEVICES_ROOT" ]]; then
+    echo "xcode-stream: XCTestDevices census failed: root not found: $XCTEST_DEVICES_ROOT" >&2
+    return 1
+  fi
+  if ! inventory=$(simctl --set "$XCTEST_DEVICES_ROOT" list devices --json 2>/dev/null); then
+    echo "xcode-stream: XCTestDevices census failed: simctl could not list $XCTEST_DEVICES_ROOT" >&2
+    return 1
+  fi
+  if ! census=$("$JQ_BIN" -ce '
+    if (type != "object") or ((.devices | type) != "object") then
+      error("inventory must contain a devices object")
+    elif (all(
+      .devices | to_entries[];
+      if (.value | type) != "array" then
+        false
+      else
+        all(.value[]; ((.udid | type) == "string") and ((.name | type) == "string"))
+      end
+    ) | not) then
+      error("every device must contain string udid and name fields")
+    else
+      [.devices | to_entries[] | .value[] | {udid, name}] | sort_by(.udid)
+    end
+  ' <<<"$inventory"); then
+    echo "xcode-stream: XCTestDevices census failed: invalid simctl inventory" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$census"
+}
+
+# shellcheck disable=SC2329 # Invoked from the EXIT-trap finalizer.
+new_xctest_devices() {
+  local before=$1
+  local after=$2
+
+  # shellcheck disable=SC2016 # jq expressions intentionally use jq variables.
+  "$JQ_BIN" -cn --argjson before "$before" --argjson after "$after" '
+    [
+      $after[] |
+      . as $device |
+      select(any($before[]; .udid == $device.udid) | not)
+    ]
+  '
+}
+
+# shellcheck disable=SC2329 # Installed as the EXIT trap below.
+finish_xctest_devices_census() {
+  local child_status=$?
+  trap - EXIT INT TERM
+  set +e
+
+  local after
+  local added
+  local owned_growth
+  local unattributed_growth
+  if ! after=$(xctest_devices_census); then
+    echo "xcode-stream: XCTestDevices census failed after gated child; refusing to pass" >&2
+    exit 1
+  fi
+  if ! added=$(new_xctest_devices "$xctest_devices_before" "$after"); then
+    echo "xcode-stream: XCTestDevices census failed while comparing inventories" >&2
+    exit 1
+  fi
+  # shellcheck disable=SC2016 # jq expressions intentionally use jq variables.
+  if ! owned_growth=$("$JQ_BIN" -c --arg owner "$IOS_SIM_GATE_DEVICE_NAME" \
+    '[.[] | select((.name == $owner) or (.name | endswith(" of " + $owner)))]' <<<"$added"); then
+    echo "xcode-stream: XCTestDevices census failed while attributing growth" >&2
+    exit 1
+  fi
+  # shellcheck disable=SC2016 # jq expressions intentionally use jq variables.
+  if ! unattributed_growth=$("$JQ_BIN" -c --arg owner "$IOS_SIM_GATE_DEVICE_NAME" \
+    '[.[] | select(((.name == $owner) or (.name | endswith(" of " + $owner))) | not)]' \
+    <<<"$added"); then
+    echo "xcode-stream: XCTestDevices census failed while classifying growth" >&2
+    exit 1
+  fi
+
+  if [[ "$unattributed_growth" != "[]" ]]; then
+    echo "xcode-stream: WARNING: XCTestDevices grew during gated run without attributable owner match: $unattributed_growth" >&2
+  fi
+  if [[ "$owned_growth" != "[]" ]]; then
+    echo "xcode-stream: XCTestDevices clone appeared for owned simulator $IOS_SIM_GATE_DEVICE_NAME: $owned_growth" >&2
+    exit 1
+  fi
+
+  exit "$child_status"
 }
 
 gate() {
@@ -412,5 +506,17 @@ internal_command=("$BASH4_BIN" "$SELF" __execute)
 [[ "$use_xcpretty" != true ]] || internal_command+=(--xcpretty)
 internal_command+=(-- "${command[@]}")
 
-exec "$BASH4_BIN" "$GATE_BIN" run "${owner_args[@]}" --udid "$owned_uuid" -- \
+if ! xctest_devices_before=$(xctest_devices_census); then
+  die "XCTestDevices census failed before gated child"
+fi
+export IOS_SIM_GATE_CENSUS_PARENT_PID=$BASHPID
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap finish_xctest_devices_census EXIT
+
+set +e
+"$BASH4_BIN" "$GATE_BIN" run "${owner_args[@]}" --udid "$owned_uuid" -- \
   "${internal_command[@]}"
+child_status=$?
+set -e
+exit "$child_status"


### PR DESCRIPTION
## Summary

- census the XCTestDevices set before and after every gated child
- fail when a new clone is attributable to the run's owned simulator and warn on unrelated concurrent growth
- run detection on success, failure, INT, and TERM while failing closed on census errors
- add the required version increment to 2.0.20 (build 39)

## Why

PR #402 blocks the historical shell-mediated `xcodebuild` shape, but command-text matching cannot cover variable indirection, token concatenation, or non-shell mediators. This change checks the effect directly: whether the parallel-testing device set grew during the gated run.

Attribution compares newly observed UUIDs and recognizes any nested clone chain ending in `of <full owned simulator name>`. The terminal match catches `Clone 2 of Clone 1 of …` without letting a sessionless `build2` stream falsely claim a `build2-collab` clone. Growth belonging to another concurrent stream is reported loudly but does not fail this run.

## Validation

- RED: owned XCTestDevices growth was allowed before implementation
- GREEN: `bash scripts/test-xcode-stream.sh`
- mutation check: disabling the INT handler failed with `expected 130, got 0`; restoring it returned GREEN
- `shellcheck scripts/xcode-stream.sh scripts/test-xcode-stream.sh`
- `bash -n scripts/xcode-stream.sh scripts/test-xcode-stream.sh`
- `scripts/check-version-increment.sh origin/main HEAD`
- real gated `/usr/bin/true` smoke completed with the actual XCTestDevices set remaining 0 → 0

Closes #400
