### PR TITLE
Preflight remaining script dependencies (#403)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,19 @@ This file provides guidelines for agentic coding assistants working on the Famil
     still use separate feature branches/worktrees and disjoint file sets.
     Read-only work does not consume a gate slot and may run concurrently from its own working copy.
 
+## Script Safety
+
+Scripts should be safe and deterministic. Any new or modified script must:
+
+- Validate external dependencies during preflight with `command -v` and a named nonzero failure
+  before doing work or touching shared state.
+- Fail closed when a check cannot run, input is unreadable, or output is unparseable; never treat
+  those conditions as a pass.
+- Propagate the exact child exit status through pipelines and wrappers.
+- Verify effects, not text forms, when an invariant matters, such as the simulator clone census.
+- Keep guards in build phases or the scripts themselves, never only in Git hooks, because API
+  commits bypass hooks.
+
 ## Build & Test Commands
 
 ### Building

--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -714,7 +714,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.20;
+				MARKETING_VERSION = 2.0.21;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -735,7 +735,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -746,7 +746,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.20;
+				MARKETING_VERSION = 2.0.21;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -894,7 +894,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -922,7 +922,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.20;
+				MARKETING_VERSION = 2.0.21;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -948,7 +948,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -976,7 +976,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.20;
+				MARKETING_VERSION = 2.0.21;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -998,12 +998,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.20;
+				MARKETING_VERSION = 2.0.21;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1024,12 +1024,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.20;
+				MARKETING_VERSION = 2.0.21;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1049,12 +1049,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.20;
+				MARKETING_VERSION = 2.0.21;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1074,12 +1074,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.20;
+				MARKETING_VERSION = 2.0.21;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1100,7 +1100,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1111,7 +1111,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.20;
+				MARKETING_VERSION = 2.0.21;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1132,7 +1132,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1143,7 +1143,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.20;
+				MARKETING_VERSION = 2.0.21;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1178,7 +1178,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.20;
+				MARKETING_VERSION = 2.0.21;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1201,7 +1201,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1212,7 +1212,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.20;
+				MARKETING_VERSION = 2.0.21;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -714,7 +714,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -735,7 +735,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -746,7 +746,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -894,7 +894,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -922,7 +922,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -948,7 +948,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -976,7 +976,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -998,12 +998,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1024,12 +1024,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1049,12 +1049,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1074,12 +1074,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1100,7 +1100,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1111,7 +1111,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1132,7 +1132,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1143,7 +1143,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1178,7 +1178,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1201,7 +1201,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1212,7 +1212,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.19;
+				MARKETING_VERSION = 2.0.20;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/docs/superpowers/plans/2026-08-11-issue-403-script-dependency-preflights.md
+++ b/docs/superpowers/plans/2026-08-11-issue-403-script-dependency-preflights.md
@@ -146,7 +146,7 @@ Use the established comment, array, `command -v` loop, named diagnostic, and exi
 required_commands=(dirname grep xcrun)
 
 # scripts/test-check-prod-schema.sh
-required_commands=(chmod cp dirname grep mkdir mktemp rm)
+required_commands=(cat chmod cp dirname grep mkdir mktemp rm)
 
 # scripts/test-fastlane-credential-routing.sh
 required_commands=(cat chmod cp dirname mkdir mktemp rm sed)

--- a/docs/superpowers/plans/2026-08-11-issue-403-script-dependency-preflights.md
+++ b/docs/superpowers/plans/2026-08-11-issue-403-script-dependency-preflights.md
@@ -1,0 +1,372 @@
+# Script Dependency Preflights Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the remaining shell entrypoints refuse deterministically and name unavailable dependencies before doing work or touching shared state.
+
+**Architecture:** Put command discovery at each script's real dependency boundary and add semantic discovery for Xcode- and Bundler-resolved tools. Keep hermetic tests independent of host `cktool` and `op` installations while proving production refusal ordering through fake-command effect logs.
+
+**Tech Stack:** Bash, `xcrun`, Bundler, Fastlane, `xcpretty`, shell fixture suites.
+
+## Global Constraints
+
+- Work only on `fix/403-script-dependency-preflights`, forked from `main@52e6929b4bb098bd35819ba9715a6334c2ea940e`.
+- Use discovery-only semantic probes: `xcrun --find cktool`, `bundle exec fastlane --version`, and `bundle exec xcpretty --version`.
+- Do not pin Xcode, Ruby, Homebrew, gem-version, or executable installation paths.
+- Missing executables return 127; an undiscoverable bundled tool or unresolved gem returns 1 and names the dependency.
+- Run all dependency validation before substantive work or shared-state mutation.
+- Preserve hermetic fake `xcrun` and `op` boundaries; the test suites must not require host installations of those tools.
+- Preserve exact runtime child statuses through `check-prod-schema.sh` and `xcode-stream.sh`.
+- Add exactly five terse Script Safety requirements to `AGENTS.md`.
+- Advance all 12 project configurations from 2.0.19 (38) to 2.0.20 (39).
+- Do not run a simulator build or test; the approved spec classifies this as a shell-only change.
+- Do not amend or force-push. Obtain independent review before the planner merges.
+
+---
+
+### Task 1: Add RED semantic-refusal fixtures
+
+**Files:**
+- Modify: `scripts/test-check-prod-schema.sh`
+- Modify: `scripts/test-xcode-stream.sh`
+- Test: `scripts/test-check-prod-schema.sh`
+- Test: `scripts/test-xcode-stream.sh`
+
+**Interfaces:**
+- Consumes: the schema suite's fake `xcrun`, the Xcode stream suite's fake `bundle`, and each suite's existing status/log helpers.
+- Produces: `FAKE_CKTOOL_AVAILABLE`, `FAKE_XCRUN_LOG`, and `XCPRETTY_PREFLIGHT_EXIT` controls that prove refusal happens before export or simulator-gate access.
+
+- [ ] **Step 1: Make fake `xcrun` distinguish discovery from export**
+
+Replace the schema fixture's unconditional fake with argument-aware behavior:
+
+```bash
+cat >"$TEST_ROOT/bin/xcrun" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >>"$FAKE_XCRUN_LOG"
+if [[ "${1:-}" == "--find" && "${2:-}" == "cktool" ]]; then
+  [[ "${FAKE_CKTOOL_AVAILABLE:-1}" -eq 1 ]] || exit 1
+  printf '/fake/cktool\n'
+  exit 0
+fi
+[[ "${1:-}" == "cktool" && "${2:-}" == "export-schema" ]] || exit 64
+if [[ "${FAKE_CKTOOL_EXIT:-0}" -ne 0 ]]; then
+  exit "$FAKE_CKTOOL_EXIT"
+fi
+printf '%s\n' "${FAKE_SCHEMA:-}"
+EOF
+```
+
+Pass `FAKE_XCRUN_LOG="$TEST_ROOT/xcrun.log"` to the copied production script in `run_gate`.
+
+- [ ] **Step 2: Add the missing-cktool refusal case**
+
+Before schema-success cases, truncate the fake log, set `FAKE_CKTOOL_AVAILABLE=0`, and assert:
+
+```bash
+[[ "$GATE_STATUS" -eq 1 ]]
+[[ "$GATE_OUTPUT" == *"cktool"* ]]
+if grep -F 'cktool export-schema' "$TEST_ROOT/xcrun.log" >/dev/null; then
+  echo "FAIL: missing cktool reached schema export"
+  exit 1
+fi
+```
+
+- [ ] **Step 3: Add semantic `xcpretty` behavior to fake Bundler**
+
+Teach `write_fake_xcpretty` to handle the probe independently from formatter execution:
+
+```bash
+if [[ "$*" == "exec xcpretty --version" ]]; then
+  exit "${XCPRETTY_PREFLIGHT_EXIT:-0}"
+fi
+[[ "$*" == "exec xcpretty" ]] || exit 64
+cat >"$XCPRETTY_INPUT_LOG"
+exit "${XCPRETTY_EXIT:-0}"
+```
+
+Unset `XCPRETTY_PREFLIGHT_EXIT` in `reset_case`.
+
+- [ ] **Step 4: Add the pre-gate formatter refusal case**
+
+Use a fresh case with no registered simulator, force the semantic probe to return 19, and assert
+the wrapper returns nonzero, names `xcpretty`, and leaves `$GATE_LOG` empty:
+
+```bash
+reset_case rejected-xcpretty-unavailable
+set +e
+output=$(XCPRETTY_PREFLIGHT_EXIT=19 run_wrapper \
+  --agent build2 --session collab --xcpretty -- xcodebuild test 2>&1)
+status=$?
+set -e
+[[ "$status" -ne 0 && "$output" == *"xcpretty"* ]] ||
+  fail "unavailable xcpretty must be named and rejected"
+[[ ! -s "$GATE_LOG" ]] || fail "unavailable xcpretty reached the gate"
+```
+
+- [ ] **Step 5: Run both suites and verify RED for intended reasons**
+
+Run:
+
+```bash
+bash scripts/test-check-prod-schema.sh
+bash scripts/test-xcode-stream.sh
+```
+
+Expected: the schema suite fails because production never calls `xcrun --find cktool`; the Xcode
+stream suite fails because production reaches the gate instead of invoking the semantic formatter
+probe. Earlier cases must reach each new assertion.
+
+- [ ] **Step 6: Commit the RED fixtures**
+
+```bash
+git add scripts/test-check-prod-schema.sh scripts/test-xcode-stream.sh
+git commit -S -m "test: expose missing script dependency preflights"
+```
+
+### Task 2: Preflight schema and Fastlane dependencies
+
+**Files:**
+- Modify: `scripts/check-prod-schema.sh`
+- Modify: `scripts/test-check-prod-schema.sh`
+- Modify: `scripts/test-fastlane-credential-routing.sh`
+- Modify: `scripts/test-fastlane-gates.sh`
+- Test: all three modified shell test suites
+
+**Interfaces:**
+- Consumes: external-command names actually invoked by each script and the production `fastlane.sh` missing-`op` contract.
+- Produces: established `required_commands` loops, semantic `cktool`/Fastlane probes, and effect-based refusal assertions.
+
+- [ ] **Step 1: Add each command loop before setup work**
+
+Use the established comment, array, `command -v` loop, named diagnostic, and exit 127. Lists:
+
+```bash
+# scripts/check-prod-schema.sh
+required_commands=(dirname grep xcrun)
+
+# scripts/test-check-prod-schema.sh
+required_commands=(chmod cp dirname grep mkdir mktemp rm)
+
+# scripts/test-fastlane-credential-routing.sh
+required_commands=(cat chmod cp dirname mkdir mktemp rm sed)
+
+# scripts/test-fastlane-gates.sh
+required_commands=(bundle cat chmod dirname mkdir mktemp rm sed)
+```
+
+Keep each future-dependency comment immediately above its array.
+
+- [ ] **Step 2: Add production `cktool` semantic discovery**
+
+After command discovery and before resolving or reading the manifest:
+
+```bash
+if ! xcrun --find cktool >/dev/null 2>&1; then
+  echo "Required Xcode tool not found: cktool" >&2
+  exit 1
+fi
+```
+
+Leave the existing `SCHEMA=$(xcrun cktool export-schema ...)` command substitution unchanged so
+an export failure still returns its exact status.
+
+- [ ] **Step 3: Strengthen the existing missing-`op` effect assertion**
+
+Delete the prior command log before the missing-`op` case and assert it remains absent afterward.
+This proves `scripts/fastlane.sh` refuses before invoking `bundle`, without requiring a host `op`.
+
+- [ ] **Step 4: Add semantic Fastlane resolution before fixture creation**
+
+After resolving `REPO_ROOT` but before `mktemp`, run the probe in the repository root:
+
+```bash
+if ! (cd "$REPO_ROOT" && bundle exec fastlane --version >/dev/null 2>&1); then
+  echo "FAIL: required bundled executable unavailable: fastlane" >&2
+  exit 1
+fi
+```
+
+Run the later `bundle exec fastlane gates` call from `$REPO_ROOT` as well so discovery and use
+share the same Bundler context.
+
+- [ ] **Step 5: Run focused GREEN verification**
+
+Run:
+
+```bash
+bash -n scripts/check-prod-schema.sh scripts/test-check-prod-schema.sh \
+  scripts/test-fastlane-credential-routing.sh scripts/test-fastlane-gates.sh
+bash scripts/test-check-prod-schema.sh
+bash scripts/test-fastlane-credential-routing.sh
+bash scripts/test-fastlane-gates.sh
+```
+
+Expected: syntax checks and suites return zero. The schema suite reports the retained distinct
+export status; the credential suite proves no Bundler effect on missing `op`; the gate suite first
+resolves Fastlane and then passes all lane cases.
+
+- [ ] **Step 6: Commit schema and Fastlane preflights**
+
+```bash
+git add scripts/check-prod-schema.sh scripts/test-check-prod-schema.sh \
+  scripts/test-fastlane-credential-routing.sh scripts/test-fastlane-gates.sh
+git commit -S -m "fix: preflight schema and Fastlane dependencies"
+```
+
+### Task 3: Refuse unavailable `xcpretty` before simulator-gate access
+
+**Files:**
+- Modify: `scripts/xcode-stream.sh`
+- Test: `scripts/test-xcode-stream.sh`
+
+**Interfaces:**
+- Consumes: public `--xcpretty`, Bundler command discovery, and the fake semantic probe from Task 1.
+- Produces: exit 127 for missing `bundle`, exit 1 for unresolved `xcpretty`, and no gate effect for either refusal.
+
+- [ ] **Step 1: Preserve the missing-Bundler distinction**
+
+Replace the current generic `die` expression with an explicit named 127 failure before
+`owner_args` and `gate status`:
+
+```bash
+command -v bundle >/dev/null || {
+  echo "xcode-stream: bundle not found; --xcpretty requires bundle exec xcpretty" >&2
+  exit 127
+}
+```
+
+- [ ] **Step 2: Add semantic formatter resolution in the same pre-gate block**
+
+```bash
+bundle exec xcpretty --version >/dev/null 2>&1 ||
+  die "xcpretty unavailable; run bundle install before using --xcpretty"
+```
+
+Do not move, call, or mutate `gate`, `REGISTRY`, simulator inventories, or owner state before these
+checks.
+
+- [ ] **Step 3: Run targeted GREEN verification**
+
+Run:
+
+```bash
+bash -n scripts/xcode-stream.sh scripts/test-xcode-stream.sh
+bash scripts/test-xcode-stream.sh
+```
+
+Expected: the suite's new semantic-refusal case passes with an empty gate log; existing exact
+23/0 and 0/17 child/formatter status cases remain green.
+
+- [ ] **Step 4: Commit the Xcode wrapper preflight**
+
+```bash
+git add scripts/xcode-stream.sh
+git commit -S -m "fix: preflight xcpretty before simulator access"
+```
+
+### Task 4: Record policy and advance release metadata
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+- Test: `scripts/test-check-version-increment.sh`
+
+**Interfaces:**
+- Consumes: maintainer principle and the approved five mechanical requirements.
+- Produces: a terse Script Safety policy and release 2.0.20 (39) in every project configuration.
+
+- [ ] **Step 1: Add the five-bullet Script Safety subsection**
+
+State that scripts should be safe and deterministic, then require new or modified scripts to:
+
+1. validate external dependencies preflight with `command -v` and a named nonzero failure before work or shared-state access;
+2. fail closed when a check cannot run, input is unreadable, or output is unparseable;
+3. propagate exact child exit status through pipelines and wrappers;
+4. verify effects, not text forms, when an invariant matters; and
+5. keep guards in build phases or scripts, never only Git hooks because API commits bypass hooks.
+
+- [ ] **Step 2: Bump all project configurations**
+
+Change every `MARKETING_VERSION = 2.0.19;` to `2.0.20` and every
+`CURRENT_PROJECT_VERSION = 38;` to `39`. Do not change other project settings.
+
+- [ ] **Step 3: Verify policy shape and version consistency**
+
+Run:
+
+```bash
+scripts/test-check-version-increment.sh
+rg -n "^## Script Safety|command -v|fail closed|exact child|verify effects|API commits" AGENTS.md
+git diff --check
+```
+
+Expected: the version gate reports 2.0.19 to 2.0.20 and 38 to 39; the policy audit identifies one
+heading and all five rules; the diff check is clean.
+
+- [ ] **Step 4: Commit policy and version**
+
+```bash
+git add AGENTS.md FamilyFoqos.xcodeproj/project.pbxproj
+git commit -S -m "docs: require safe deterministic scripts"
+```
+
+### Task 5: Verify, review, publish, and hand off
+
+**Files:**
+- Verify only: all files changed from `origin/main`.
+
+**Interfaces:**
+- Consumes: the exact committed head from Tasks 1–4.
+- Produces: evidence for independent review, one non-draft green PR closing #403, and an urgent planner merge handoff.
+
+- [ ] **Step 1: Run exact-head verification**
+
+Run:
+
+```bash
+bash -n scripts/check-prod-schema.sh scripts/test-check-prod-schema.sh \
+  scripts/test-fastlane-credential-routing.sh scripts/test-fastlane-gates.sh \
+  scripts/xcode-stream.sh scripts/test-xcode-stream.sh
+bash scripts/test-check-prod-schema.sh
+bash scripts/test-fastlane-credential-routing.sh
+bash scripts/test-fastlane-gates.sh
+bash scripts/test-xcode-stream.sh
+scripts/test-check-version-increment.sh
+scripts/check-c2-guards.sh
+scripts/check-sync-guards.sh
+bundle exec ruby scripts/check-log-privacy.rb
+git diff --check origin/main...HEAD
+```
+
+Expected: every command returns zero. No Xcode or simulator command runs.
+
+- [ ] **Step 2: Freeze git and behavior evidence**
+
+Record `HEAD`, `origin/main`, merge-base ancestry, commit list, clean status, diff stat, the
+missing-cktool no-export proof, the missing-`op` no-Bundler proof, the unavailable-`xcpretty`
+empty-gate proof, and the exact child-status regression results.
+
+- [ ] **Step 3: Request independent read-only AMQ review**
+
+Send the reviewer base/head SHAs, issue/spec/plan paths, RED/GREEN evidence, all verification
+results, exit-code contract, version, and diff scope. Ask for Critical/Important/Minor findings and
+READY yes/no. The reviewer must not mutate the shared files or run Xcode.
+
+- [ ] **Step 4: Address findings with new commits**
+
+Fix all Critical and Important findings without amending, rerun proportionate verification, and
+request review of the new exact head. Do not merge.
+
+- [ ] **Step 5: Push and open one ready PR**
+
+Refresh `origin/main`, confirm it remains the reviewed ancestor, push
+`fix/403-script-dependency-preflights`, and open a non-draft PR titled
+`Preflight remaining script dependencies (#403)`. Include `Closes #403`, the 127/1 refusal split,
+effect-order proofs, test evidence, and version 2.0.20 (39).
+
+- [ ] **Step 6: Require green GitHub checks and hand off**
+
+Verify the PR is OPEN, non-draft, MERGEABLE, based on `main`, pinned to the reviewed head, and has
+no failing or pending required checks. Send an urgent AMQ todo with the PR URL and evidence to the
+planner for merge. Never merge it locally.

--- a/docs/superpowers/specs/2026-08-11-issue-403-script-dependency-preflights-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-403-script-dependency-preflights-design.md
@@ -1,0 +1,93 @@
+# Issue #403: Preflight Remaining Script Dependencies
+
+## Goal
+
+Make repository scripts safe and deterministic when an external command, Xcode-bundled tool, or
+Bundler-resolved executable is unavailable. A script must refuse before doing substantive work or
+touching shared state, name the unavailable dependency, and return nonzero.
+
+## Dependency boundaries
+
+Each changed script owns validation of the external commands it directly invokes. Test harnesses
+continue to inject fakes for dependencies whose failure behavior they are testing; they must not
+turn hermetic fixtures into workstation audits.
+
+The required semantic probes are discovery-based and do not pin an Xcode, Ruby, gem, or Homebrew
+installation path:
+
+```bash
+xcrun --find cktool
+bundle exec fastlane --version
+bundle exec xcpretty --version
+```
+
+The production schema gate validates `xcrun` with `command -v`, then uses `xcrun --find cktool`
+before reading its manifest or exporting the production schema. The schema harness keeps its fake
+`xcrun` and adds a fixture proving an unavailable `cktool` is named and rejected before any export
+attempt.
+
+The Fastlane credential-routing harness preflights the ordinary external commands used to build
+its fixtures. It keeps fake `op` and `bundle` commands so it can prove credential lanes reject a
+missing `op` before invoking Bundler. The Fastlane gates integration harness preflights `bundle`
+and verifies the resolved Fastlane executable with `bundle exec fastlane --version` before it
+creates fixtures or runs the gate lane.
+
+For formatted Xcode commands, the public `scripts/xcode-stream.sh --xcpretty` path validates
+`bundle`, then verifies the resolved formatter with `bundle exec xcpretty --version`. Both checks
+run before `gate status`, registry initialization, simulator lookup, or allocation. A fixture must
+force the semantic formatter probe to fail and prove the simulator-gate log remains empty.
+
+## Common preflight shape
+
+Shell test scripts use the established array-and-loop pattern at the top of the file:
+
+```bash
+# Keep this list in sync whenever the suite starts invoking another external tool.
+required_commands=(...)
+for required_command in "${required_commands[@]}"; do
+  command -v "$required_command" >/dev/null || {
+    echo "FAIL: required command not found: $required_command" >&2
+    exit 127
+  }
+done
+```
+
+Production entrypoints use equivalent named failures in their own diagnostic style. Missing
+executables return 127. A command that exists but cannot discover its bundled tool or resolve its
+gem returns 1. Runtime child failures keep their existing exact exit-status contracts.
+
+## Script safety policy
+
+Add a terse `Script Safety` subsection to `AGENTS.md` for every new or modified script:
+
+- validate external dependencies before work or shared-state mutation, naming missing tools;
+- fail closed when a check cannot run, input cannot be read, or output cannot be parsed;
+- propagate exact child exit statuses through pipelines and wrappers;
+- verify effects rather than textual forms when enforcing an invariant; and
+- place guards in build phases or scripts, never solely in Git hooks.
+
+This policy records the maintainer's governing principle: scripts should be safe and
+deterministic.
+
+## Tests and release metadata
+
+Write the refusal fixtures before implementation, then run all four focused shell suites:
+
+```bash
+bash scripts/test-check-prod-schema.sh
+bash scripts/test-fastlane-credential-routing.sh
+bash scripts/test-fastlane-gates.sh
+bash scripts/test-xcode-stream.sh
+```
+
+Also syntax-check every modified shell file, run the repository policy gates relevant to the
+changed scripts and documentation, and obtain independent code review. No simulator build is
+needed because this change is confined to shell execution and project release metadata. Advance
+the release from 2.0.19 (38) to 2.0.20 (39).
+
+## Rejected alternatives
+
+Command-name-only validation cannot detect an absent Xcode component or unresolved gem. Pinning
+absolute executable paths would ignore `DEVELOPER_DIR`, `xcode-select`, Bundler resolution, Ruby
+homes, and future gem upgrades. Requiring real `cktool` or `op` installations in hermetic test
+harnesses would test the host rather than the scripted behavior.

--- a/scripts/check-prod-schema.sh
+++ b/scripts/check-prod-schema.sh
@@ -4,6 +4,20 @@
 # This checks record-type existence only; it does not compare field definitions.
 set -euo pipefail
 
+# Keep this list in sync whenever the script starts invoking another external tool.
+required_commands=(dirname grep xcrun)
+for required_command in "${required_commands[@]}"; do
+  command -v "$required_command" >/dev/null || {
+    echo "Required command not found: $required_command" >&2
+    exit 127
+  }
+done
+
+if ! xcrun --find cktool >/dev/null 2>&1; then
+  echo "Required Xcode tool not found: cktool" >&2
+  exit 1
+fi
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 REQUIRED_FILE="$REPO_ROOT/fastlane/required-prod-schema.txt"
 TEAM_ID="BU7526J4QY"

--- a/scripts/test-check-prod-schema.sh
+++ b/scripts/test-check-prod-schema.sh
@@ -16,6 +16,13 @@ cp "$REPO_ROOT/scripts/check-prod-schema.sh" "$TEST_ROOT/scripts/check-prod-sche
 
 cat >"$TEST_ROOT/bin/xcrun" <<'EOF'
 #!/bin/bash
+printf '%s\n' "$*" >>"$FAKE_XCRUN_LOG"
+if [[ "${1:-}" == "--find" && "${2:-}" == "cktool" ]]; then
+  [[ "${FAKE_CKTOOL_AVAILABLE:-1}" -eq 1 ]] || exit 1
+  printf '/fake/cktool\n'
+  exit 0
+fi
+[[ "${1:-}" == "cktool" && "${2:-}" == "export-schema" ]] || exit 64
 if [[ "${FAKE_CKTOOL_EXIT:-0}" -ne 0 ]]; then
   exit "$FAKE_CKTOOL_EXIT"
 fi
@@ -25,7 +32,8 @@ chmod +x "$TEST_ROOT/bin/xcrun"
 
 run_gate() {
   set +e
-  GATE_OUTPUT=$(PATH="$TEST_ROOT/bin:$PATH" "$TEST_ROOT/scripts/check-prod-schema.sh" 2>&1)
+  GATE_OUTPUT=$(FAKE_XCRUN_LOG="$TEST_ROOT/xcrun.log" PATH="$TEST_ROOT/bin:$PATH" \
+    "$TEST_ROOT/scripts/check-prod-schema.sh" 2>&1)
   GATE_STATUS=$?
   set -e
 }
@@ -59,6 +67,19 @@ EMPTY_OUTPUT=$GATE_OUTPUT
 EMPTY_STATUS=$GATE_STATUS
 
 printf 'RECORD TYPE Present\n' >"$TEST_ROOT/fastlane/required-prod-schema.txt"
+: >"$TEST_ROOT/xcrun.log"
+FAKE_CKTOOL_AVAILABLE=0 run_gate
+if [[ "$GATE_STATUS" -ne 1 || "$GATE_OUTPUT" != *"cktool"* ]]; then
+  echo "FAIL: unavailable cktool must exit 1 and name cktool"
+  echo "actual exit: $GATE_STATUS"
+  echo "$GATE_OUTPUT"
+  exit 1
+fi
+if grep -F 'cktool export-schema' "$TEST_ROOT/xcrun.log" >/dev/null; then
+  echo "FAIL: unavailable cktool reached schema export"
+  exit 1
+fi
+
 FAKE_SCHEMA='RECORD TYPE Present (' run_gate
 if [[ "$GATE_STATUS" -ne 0 || "$GATE_OUTPUT" != *"Production schema OK."* ]]; then
   echo "FAIL: matching production schema must pass"

--- a/scripts/test-check-prod-schema.sh
+++ b/scripts/test-check-prod-schema.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+# Keep this list in sync whenever the suite starts invoking another external tool.
+required_commands=(chmod cp dirname grep mkdir mktemp rm)
+for required_command in "${required_commands[@]}"; do
+  command -v "$required_command" >/dev/null || {
+    echo "FAIL: required command not found: $required_command" >&2
+    exit 127
+  }
+done
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TEST_ROOT=$(mktemp -d)
 

--- a/scripts/test-check-prod-schema.sh
+++ b/scripts/test-check-prod-schema.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Keep this list in sync whenever the suite starts invoking another external tool.
-required_commands=(chmod cp dirname grep mkdir mktemp rm)
+required_commands=(cat chmod cp dirname grep mkdir mktemp rm)
 for required_command in "${required_commands[@]}"; do
   command -v "$required_command" >/dev/null || {
     echo "FAIL: required command not found: $required_command" >&2

--- a/scripts/test-fastlane-credential-routing.sh
+++ b/scripts/test-fastlane-credential-routing.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+# Keep this list in sync whenever the suite starts invoking another external tool.
+required_commands=(cat chmod cp dirname mkdir mktemp rm sed)
+for required_command in "${required_commands[@]}"; do
+  command -v "$required_command" >/dev/null || {
+    echo "FAIL: required command not found: $required_command" >&2
+    exit 127
+  }
+done
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WRAPPER="$REPO_ROOT/scripts/fastlane.sh"
 REFS_FILE="$REPO_ROOT/fastlane/asc.env"
@@ -122,6 +131,7 @@ for lane in screenshots lanes gates build_number; do
   fi
 done
 
+rm -f "$TEST_ROOT/command.log"
 set +e
 MISSING_OP_OUTPUT=$(run_wrapper "$TEST_ROOT/no-op-ruby" check_asc_key 2>&1)
 MISSING_OP_STATUS=$?
@@ -129,6 +139,10 @@ set -e
 if [[ "$MISSING_OP_STATUS" -eq 0 || "$MISSING_OP_OUTPUT" != *"1Password CLI 'op' is required"* ]]; then
   echo "FAIL: missing op must fail with a friendly error"
   printf 'exit: %s\n%s\n' "$MISSING_OP_STATUS" "$MISSING_OP_OUTPUT"
+  exit 1
+fi
+if [[ -e "$TEST_ROOT/command.log" ]]; then
+  echo "FAIL: missing op invoked bundle"
   exit 1
 fi
 

--- a/scripts/test-fastlane-gates.sh
+++ b/scripts/test-fastlane-gates.sh
@@ -1,7 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
+# Keep this list in sync whenever the suite starts invoking another external tool.
+required_commands=(bundle cat chmod dirname mkdir mktemp rm sed)
+for required_command in "${required_commands[@]}"; do
+  command -v "$required_command" >/dev/null || {
+    echo "FAIL: required command not found: $required_command" >&2
+    exit 127
+  }
+done
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+if ! (cd "$REPO_ROOT" && bundle exec fastlane --version >/dev/null 2>&1); then
+  echo "FAIL: required bundled executable unavailable: fastlane" >&2
+  exit 1
+fi
+
 TEST_ROOT=$(mktemp -d)
 
 cleanup() {
@@ -43,6 +57,7 @@ chmod +x "$TEST_ROOT/bin/gh" "$TEST_ROOT/bin/xcrun"
 run_gates() {
   set +e
   GATE_OUTPUT=$(
+    cd "$REPO_ROOT"
     PATH="$TEST_ROOT/bin:$PATH" \
       FAKE_SCHEMA_FILE="$REPO_ROOT/fastlane/required-prod-schema.txt" \
       bundle exec fastlane gates 2>&1

--- a/scripts/test-xcode-stream.sh
+++ b/scripts/test-xcode-stream.sh
@@ -238,7 +238,10 @@ write_fake_xcpretty() {
   cat >"$TEST_ROOT/bin/bundle" <<'EOF'
 #!/opt/homebrew/bin/bash
 set -euo pipefail
-[[ "$#" -eq 2 && "$1" == "exec" && "$2" == "xcpretty" ]] || exit 64
+if [[ "$*" == "exec xcpretty --version" ]]; then
+  exit "${XCPRETTY_PREFLIGHT_EXIT:-0}"
+fi
+[[ "$*" == "exec xcpretty" ]] || exit 64
 cat >"$XCPRETTY_INPUT_LOG"
 exit "${XCPRETTY_EXIT:-0}"
 EOF
@@ -317,7 +320,8 @@ reset_case() {
   export NEXT_UUID_FILE="$CASE_ROOT/next-uuid"
   export JQ_BIN WINNER_UUID
   unset IOS_SIM_GATE_DEVICE_TYPE IOS_SIM_GATE_RUNTIME SIMULATE_REGISTER_RACE XCODEBUILD_EXIT \
-    XCODEBUILD_STDOUT XCODEBUILD_STDERR XCPRETTY_EXIT GATE_STATUS_EXIT INCOMPATIBLE_RUNTIME
+    XCODEBUILD_STDOUT XCODEBUILD_STDERR XCPRETTY_EXIT XCPRETTY_PREFLIGHT_EXIT GATE_STATUS_EXIT \
+    INCOMPATIBLE_RUNTIME
 }
 
 add_device() {
@@ -529,6 +533,17 @@ XCODEBUILD_EXIT=23 run_wrapper --agent build2 --session collab -- xcodebuild tes
 status=$?
 set -e
 [[ "$status" -eq 23 ]] || fail "expected xcodebuild exit 23, got $status"
+
+reset_case rejected-xcpretty-unavailable
+set +e
+output=$(XCPRETTY_PREFLIGHT_EXIT=19 run_wrapper \
+  --agent build2 --session collab --xcpretty -- xcodebuild test 2>&1)
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"xcpretty"* ]]; then
+  fail "unavailable xcpretty must be named and rejected: $output"
+fi
+[[ ! -s "$GATE_LOG" ]] || fail "unavailable xcpretty reached the gate"
 
 reset_case formatted-preflight-status
 set +e

--- a/scripts/test-xcode-stream.sh
+++ b/scripts/test-xcode-stream.sh
@@ -534,6 +534,23 @@ status=$?
 set -e
 [[ "$status" -eq 23 ]] || fail "expected xcodebuild exit 23, got $status"
 
+reset_case rejected-missing-bundle
+mkdir -p "$CASE_ROOT/no-bundle-bin"
+cat >"$CASE_ROOT/no-bundle-bin/dirname" <<'EOF'
+#!/opt/homebrew/bin/bash
+exec /usr/bin/dirname "$@"
+EOF
+chmod +x "$CASE_ROOT/no-bundle-bin/dirname"
+set +e
+output=$(PATH="$CASE_ROOT/no-bundle-bin" "$WRAPPER" \
+  --agent build2 --session collab --xcpretty -- xcodebuild test 2>&1)
+status=$?
+set -e
+if [[ "$status" -ne 127 || "$output" != *"bundle"* ]]; then
+  fail "missing bundle must exit 127 and name bundle: exit=$status output=$output"
+fi
+[[ ! -s "$GATE_LOG" ]] || fail "missing bundle reached the gate"
+
 reset_case rejected-xcpretty-unavailable
 set +e
 output=$(XCPRETTY_PREFLIGHT_EXIT=19 run_wrapper \

--- a/scripts/xcode-stream.sh
+++ b/scripts/xcode-stream.sh
@@ -242,7 +242,12 @@ reject_shell_mediated_xcodebuild "${command[@]}"
 [[ "$use_xcpretty" != true || "${command[0]##*/}" == "xcodebuild" ]] ||
   die "--xcpretty requires xcodebuild immediately after --"
 if [[ "$use_xcpretty" == true ]]; then
-  command -v bundle >/dev/null || die "bundle not found; --xcpretty requires bundle exec xcpretty"
+  command -v bundle >/dev/null || {
+    echo "xcode-stream: bundle not found; --xcpretty requires bundle exec xcpretty" >&2
+    exit 127
+  }
+  bundle exec xcpretty --version >/dev/null 2>&1 ||
+    die "xcpretty unavailable; run bundle install before using --xcpretty"
 fi
 owner_args=(--project "$PROJECT" --agent "$agent")
 if [[ -n "$session" ]]; then


### PR DESCRIPTION
## Summary

- preflight external commands in the remaining schema and Fastlane shell scripts
- discover `cktool`, Fastlane, and `xcpretty` through `xcrun` and Bundler without pinning installation paths
- reject unavailable formatting dependencies before the simulator gate or XCTestDevices census is touched
- record the maintainer rule that scripts should be safe and deterministic
- advance the app to 2.0.21 (40) after merging the preceding census release bump

## Failure contract

- missing executables return 127 and name the command
- an unavailable Xcode-bundled tool or Bundler-resolved executable returns 1 and names the dependency
- schema export, `xcodebuild`, and formatter runtime failures retain their existing exact statuses
- hermetic schema and credential fixtures continue to use fake `xcrun` and `op` commands

The refusal tests verify effects rather than source text: unavailable `cktool` never reaches schema export, missing `op` never invokes Bundler, and missing `bundle` or `xcpretty` leaves the simulator-gate log empty. The merged #400 census tests also remain green, proving these checks run before census and slot acquisition.

## Verification

- Bash syntax checks and ShellCheck on all six changed shell files
- `scripts/test-check-prod-schema.sh`
- `scripts/test-fastlane-credential-routing.sh`
- `scripts/test-fastlane-gates.sh`
- expanded `scripts/test-xcode-stream.sh`
- `scripts/test-check-version-increment.sh`
- C2 and sync guards
- log privacy lint: 232 files discovered/analyzed, 500 sites, 0 annotations
- `git diff --check` and current-main ancestry
- independent AMQ review: READY at `f1cacbf`, no Critical, Important, or Minor findings

Closes #403
