### PR TITLE
Pin log privacy lint to system Ruby

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -562,7 +562,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "command -v ruby >/dev/null 2>&1 || {\n  echo \"error: Log Privacy Lint requires ruby on PATH\" >&2\n  exit 2\n}\nruby \"${SRCROOT}/scripts/check-log-privacy.rb\" --root \"${SRCROOT}\"\n";
+			shellScript = "[ -x /usr/bin/ruby ] || {\n  echo \"error: Log Privacy Lint requires macOS system Ruby at /usr/bin/ruby\" >&2\n  exit 2\n}\n/usr/bin/ruby \"${SRCROOT}/scripts/check-log-privacy.rb\" --root \"${SRCROOT}\"\n";
 		};
 		D472D4332F3200DE00AA3453 /* Concurrency Escape Hatch Lint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -703,7 +703,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -714,7 +714,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.21;
+				MARKETING_VERSION = 2.0.22;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -735,7 +735,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -746,7 +746,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.21;
+				MARKETING_VERSION = 2.0.22;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -894,7 +894,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -922,7 +922,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.21;
+				MARKETING_VERSION = 2.0.22;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -948,7 +948,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -976,7 +976,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.21;
+				MARKETING_VERSION = 2.0.22;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -998,12 +998,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.21;
+				MARKETING_VERSION = 2.0.22;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1024,12 +1024,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.21;
+				MARKETING_VERSION = 2.0.22;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1049,12 +1049,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.21;
+				MARKETING_VERSION = 2.0.22;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1074,12 +1074,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.21;
+				MARKETING_VERSION = 2.0.22;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1100,7 +1100,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1111,7 +1111,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.21;
+				MARKETING_VERSION = 2.0.22;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1132,7 +1132,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1143,7 +1143,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.21;
+				MARKETING_VERSION = 2.0.22;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1178,7 +1178,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.21;
+				MARKETING_VERSION = 2.0.22;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1201,7 +1201,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
+				CURRENT_PROJECT_VERSION = 41;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1212,7 +1212,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.21;
+				MARKETING_VERSION = 2.0.22;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/docs/superpowers/plans/2026-08-11-issue-406-log-privacy-ruby.md
+++ b/docs/superpowers/plans/2026-08-11-issue-406-log-privacy-ruby.md
@@ -1,0 +1,214 @@
+# Deterministic Log Privacy Ruby Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Log Privacy Lint behave identically in GUI Xcode, CLI builds, and agent runs by shipping and testing against macOS system Ruby 2.6.
+
+**Architecture:** The Xcode phase and fixture analyzer subprocesses use absolute `/usr/bin/ruby`, guarded by a named executable preflight. Both Ruby scripts load their own standard-library dependencies, and the analyzer replaces its sole Ruby-2.7 API with a Ruby-2.6 equivalent while preserving all 52 privacy outcomes.
+
+**Tech Stack:** Ruby 2.6 and Ruby 4, Xcode PBX shell phase, Open3 fixture harness, RuboCop.
+
+## Global Constraints
+
+- The shipped analyzer runtime is `/usr/bin/ruby`; no PATH lookup may select the build-phase interpreter.
+- The phase must fail with status 2 and name `/usr/bin/ruby` if the executable is unavailable.
+- The complete 52-case suite must pass under both `/usr/bin/ruby` and PATH `ruby`.
+- Every fixture analyzer subprocess must use `/usr/bin/ruby`, including when the harness runs under PATH Ruby.
+- Privacy findings, diagnostics, baselines, Swift fixtures, and Fastlane runtime behavior must not change.
+- MARKETING_VERSION increases from 2.0.21 to 2.0.22 and CURRENT_PROJECT_VERSION from 40 to 41.
+- Commits remain signed; never amend or force-push; request independent review before merge.
+
+---
+
+### Task 1: Port analyzer and harness to the shipped Ruby runtime
+
+**Files:**
+- Modify: `scripts/check-log-privacy.rb:1-8,597-615`
+- Modify: `scripts/test-check-log-privacy.rb:1-12,430-433`
+
+**Interfaces:**
+- Consumes: `/usr/bin/ruby`, Ruby standard libraries `pathname`, `set`, and `optparse`.
+- Produces: `SYSTEM_RUBY = '/usr/bin/ruby'` in the fixture harness and Ruby-2.6-compatible analyzer execution.
+
+- [ ] **Step 1: Preserve the RED evidence**
+
+Run on the unmodified implementation commit:
+
+```bash
+/usr/bin/ruby scripts/test-check-log-privacy.rb
+```
+
+Expected: exit 1 with `undefined method 'Pathname'` at harness line 7. Also run the analyzer directly and with explicit standard libraries to record its two-stage failure:
+
+```bash
+/usr/bin/ruby scripts/check-log-privacy.rb --root .
+/usr/bin/ruby -rpathname -rset scripts/check-log-privacy.rb --root .
+```
+
+Expected: missing `Pathname`, followed by missing `filter_map` at analyzer line 599.
+
+- [ ] **Step 2: Load standard-library dependencies explicitly**
+
+At the analyzer top, use:
+
+```ruby
+require 'optparse'
+require 'pathname'
+require 'set'
+```
+
+At the fixture harness top, use:
+
+```ruby
+require 'fileutils'
+require 'open3'
+require 'pathname'
+require 'tmpdir'
+```
+
+- [ ] **Step 3: Pin fixture subprocesses to system Ruby**
+
+Define beside the existing path constants:
+
+```ruby
+SYSTEM_RUBY = '/usr/bin/ruby'
+```
+
+and change the subprocess boundary to:
+
+```ruby
+Open3.capture3(SYSTEM_RUBY, ANALYZER.to_s, '--root', root.to_s)
+```
+
+- [ ] **Step 4: Replace `filter_map` without changing results**
+
+Change `analyze_interpolations` to collect with:
+
+```ruby
+call.interpolations.each_with_object([]) do |interpolation, findings|
+  expression = interpolation.expression.strip
+  next if safe_expression?(expression)
+
+  if sensitive_display_name?(expression)
+    declarations ||= declarations_before(call, lexer)
+    next if safe_presentation_display_name?(expression, declarations)
+  end
+
+  message = violation_message(expression)
+  finding =
+    if message
+      Finding.new(path: call.path, line: interpolation.line, message: message)
+    elsif (identifier = semantic_identifier(expression))
+      analyze_semantic_origin(identifier, call, interpolation, lexer)
+    end
+  findings << finding if finding
+end
+```
+
+- [ ] **Step 5: Run GREEN under system Ruby**
+
+Run:
+
+```bash
+/usr/bin/ruby scripts/test-check-log-privacy.rb
+```
+
+Expected: `PASS: 52 log privacy lint cases`.
+
+### Task 2: Pin the Xcode build phase and verify interpreter parity
+
+**Files:**
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj:565`
+- Test: `scripts/test-check-log-privacy.rb`
+
+**Interfaces:**
+- Consumes: system-Ruby-compatible analyzer from Task 1.
+- Produces: a deterministic Log Privacy Lint phase with a named dependency error.
+
+- [ ] **Step 1: Replace the PATH-dependent phase command**
+
+Set the phase script to the PBX-escaped equivalent of:
+
+```sh
+[ -x /usr/bin/ruby ] || {
+  echo "error: Log Privacy Lint requires macOS system Ruby at /usr/bin/ruby" >&2
+  exit 2
+}
+/usr/bin/ruby "${SRCROOT}/scripts/check-log-privacy.rb" --root "${SRCROOT}"
+```
+
+- [ ] **Step 2: Run the full fixture suite under both harness interpreters**
+
+Run:
+
+```bash
+/usr/bin/ruby scripts/test-check-log-privacy.rb
+ruby scripts/test-check-log-privacy.rb
+```
+
+Expected from each: `PASS: 52 log privacy lint cases`. The analyzer subprocess is `/usr/bin/ruby` in both runs.
+
+- [ ] **Step 3: Run system-Ruby production analysis and syntax checks**
+
+Run:
+
+```bash
+/usr/bin/ruby scripts/check-log-privacy.rb --root .
+/usr/bin/ruby -c scripts/check-log-privacy.rb
+/usr/bin/ruby -c scripts/test-check-log-privacy.rb
+```
+
+Expected: production lint passes with discovered/analyzed totals equal; both syntax checks say `Syntax OK`.
+
+- [ ] **Step 4: Run project Ruby lint and inspect the phase**
+
+Run:
+
+```bash
+bundle exec rubocop scripts/check-log-privacy.rb scripts/test-check-log-privacy.rb
+rg -n "Log Privacy Lint requires|command -v ruby|/usr/bin/ruby" FamilyFoqos.xcodeproj/project.pbxproj
+```
+
+Expected: RuboCop reports no offenses; the phase contains the named `/usr/bin/ruby` preflight and invocation, with no `command -v ruby`.
+
+### Task 3: Version, review, and publish
+
+**Files:**
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj` version settings
+- Include: `docs/superpowers/specs/2026-08-11-issue-406-log-privacy-ruby-design.md`
+- Include: `docs/superpowers/plans/2026-08-11-issue-406-log-privacy-ruby.md`
+
+**Interfaces:**
+- Consumes: the dual-interpreter GREEN implementation.
+- Produces: a signed, reviewed, merge-ready PR closing issue #406.
+
+- [ ] **Step 1: Apply the required version increment**
+
+Replace every consistent project setting:
+
+```text
+MARKETING_VERSION = 2.0.21 -> 2.0.22
+CURRENT_PROJECT_VERSION = 40 -> 41
+```
+
+- [ ] **Step 2: Commit implementation and plan**
+
+Stage only the project file, analyzer, harness, and plan; create a new signed commit. Do not amend the two design commits.
+
+- [ ] **Step 3: Run fresh post-commit verification**
+
+Repeat both full fixture-suite commands, production analysis, both Ruby 2.6 syntax checks, RuboCop, `git diff --check`, and:
+
+```bash
+scripts/check-version-increment.sh origin/main HEAD
+```
+
+Expected version-gate output: 2.0.21 -> 2.0.22 and 40 -> 41.
+
+- [ ] **Step 4: Request independent read-only review**
+
+Provide the reviewer base `cd6d1f4`, the final head, this plan, exact RED/GREEN evidence, and attention points: build-phase preflight, analyzer subprocess pin, Ruby-2.6 API parity, unchanged privacy outcomes, and dual-interpreter semantics. The reviewer must not run Xcode builds or simulator tests.
+
+- [ ] **Step 5: Publish merge-ready**
+
+After review readiness and fresh verification, push `fix/406-pin-log-privacy-ruby` and open an un-drafted PR with `Closes #406`. Wait for all required checks, then hand the clean PR to the planner for merge.

--- a/docs/superpowers/specs/2026-08-11-issue-406-log-privacy-ruby-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-406-log-privacy-ruby-design.md
@@ -1,0 +1,82 @@
+# Issue #406: Deterministic Log Privacy Ruby Design
+
+## Context
+
+The Log Privacy Lint build phase currently checks `command -v ruby` and invokes the first Ruby on
+`PATH`. Agent shells resolve Homebrew Ruby 4.0.6, while GUI Xcode resolves macOS system Ruby 2.6.10.
+The same build guard therefore passes or crashes depending on how Xcode was launched, blocking
+maintainer device testing.
+
+The failure is reproducible and bounded:
+
+- `/usr/bin/ruby scripts/test-check-log-privacy.rb` crashes because the harness uses `Pathname`
+  without requiring `pathname`.
+- `/usr/bin/ruby scripts/check-log-privacy.rb --root .` reaches the same missing dependency in the
+  analyzer.
+- Explicitly loading `pathname` and `set` reaches `Enumerable#filter_map`, which is unavailable in
+  Ruby 2.6.
+- A diagnostic shim for those three deltas makes all 52 fixtures and the production-tree analysis
+  pass under system Ruby. A repository-wide Ruby API audit found no other post-2.6 method usage.
+
+## Decision
+
+System Ruby is the runtime contract for the build guard.
+
+- The Xcode build phase invokes `/usr/bin/ruby` directly. It performs no interpreter lookup and
+  does not depend on GUI or shell `PATH` configuration.
+- The fixture harness invokes every analyzer subprocess with `/usr/bin/ruby`, matching the runtime
+  shipped by the build phase even when the harness itself runs under another Ruby.
+- Both analyzer and fixture harness explicitly load `pathname`; the analyzer also explicitly loads
+  `set` because it constructs `Set` instances.
+- `filter_map` becomes a Ruby-2.6-compatible `each_with_object([])` implementation with identical
+  behavior: safe or unclassified interpolations add nothing, and findings append to the result.
+
+The build phase remains the effect-based enforcement point. Any future analyzer use of a runtime API
+missing from system Ruby will fail every build rather than passing under one developer's PATH.
+
+## Alternatives Rejected
+
+### Pin Homebrew Ruby
+
+An absolute `/opt/homebrew/bin/ruby` path is not guaranteed on Intel Macs or machines without that
+Homebrew installation. Looking up `brew --prefix ruby` reintroduces an external build dependency and
+GUI environment variance. This does not satisfy deterministic local builds.
+
+### Vendor or manage a Ruby runtime
+
+A bundled runtime, version manager, or Gem-based toolchain would make a standard-library-only build
+guard depend on installation and maintenance machinery. The analyzer needs only Ruby 2.6-compatible
+APIs, so that dependency has no compensating value.
+
+## Test Strategy
+
+The existing 52-case fixture suite is the behavioral oracle; privacy classifications and diagnostics
+must not change.
+
+The RED baseline is the unmodified system-Ruby suite crash. After the port, verification runs the
+complete suite twice:
+
+```bash
+/usr/bin/ruby scripts/test-check-log-privacy.rb
+ruby scripts/test-check-log-privacy.rb
+```
+
+In the first run, both harness and analyzer subprocesses use system Ruby. In the second, the harness
+uses PATH Ruby while analyzer subprocesses remain pinned to the shipped system runtime. Thus every
+fixture always exercises the deployed analyzer interpreter, while the harness remains compatible
+with the developer runtime too.
+
+Additional verification runs Ruby 2.6 syntax checks for both scripts, RuboCop under the project
+bundle, the analyzer against the production tree with `/usr/bin/ruby`, and a static inspection of the
+Xcode phase confirming `/usr/bin/ruby` replaces `command -v ruby` and the bare `ruby` invocation.
+
+## Scope
+
+Files changed by implementation:
+
+- `FamilyFoqos.xcodeproj/project.pbxproj`
+- `scripts/check-log-privacy.rb`
+- `scripts/test-check-log-privacy.rb`
+- project version settings, from 2.0.21/build 40 to 2.0.22/build 41
+
+No privacy policy, fixtures, baselines, Swift sources, Fastlane runtime, or other scripts change.

--- a/docs/superpowers/specs/2026-08-11-issue-406-log-privacy-ruby-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-406-log-privacy-ruby-design.md
@@ -68,6 +68,11 @@ uses PATH Ruby while analyzer subprocesses remain pinned to the shipped system r
 fixture always exercises the deployed analyzer interpreter, while the harness remains compatible
 with the developer runtime too.
 
+Both scripts run under macOS system Ruby (`/usr/bin/ruby`, currently 2.6) and therefore must use only
+Ruby 2.6-compatible APIs. The project's RuboCop configuration targets Ruby 4.0 and will not catch
+compatibility violations; it is a style check, not the compatibility guard. The complete
+dual-interpreter fixture suite is that guard and must be run under `/usr/bin/ruby`.
+
 Additional verification runs Ruby 2.6 syntax checks for both scripts, RuboCop under the project
 bundle, the analyzer against the production tree with `/usr/bin/ruby`, and a static inspection of the
 Xcode phase confirming `/usr/bin/ruby` replaces `command -v ruby` and the bare `ruby` invocation.

--- a/docs/superpowers/specs/2026-08-11-issue-406-log-privacy-ruby-design.md
+++ b/docs/superpowers/specs/2026-08-11-issue-406-log-privacy-ruby-design.md
@@ -22,8 +22,10 @@ The failure is reproducible and bounded:
 
 System Ruby is the runtime contract for the build guard.
 
-- The Xcode build phase invokes `/usr/bin/ruby` directly. It performs no interpreter lookup and
-  does not depend on GUI or shell `PATH` configuration.
+- The Xcode build phase first checks `[ -x /usr/bin/ruby ]` and emits the named dependency error
+  `Log Privacy Lint requires macOS system Ruby at /usr/bin/ruby` if it is unavailable, then invokes
+  `/usr/bin/ruby` directly. It performs no interpreter lookup and does not depend on GUI or shell
+  `PATH` configuration.
 - The fixture harness invokes every analyzer subprocess with `/usr/bin/ruby`, matching the runtime
   shipped by the build phase even when the harness itself runs under another Ruby.
 - Both analyzer and fixture harness explicitly load `pathname`; the analyzer also explicitly loads

--- a/scripts/check-log-privacy.rb
+++ b/scripts/check-log-privacy.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 require 'optparse'
+# Ruby 2.6 does not preload these constants when Xcode launches the analyzer.
+# rubocop:disable Lint/RedundantRequireStatement
+require 'pathname'
+require 'set'
+# rubocop:enable Lint/RedundantRequireStatement
 
 module LogPrivacy
   PRODUCTION_ROOTS = %w[
@@ -596,7 +601,7 @@ module LogPrivacy
 
     def analyze_interpolations(call, lexer)
       declarations = nil
-      call.interpolations.filter_map do |interpolation|
+      call.interpolations.each_with_object([]) do |interpolation, findings|
         expression = interpolation.expression.strip
         next if safe_expression?(expression)
 
@@ -606,11 +611,13 @@ module LogPrivacy
         end
 
         message = violation_message(expression)
-        if message
-          Finding.new(path: call.path, line: interpolation.line, message: message)
-        elsif (identifier = semantic_identifier(expression))
-          analyze_semantic_origin(identifier, call, interpolation, lexer)
-        end
+        finding =
+          if message
+            Finding.new(path: call.path, line: interpolation.line, message: message)
+          elsif (identifier = semantic_identifier(expression))
+            analyze_semantic_origin(identifier, call, interpolation, lexer)
+          end
+        findings << finding if finding
       end
     end
 

--- a/scripts/check-log-privacy.rb
+++ b/scripts/check-log-privacy.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# Runs under macOS system Ruby (/usr/bin/ruby, currently 2.6): use only 2.6-compatible APIs.
+# RuboCop targets Ruby 4.0 and will not catch violations; the dual-interpreter fixture suite is the
+# only guard, so run it under /usr/bin/ruby.
+
 require 'optparse'
 # Ruby 2.6 does not preload these constants when Xcode launches the analyzer.
 # rubocop:disable Lint/RedundantRequireStatement

--- a/scripts/test-check-log-privacy.rb
+++ b/scripts/test-check-log-privacy.rb
@@ -2,8 +2,13 @@
 
 require 'fileutils'
 require 'open3'
+# Ruby 2.6 does not preload Pathname when it launches the fixture harness.
+# rubocop:disable Lint/RedundantRequireStatement
+require 'pathname'
+# rubocop:enable Lint/RedundantRequireStatement
 require 'tmpdir'
 
+SYSTEM_RUBY = '/usr/bin/ruby'
 REPO_ROOT = Pathname(__dir__).parent.freeze
 ANALYZER = REPO_ROOT.join('scripts/check-log-privacy.rb').freeze
 FIXTURE_ROOT = REPO_ROOT.join('scripts/fixtures/log-privacy').freeze
@@ -428,7 +433,7 @@ def with_fixture_root(fixture:, site_floor:, annotation_count:)
 end
 
 def run_analyzer(root)
-  Open3.capture3(RbConfig.ruby, ANALYZER.to_s, '--root', root.to_s)
+  Open3.capture3(SYSTEM_RUBY, ANALYZER.to_s, '--root', root.to_s)
 end
 
 def result_matches?(

--- a/scripts/test-check-log-privacy.rb
+++ b/scripts/test-check-log-privacy.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# Runs under macOS system Ruby (/usr/bin/ruby, currently 2.6): use only 2.6-compatible APIs.
+# RuboCop targets Ruby 4.0 and will not catch violations; the dual-interpreter fixture suite is the
+# only guard, so run it under /usr/bin/ruby.
+
 require 'fileutils'
 require 'open3'
 # Ruby 2.6 does not preload Pathname when it launches the fixture harness.


### PR DESCRIPTION
## Summary

- pin the Xcode Log Privacy Lint phase and fixture analyzer subprocesses to macOS system Ruby
- explicitly load Ruby 2.6 standard-library dependencies and replace the sole Ruby-2.7 API
- verify all 52 privacy fixtures under both system Ruby 2.6 and PATH Ruby 4
- increment the app version to 2.0.22 (build 41)

## Root cause

The build phase selected `ruby` through PATH. GUI Xcode resolves `/usr/bin/ruby` 2.6, while agent shells resolve Homebrew Ruby 4.0.6. The analyzer and harness relied on Ruby 4's incidental preloads for `Pathname` and `Set`, and the analyzer used `filter_map`, which Ruby 2.6 does not provide.

The phase now performs a named `/usr/bin/ruby` executable preflight and invokes that interpreter absolutely. Fixture analyzer subprocesses use the same shipped runtime, and `each_with_object` preserves the existing privacy findings without requiring Ruby 2.7.

## Validation

- RED: `/usr/bin/ruby scripts/test-check-log-privacy.rb` failed on missing `Pathname`; the analyzer then failed on `filter_map` after explicit stdlib loading
- diagnostic compatibility shim proved the port was bounded: all 52 fixtures passed under Ruby 2.6 with only `pathname`, `set`, and `filter_map` compatibility supplied
- `/usr/bin/ruby scripts/test-check-log-privacy.rb` — 52 cases pass
- `ruby scripts/test-check-log-privacy.rb` — 52 cases pass
- `/usr/bin/ruby scripts/check-log-privacy.rb --root .` — 232/232 files and 500 sites analyzed
- Ruby 2.6 syntax checks — both scripts pass
- RuboCop — no offenses
- version gate — 2.0.21/40 → 2.0.22/41

Closes #406
