### PR TITLE
Document CloudKit schema upgrade process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ outside the wrapper.
 ### Code Formatting
 The project uses swift-format to maintain consistent code style. Configuration is in `.swift-format` at the repo root. A pre-commit hook auto-formats staged Swift files.
 
-**Prerequisite:** Install swift-format: `brew install swift-format`
+**Prerequisites:** Install swift-format and ripgrep: `brew install swift-format ripgrep`
 
 ```bash
 # Format all Swift files

--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -714,7 +714,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.23;
+				MARKETING_VERSION = 2.0.24;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -735,7 +735,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -746,7 +746,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.23;
+				MARKETING_VERSION = 2.0.24;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -894,7 +894,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -922,7 +922,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.23;
+				MARKETING_VERSION = 2.0.24;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -948,7 +948,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -976,7 +976,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.23;
+				MARKETING_VERSION = 2.0.24;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -998,12 +998,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.23;
+				MARKETING_VERSION = 2.0.24;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1024,12 +1024,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.23;
+				MARKETING_VERSION = 2.0.24;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1049,12 +1049,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.23;
+				MARKETING_VERSION = 2.0.24;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1074,12 +1074,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.23;
+				MARKETING_VERSION = 2.0.24;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1100,7 +1100,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1111,7 +1111,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.23;
+				MARKETING_VERSION = 2.0.24;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1132,7 +1132,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1143,7 +1143,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.23;
+				MARKETING_VERSION = 2.0.24;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1167,7 +1167,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1178,7 +1178,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.23;
+				MARKETING_VERSION = 2.0.24;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1201,7 +1201,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1212,7 +1212,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.23;
+				MARKETING_VERSION = 2.0.24;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/docs/cloudkit-production-schema.md
+++ b/docs/cloudkit-production-schema.md
@@ -14,6 +14,8 @@ Use this checklist whenever a code change adds or changes a CloudKit record type
 1. Make the record-type or field change in code.
 2. Run the manifest header searches to find every declared record type and field:
 
+   Prerequisite: install ripgrep with `brew install ripgrep`.
+
    ```bash
    rg -n 'static let recordType\s*=\s*"[^"]+"' Foqos FoqosDeviceMonitor FoqosShieldConfig FoqosWidget
    rg -n 'CKRecord\(recordType:\s*"[^"]+"' Foqos FoqosDeviceMonitor FoqosShieldConfig FoqosWidget

--- a/docs/cloudkit-production-schema.md
+++ b/docs/cloudkit-production-schema.md
@@ -1,4 +1,4 @@
-# CloudKit Production Schema Runbook
+# CloudKit Schema Upgrade Process
 
 Container: `iCloud.com.cynexia.family-foqos`
 
@@ -7,43 +7,71 @@ Production environment, so promote the final Development schema before uploading
 that depends on it. Production schema changes are additive-only; never rename or remove a deployed
 record type or field.
 
-## Repository Preflight
+## 1. Routine Schema Change
 
-Run these checks after the final schema-touching pull request has merged:
+Use this checklist whenever a code change adds or changes a CloudKit record type or field.
 
-```bash
-bash scripts/check-cloudkit-schema-export.sh
-bash scripts/test-check-prod-schema.sh
-```
+1. Make the record-type or field change in code.
+2. Run the manifest header searches to find every declared record type and field:
 
-Review `Foqos/CloudKit/cloudkit-schema.ckdb` against the pending Development schema in CloudKit
-Console. The local checker proves that the `.ckdb` covers every record type and field listed in
-`fastlane/required-prod-schema.txt`. Keep that manifest aligned with the app's declared `FieldKey`
-and `RecordKey` values through the hand-reconciliation commands in its header. Field review remains
-part of the Console promotion review because the checker does not derive the manifest from code.
+   ```bash
+   rg -n 'static let recordType\s*=\s*"[^"]+"' Foqos FoqosDeviceMonitor FoqosShieldConfig FoqosWidget
+   rg -n 'CKRecord\(recordType:\s*"[^"]+"' Foqos FoqosDeviceMonitor FoqosShieldConfig FoqosWidget
+   rg -n 'static let recordType|enum FieldKey: String|^[[:space:]]+case [[:alnum:]_]+( = "[^"]+")?$' Foqos/CloudKit/SyncModels.swift Foqos/CloudKit/ProfileSessionRecord.swift
+   rg -n 'static let recordType|enum RecordKey|^[[:space:]]+static let [[:alnum:]_]+ = "[^"]+"' Foqos/Models/DeviceHeartbeat.swift Foqos/Models/FamilyCommand.swift Foqos/Models/FamilyLockCode.swift Foqos/Models/FamilyMember.swift
+   rg -n 'rootRecord\["[^"]+"\]' Foqos/CloudKit/CloudKitNetworkService.swift Foqos/CloudKit/CloudKitNetworkService+Sharing.swift
+   ```
 
-## Promote to Production — Maintainer Only
+3. Reconcile `fastlane/required-prod-schema.txt` with the search results. Preserve built-in and
+   deprecated requirements, and update the reconciliation date and descriptive counts in its
+   header.
+4. Reconcile `Foqos/CloudKit/cloudkit-schema.ckdb` with the CloudKit Development schema. Preserve
+   declarations already deployed to Production for compatibility.
+5. Run the checked-in schema checker and its harness:
 
-1. Sign in to [CloudKit Console](https://icloud.developer.apple.com/).
-2. Select `iCloud.com.cynexia.family-foqos` and its CloudKit Database.
-3. Confirm the Development schema contains the record types and fields in
-   `Foqos/CloudKit/cloudkit-schema.ckdb`.
-4. Review the pending schema changes and deploy them to Production.
-5. Confirm the deployment completes before creating the TestFlight archive.
+   ```bash
+   bash scripts/check-cloudkit-schema-export.sh
+   bash scripts/test-check-cloudkit-schema-export.sh
+   ```
 
-This Console deployment is a maintainer keystroke. Agents update and verify repository artifacts;
-they do not promote the Production schema.
+6. Include the code change, manifest, `.ckdb`, and successful checker and harness output in the pull
+   request.
 
-## Postflight
+## 2. Release Promotion
 
-With `cktool` authenticated for the container, verify the deployed Production record types:
+Use this checklist after the final schema-touching pull request has merged and before the first
+TestFlight or App Store build that depends on it.
 
-```bash
-bash scripts/check-prod-schema.sh
-```
+1. Run repository preflight:
 
-The command must print `Production schema OK.` before TestFlight upload. It checks required record
-types; also confirm the newly promoted fields in CloudKit Console.
+   ```bash
+   bash scripts/check-cloudkit-schema-export.sh
+   bash scripts/test-check-prod-schema.sh
+   ```
+
+2. Sign in to [CloudKit Console](https://icloud.developer.apple.com/), select
+   `iCloud.com.cynexia.family-foqos`, choose its CloudKit Database, and select the Development
+   environment. Compare its schema with `Foqos/CloudKit/cloudkit-schema.ckdb`.
+3. Review the pending additive changes, choose **Deploy Schema Changes**, confirm the deployment,
+   and wait for completion.
+4. With `cktool` authenticated for the container, run Production postflight:
+
+   ```bash
+   bash scripts/check-prod-schema.sh
+   ```
+
+   Do not continue unless the command exits `0` and prints `Production schema OK.`. Also confirm
+   newly promoted fields in CloudKit Console because this postflight checks required record types.
+5. Close the release's schema tracking issue.
+6. Proceed with the appropriate upload only after postflight is green:
+
+   ```bash
+   scripts/fastlane.sh beta     # TestFlight
+   scripts/fastlane.sh release  # App Store submission
+   ```
+
+The Console deployment is a maintainer-only action. Agents can update, check, and review repository
+artifacts, but they must not promote the Production schema.
 
 ## Apple References
 

--- a/docs/superpowers/plans/2026-08-12-cloudkit-schema-upgrade-process.md
+++ b/docs/superpowers/plans/2026-08-12-cloudkit-schema-upgrade-process.md
@@ -1,0 +1,327 @@
+# CloudKit Schema Upgrade Process Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make routine CloudKit schema changes and release-time Production promotion two explicit,
+numbered operator workflows, with concise script output that points maintainers to the canonical
+runbook and clearly labels expected harness failures.
+
+**Architecture:** Keep `docs/cloudkit-production-schema.md` as the single source of procedural
+truth. The checked-in schema checker will emit one documentation pointer only after successful
+validation, while the production gate harness will label only the three deliberately surfaced
+negative-case lines; neither change alters fail-closed validation or exit-status behavior.
+
+**Tech Stack:** Markdown, Bash, `rg`, `shellcheck`, Xcode project build settings
+
+## Global Constraints
+
+- Keep `docs/cloudkit-production-schema.md` as the one canonical schema workflow document.
+- Use exactly two numbered workflows: **Routine Schema Change** and **Release Promotion**.
+- Keep record-type and field counts descriptive in `fastlane/required-prod-schema.txt`; do not
+  hardcode them into procedural checklist steps.
+- Preserve the additive-only Production rule and maintainer-only CloudKit Console deployment.
+- Preserve every checker and harness exit status; `[expected-failure]` is presentation-only.
+- The successful checked-in schema checker must print exactly:
+  `Next: if preparing a release, promote via docs/cloudkit-production-schema.md`
+- Prefix only the three deliberate negative-case lines at the end of
+  `scripts/test-check-prod-schema.sh`; leave its final `PASS:` line unprefixed.
+- Set the app version to `2.0.24` and build number to `43` in every Xcode project build setting.
+- Do not run Xcode or iOS Simulator builds: this change touches release/operator documentation,
+  standalone shell tooling, and build-setting text only.
+- All commits must be signed, must be new commits, and must never amend or force-push history.
+
+---
+
+### Task 1: Point successful schema checks to the canonical workflow
+
+**Files:**
+- Modify: `scripts/test-check-cloudkit-schema-export.sh:39-48`
+- Modify: `scripts/check-cloudkit-schema-export.sh:67`
+
+**Interfaces:**
+- Consumes: `CHECK_OUTPUT` captured from the copied schema checker in the hermetic fixture.
+- Produces: a successful checker output containing the existing coverage sentence followed by the
+  exact `Next:` line from Global Constraints.
+
+- [ ] **Step 1: Strengthen the successful fixture first**
+
+Replace the matching-schema assertion with an assertion for both success lines:
+
+```bash
+if [[ "$CHECK_STATUS" -ne 0 ||
+  "$CHECK_OUTPUT" != *"Checked-in CloudKit schema covers every required record type and field."* ||
+  "$CHECK_OUTPUT" != *"Next: if preparing a release, promote via docs/cloudkit-production-schema.md"* ]]; then
+  echo "FAIL: matching schema with compatibility extras must pass and point to the runbook"
+  echo "$CHECK_OUTPUT"
+  exit 1
+fi
+```
+
+- [ ] **Step 2: Run the fixture and observe RED**
+
+Run:
+
+```bash
+bash scripts/test-check-cloudkit-schema-export.sh
+```
+
+Expected: exit `1` with
+`FAIL: matching schema with compatibility extras must pass and point to the runbook`, because the
+checker does not yet print the documentation pointer.
+
+- [ ] **Step 3: Add the minimal successful-output pointer**
+
+Immediately after the existing success sentence in `scripts/check-cloudkit-schema-export.sh`, add:
+
+```bash
+echo "Next: if preparing a release, promote via docs/cloudkit-production-schema.md"
+```
+
+Do not add this line to any error branch.
+
+- [ ] **Step 4: Run focused checks and observe GREEN**
+
+Run:
+
+```bash
+bash scripts/test-check-cloudkit-schema-export.sh
+bash scripts/check-cloudkit-schema-export.sh
+```
+
+Expected: both exit `0`; the fixture ends with
+`PASS: checked-in CloudKit schema gate cases`, and the real checker prints the coverage sentence
+followed by the exact `Next:` line.
+
+- [ ] **Step 5: Commit the independently tested output contract**
+
+```bash
+git add scripts/check-cloudkit-schema-export.sh scripts/test-check-cloudkit-schema-export.sh
+git commit -S -m "Point schema checks to promotion runbook"
+```
+
+### Task 2: Label deliberate production-gate harness failures
+
+**Files:**
+- Modify: `scripts/test-check-prod-schema.sh:118-121`
+
+**Interfaces:**
+- Consumes: `EMPTY_OUTPUT`, `EMPTY_STATUS`, and `QUERY_FAILURE_STATUS` captured only after their
+  existing assertions have proved the deliberate failure cases behaved correctly.
+- Produces: exactly three console lines beginning with `[expected-failure]`, followed by the
+  unchanged unprefixed `PASS: production-schema gate cases` line.
+
+- [ ] **Step 1: Run a transient acceptance assertion and observe RED**
+
+Run:
+
+```bash
+PROD_OUTPUT=$(bash scripts/test-check-prod-schema.sh)
+[[ "$(printf '%s\n' "$PROD_OUTPUT" | grep -c '^\[expected-failure\]')" -eq 3 ]]
+```
+
+Expected: the harness itself exits `0`, then the assertion exits `1` because no successful-run
+console line currently carries the prefix.
+
+- [ ] **Step 2: Prefix only the deliberate failure presentation**
+
+Replace the final four output statements with:
+
+```bash
+echo "[expected-failure] $EMPTY_OUTPUT"
+echo "[expected-failure] empty-manifest exit: $EMPTY_STATUS"
+echo "[expected-failure] forced-cktool exit: $QUERY_FAILURE_STATUS"
+echo "PASS: production-schema gate cases"
+```
+
+Do not change fixture execution, assertions, captured statuses, or error-branch diagnostics.
+
+- [ ] **Step 3: Run exact output assertions and observe GREEN**
+
+Run:
+
+```bash
+PROD_OUTPUT=$(bash scripts/test-check-prod-schema.sh)
+[[ "$(printf '%s\n' "$PROD_OUTPUT" | grep -c '^\[expected-failure\]')" -eq 3 ]]
+[[ "$PROD_OUTPUT" == *$'\nPASS: production-schema gate cases' ]]
+[[ "$PROD_OUTPUT" != *$'\n[expected-failure] PASS: production-schema gate cases' ]]
+printf '%s\n' "$PROD_OUTPUT"
+```
+
+Expected: exit `0`; the three deliberate lines are prefixed and the final `PASS:` line is not.
+
+- [ ] **Step 4: Commit the independently verified presentation change**
+
+```bash
+git add scripts/test-check-prod-schema.sh
+git commit -S -m "Label expected production schema failures"
+```
+
+### Task 3: Restructure the canonical runbook around operator tasks
+
+**Files:**
+- Modify: `docs/cloudkit-production-schema.md:1-51`
+
+**Interfaces:**
+- Consumes: the manifest reconciliation commands in `fastlane/required-prod-schema.txt`, the
+  checked-in `.ckdb` reference, the two checker commands, CloudKit Console, and the two Fastlane
+  wrapper commands.
+- Produces: one canonical page with two numbered checklists whose first steps match the
+  maintainer's actual triggers.
+
+- [ ] **Step 1: Replace the reference-first layout with a Routine Schema Change checklist**
+
+Keep the title, container identifier, Production behavior, additive-only warning, and Apple
+references. Make the first workflow heading `## 1. Routine Schema Change` and introduce it with:
+
+```markdown
+Use this checklist whenever a code change adds or changes a CloudKit record type or field.
+```
+
+The numbered checklist must direct the operator to:
+
+1. make the code field or record-type change;
+2. run all five exact `rg` searches from the header of
+   `fastlane/required-prod-schema.txt`;
+3. reconcile `fastlane/required-prod-schema.txt`, preserving built-in and deprecated schema
+   requirements and updating its reconciliation date/count note without embedding those counts in
+   this runbook;
+4. reconcile `Foqos/CloudKit/cloudkit-schema.ckdb` with the CloudKit Development schema, preserving
+   deployed compatibility declarations;
+5. run `bash scripts/check-cloudkit-schema-export.sh` and
+   `bash scripts/test-check-cloudkit-schema-export.sh`; and
+6. include the code, manifest, `.ckdb`, and successful checker/harness output in the pull request.
+
+Copy these exact searches into the checklist's command block:
+
+```bash
+rg -n 'static let recordType\s*=\s*"[^"]+"' Foqos FoqosDeviceMonitor FoqosShieldConfig FoqosWidget
+rg -n 'CKRecord\(recordType:\s*"[^"]+"' Foqos FoqosDeviceMonitor FoqosShieldConfig FoqosWidget
+rg -n 'static let recordType|enum FieldKey: String|^[[:space:]]+case [[:alnum:]_]+( = "[^"]+")?$' Foqos/CloudKit/SyncModels.swift Foqos/CloudKit/ProfileSessionRecord.swift
+rg -n 'static let recordType|enum RecordKey|^[[:space:]]+static let [[:alnum:]_]+ = "[^"]+"' Foqos/Models/DeviceHeartbeat.swift Foqos/Models/FamilyCommand.swift Foqos/Models/FamilyLockCode.swift Foqos/Models/FamilyMember.swift
+rg -n 'rootRecord\["[^"]+"\]' Foqos/CloudKit/CloudKitNetworkService.swift Foqos/CloudKit/CloudKitNetworkService+Sharing.swift
+```
+
+- [ ] **Step 2: Add a Release Promotion checklist with explicit stop/go gates**
+
+Make the second workflow heading `## 2. Release Promotion` and introduce it with:
+
+```markdown
+Use this checklist after the final schema-touching pull request has merged and before the first
+TestFlight or App Store build that depends on it.
+```
+
+The numbered checklist must direct the maintainer to:
+
+1. run repository preflight with `bash scripts/check-cloudkit-schema-export.sh` and
+   `bash scripts/test-check-prod-schema.sh`;
+2. sign in to CloudKit Console, select `iCloud.com.cynexia.family-foqos`, choose the correct
+   CloudKit Database and environment, and compare the Development schema with the checked-in
+   `.ckdb`;
+3. review pending additive changes, choose **Deploy Schema Changes**, and confirm completion;
+4. run authenticated postflight with `bash scripts/check-prod-schema.sh` and require
+   `Production schema OK.`;
+5. close the release's schema tracking issue; and
+6. only then run `scripts/fastlane.sh beta` for TestFlight or
+   `scripts/fastlane.sh release` for App Store submission.
+
+Keep an adjacent note stating that the Console deployment is maintainer-only and agents must not
+perform it.
+
+- [ ] **Step 3: Validate workflow structure and command fidelity**
+
+Run:
+
+```bash
+rg -n '^## [12]\. (Routine Schema Change|Release Promotion)$|Deploy Schema Changes|scripts/fastlane\.sh (beta|release)|bash scripts/check-(cloudkit-schema-export|prod-schema)\.sh' docs/cloudkit-production-schema.md
+for command in \
+  "static let recordType\\s*=\\s*\"[^\"]+\"" \
+  "CKRecord\\(recordType:\\s*\"[^\"]+\"" \
+  "enum FieldKey: String" \
+  "enum RecordKey" \
+  "rootRecord\\[\"[^\"]+\"\\]"; do
+  grep -F "$command" docs/cloudkit-production-schema.md >/dev/null
+done
+```
+
+Expected: the first command shows both workflow headings, both schema checker commands, the
+Console action, and both Fastlane commands; the loop exits `0`, proving every manifest-header
+search family appears in the runbook.
+
+- [ ] **Step 4: Commit the canonical operator workflow**
+
+```bash
+git add docs/cloudkit-production-schema.md
+git commit -S -m "Document CloudKit schema upgrade workflows"
+```
+
+### Task 4: Bump version and run the complete verification gate
+
+**Files:**
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj:706-1146`
+- Verify: `docs/cloudkit-production-schema.md`
+- Verify: `scripts/check-cloudkit-schema-export.sh`
+- Verify: `scripts/test-check-cloudkit-schema-export.sh`
+- Verify: `scripts/test-check-prod-schema.sh`
+
+**Interfaces:**
+- Consumes: all completed documentation and script changes from Tasks 1-3.
+- Produces: version `2.0.24` / build `43`, complete static and focused-test evidence, and a clean
+  branch ready for independent review.
+
+- [ ] **Step 1: Update every Xcode build setting**
+
+Change every `MARKETING_VERSION = 2.0.23;` to `MARKETING_VERSION = 2.0.24;` and every
+`CURRENT_PROJECT_VERSION = 42;` to `CURRENT_PROJECT_VERSION = 43;` in
+`FamilyFoqos.xcodeproj/project.pbxproj`.
+
+- [ ] **Step 2: Verify the version matrix before committing**
+
+Run:
+
+```bash
+! rg -n 'MARKETING_VERSION = 2\.0\.23|CURRENT_PROJECT_VERSION = 42' FamilyFoqos.xcodeproj/project.pbxproj
+rg -c 'MARKETING_VERSION = 2\.0\.24;' FamilyFoqos.xcodeproj/project.pbxproj
+rg -c 'CURRENT_PROJECT_VERSION = 43;' FamilyFoqos.xcodeproj/project.pbxproj
+```
+
+Expected: the first command has no matches; the two counts are equal and nonzero.
+
+- [ ] **Step 3: Commit the version bump**
+
+```bash
+git add FamilyFoqos.xcodeproj/project.pbxproj
+git commit -S -m "Bump version for schema process update"
+```
+
+- [ ] **Step 4: Run all focused behavior and static checks**
+
+Run:
+
+```bash
+bash scripts/test-check-cloudkit-schema-export.sh
+bash scripts/check-cloudkit-schema-export.sh
+bash scripts/test-check-prod-schema.sh
+bash -n scripts/check-cloudkit-schema-export.sh scripts/test-check-cloudkit-schema-export.sh scripts/test-check-prod-schema.sh
+shellcheck scripts/check-cloudkit-schema-export.sh scripts/test-check-cloudkit-schema-export.sh scripts/test-check-prod-schema.sh
+git diff --check origin/main...HEAD
+git status --short
+```
+
+Expected: all commands exit `0`; checker and harness success markers are present; exactly three
+successful-run production harness lines begin with `[expected-failure]`; `git diff --check` is
+silent; and `git status --short` is empty. No Xcode build or simulator is required by Global
+Constraints.
+
+- [ ] **Step 5: Verify signed history and request independent AMQ review**
+
+Run:
+
+```bash
+git log --show-signature --format='%h %G? %s' origin/main..HEAD
+```
+
+Expected: every commit displays a good signature. Send the approved spec, this plan, the complete
+diff, and verification evidence to the planner/reviewer through AMQ. Address all actionable review
+feedback with new signed commits, rerun Step 4, request re-review, then create an undrafted pull
+request only after approval. Do not merge; send the approved PR URL to the planner for the required
+merge step.

--- a/docs/superpowers/specs/2026-08-12-cloudkit-schema-upgrade-process-design.md
+++ b/docs/superpowers/specs/2026-08-12-cloudkit-schema-upgrade-process-design.md
@@ -92,6 +92,11 @@ manifest requirement, CloudKit container setting, or Production deployment is ch
 The runbook continues to state that Production schema changes are additive-only: operators must not
 rename or remove deployed record types or fields.
 
+Repository scripts must not acquire an optional `ripgrep` dependency because missing script tools
+must fail closed rather than silently skip checks. The routine checklist may use its existing
+`rg`-flavored manifest searches because a human operator sees `command not found`; both `AGENTS.md`
+and the checklist document `brew install ripgrep` as the prerequisite.
+
 The expected-failure prefix is presentation only. It does not suppress fixture stderr, change any
 assertion, or turn an unexpected harness failure into a pass.
 
@@ -130,6 +135,7 @@ not Xcode build-phase tooling.
 Implementation changes are limited to:
 
 - `docs/cloudkit-production-schema.md`
+- `AGENTS.md` prerequisite documentation
 - `scripts/check-cloudkit-schema-export.sh`
 - `scripts/test-check-cloudkit-schema-export.sh`
 - `scripts/test-check-prod-schema.sh`

--- a/docs/superpowers/specs/2026-08-12-cloudkit-schema-upgrade-process-design.md
+++ b/docs/superpowers/specs/2026-08-12-cloudkit-schema-upgrade-process-design.md
@@ -29,8 +29,8 @@ in code.” It directs the operator to:
 2. reconcile that manifest with the code while preserving built-in and deprecated requirements;
 3. update `Foqos/CloudKit/cloudkit-schema.ckdb` from the CloudKit Development schema;
 4. run the checked-in schema checker and its harness; and
-5. include the code, manifest, schema export, and relevant verification evidence in the pull
-   request.
+5. include the code, manifest, schema export, and successful checker and harness outputs in the
+   pull request.
 
 The checklist does not hardcode the current record-type or field counts. Those counts are useful
 reconciliation notes in the manifest header, but procedural steps that repeat them would become
@@ -46,7 +46,8 @@ The second checklist directs the maintainer to:
 3. review the pending additive schema, choose **Deploy Schema Changes**, and confirm completion;
 4. run `bash scripts/check-prod-schema.sh` with authenticated `cktool` as postflight;
 5. close the release's schema tracking issue; and
-6. proceed to the applicable Fastlane beta or release lane only after postflight is green.
+6. run `scripts/fastlane.sh beta` for TestFlight or `scripts/fastlane.sh release` for App Store
+   submission only after postflight is green.
 
 The Console deployment remains maintainer-only. Agents can update, check, and review repository
 artifacts but cannot promote the Production schema.

--- a/docs/superpowers/specs/2026-08-12-cloudkit-schema-upgrade-process-design.md
+++ b/docs/superpowers/specs/2026-08-12-cloudkit-schema-upgrade-process-design.md
@@ -1,0 +1,140 @@
+# CloudKit Schema Upgrade Process Design
+
+## Context
+
+The repository has a technically accurate CloudKit Production schema runbook, but it begins with
+background and verification detail rather than telling an operator what to do. During live release
+work, the maintainer had to infer two distinct workflows:
+
+1. how to update repository schema artifacts after adding or changing a CloudKit field in code; and
+2. how to promote a reviewed Development schema to Production before a release.
+
+Two tool-output details compound the problem. The checked-in schema checker reports success without
+pointing at the promotion workflow, and the production-schema harness deliberately prints a fixture
+failure before its final PASS without marking that failure as expected.
+
+## Decision
+
+`docs/cloudkit-production-schema.md` remains the single canonical document and becomes task-first.
+It opens with two numbered operator checklists in plain product language, followed by compact safety
+and reference detail.
+
+### Routine repository update
+
+The first checklist starts from the operator's real trigger: “you added or changed a CloudKit field
+in code.” It directs the operator to:
+
+1. run the exact record-type and field searches from the header of
+   `fastlane/required-prod-schema.txt`;
+2. reconcile that manifest with the code while preserving built-in and deprecated requirements;
+3. update `Foqos/CloudKit/cloudkit-schema.ckdb` from the CloudKit Development schema;
+4. run the checked-in schema checker and its harness; and
+5. include the code, manifest, schema export, and relevant verification evidence in the pull
+   request.
+
+The checklist does not hardcode the current record-type or field counts. Those counts are useful
+reconciliation notes in the manifest header, but procedural steps that repeat them would become
+stale as the schema grows.
+
+### Release promotion
+
+The second checklist directs the maintainer to:
+
+1. run the checked-in export checker and both schema harnesses as repository preflight;
+2. open CloudKit Console for `iCloud.com.cynexia.family-foqos` and select the Development
+   environment;
+3. review the pending additive schema, choose **Deploy Schema Changes**, and confirm completion;
+4. run `bash scripts/check-prod-schema.sh` with authenticated `cktool` as postflight;
+5. close the release's schema tracking issue; and
+6. proceed to the applicable Fastlane beta or release lane only after postflight is green.
+
+The Console deployment remains maintainer-only. Agents can update, check, and review repository
+artifacts but cannot promote the Production schema.
+
+## Tool Output Contracts
+
+On success, `scripts/check-cloudkit-schema-export.sh` retains its existing coverage line and adds:
+
+```text
+Next: if preparing a release, promote via docs/cloudkit-production-schema.md
+```
+
+The existing `scripts/test-check-cloudkit-schema-export.sh` harness asserts that next-step line as a
+behavioral contract, as well as the existing coverage message.
+
+Only `scripts/test-check-prod-schema.sh` changes expected-failure presentation. Its successful test
+run currently surfaces three deliberate failure lines: the empty-manifest diagnostic, its exit
+status, and the forced `cktool` exit status. Each receives an `[expected-failure]` prefix; the final
+`PASS: production-schema gate cases` line remains unprefixed.
+
+Other harnesses remain unchanged. They print captured stderr only when the harness's own assertion
+fails, so their output represents a real test failure and must not be relabelled as expected.
+
+## Alternatives Rejected
+
+### Add a second process document
+
+A separate “schema upgrade process” document could have a more obvious title, but it would create
+two authoritative-looking entry points and require permanent cross-link maintenance. Restructuring
+the current runbook keeps one stable path for operators and for the checker’s next-step output.
+
+### Put the process in command output
+
+Scripts can point to the canonical guide, but embedding the Console and release workflow in command
+output would deliver instructions too late and make prose maintenance awkward. The document owns the
+workflow; tools provide short contextual next steps.
+
+## Error Handling and Safety
+
+Existing schema checks remain fail-closed and preserve their exit statuses. No schema artifact,
+manifest requirement, CloudKit container setting, or Production deployment is changed by this work.
+The runbook continues to state that Production schema changes are additive-only: operators must not
+rename or remove deployed record types or fields.
+
+The expected-failure prefix is presentation only. It does not suppress fixture stderr, change any
+assertion, or turn an unexpected harness failure into a pass.
+
+## Test Strategy
+
+The baseline output establishes both requested behavior changes:
+
+```text
+Checked-in CloudKit schema covers every required record type and field.
+```
+
+has no next step, while the successful production-schema harness begins with an unlabelled
+`Required schema file is empty or unreadable` fixture diagnostic.
+
+Implementation verification runs:
+
+```bash
+bash scripts/test-check-cloudkit-schema-export.sh
+bash scripts/check-cloudkit-schema-export.sh
+bash scripts/test-check-prod-schema.sh
+bash -n scripts/check-cloudkit-schema-export.sh
+bash -n scripts/test-check-cloudkit-schema-export.sh
+bash -n scripts/test-check-prod-schema.sh
+```
+
+The export harness must fail before the checker change when it first requires the new next-step line,
+then pass after the checker emits it. Final direct output must contain both success lines. The
+production harness must show three `[expected-failure]` lines followed by its unprefixed PASS line.
+
+Version-gate verification, `git diff --check`, independent review, and required GitHub checks finish
+the change. No Xcode build or simulator run is needed: these files are release/operator shell tools,
+not Xcode build-phase tooling.
+
+## Scope
+
+Implementation changes are limited to:
+
+- `docs/cloudkit-production-schema.md`
+- `scripts/check-cloudkit-schema-export.sh`
+- `scripts/test-check-cloudkit-schema-export.sh`
+- `scripts/test-check-prod-schema.sh`
+- `FamilyFoqos.xcodeproj/project.pbxproj` version settings, from 2.0.23/build 42 to
+  2.0.24/build 43
+- this design and its implementation plan
+
+CloudKit schema exports, required-schema manifest contents, app code, Fastlane lanes, and Production
+schema state do not change.

--- a/scripts/check-cloudkit-schema-export.sh
+++ b/scripts/check-cloudkit-schema-export.sh
@@ -69,3 +69,4 @@ if [[ "$missing" -ne 0 ]]; then
 fi
 
 echo "Checked-in CloudKit schema covers every required record type and field."
+echo "Next: if preparing a release, promote via docs/cloudkit-production-schema.md"

--- a/scripts/test-check-cloudkit-schema-export.sh
+++ b/scripts/test-check-cloudkit-schema-export.sh
@@ -44,8 +44,10 @@ printf '%s\n' \
   ');' \
   >"$TEST_ROOT/Foqos/CloudKit/cloudkit-schema.ckdb"
 run_check
-if [[ "$CHECK_STATUS" -ne 0 || "$CHECK_OUTPUT" != *"covers every required record type"* ]]; then
-  echo "FAIL: matching schema with compatibility extras must pass"
+if [[ "$CHECK_STATUS" -ne 0 ||
+  "$CHECK_OUTPUT" != *"Checked-in CloudKit schema covers every required record type and field."* ||
+  "$CHECK_OUTPUT" != *"Next: if preparing a release, promote via docs/cloudkit-production-schema.md"* ]]; then
+  echo "FAIL: matching schema with compatibility extras must pass and point to the runbook"
   echo "$CHECK_OUTPUT"
   exit 1
 fi

--- a/scripts/test-check-prod-schema.sh
+++ b/scripts/test-check-prod-schema.sh
@@ -115,7 +115,7 @@ if [[ "$GATE_STATUS" -ne 42 ]]; then
 fi
 QUERY_FAILURE_STATUS=$GATE_STATUS
 
-echo "$EMPTY_OUTPUT"
-echo "empty-manifest exit: $EMPTY_STATUS"
-echo "forced-cktool exit: $QUERY_FAILURE_STATUS"
+echo "[expected-failure] $EMPTY_OUTPUT"
+echo "[expected-failure] empty-manifest exit: $EMPTY_STATUS"
+echo "[expected-failure] forced-cktool exit: $QUERY_FAILURE_STATUS"
 echo "PASS: production-schema gate cases"


### PR DESCRIPTION
## Summary

- restructure the canonical CloudKit schema document into separate Routine Schema Change and Release Promotion checklists
- point successful checked-in schema checks to that runbook
- label deliberate negative-case harness output with `[expected-failure]`
- document ripgrep as the operator prerequisite without adding it to fail-closed scripts
- bump the app to version 2.0.24 (build 43)

## Why

Routine schema edits and release-time Production promotion previously shared a reference-first runbook, making the maintainer-only Console step easy to miss under release pressure. This makes each operator trigger explicit while preserving additive-only and fail-closed safety.

## Impact

Maintainers now have an end-to-end code → manifest → checked-in schema → PR workflow and a distinct preflight → Console deployment → postflight → Fastlane workflow. Checker exit statuses and Production behavior are unchanged.

## Validation

- `bash scripts/test-check-cloudkit-schema-export.sh`
- `bash scripts/check-cloudkit-schema-export.sh`
- `bash scripts/test-check-prod-schema.sh`
- `bash -n` on all three modified shell scripts
- `shellcheck` on all three modified shell scripts
- exact output-contract, workflow-fidelity, prerequisite, version-matrix, signature, and `git diff --check` assertions
- independent AMQ review: READY at `4b700b8`, no findings

No Xcode or simulator run: the changed shell tools are not referenced by Xcode build phases, and the remaining changes are operator documentation and build-setting text.