### PR TITLE
Harden CloudKit drift reporting

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/docs/cloudkit-production-schema.md
+++ b/docs/cloudkit-production-schema.md
@@ -96,7 +96,10 @@ alternative requires a reviewed tooling change before it can be used.
    Treat the checked-in file as canonical. Import applies it to Development and may remove
    Development-only experiments that are absent from the file. CloudKit rejects the update without
    making changes if the required modifications could cause data loss relative to Production;
-   resolve any rejection before continuing.
+   resolve any rejection before continuing. The only known import-rejection candidate on this
+   container is the built-in `Users.roles` field (`LIST<INT64>`). If CloudKit rejects that field,
+   record the exact response and stop for maintainer resolution instead of changing reviewed
+   app-owned records.
 3. In CloudKit Console, choose **Deploy Schema Changes** and review the actual
    Development-to-Production additive diff. If nothing is pending, record that the canonical schema
    is already deployed and continue to postflight. Otherwise, confirm the deployment and wait for
@@ -129,4 +132,5 @@ schema.
 - [Integrating a Text-Based Schema into Your Workflow](https://developer.apple.com/documentation/cloudkit/integrating-a-text-based-schema-into-your-workflow)
 - [Deploying an iCloud Container’s Schema](https://developer.apple.com/documentation/cloudkit/deploying-an-icloud-container-s-schema)
 - [Cloud-Managed Certificates](https://developer.apple.com/help/account/certificates/cloud-managed-certificates/)
+- [Roles and Access](https://developer.apple.com/help/account/access/roles/)
 - [App Store Connect API](https://developer.apple.com/help/app-store-connect/get-started/app-store-connect-api/)

--- a/scripts/report-cloudkit-schema-drift.sh
+++ b/scripts/report-cloudkit-schema-drift.sh
@@ -117,9 +117,39 @@ awk '
 ' "$SCHEMA_FILE" | sort -u >"$TEMP_DIR/schema"
 
 # Built-in CloudKit sharing record intentionally exists in manifest/schema but not app declarations.
-MANIFEST_ONLY_EXCEPTION='RECORD TYPE "cloudkit.share"'
+BUILTIN_TYPE_ONLY_EXCEPTION='RECORD TYPE "cloudkit.share"'
+# Legacy SyncedSession is retained only so the app can delete old records; it owns no live fields.
+LEGACY_TYPE_ONLY_EXCEPTION='RECORD TYPE SyncedSession'
+MANIFEST_ONLY_EXCEPTION="$BUILTIN_TYPE_ONLY_EXCEPTION"
 # Deprecated FamilyPolicy intentionally remains in the additive-only checked-in schema.
 SCHEMA_ONLY_EXCEPTION_PREFIX='RECORD TYPE FamilyPolicy'
+
+awk \
+  -v builtin_exception="$BUILTIN_TYPE_ONLY_EXCEPTION" \
+  -v legacy_exception="$LEGACY_TYPE_ONLY_EXCEPTION" '
+  function record_type(entry, rest, quote, dot) {
+    rest=substr(entry, length("RECORD TYPE ") + 1)
+    if (substr(rest, 1, 1) == "\"") {
+      quote=index(substr(rest, 2), "\"") + 1
+      return "RECORD TYPE " substr(rest, 1, quote)
+    }
+    dot=index(rest, ".")
+    return dot ? "RECORD TYPE " substr(rest, 1, dot - 1) : entry
+  }
+  FILENAME == ARGV[1] { live_types[record_type($0)]=1; next }
+  {
+    type=record_type($0)
+    manifest_types[type]=1
+    if ($0 != type) has_fields[type]=1
+  }
+  END {
+    for (type in manifest_types) {
+      if (live_types[type] && !has_fields[type] && type != builtin_exception && type != legacy_exception) {
+        print type
+      }
+    }
+  }
+' "$TEMP_DIR/code" "$TEMP_DIR/manifest" | sort >"$TEMP_DIR/fieldless-live-manifest"
 
 comm -23 "$TEMP_DIR/code" "$TEMP_DIR/manifest" >"$TEMP_DIR/missing-manifest"
 comm -13 "$TEMP_DIR/code" "$TEMP_DIR/manifest" |
@@ -160,6 +190,7 @@ comm -13 "$TEMP_DIR/manifest" "$TEMP_DIR/schema" |
   ' "$TEMP_DIR/manifest" - >"$TEMP_DIR/extra-schema"
 
 drift=0
+while IFS= read -r line; do [[ -z "$line" ]] || { echo "FIELDLESS live manifest type: $line"; drift=1; }; done <"$TEMP_DIR/fieldless-live-manifest"
 while IFS= read -r line; do [[ -z "$line" ]] || { echo "MISSING from manifest: $line"; drift=1; }; done <"$TEMP_DIR/missing-manifest"
 while IFS= read -r line; do [[ -z "$line" ]] || { echo "EXTRA in manifest: $line"; drift=1; }; done <"$TEMP_DIR/extra-manifest"
 while IFS= read -r line; do [[ -z "$line" ]] || { echo "MISSING from checked-in schema: $line"; drift=1; }; done <"$TEMP_DIR/missing-schema"

--- a/scripts/test-report-cloudkit-schema-drift.sh
+++ b/scripts/test-report-cloudkit-schema-drift.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-required_commands=(cp dirname mktemp rm sed)
+required_commands=(cp dirname mkdir mktemp rm sed)
 for required_command in "${required_commands[@]}"; do
   command -v "$required_command" >/dev/null || {
     echo "FAIL: required command not found: $required_command" >&2
@@ -25,31 +25,125 @@ REAL_OUTPUT=$("$REPORTER")
 }
 
 FIXTURE_ROOT="$TEST_ROOT/repo"
-mkdir -p "$FIXTURE_ROOT"
-cp -R \
-  "$REPO_ROOT/Foqos" \
-  "$REPO_ROOT/FoqosDeviceMonitor" \
-  "$REPO_ROOT/FoqosShieldConfig" \
-  "$REPO_ROOT/FoqosWidget" \
-  "$REPO_ROOT/fastlane" \
-  "$FIXTURE_ROOT/"
+reset_fixture() {
+  rm -rf -- "$FIXTURE_ROOT"
+  mkdir -p "$FIXTURE_ROOT"
+  cp -R \
+    "$REPO_ROOT/Foqos" \
+    "$REPO_ROOT/FoqosDeviceMonitor" \
+    "$REPO_ROOT/FoqosShieldConfig" \
+    "$REPO_ROOT/FoqosWidget" \
+    "$REPO_ROOT/fastlane" \
+    "$FIXTURE_ROOT/"
+}
 
+assert_drift() {
+  local expected_line=$1
+  local description=$2
+  local drift_output
+  local drift_status
+
+  set +e
+  drift_output=$(CLOUDKIT_SCHEMA_REPO_ROOT="$FIXTURE_ROOT" "$REPORTER" 2>&1)
+  drift_status=$?
+  set -e
+  if [[ "$drift_status" -ne 1 ||
+    "$drift_output" != *"$expected_line"* ||
+    "$drift_output" != *"CloudKit schema drift detected."* ]]; then
+    echo "FAIL: $description"
+    printf 'exit: %s\n%s\n' "$drift_status" "$drift_output"
+    exit 1
+  fi
+}
+
+# FieldKey enum discovery.
+reset_fixture
 sed '/case profileSchemaVersion/a\
     case smokeTestField
 ' \
   "$FIXTURE_ROOT/Foqos/CloudKit/SyncModels.swift" >"$TEST_ROOT/SyncModels.swift"
 cp "$TEST_ROOT/SyncModels.swift" "$FIXTURE_ROOT/Foqos/CloudKit/SyncModels.swift"
+assert_drift \
+  'MISSING from manifest: RECORD TYPE SyncedProfile.smokeTestField' \
+  'FieldKey discovery must report a fake field'
 
-set +e
-DRIFT_OUTPUT=$(CLOUDKIT_SCHEMA_REPO_ROOT="$FIXTURE_ROOT" "$REPORTER" 2>&1)
-DRIFT_STATUS=$?
-set -e
-if [[ "$DRIFT_STATUS" -ne 1 ||
-  "$DRIFT_OUTPUT" != *"MISSING from manifest: RECORD TYPE SyncedProfile.smokeTestField"* ||
-  "$DRIFT_OUTPUT" != *"CloudKit schema drift detected."* ]]; then
-  echo "FAIL: fake field must be reported as manifest drift"
-  printf 'exit: %s\n%s\n' "$DRIFT_STATUS" "$DRIFT_OUTPUT"
-  exit 1
-fi
+# Static recordType discovery.
+reset_fixture
+sed '/\/\/ MARK: - SyncedSession (Legacy)/i\
+enum SmokeStaticRecordType {\
+  static let recordType = "SmokeStaticRecordType"\
+}\
+' \
+  "$FIXTURE_ROOT/Foqos/CloudKit/SyncModels.swift" >"$TEST_ROOT/SyncModels.swift"
+cp "$TEST_ROOT/SyncModels.swift" "$FIXTURE_ROOT/Foqos/CloudKit/SyncModels.swift"
+assert_drift \
+  'MISSING from manifest: RECORD TYPE SmokeStaticRecordType' \
+  'static recordType discovery must report a fake type'
 
-echo "PASS: CloudKit schema drift smoke test"
+# Literal CKRecord record-type discovery.
+reset_fixture
+sed '/let rootRecord = CKRecord(recordType: "FamilyRoot"/i\
+      _ = CKRecord(recordType: "SmokeLiteralRecord", recordID: rootRecordID)
+' \
+  "$FIXTURE_ROOT/Foqos/CloudKit/CloudKitNetworkService+Sharing.swift" \
+  >"$TEST_ROOT/CloudKitNetworkService+Sharing.swift"
+cp \
+  "$TEST_ROOT/CloudKitNetworkService+Sharing.swift" \
+  "$FIXTURE_ROOT/Foqos/CloudKit/CloudKitNetworkService+Sharing.swift"
+assert_drift \
+  'MISSING from manifest: RECORD TYPE SmokeLiteralRecord' \
+  'literal CKRecord discovery must report a fake type'
+
+# RecordKey enum discovery.
+reset_fixture
+sed '/static let createdBy = "createdBy"/a\
+    static let smokeRecordKey = "smokeRecordKey"
+' \
+  "$FIXTURE_ROOT/Foqos/Models/FamilyCommand.swift" >"$TEST_ROOT/FamilyCommand.swift"
+cp "$TEST_ROOT/FamilyCommand.swift" "$FIXTURE_ROOT/Foqos/Models/FamilyCommand.swift"
+assert_drift \
+  'MISSING from manifest: RECORD TYPE FamilyCommand.smokeRecordKey' \
+  'RecordKey discovery must report a fake field'
+
+# FamilyRoot subscript-write discovery.
+reset_fixture
+sed '/rootRecord\["createdAt"\] = Date()/a\
+      rootRecord["smokeFamilyRootField"] = Date()
+' \
+  "$FIXTURE_ROOT/Foqos/CloudKit/CloudKitNetworkService+Sharing.swift" \
+  >"$TEST_ROOT/CloudKitNetworkService+Sharing.swift"
+cp \
+  "$TEST_ROOT/CloudKitNetworkService+Sharing.swift" \
+  "$FIXTURE_ROOT/Foqos/CloudKit/CloudKitNetworkService+Sharing.swift"
+assert_drift \
+  'MISSING from manifest: RECORD TYPE FamilyRoot.smokeFamilyRootField' \
+  'FamilyRoot write discovery must report a fake field'
+
+# A code-live manifest type cannot use a type-only entry to hide schema fields.
+reset_fixture
+sed '/let rootRecord = CKRecord(recordType: "FamilyRoot"/i\
+      _ = CKRecord(recordType: "SmokeFieldless", recordID: rootRecordID)
+' \
+  "$FIXTURE_ROOT/Foqos/CloudKit/CloudKitNetworkService+Sharing.swift" \
+  >"$TEST_ROOT/CloudKitNetworkService+Sharing.swift"
+cp \
+  "$TEST_ROOT/CloudKitNetworkService+Sharing.swift" \
+  "$FIXTURE_ROOT/Foqos/CloudKit/CloudKitNetworkService+Sharing.swift"
+sed '$a\
+RECORD TYPE SmokeFieldless
+' \
+  "$FIXTURE_ROOT/fastlane/required-prod-schema.txt" >"$TEST_ROOT/required-prod-schema.txt"
+cp "$TEST_ROOT/required-prod-schema.txt" "$FIXTURE_ROOT/fastlane/required-prod-schema.txt"
+sed '$a\
+\
+    RECORD TYPE SmokeFieldless (\
+        ghostField STRING\
+    );
+' \
+  "$FIXTURE_ROOT/Foqos/CloudKit/cloudkit-schema.ckdb" >"$TEST_ROOT/cloudkit-schema.ckdb"
+cp "$TEST_ROOT/cloudkit-schema.ckdb" "$FIXTURE_ROOT/Foqos/CloudKit/cloudkit-schema.ckdb"
+assert_drift \
+  'FIELDLESS live manifest type: RECORD TYPE SmokeFieldless' \
+  'a fieldless live manifest type must fail closed'
+
+echo "PASS: CloudKit schema drift discovery and fieldless-manifest guards"


### PR DESCRIPTION
## Summary

- reject code-live CloudKit manifest types that have no declared fields, while preserving the two explicit type-only exceptions
- mutation-pin every reporter discovery family: static and literal record types, `FieldKey`, `RecordKey`, and `FamilyRoot` writes
- document the built-in `Users.roles LIST<INT64>` import-rejection candidate and add Apple's roles matrix
- bump all targets to version 2.0.26 (build 45) for the repository version gate

Closes #413.

## Implementation plan

1. Characterize all five existing extraction families with isolated fixture mutations.
2. Reproduce the ghost-field false negative using a code-live type, a type-only manifest entry, and a schema field.
3. Fail closed for that state, with named exceptions for legacy `SyncedSession` and built-in `"cloudkit.share"`.
4. Add the two release-runbook clarifications and satisfy the mandatory version gate.

The reporter remains one shell script; no new manifest annotation grammar or debug mode was added.

## TDD evidence

Before the guard existed, the new ghost-field case failed its harness with:

```text
FAIL: a fieldless live manifest type must fail closed
exit: 0
OK: no CloudKit schema drift.
```

After the guard, the same harness passes. The real repository baseline also stays green, proving the two intentional type-only exceptions remain accepted.

## Verification

```text
bash -n scripts/report-cloudkit-schema-drift.sh scripts/test-report-cloudkit-schema-drift.sh
shellcheck scripts/report-cloudkit-schema-drift.sh scripts/test-report-cloudkit-schema-drift.sh
bash scripts/report-cloudkit-schema-drift.sh
bash scripts/test-report-cloudkit-schema-drift.sh
bash scripts/check-cloudkit-schema-export.sh
bash scripts/test-check-cloudkit-schema-export.sh
bash scripts/test-check-prod-schema.sh
plutil -lint FamilyFoqos.xcodeproj/project.pbxproj
scripts/check-version-increment.sh main HEAD
git diff --check main...HEAD
git verify-commit HEAD
```

No Xcode build or simulator run was needed: this changes shell validation, its disposable fixture harness, documentation, and the mandatory version settings only.
