### PR TITLE
Make log privacy lint locale-independent

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -714,7 +714,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.22;
+				MARKETING_VERSION = 2.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -735,7 +735,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -746,7 +746,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.22;
+				MARKETING_VERSION = 2.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -894,7 +894,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -922,7 +922,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.22;
+				MARKETING_VERSION = 2.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -948,7 +948,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -976,7 +976,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.22;
+				MARKETING_VERSION = 2.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -998,12 +998,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.22;
+				MARKETING_VERSION = 2.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1024,12 +1024,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.22;
+				MARKETING_VERSION = 2.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1049,12 +1049,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.22;
+				MARKETING_VERSION = 2.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1074,12 +1074,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.22;
+				MARKETING_VERSION = 2.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1100,7 +1100,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1111,7 +1111,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.22;
+				MARKETING_VERSION = 2.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1132,7 +1132,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1143,7 +1143,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.22;
+				MARKETING_VERSION = 2.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1178,7 +1178,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.22;
+				MARKETING_VERSION = 2.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1201,7 +1201,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 41;
+				CURRENT_PROJECT_VERSION = 42;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1212,7 +1212,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.22;
+				MARKETING_VERSION = 2.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/docs/superpowers/plans/2026-08-12-issue-408-log-privacy-utf8.md
+++ b/docs/superpowers/plans/2026-08-12-issue-408-log-privacy-utf8.md
@@ -1,0 +1,237 @@
+# Locale-Independent Log Privacy UTF-8 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Log Privacy Lint decode all text inputs as UTF-8 and keep its complete fixture suite green when macOS system Ruby has no locale variables.
+
+**Architecture:** The analyzer owns encoding at each `Pathname#read` boundary instead of mutating Ruby's process default or relying on launcher flags. The fixture harness removes `LANG`, `LC_ALL`, and `LC_CTYPE` from every pinned `/usr/bin/ruby` analyzer subprocess, permanently exercising the GUI Xcode environment.
+
+**Tech Stack:** Ruby 2.6 and Ruby 4, `Pathname`, `Open3`, Xcode project version settings, RuboCop.
+
+## Global Constraints
+
+- The shipped analyzer runtime remains `/usr/bin/ruby`; do not change the Xcode Log Privacy Lint phase command.
+- Use only APIs supported by macOS system Ruby 2.6; RuboCop targets Ruby 4.0 and is not the compatibility guard.
+- Decode every analyzer text input explicitly as `Encoding::UTF_8`; do not assign `Encoding.default_external` or add `-E` launcher flags.
+- Every fixture analyzer subprocess must remove `LANG`, `LC_ALL`, and `LC_CTYPE`.
+- Preserve all 52 fixture classifications, diagnostics, Swift fixtures, and baseline values.
+- Genuinely invalid UTF-8 must remain a loud nonzero failure; do not normalize or replace invalid bytes.
+- Increment `MARKETING_VERSION` from 2.0.22 to 2.0.23 and `CURRENT_PROJECT_VERSION` from 41 to 42.
+- Do not run Xcode or simulator tests; locale-stripped Ruby commands reproduce the exact GUI failure boundary.
+- Never amend or force-push. All commits must be signed, and independent review is required before merge.
+
+---
+
+### Task 1: Make the locale-stripped fixture condition permanent
+
+**Files:**
+- Modify: `scripts/test-check-log-privacy.rb:14-18,439-441`
+- Test: `scripts/fixtures/log-privacy/pass/lexer_boundaries.swift` through the existing harness case `lexer skips comments and string contents`
+
+**Interfaces:**
+- Consumes: `SYSTEM_RUBY = '/usr/bin/ruby'`, `Open3.capture3`, and the existing 52-case fixture suite.
+- Produces: `ANALYZER_ENVIRONMENT`, a frozen hash passed as the first argument to `Open3.capture3` so analyzer subprocesses run without locale variables.
+
+- [ ] **Step 1: Record the existing locale-stripped RED**
+
+Run:
+
+```bash
+env -u LANG -u LC_ALL -u LC_CTYPE /usr/bin/ruby scripts/test-check-log-privacy.rb
+```
+
+Expected: exit 1; `lexer skips comments and string contents` reports `invalid byte sequence in US-ASCII` from `SwiftLexer#code_mask`.
+
+- [ ] **Step 2: Add the GUI environment to the harness**
+
+Beside `SYSTEM_RUBY`, add:
+
+```ruby
+ANALYZER_ENVIRONMENT = {
+  'LANG' => nil,
+  'LC_ALL' => nil,
+  'LC_CTYPE' => nil
+}.freeze
+```
+
+Change `run_analyzer` to:
+
+```ruby
+def run_analyzer(root)
+  Open3.capture3(
+    ANALYZER_ENVIRONMENT,
+    SYSTEM_RUBY,
+    ANALYZER.to_s,
+    '--root',
+    root.to_s
+  )
+end
+```
+
+- [ ] **Step 3: Run the ordinary system-Ruby suite to verify the harness itself exposes the bug**
+
+Run:
+
+```bash
+/usr/bin/ruby scripts/test-check-log-privacy.rb
+```
+
+Expected: exit 1 with the same Unicode lexer fixture and US-ASCII error, proving ordinary harness runs now exercise the deployed GUI environment.
+
+### Task 2: Decode analyzer inputs explicitly as UTF-8
+
+**Files:**
+- Modify: `scripts/check-log-privacy.rb:431-436,507-510`
+- Test: `scripts/test-check-log-privacy.rb`
+
+**Interfaces:**
+- Consumes: production Swift paths and numeric baseline paths as `Pathname` values.
+- Produces: valid UTF-8 strings from `Pathname#read(encoding: Encoding::UTF_8)` under both terminal and GUI-like environments.
+
+- [ ] **Step 1: Pin production Swift source reads**
+
+In `Analyzer#analyze`, replace the implicit read with:
+
+```ruby
+source = file.read(encoding: Encoding::UTF_8)
+```
+
+- [ ] **Step 2: Pin baseline text reads**
+
+In `read_nonnegative_integer`, replace the implicit read with:
+
+```ruby
+value = path.read(encoding: Encoding::UTF_8)
+```
+
+- [ ] **Step 3: Run the complete suite under every required harness context**
+
+Run:
+
+```bash
+/usr/bin/ruby scripts/test-check-log-privacy.rb
+ruby scripts/test-check-log-privacy.rb
+env -u LANG -u LC_ALL -u LC_CTYPE /usr/bin/ruby scripts/test-check-log-privacy.rb
+```
+
+Expected from each: `PASS: 52 log privacy lint cases`. Every analyzer subprocess is system Ruby with locale variables removed; the third command also proves the harness itself works without a locale.
+
+- [ ] **Step 4: Verify production behavior is locale-independent by effect**
+
+Run:
+
+```bash
+/usr/bin/ruby scripts/check-log-privacy.rb --root .
+env -u LANG -u LC_ALL -u LC_CTYPE /usr/bin/ruby scripts/check-log-privacy.rb --root .
+```
+
+Expected from each: `files_discovered=232 files_analyzed=232 sites_analyzed=500 annotations=0`.
+
+### Task 3: Increment the application version and commit implementation
+
+**Files:**
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+- Include: `scripts/check-log-privacy.rb`
+- Include: `scripts/test-check-log-privacy.rb`
+
+**Interfaces:**
+- Consumes: the green locale-independent analyzer and harness from Tasks 1-2.
+- Produces: version 2.0.23/build 42 and one signed implementation commit without changes to the Log Privacy Lint phase command.
+
+- [ ] **Step 1: Update all consistent project version settings**
+
+Replace every project build-setting occurrence:
+
+```text
+MARKETING_VERSION = 2.0.22; -> MARKETING_VERSION = 2.0.23;
+CURRENT_PROJECT_VERSION = 41; -> CURRENT_PROJECT_VERSION = 42;
+```
+
+Do not modify the `shellScript` field for Log Privacy Lint.
+
+- [ ] **Step 2: Verify the version delta and Xcode phase stability before committing**
+
+Run:
+
+```bash
+git diff -- FamilyFoqos.xcodeproj/project.pbxproj
+rg -n 'Log Privacy Lint requires|/usr/bin/ruby' FamilyFoqos.xcodeproj/project.pbxproj
+```
+
+The raw diff must show only 2.0.22/41 to 2.0.23/42 changes in the project file. The phase inspection
+must show the existing named `/usr/bin/ruby` preflight and absolute invocation unchanged. The
+commit-range version gate runs after the implementation commit in Task 4.
+
+- [ ] **Step 3: Run syntax, style, and diff hygiene checks**
+
+Run:
+
+```bash
+/usr/bin/ruby -c scripts/check-log-privacy.rb
+/usr/bin/ruby -c scripts/test-check-log-privacy.rb
+bundle exec rubocop scripts/check-log-privacy.rb scripts/test-check-log-privacy.rb
+git diff --check
+```
+
+Expected: both syntax checks report `Syntax OK`, RuboCop reports no offenses, and diff check is silent.
+
+- [ ] **Step 4: Create a new signed implementation commit**
+
+Run:
+
+```bash
+git add FamilyFoqos.xcodeproj/project.pbxproj \
+  scripts/check-log-privacy.rb scripts/test-check-log-privacy.rb
+git commit -S -m "Pin log privacy text inputs to UTF-8"
+```
+
+Never amend the design or plan commit.
+
+### Task 4: Fresh verification, independent review, and publication
+
+**Files:**
+- Verify: all files changed from `origin/main` through final `HEAD`
+- Publish: branch `fix/408-pin-log-privacy-utf8`
+
+**Interfaces:**
+- Consumes: signed design, plan, and implementation commits plus issue #408.
+- Produces: an independently reviewed, undrafted, green PR closing #408 for planner merge.
+
+- [ ] **Step 1: Run all post-commit gates from the clean worktree**
+
+Run the three complete fixture-suite commands and both production-analysis commands from Task 2, then:
+
+```bash
+/usr/bin/ruby -c scripts/check-log-privacy.rb
+/usr/bin/ruby -c scripts/test-check-log-privacy.rb
+bundle exec rubocop scripts/check-log-privacy.rb scripts/test-check-log-privacy.rb
+scripts/check-version-increment.sh origin/main HEAD
+git diff --check origin/main...HEAD
+git status --porcelain=v1
+git log --show-signature --format='%h %G? %s' origin/main..HEAD
+```
+
+Expected: all suites pass 52 cases; both production runs report identical 232/232 and 500-site totals; syntax, style, version, and diff gates pass; status is empty; every commit has a good signature.
+
+- [ ] **Step 2: Request independent AMQ review**
+
+Send the reviewer the base `814c961`, final head, issue #408, design and plan paths, exact RED/GREEN evidence, and these attention points:
+
+```text
+- UTF-8 is explicit at every analyzer text read boundary.
+- Harness analyzer subprocesses always remove LANG/LC_ALL/LC_CTYPE.
+- No process-global encoding mutation or -E launcher flag exists.
+- Xcode build-phase command is unchanged.
+- All privacy outcomes and counts are unchanged.
+- Version is exactly 2.0.23/build 42.
+```
+
+The reviewer must not run Xcode or simulator work. Resolve every actionable finding with a new signed commit, never an amend, and request a delta review.
+
+- [ ] **Step 3: Push and open an undrafted PR after reviewer readiness**
+
+Push `fix/408-pin-log-privacy-utf8`, then create an undrafted PR against `main` with `Closes #408`. Include the root cause, the incidental privacy-prompt ruling, and all verification commands/results.
+
+- [ ] **Step 4: Hand merge ownership to the planner**
+
+Confirm the PR is not a draft and required GitHub checks have started. Send the planner the PR URL, reviewed head, verification evidence, and current check state. The planner merges after required checks; do not merge locally or through GitHub yourself.

--- a/docs/superpowers/plans/2026-08-12-issue-408-log-privacy-utf8.md
+++ b/docs/superpowers/plans/2026-08-12-issue-408-log-privacy-utf8.md
@@ -14,8 +14,8 @@
 - Use only APIs supported by macOS system Ruby 2.6; RuboCop targets Ruby 4.0 and is not the compatibility guard.
 - Decode every analyzer text input explicitly as `Encoding::UTF_8`; do not assign `Encoding.default_external` or add `-E` launcher flags.
 - Every fixture analyzer subprocess must remove `LANG`, `LC_ALL`, and `LC_CTYPE`.
-- Preserve all 52 fixture classifications, diagnostics, Swift fixtures, and baseline values.
-- Genuinely invalid UTF-8 must remain a loud nonzero failure; do not normalize or replace invalid bytes.
+- Preserve all 52 existing privacy-case classifications, diagnostics, Swift fixtures, and baseline values.
+- Genuinely invalid UTF-8 must produce a named nonzero file diagnostic; do not normalize or replace invalid bytes.
 - Increment `MARKETING_VERSION` from 2.0.22 to 2.0.23 and `CURRENT_PROJECT_VERSION` from 41 to 42.
 - Do not run Xcode or simulator tests; locale-stripped Ruby commands reproduce the exact GUI failure boundary.
 - Never amend or force-push. All commits must be signed, and independent review is required before merge.
@@ -29,7 +29,7 @@
 - Test: `scripts/fixtures/log-privacy/pass/lexer_boundaries.swift` through the existing harness case `lexer skips comments and string contents`
 
 **Interfaces:**
-- Consumes: `SYSTEM_RUBY = '/usr/bin/ruby'`, `Open3.capture3`, and the existing 52-case fixture suite.
+- Consumes: `SYSTEM_RUBY = '/usr/bin/ruby'`, `Open3.capture3`, and the existing 52-case privacy suite.
 - Produces: `ANALYZER_ENVIRONMENT`, a frozen hash passed as the first argument to `Open3.capture3` so analyzer subprocesses run without locale variables.
 
 - [ ] **Step 1: Record the existing locale-stripped RED**
@@ -104,7 +104,15 @@ In `read_nonnegative_integer`, replace the implicit read with:
 value = path.read(encoding: Encoding::UTF_8)
 ```
 
-- [ ] **Step 3: Run the complete suite under every required harness context**
+- [ ] **Step 3: Add a named invalid-UTF-8 regression case**
+
+Use `with_fixture_root` to overwrite its temporary `Foqos/Fixture.swift` with
+`File.binwrite(destination, [0xFF].pack('C'))`. Run the real analyzer and require status 2 plus the
+literal diagnostic `Foqos/Fixture.swift:1: error: invalid byte sequence in UTF-8`. Add
+`ArgumentError` to the existing per-file rescue list so the analyzer converts the exception into a
+path-bearing `Finding` without accepting the damaged file.
+
+- [ ] **Step 4: Run the complete suite under every required harness context**
 
 Run:
 
@@ -114,9 +122,9 @@ ruby scripts/test-check-log-privacy.rb
 env -u LANG -u LC_ALL -u LC_CTYPE /usr/bin/ruby scripts/test-check-log-privacy.rb
 ```
 
-Expected from each: `PASS: 52 log privacy lint cases`. Every analyzer subprocess is system Ruby with locale variables removed; the third command also proves the harness itself works without a locale.
+Expected from each: `PASS: 53 log privacy lint cases`. Every analyzer subprocess is system Ruby with locale variables removed; the third command also proves the harness itself works without a locale.
 
-- [ ] **Step 4: Verify production behavior is locale-independent by effect**
+- [ ] **Step 5: Verify production behavior is locale-independent by effect**
 
 Run:
 
@@ -211,7 +219,7 @@ git status --porcelain=v1
 git log --show-signature --format='%h %G? %s' origin/main..HEAD
 ```
 
-Expected: all suites pass 52 cases; both production runs report identical 232/232 and 500-site totals; syntax, style, version, and diff gates pass; status is empty; every commit has a good signature.
+Expected: all suites pass 53 cases; both production runs report identical 232/232 and 500-site totals; syntax, style, version, and diff gates pass; status is empty; every commit has a good signature.
 
 - [ ] **Step 2: Request independent AMQ review**
 

--- a/docs/superpowers/specs/2026-08-12-issue-408-log-privacy-utf8-design.md
+++ b/docs/superpowers/specs/2026-08-12-issue-408-log-privacy-utf8-design.md
@@ -1,0 +1,153 @@
+# Issue #408: Locale-Independent Log Privacy UTF-8 Design
+
+## Context
+
+PR #407 made `/usr/bin/ruby` 2.6 the deterministic runtime for the Log Privacy Lint phase, but the
+analyzer still inherits that process's external text encoding. Terminal sessions provide a UTF-8
+locale, while GUI Xcode launches build phases without `LANG`, `LC_ALL`, or `LC_CTYPE`. In that GUI
+environment, system Ruby selects US-ASCII as `Encoding.default_external`.
+
+The analyzer currently reads Swift files with `Pathname#read`. Under the GUI environment, the first
+non-ASCII file in sorted production order,
+`Foqos/CloudKit/CloudKitNetworkService+Heartbeat.swift`, contains valid UTF-8 bytes but is tagged as
+invalid US-ASCII. `SwiftLexer#code_mask` raises `invalid byte sequence in US-ASCII` when its regular
+expression scans that string, blocking maintainer device builds.
+
+The causal boundary is reproducible without Xcode:
+
+```bash
+env -u LANG -u LC_ALL -u LC_CTYPE /usr/bin/ruby \
+  scripts/check-log-privacy.rb --root .
+```
+
+Changing only Ruby's external encoding with `-EUTF-8:UTF-8` makes the unchanged analyzer pass all
+232 files and 500 sites. The existing `lexer skips comments and string contents` fixture also
+contains Unicode and makes the complete fixture suite fail when run with the locale variables
+removed. No new fixture is necessary to preserve a RED regression.
+
+## Decision
+
+Text encoding belongs to the analyzer's file-read boundary, not to its launcher or process-global
+state.
+
+- Every analyzer text input is read explicitly as `Encoding::UTF_8`. This includes production Swift
+  sources and the two numeric baseline files. `Pathname#read(encoding: Encoding::UTF_8)` is supported
+  by the shipped macOS Ruby 2.6 runtime and returns the production source as valid UTF-8 even when
+  locale variables are absent.
+- The fixture harness always removes `LANG`, `LC_ALL`, and `LC_CTYPE` from analyzer subprocesses by
+  passing a frozen environment override to `Open3.capture3`. Every one of the existing 52 cases then
+  exercises the harshest deployed environment automatically, regardless of the terminal or harness
+  interpreter.
+- The Xcode phase remains unchanged. It already invokes `/usr/bin/ruby` absolutely and needs no
+  locale setup once the analyzer owns its input encoding.
+- Genuinely invalid UTF-8 remains a loud, nonzero analyzer failure. Adding a specialized per-file
+  diagnostic is outside this fix because no project input exhibits that condition and current
+  behavior already fails closed.
+
+This design preserves all privacy classifications, diagnostics, fixtures, and baselines. It changes
+only how existing bytes are decoded and how the harness constructs the analyzer environment.
+
+## Data Flow
+
+The deployed path becomes:
+
+```text
+GUI Xcode (locale absent)
+  -> /usr/bin/ruby scripts/check-log-privacy.rb
+  -> Pathname#read(encoding: UTF-8)
+  -> valid UTF-8 Swift string
+  -> unchanged lexer and privacy analysis
+```
+
+The regression path becomes:
+
+```text
+system-Ruby or PATH-Ruby fixture harness
+  -> Open3 environment removes LANG/LC_ALL/LC_CTYPE
+  -> /usr/bin/ruby analyzer subprocess
+  -> explicit UTF-8 reads
+  -> unchanged expected result for each of 52 fixtures
+```
+
+The harness remains compatible with both system Ruby 2.6 and the developer's PATH Ruby. Analyzer
+subprocesses remain pinned to `/usr/bin/ruby`, as established by #406.
+
+## Alternatives Rejected
+
+### Set `Encoding.default_external` globally
+
+Assigning `Encoding.default_external = Encoding::UTF_8` would be a smaller edit, but it mutates
+process-wide state and makes unrelated library or future file reads change behavior implicitly.
+Explicit read-boundary encoding documents which inputs carry the UTF-8 contract and keeps the effect
+local.
+
+### Pass `-EUTF-8:UTF-8` from launchers
+
+Adding `-E` to the Xcode phase and `Open3` command would fix those two launch paths, but direct
+analyzer invocations would remain locale-dependent. It would also duplicate an input-format
+requirement across callers. The analyzer must be deterministic on its own.
+
+## Error Handling
+
+Missing files and malformed numeric baselines retain their existing named, nonzero diagnostics.
+Unreadable files retain the existing fail-closed handling. Invalid UTF-8 remains nonzero rather than
+being normalized, replaced, or silently skipped; accepting damaged source would weaken a build
+guard.
+
+The macOS Privacy & Security prompt that concurrently said `ruby` was prevented from modifying a
+path is incidental to this encoding failure. The production analyzer has no write operations, the
+captured build log has no permission or sandbox denial, and the identical failure reproduces in a
+read-only shell run without the prompt. If that prompt recurs, its exact target path should be
+captured and investigated separately.
+
+## Test Strategy
+
+The unmodified RED commands are:
+
+```bash
+env -u LANG -u LC_ALL -u LC_CTYPE /usr/bin/ruby \
+  scripts/test-check-log-privacy.rb
+env -u LANG -u LC_ALL -u LC_CTYPE /usr/bin/ruby \
+  scripts/check-log-privacy.rb --root .
+```
+
+The suite fails the existing Unicode lexer fixture, and production analysis raises from
+`SwiftLexer#code_mask`.
+
+After implementation, run the complete suite through all required harness contexts:
+
+```bash
+/usr/bin/ruby scripts/test-check-log-privacy.rb
+ruby scripts/test-check-log-privacy.rb
+env -u LANG -u LC_ALL -u LC_CTYPE /usr/bin/ruby \
+  scripts/test-check-log-privacy.rb
+```
+
+Because the harness strips locale from every analyzer subprocess, all three commands enforce the GUI
+environment; the third additionally proves the harness itself works without a locale.
+
+Then verify the production analyzer by effect in both process environments:
+
+```bash
+/usr/bin/ruby scripts/check-log-privacy.rb --root .
+env -u LANG -u LC_ALL -u LC_CTYPE /usr/bin/ruby \
+  scripts/check-log-privacy.rb --root .
+```
+
+Both must report 232/232 files, 500 sites, and 0 annotations. Ruby 2.6 syntax checks, project RuboCop,
+`git diff --check`, and the version-increment gate complete verification. No Xcode or simulator run
+is required for this Ruby-only behavior because the stripped environment reproduces the exact GUI
+failure boundary.
+
+## Scope
+
+Implementation changes are limited to:
+
+- `scripts/check-log-privacy.rb`
+- `scripts/test-check-log-privacy.rb`
+- `FamilyFoqos.xcodeproj/project.pbxproj` version settings, from 2.0.22/build 41 to
+  2.0.23/build 42
+- this design and its implementation plan
+
+The build-phase command, Swift production sources, privacy rules, fixtures, baselines, and Fastlane
+runtime do not change.

--- a/docs/superpowers/specs/2026-08-12-issue-408-log-privacy-utf8-design.md
+++ b/docs/superpowers/specs/2026-08-12-issue-408-log-privacy-utf8-design.md
@@ -35,14 +35,13 @@ state.
   by the shipped macOS Ruby 2.6 runtime and returns the production source as valid UTF-8 even when
   locale variables are absent.
 - The fixture harness always removes `LANG`, `LC_ALL`, and `LC_CTYPE` from analyzer subprocesses by
-  passing a frozen environment override to `Open3.capture3`. Every one of the existing 52 cases then
-  exercises the harshest deployed environment automatically, regardless of the terminal or harness
-  interpreter.
+  passing a frozen environment override to `Open3.capture3`. Every case then exercises the harshest
+  deployed environment automatically, regardless of the terminal or harness interpreter.
 - The Xcode phase remains unchanged. It already invokes `/usr/bin/ruby` absolutely and needs no
   locale setup once the analyzer owns its input encoding.
-- Genuinely invalid UTF-8 remains a loud, nonzero analyzer failure. Adding a specialized per-file
-  diagnostic is outside this fix because no project input exhibits that condition and current
-  behavior already fails closed.
+- Genuinely invalid UTF-8 produces a named, nonzero Xcode-formatted diagnostic for the offending
+  file. The existing per-file rescue converts `ArgumentError` into a `Finding`; it does not normalize,
+  replace, or silently skip invalid bytes.
 
 This design preserves all privacy classifications, diagnostics, fixtures, and baselines. It changes
 only how existing bytes are decoded and how the harness constructs the analyzer environment.
@@ -66,7 +65,7 @@ system-Ruby or PATH-Ruby fixture harness
   -> Open3 environment removes LANG/LC_ALL/LC_CTYPE
   -> /usr/bin/ruby analyzer subprocess
   -> explicit UTF-8 reads
-  -> unchanged expected result for each of 52 fixtures
+  -> unchanged expected result for each privacy fixture
 ```
 
 The harness remains compatible with both system Ruby 2.6 and the developer's PATH Ruby. Analyzer
@@ -90,9 +89,10 @@ requirement across callers. The analyzer must be deterministic on its own.
 ## Error Handling
 
 Missing files and malformed numeric baselines retain their existing named, nonzero diagnostics.
-Unreadable files retain the existing fail-closed handling. Invalid UTF-8 remains nonzero rather than
-being normalized, replaced, or silently skipped; accepting damaged source would weaken a build
-guard.
+Unreadable files retain the existing fail-closed handling. A genuinely invalid UTF-8 source is
+converted at the per-file rescue boundary into `path:1: error: invalid byte sequence in UTF-8`, while
+the analyzer remains nonzero and reports incomplete file coverage. It is never normalized, replaced,
+or silently skipped; accepting damaged source would weaken a build guard.
 
 The macOS Privacy & Security prompt that concurrently said `ruby` was prevented from modifying a
 path is incidental to this encoding failure. The production analyzer has no write operations, the
@@ -112,7 +112,8 @@ env -u LANG -u LC_ALL -u LC_CTYPE /usr/bin/ruby \
 ```
 
 The suite fails the existing Unicode lexer fixture, and production analysis raises from
-`SwiftLexer#code_mask`.
+`SwiftLexer#code_mask`. A separate temporary invalid-byte case proves the pre-fix analyzer emits a
+raw backtrace without naming the offending Swift file.
 
 After implementation, run the complete suite through all required harness contexts:
 
@@ -124,7 +125,8 @@ env -u LANG -u LC_ALL -u LC_CTYPE /usr/bin/ruby \
 ```
 
 Because the harness strips locale from every analyzer subprocess, all three commands enforce the GUI
-environment; the third additionally proves the harness itself works without a locale.
+environment; the third additionally proves the harness itself works without a locale. Each reports
+53 cases: the unchanged 52 privacy cases plus the invalid-UTF-8 named-failure case.
 
 Then verify the production analyzer by effect in both process environments:
 

--- a/scripts/check-log-privacy.rb
+++ b/scripts/check-log-privacy.rb
@@ -442,7 +442,7 @@ module LogPrivacy
             findings.concat(analyze_interpolations(call, lexer))
           end
           analyzed += 1
-        rescue AnalysisError, Errno::EACCES, Errno::ENOENT => e
+        rescue AnalysisError, ArgumentError, Errno::EACCES, Errno::ENOENT => e
           line = e.respond_to?(:line) ? e.line : nil
           errors << Finding.new(
             path: file,

--- a/scripts/check-log-privacy.rb
+++ b/scripts/check-log-privacy.rb
@@ -431,7 +431,7 @@ module LogPrivacy
       files.each do |file|
         relative_path = file.relative_path_from(root).to_s
         begin
-          source = file.read
+          source = file.read(encoding: Encoding::UTF_8)
           lexer = SwiftLexer.new(file, source)
           calls = lexer.log_calls
           sites += calls.length
@@ -505,7 +505,7 @@ module LogPrivacy
     end
 
     def read_nonnegative_integer(path, label)
-      value = path.read
+      value = path.read(encoding: Encoding::UTF_8)
       return Integer(value, 10) if value.match?(/\A\d+\n?\z/)
 
       raise AnalysisError.new("malformed #{label}: #{path}", path: path, line: 1)

--- a/scripts/test-check-log-privacy.rb
+++ b/scripts/test-check-log-privacy.rb
@@ -582,9 +582,22 @@ with_fixture_root(fixture: 'pass/roster_display_name.swift', site_floor: 0, anno
   end
 end
 
+with_fixture_root(fixture: 'pass/roster_display_name.swift', site_floor: 0, annotation_count: 0) do |root, destination|
+  File.binwrite(destination, [0xFF].pack('C'))
+  stdout, stderr, status = run_analyzer(root)
+  failures += 1 unless result_matches?(
+    name: 'invalid UTF-8 names the discovered file',
+    expected_status: 2,
+    diagnostic: 'Foqos/Fixture.swift:1: error: invalid byte sequence in UTF-8',
+    stdout: stdout,
+    stderr: stderr,
+    process_status: status
+  )
+end
+
 if failures.positive?
   warn "FAIL: #{failures} log privacy lint test(s) failed"
   exit 1
 end
 
-puts "PASS: #{CASES.length + 6} log privacy lint cases"
+puts "PASS: #{CASES.length + 7} log privacy lint cases"

--- a/scripts/test-check-log-privacy.rb
+++ b/scripts/test-check-log-privacy.rb
@@ -13,6 +13,11 @@ require 'pathname'
 require 'tmpdir'
 
 SYSTEM_RUBY = '/usr/bin/ruby'
+ANALYZER_ENVIRONMENT = {
+  'LANG' => nil,
+  'LC_ALL' => nil,
+  'LC_CTYPE' => nil
+}.freeze
 REPO_ROOT = Pathname(__dir__).parent.freeze
 ANALYZER = REPO_ROOT.join('scripts/check-log-privacy.rb').freeze
 FIXTURE_ROOT = REPO_ROOT.join('scripts/fixtures/log-privacy').freeze
@@ -437,7 +442,13 @@ def with_fixture_root(fixture:, site_floor:, annotation_count:)
 end
 
 def run_analyzer(root)
-  Open3.capture3(SYSTEM_RUBY, ANALYZER.to_s, '--root', root.to_s)
+  Open3.capture3(
+    ANALYZER_ENVIRONMENT,
+    SYSTEM_RUBY,
+    ANALYZER.to_s,
+    '--root',
+    root.to_s
+  )
 end
 
 def result_matches?(


### PR DESCRIPTION
## Summary

- decode Log Privacy Lint text inputs explicitly as UTF-8 instead of inheriting Ruby's locale-dependent external encoding
- run every fixture analyzer subprocess with `LANG`, `LC_ALL`, and `LC_CTYPE` removed, matching GUI Xcode
- preserve all 52 privacy outcomes, add a named invalid-UTF-8 failure case, and increment the app to 2.0.23 (build 42)

## Root cause

GUI Xcode launches build phases without locale variables, so macOS system Ruby 2.6 selects US-ASCII as its default external encoding. `Pathname#read` therefore tagged valid UTF-8 Swift bytes as invalid US-ASCII, and the lexer raised when scanning the first non-ASCII production file.

The analyzer now owns the encoding contract at both text-read boundaries with `Encoding::UTF_8`. The harness permanently exercises the deployed GUI environment by unsetting locale variables for every pinned `/usr/bin/ruby` analyzer subprocess. Invalid UTF-8 is converted at the existing per-file rescue boundary into a named Xcode-formatted analysis error without accepting damaged input. The Xcode phase command remains unchanged.

The concurrent macOS privacy prompt is incidental to this failure: the analyzer has no write operations, the build log contains no permission denial, and the same read-only shell reproduction fails without the prompt. If it recurs, its exact target path should be captured separately.

## Validation

- RED: locale-stripped system-Ruby suite failed the existing Unicode lexer fixture with `invalid byte sequence in US-ASCII`
- RED: after the harness-only change, the ordinary system-Ruby suite failed identically
- `/usr/bin/ruby scripts/test-check-log-privacy.rb` — 53 cases pass
- `ruby scripts/test-check-log-privacy.rb` — 53 cases pass
- locale-stripped system-Ruby fixture suite — 53 cases pass
- normal and locale-stripped production analysis — identical 232/232 files, 500 sites, 0 annotations
- Ruby 2.6 syntax checks — both scripts pass
- RuboCop — no offenses
- version gate — 2.0.22/41 → 2.0.23/42
- diff hygiene and signed-commit checks — pass

Closes #408
