### PR TITLE
Rewrite agent guide with progressive disclosure (#387)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,426 +1,63 @@
 # Family Foqos Developer Guidelines
 
-This file provides guidelines for agentic coding assistants working on the Family Foqos iOS app codebase.
+This always-loaded file is the invariant sheet for agentic work in Family Foqos. Follow its linked runbooks when a task enters that area.
 
-## Key rules agents often forget but must ALWAYS follow:
+## Engineering Invariants
 
-  - **NEVER** force commit or amend commits. Ever. Always create new commits for fixes, and use Git's revert feature to undo changes if needed. This preserves the integrity of the commit history and allows for proper code review.
-  - **ALWAYS request code review before merging any changes.** This ensures that all changes are vetted for quality, correctness, and adherence to project standards.
-  - **WARM GIT CREDENTIALS BEFORE ANY IMPLEMENTATION WORK.** At session start, while the human
-    is present, every implementation subagent must warm both 1Password-backed Git paths in its
-    clean assigned worktree before real work. Run this block so commit-signing and SSH prompts
-    happen while the human can touch the sensor:
+- Keep implementations DRY and KISS; in general, apply YAGNI.
+- Never amend or force commits. Put every fix in a new signed commit; revert with a new commit when needed.
+- Obtain independent code review before every merge. The planner merges unless the active workflow explicitly names another merger.
+- Before implementation, while the human is present, every implementation stream runs `scripts/warm-git-credentials.sh` in its clean assigned feature worktree.
+- The gate supports up to three Xcode/simulator streams when all simulator work uses `scripts/xcode-stream.sh --agent <agent> --session <session>` with stable ownership and UUID destinations only, never device-name destinations; it injects `-parallel-testing-enabled NO` and `-disable-concurrent-destination-testing`.
+- Keep implementation streams on separate feature branches/worktrees with disjoint files. Read-only work does not consume a gate slot and may run concurrently from another working copy.
 
-    ```bash
-    (
-      set -e
-      test -z "$(git status --porcelain)"
-      start_branch="$(git branch --show-current)"
-      test -n "$start_branch"
-      case "$(git remote get-url --push origin)" in git@*|ssh://*) ;; *) exit 1 ;; esac
-      scratch="scratch/biometric-warmup/$(date -u +%Y%m%dT%H%M%SZ)-$$"
-      git switch -c "$scratch"
-      trap 'git switch "$start_branch"; git branch -D "$scratch"' EXIT
-      git commit -S --allow-empty -m "chore: biometric warm-up (discard)"
-      git push --dry-run origin "HEAD:refs/heads/$scratch"
-    )
-    ```
-
-    The dry run must use the SSH push URL and must not create a remote ref. Start real work only
-    after the block succeeds and the assigned worktree is back on its starting branch and clean.
-
-    If signing or SSH approval expires mid-session, rerun the block while the human is present. If
-    the human is absent, commit-only work may use the authorized GitHub `createCommitOnBranch` API
-    when one server-side commit exactly represents the change; otherwise wait. Never disable
-    signing, create an unsigned production commit, amend, or force-push to evade a prompt.
-
-    The separate `op` prompt is handled by #365's service-account credential path, not this Git
-    warm-up.
-
-  - **All simulator builds and tests use the machine-wide gate.** The host supports up to three
-    Xcode/simulator streams when every stream enters through `scripts/xcode-stream.sh`. The gate
-    assigns a distinct simulator UUID, DerivedData directory, and capacity slot to each exact
-    `(project, agent, session)` owner. UUID destinations only; device-name destinations are
-    forbidden. The wrapper injects `-parallel-testing-enabled NO` and
-    `-disable-concurrent-destination-testing` to prevent XCTestDevices clones. Writing streams
-    still use separate feature branches/worktrees and disjoint file sets.
-    Read-only work does not consume a gate slot and may run concurrently from its own working copy.
+See [Development Workflow](docs/development-workflow.md) for credential fallback, simulator ownership, command rationale, and complete build/test/format guidance.
 
 ## Script Safety
 
-Scripts should be safe and deterministic. Any new or modified script must:
-
-- Validate external dependencies during preflight with `command -v` and a named nonzero failure
-  before doing work or touching shared state.
-- Fail closed when a check cannot run, input is unreadable, or output is unparseable; never treat
-  those conditions as a pass.
-- Propagate the exact child exit status through pipelines and wrappers.
-- Verify effects, not text forms, when an invariant matters, such as the simulator clone census.
-- Keep guards in build phases or the scripts themselves, never only in Git hooks, because API
-  commits bypass hooks.
+- Validate external dependencies with `command -v` and a named nonzero failure before touching shared state.
+- Fail closed when a check cannot run or input/output is unusable; never interpret that as a pass.
+- Propagate the exact child exit status through every pipeline and wrapper.
+- Verify effects rather than text forms when an invariant matters, including simulator-clone checks.
+- Put mandatory guards in build phases or scripts, never only Git hooks, because API commits bypass hooks.
 
 ## Multi-Agent Coordination
 
-- **Route human gates through the planner.** Never park `gate/*` approvals in the AMQ `user` mailbox; send `blocked on human gate: <what>` on the normal planner thread.
-- **Heartbeat quiet agents.** After 30 minutes without a message from an agent with in-flight work, the planner drains the planner inbox, inspects the agent's `inbox/new`, sweeps the `user` mailbox for parked gates, inspects commit age, dirty files, and CPU delta, then pings the agent directly.
-- **Treat presence only as presence.** `notifier_live` proves only that the wake process is running; never treat it as work or progress evidence.
-- **Announce blockers immediately.** Send a status when any waiting state for a gate, review, or dependency begins.
-- **Make merge readiness literal.** A PR reported approved or merge-ready must already be ready for review and must not be a draft.
-- **End with evidence, not promises.** Never end a turn with only promised future work; state exactly what remains, and verify work using commit age, dirty files, and CPU delta, never message recency.
-
-See [Multi-Agent Coordination](docs/multi-agent-coordination.md) for the gate-routing examples, full heartbeat, and fail-closed CPU recipes.
-
-## Build & Test Commands
-
-### Building
-
-Agents must not invoke raw `xcodebuild` for simulator work. Give every stream a stable agent name
-and optional session name, then use the wrapper. It allocates or reuses the registry-owned iPhone
-17 on the newest compatible installed iOS runtime. Set `IOS_SIM_GATE_DEVICE_TYPE` or
-`IOS_SIM_GATE_RUNTIME` only when the task requires an override.
-Always place `xcodebuild` directly after the wrapper's `--`; never mediate it through `xcrun`,
-`env`, `bundle`, or a shell command.
-
-```bash
-# Build from command line with wrapper-owned output formatting.
-scripts/xcode-stream.sh --agent <agent> --session <session> --xcpretty -- \
-  xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
-  -configuration Debug build
-
-# Clean only this owner's gate-assigned DerivedData.
-scripts/xcode-stream.sh --agent <agent> --session <session> -- scripts/clean-build.sh
-```
-
-The screenshots lane also boots a simulator, so gate its entire process tree:
-
-```bash
-scripts/xcode-stream.sh --agent <agent> --session <session> -- \
-  scripts/fastlane.sh screenshots
-```
-
-Archive and upload lanes do not boot simulators and remain unchanged; run them through
-`scripts/fastlane.sh` without the simulator gate.
-
-### Running Tests
-The project has unit tests in the `FoqosTests` target.
-
-**Never pass a destination or DerivedData path yourself.** The wrapper injects the exact registered
-UUID and owner-scoped DerivedData. A device-name destination can create a new simulator under
-`~/Library/Developer/XCTestDevices/` on every invocation, consuming about 16 GB each.
-
-```bash
-# Run all tests. The wrapper injects UUID destination, DerivedData, and no-clone flags.
-scripts/xcode-stream.sh --agent <agent> --session <session> -- \
-  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos
-
-# Run a single test class.
-scripts/xcode-stream.sh --agent <agent> --session <session> -- \
-  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
-  -only-testing:FoqosTests/ClassName
-```
-
-The first run may spend several minutes booting the simulator. Later runs with the same exact
-agent/session owner reuse its registered UUID. Do not boot, clone, erase, or delete that simulator
-outside the wrapper.
-
-### Code Formatting
-The project uses swift-format to maintain consistent code style. Configuration is in `.swift-format` at the repo root. A pre-commit hook auto-formats staged Swift files.
-
-**Prerequisites:** Install swift-format and ripgrep: `brew install swift-format ripgrep`
-
-```bash
-# Format all Swift files
-swift-format --in-place --recursive .
-
-# Check for formatting violations without making changes
-swift-format lint --recursive .
-```
-
-## Code Style Guidelines
-
-### Formatting & Indentation
-- **Indentation**: 2 spaces (no tabs)
-- **Line width**: Prefer 100-120 characters max
-- **Trailing whitespace**: Remove all trailing whitespace
-- **Blank lines**: One blank line between functions, two between major sections
-
-### Imports
-- Place at the top of each file
-- Group alphabetically (system frameworks first, then third-party)
-- Separate groups with blank lines
-- Remove unused imports
-
-```swift
-import DeviceActivity
-import FamilyControls
-import SwiftUI
-import WidgetKit
-```
-
-### Naming Conventions
-- **Types** (struct, class, enum): PascalCase
-  - Views: PascalCase + "View" suffix (e.g., `HomeView`, `ActionButton`)
-  - Managers: PascalCase + "Manager" suffix (e.g., `StrategyManager`)
-  - Utilities: PascalCase + "Util" suffix (e.g., `TimersUtil`)
-  - Models: PascalCase (e.g., `BlockedProfiles`)
-- **Functions/Methods**: camelCase, verb-based (e.g., `startBlocking`, `stopBlocking`)
-- **Variables/Properties**: camelCase
-- **Constants**: camelCase (not UPPER_CASE)
-- **Booleans**: Prefix with `is`, `has`, `enable`, `allow` (e.g., `isActive`, `hasPermission`)
-- **Private properties**: camelCase, no underscore prefix
-- **Static properties**: camelCase or PascalCase based on usage
-- **UserDefaults keys**: Use `family_foqos_` prefix (e.g., `family_foqos_app_mode`)
-
-### SwiftUI Patterns
-- Use `@State` for local view state
-- Use `@Binding` for parent-child data flow
-- Use `@Environment(\.keyPath)` for environment values
-- Use `@EnvironmentObject` for shared state managers
-- Use `@SafeQuery` for SwiftData queries (never raw `@Query`)
-- Prefer trailing closure syntax for view modifiers
-
-```swift
-@State private var isPresenting = false
-@Environment(\.modelContext) private var context
-@EnvironmentObject var strategyManager: StrategyManager
-@SafeQuery(sort: \BlockedProfiles.order) private var profiles: [BlockedProfiles]
-```
-
-### SwiftData Patterns
-- Mark models with `@Model`
-- Use `@Attribute(.unique)` for unique identifiers
-- Use `@Relationship` for relationships between models
-- Use `#Predicate` for complex queries
-- Always call `context.save()` after modifications
-
-```swift
-@Model
-class BlockedProfiles {
-  @Attribute(.unique) var id: UUID
-  @Relationship var sessions: [BlockedProfileSession] = []
-}
-```
-
-### SwiftData Safety with @SafeQuery
-
-Always use `@SafeQuery` instead of `@Query` in views. `@SafeQuery` is a `DynamicProperty` wrapper (defined in `Foqos/Utils/SafeQuery.swift`) that auto-filters deleted SwiftData models, preventing `EXC_BREAKPOINT` crashes from zombie objects.
-
-```swift
-// CORRECT - auto-filters deleted models
-@SafeQuery(sort: \BlockedProfiles.order) private var profiles: [BlockedProfiles]
-
-// WRONG - can crash; also rejected by pre-commit hook
-@Query(sort: \BlockedProfiles.order) private var profiles: [BlockedProfiles]
-```
-
-`@SafeQuery` mirrors the `@Query` initializers used in this codebase (excluding `animation:` and `transaction:` parameters). Use it the same way, including underscore-init for dynamic predicates:
-
-```swift
-_sessions = SafeQuery(
-  filter: #Predicate<BlockedProfileSession> { $0.blockedProfile.id == profileId },
-  sort: \BlockedProfileSession.startTime,
-  order: .reverse
-)
-```
-
-**For non-query contexts** (components receiving arrays as parameters), use the `.valid` extension:
-
-```swift
-// In components that receive [PersistentModel] arrays (not @SafeQuery)
-ForEach(profiles.valid) { profile in
-  ProfileCard(profile: profile)
-}
-```
-
-### Protocols & Strategy Pattern
-- Define clear protocols for extensible behavior
-- Protocol methods should be minimal and focused
-- Use associated types or generic constraints when appropriate
-- Strategy implementations return optional views for custom UI
-
-```swift
-protocol BlockingStrategy {
-  static var id: String { get }
-  var name: String { get }
-  func startBlocking(context: ModelContext, profile: BlockedProfiles, forceStart: Bool?) -> (any View)?
-  func stopBlocking(context: ModelContext, session: BlockedProfileSession) -> (any View)?
-}
-```
-
-### Error Handling
-- Use `try-catch` for throwing functions
-- Provide descriptive error messages for user feedback
-- Use `fatalError()` only for truly unrecoverable states (e.g., ModelContainer initialization)
-- Use `Log.debug()` for debugging instead of print()
-
-```swift
-do {
-  try context.save()
-} catch {
-  errorMessage = "Failed to save changes: \(error.localizedDescription)"
-}
-```
-
-### Logging
-
-The app uses a custom privacy-focused logging framework. Use `Log` instead of `print()`:
-
-```swift
-import Foundation  // Log is available globally
-
-// Use appropriate level and category
-Log.debug("Button tapped", category: .ui)
-Log.info("Session started for profile: \(profileId)", category: .session)
-Log.warning("Sync conflict detected", category: .sync)
-Log.error("Failed to save: \(error.localizedDescription)", category: .cloudKit)
-```
-
-**Log Levels:**
-- `debug`: Detailed debugging info (hidden in production)
-- `info`: Normal operations worth noting
-- `warning`: Potential issues that don't block functionality
-- `error`: Failures that need attention
-
-**Log Categories:**
-- `.app` - General app lifecycle
-- `.cloudKit` - CloudKit operations
-- `.sync` - Profile/session sync
-- `.strategy` - Blocking strategy operations
-- `.session` - Session lifecycle
-- `.ui` - User interface events
-- `.location` - Geofence/location
-- `.nfc` - NFC operations
-- `.timer` - Timer/scheduling
-- `.authorization` - FamilyControls auth
-- `.liveActivity` - Live Activity widgets
-- `.familyControls` - Device restrictions
-
-**Privacy:**
-- Never log passwords, lock codes, or personal identifiers
-- Profile names are acceptable (user-defined)
-- UUIDs and timestamps are acceptable
-- Users can export and share logs via:
-  - Home → version footer "Debug mode" link (when profile active) → Export Logs
-  - Settings → Diagnostics → Debug Mode → Export Logs
-
-### Control Flow
-- Use `guard` for early returns and validation
-- Prefer early returns over nested if statements
-- Use optional chaining extensively
-- Use nil-coalescing operator `??` for default values
-
-```swift
-guard let profile = try? BlockedProfiles.findProfile(byID: id, in: context) else {
-  errorMessage = "Profile not found"
-  return
-}
-```
-
-### Computed Properties
-- Use computed properties instead of functions when no parameters are needed
-- Keep computed properties lightweight
-- Avoid side effects in computed properties
-
-```swift
-var isBlocking: Bool {
-  return activeSession?.isActive == true
-}
-```
-
-### Closures
-- Prefer trailing closure syntax
-- Mark closure parameters with `@escaping` when stored
-- Use weak references in closures to avoid retain cycles in classes
-
-```swift
-strategy.onSessionCreation = { [weak self] status in
-  self?.handleSessionStatus(status)
-}
-```
-
-### Comments
-- Comments are minimal; let code be self-documenting
-- Use comments to explain "why", not "what"
-- Comment sections of related functionality
-- Document complex business logic or workarounds
-
-### Previews
-- Include `#Preview` blocks for SwiftUI views
-- Create realistic preview data
-- Use separate UserDefaults for previews
-
-```swift
-#Preview {
-  HomeView()
-    .environmentObject(RequestAuthorizer())
-    .defaultAppStorage(UserDefaults(suiteName: "preview")!)
-}
-```
-
-### Architectural Patterns
-- Use singleton pattern for shared managers via `static let shared`
-- Dependency injection via environment objects
-- Repository-like static methods on models for data operations
-- Coordinator pattern for complex flows (StrategyManager)
-
-### File Organization
-- Group related files in subdirectories (Views/, Models/, Components/, Utils/)
-- One public type per file when possible
-- Private types can be in same file
-- Extensions on types should be in separate files or grouped logically
-
-## Testing Best Practices (When Adding Tests)
-- Test public interfaces, not private implementation
-- Use async/await for async operations
-- Mock dependencies for unit tests
-- Test both success and failure paths
-- Name tests descriptively: `testGivenX_WhenY_ThenZ()`
-- Pin time in tests: never call `Date()` more than once per test. Capture a single `let now = Date()` and derive all other dates from it. Inject `now` into the method under test via `now:` parameters. This prevents flaky failures from clock drift between independent `Date()` calls.
-
-## App Modes & Lock Code Behavior
-
-The app has three operating modes with distinct lock code behaviors:
-
-| Mode | Lock Code | Can Create Unlocked Items | Can Create Locked Items | Blocked by Locked Items |
-|------|-----------|--------------------------|------------------------|------------------------|
-| **Individual** | None possible | Yes | No | No |
-| **Parent** | Can SET code | Yes | Yes | No (full access) |
-| **Child** | Synced from parent | Yes | No | Yes (requires code) |
-
-> **Individual → Parent promotion:** an Individual device can set a lock code via the Family
-> Controls Dashboard (the only user-initiated path to Parent — `ModeSelectionView` offers only
-> Individual/Child). Doing so **promotes the device to Parent** in the same action, so the
-> "Individual: Can Create Locked Items = No" invariant holds — a device never persists as
-> Individual *with* a lock code. The `setLockCode` guard therefore stays `!= .child` (not
-> `== .parent`), otherwise the promotion would deadlock.
-
-### Critical Rule for Lock Checks
-
-When checking if lock code restrictions apply:
-- **CORRECT:** `appModeManager.currentMode == .child`
-- **WRONG:** `appModeManager.currentMode != .parent`
-
-The wrong pattern blocks both Individual AND Child modes. Only Child mode should be blocked by lock codes.
-
-### When to Show Lock-Related UI
-
-- **Lock toggles** (to create locked items): Show only in Parent mode
-  ```swift
-  appModeManager.currentMode == .parent && lockCodeManager.hasAnyLockCode
-  ```
-
-- **Lock verification prompts** (to edit/delete locked items): Show only in Child mode
-  ```swift
-  item.isLocked && appModeManager.currentMode == .child
-  ```
-
-## Build Output
-
-When formatting a gated xcodebuild, use the wrapper-owned option. This retains the exact child
-status without depending on caller shell options:
-
-```bash
-scripts/xcode-stream.sh --agent <agent> --session <session> --xcpretty -- \
-  xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
-  -configuration Debug build
-```
+- Route human gates through the planner; never park `gate/*` approvals in AMQ `user`, and send `blocked on human gate: <what>` on the normal planner thread.
+- After 30 quiet minutes with in-flight work, the planner drains its inbox, inspects the agent's `inbox/new`, sweeps `user`, checks commit age/dirty files/CPU delta, then pings directly.
+- `notifier_live` proves only that the wake process runs; never treat it as work or progress evidence.
+- Announce every wait for a gate, review, or dependency when it begins.
+- A PR reported approved or merge-ready must already be ready for review and must not be a draft.
+- Never end with only promised future work; state exactly what remains, and use commit age, dirty files, and CPU delta—not message recency—as evidence.
+
+See [Multi-Agent Coordination](docs/multi-agent-coordination.md) for gate examples, heartbeat diagnostics, CPU recipes, and calibrated operator-doc sign-off.
+
+## Build, Test, and Format Commands
+
+- Build: `scripts/xcode-stream.sh --agent <agent> --session <session> --xcpretty -- xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -configuration Debug build`
+- Clean only the owner's DerivedData: `scripts/xcode-stream.sh --agent <agent> --session <session> -- scripts/clean-build.sh`
+- Test all: `scripts/xcode-stream.sh --agent <agent> --session <session> -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos`
+- Test one class: append `-only-testing:FoqosTests/ClassName` to the test command.
+- Screenshots: `scripts/xcode-stream.sh --agent <agent> --session <session> -- scripts/fastlane.sh screenshots`
+- Archive and upload lanes do not boot simulators: run them through `scripts/fastlane.sh` without the simulator gate.
+- Put `xcodebuild` directly after the wrapper's `--`; never insert `xcrun`, `env`, `bundle`, a shell, your own destination, or your own DerivedData path.
+- Format: `swift-format --in-place --recursive .`; lint: `swift-format lint --recursive .` (install with `brew install swift-format ripgrep`).
+
+## Swift and Test Invariants
+
+- Use 2-space indentation, follow `.swift-format`, and keep imports grouped/alphabetized with unused imports removed.
+- In views, use `@SafeQuery`, never raw `@Query`; for received persistent-model arrays, iterate `.valid`.
+- Save SwiftData mutations with `context.save()` and surface descriptive errors.
+- Use privacy-focused `Log`, never `print`; never log passwords, lock codes, or personal identifiers.
+- Pin time in tests: call `Date()` once per test, derive other dates, and inject `now:` into the method under test.
+
+See [Swift Style Guide](docs/swift-style-guide.md) for naming, SwiftUI/SwiftData patterns, logging categories, examples, architecture, and testing practices.
+
+## App Modes and Locking
+
+- Individual has no lock code and creates only unlocked items; Parent may set a code/create locked items and has full access; Child receives the code, creates only unlocked items, and is blocked by locked items.
+- Lock restrictions apply only when `appModeManager.currentMode == .child`, never by checking `!= .parent`.
+- Parent lock toggles require `appModeManager.currentMode == .parent && lockCodeManager.hasAnyLockCode`; Child verification requires `item.isLocked && appModeManager.currentMode == .child`.
+- Individual-to-Parent lock-code setup must keep the `setLockCode` guard `!= .child`; requiring `== .parent` deadlocks promotion.
+
+See [App Modes and Locking](docs/app-modes-and-locking.md) for the full matrix, promotion rationale, and UI rules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,26 @@ Scripts should be safe and deterministic. Any new or modified script must:
 - Keep guards in build phases or the scripts themselves, never only in Git hooks, because API
   commits bypass hooks.
 
+## Multi-agent coordination
+
+- **Human interaction routes via the planner.** The maintainer speaks through the planner session.
+  Never post `gate/*` approval requests to the AMQ `user` mailbox and wait. On the agent's normal
+  planner thread, immediately send an explicit `blocked on human gate: <what>` status instead. The
+  planner relays existing maintainer authority or obtains it.
+- **Planner heartbeat for quiet agents.** If an agent with in-flight work has sent nothing for
+  30 minutes, the planner must actively check it: drain the planner inbox, inspect the agent's
+  `inbox/new` to determine whether instructions were consumed, sweep the `user` mailbox for parked
+  gates, inspect work evidence, then ping the agent directly.
+- **Presence flags are not progress.** `notifier_live` proves only that the wake process is running;
+  never infer work or progress from it.
+- **Blockers are announced, never silent.** Any agent entering a waiting state for a gate, review,
+  or dependency sends a status message at the moment it starts waiting.
+- **Merge-ready means ready for review.** An agent reporting a PR as approved or merge-ready must
+  have already marked it ready for review; the PR must not be a draft.
+- **Never end a turn announcing future work.** If a turn must end mid-task, the final message states
+  exactly what remains so the planner can re-prompt. The planner's heartbeat verifies work through
+  commit age, dirty files, and CPU delta; message recency is not evidence of work.
+
 ## Build & Test Commands
 
 ### Building

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,11 +62,11 @@ Scripts should be safe and deterministic. Any new or modified script must:
 ## Multi-Agent Coordination
 
 - **Route human gates through the planner.** Never park `gate/*` approvals in the AMQ `user` mailbox; send `blocked on human gate: <what>` on the normal planner thread.
-- **Heartbeat quiet agents.** After 30 minutes without a message from an agent with in-flight work, the planner runs the five-step heartbeat and pings the agent directly.
+- **Heartbeat quiet agents.** After 30 minutes without a message from an agent with in-flight work, the planner drains the planner inbox, inspects the agent's `inbox/new`, sweeps the `user` mailbox for parked gates, inspects commit age, dirty files, and CPU delta, then pings the agent directly.
 - **Treat presence only as presence.** `notifier_live` proves only that the wake process is running; never treat it as work or progress evidence.
 - **Announce blockers immediately.** Send a status when any waiting state for a gate, review, or dependency begins.
 - **Make merge readiness literal.** A PR reported approved or merge-ready must already be ready for review and must not be a draft.
-- **End with evidence, not promises.** State exactly what remains; verify work using commit age, dirty files, and CPU delta, never message recency.
+- **End with evidence, not promises.** Never end a turn with only promised future work; state exactly what remains, and verify work using commit age, dirty files, and CPU delta, never message recency.
 
 See [Multi-Agent Coordination](docs/multi-agent-coordination.md) for the gate-routing examples, full heartbeat, and fail-closed CPU recipes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,12 @@ Scripts should be safe and deterministic. Any new or modified script must:
   exactly what remains so the planner can re-prompt. The planner's heartbeat verifies work through
   commit age, dirty files, and CPU delta; message recency is not evidence of work.
 
-  To measure CPU delta, resolve the role's tmux pane through the managed fleet and sample its
-  cumulative CPU time twice. Set `target_role` to the quiet agent; if the terminal is not already
-  pinned to the fleet, set `fleet_session` to its `agentctl status --json` session name:
+  To measure CPU delta, use the ownership path that actually launched the target agent and sample
+  its cumulative CPU time twice. Never borrow a fleet session from another project merely because
+  it contains the same role name; that process is not this project's agent.
+
+  For an `agentctl`-managed agent, resolve the role's tmux pane through that project's managed
+  fleet. Set `target_role` to the quiet agent and `fleet_session` to the session that owns it:
 
   ```bash
   fleet_session="${AGENTCTL_SESSION:?set the managed fleet session}"
@@ -92,6 +95,45 @@ Scripts should be safe and deterministic. Any new or modified script must:
   [ -n "$pane_id" ] || { echo "no pane for role $target_role" >&2; exit 1; }
   pane_pid=$(tmux display-message -p -t "$pane_id" '#{pane_pid}')
   ps -o pid=,time= -p "$pane_pid"
+  # Repeat after a short interval and compare TIME; use this with commit age and dirty files.
+  ```
+
+  For an agent not managed by `agentctl`, match its main executable, `AM_ME` role, and this
+  project's exact `AM_ROOT`. Descendants inherit the AMQ environment, so set `agent_executable` to
+  the main process (`codex` or `claude`) rather than matching every inherited process:
+
+  ```bash
+  target_role=build1
+  agent_executable=codex
+  project_am_root="${AM_ROOT:?run inside the project AMQ session}"
+  ps eww -axo pid=,time=,comm=,command= | awk \
+    -v executable="$agent_executable" \
+    -v target="$target_role" \
+    -v role="AM_ME=$target_role" \
+    -v root="AM_ROOT=$project_am_root" '
+      {
+        executable_name = $3
+        sub(/^.*\//, "", executable_name)
+        if (executable_name != executable) next
+        has_role = has_root = 0
+        for (field = 4; field <= NF; field++) {
+          if ($field == role) has_role = 1
+          if ($field == root) has_root = 1
+        }
+        if (has_role && has_root) {
+          count++
+          agent_pid = $1
+          agent_time = $2
+        }
+      }
+      END {
+        if (count != 1) {
+          printf "expected exactly one %s agent process for role %s under %s; found %d\n", \
+            executable, target, root, count > "/dev/stderr"
+          exit 1
+        }
+        print agent_pid, agent_time
+      }'
   # Repeat after a short interval and compare TIME; use this with commit age and dirty files.
   ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This always-loaded file is the invariant sheet for agentic work in Family Foqos.
 - Keep implementations DRY and KISS; in general, apply YAGNI.
 - Never amend or force commits. Put every fix in a new signed commit; revert with a new commit when needed.
 - Obtain independent code review before every merge. The planner merges unless the active workflow explicitly names another merger.
-- Before implementation, while the human is present, every implementation stream runs `scripts/warm-git-credentials.sh` in its clean assigned feature worktree.
+- At fleet/session startup while the human is present, the planner dispatches `scripts/warm-git-credentials.sh` to every implementation stream; each stream runs it in its clean assigned feature worktree before taking implementation work, and reruns it only if signing or SSH approval expires mid-session while the human is present.
 - The gate supports up to three Xcode/simulator streams when all simulator work uses `scripts/xcode-stream.sh --agent <agent> --session <session>` with stable ownership and UUID destinations only, never device-name destinations; it injects `-parallel-testing-enabled NO` and `-disable-concurrent-destination-testing`.
 - Keep implementation streams on separate feature branches/worktrees with disjoint files. Read-only work does not consume a gate slot and may run concurrently from another working copy.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,81 +61,14 @@ Scripts should be safe and deterministic. Any new or modified script must:
 
 ## Multi-Agent Coordination
 
-- **Human interaction routes via the planner.** The maintainer speaks through the planner session.
-  Never post `gate/*` approval requests to the AMQ `user` mailbox and wait. On the agent's normal
-  planner thread, immediately send an explicit `blocked on human gate: <what>` status instead. The
-  planner relays existing maintainer authority or obtains it.
-- **Planner heartbeat for quiet agents.** If an agent with in-flight work has sent nothing for
-  30 minutes, the planner must actively check it: drain the planner inbox, inspect the agent's
-  `inbox/new` to determine whether instructions were consumed, sweep the `user` mailbox for parked
-  gates, inspect work evidence, then ping the agent directly.
-- **Presence flags are not progress.** `notifier_live` proves only that the wake process is running;
-  never infer work or progress from it.
-- **Blockers are announced, never silent.** Any agent entering a waiting state for a gate, review,
-  or dependency sends a status message at the moment it starts waiting.
-- **Merge-ready means ready for review.** An agent reporting a PR as approved or merge-ready must
-  have already marked it ready for review; the PR must not be a draft.
-- **Never end a turn announcing future work.** If a turn must end mid-task, the final message states
-  exactly what remains so the planner can re-prompt. The planner's heartbeat verifies work through
-  commit age, dirty files, and CPU delta; message recency is not evidence of work.
+- **Route human gates through the planner.** Never park `gate/*` approvals in the AMQ `user` mailbox; send `blocked on human gate: <what>` on the normal planner thread.
+- **Heartbeat quiet agents.** After 30 minutes without a message from an agent with in-flight work, the planner runs the five-step heartbeat and pings the agent directly.
+- **Treat presence only as presence.** `notifier_live` proves only that the wake process is running; never treat it as work or progress evidence.
+- **Announce blockers immediately.** Send a status when any waiting state for a gate, review, or dependency begins.
+- **Make merge readiness literal.** A PR reported approved or merge-ready must already be ready for review and must not be a draft.
+- **End with evidence, not promises.** State exactly what remains; verify work using commit age, dirty files, and CPU delta, never message recency.
 
-  To measure CPU delta, use the ownership path that actually launched the target agent and sample
-  its cumulative CPU time twice. Never borrow a fleet session from another project merely because
-  it contains the same role name; that process is not this project's agent.
-
-  For an `agentctl`-managed agent, resolve the role's tmux pane through that project's managed
-  fleet. Set `target_role` to the quiet agent and `fleet_session` to the session that owns it:
-
-  ```bash
-  fleet_session="${AGENTCTL_SESSION:?set the managed fleet session}"
-  target_role=build1
-  status_json=$(agentctl status --session "$fleet_session" --json)
-  pane_id=$(jq -r --arg role "$target_role" \
-    '.agents[] | select(.role == $role) | .pane_id' <<<"$status_json")
-  [ -n "$pane_id" ] || { echo "no pane for role $target_role" >&2; exit 1; }
-  pane_pid=$(tmux display-message -p -t "$pane_id" '#{pane_pid}')
-  ps -o pid=,time= -p "$pane_pid"
-  # Repeat after a short interval and compare TIME; use this with commit age and dirty files.
-  ```
-
-  For an agent not managed by `agentctl`, match its main executable, `AM_ME` role, and this
-  project's exact `AM_ROOT`. Descendants inherit the AMQ environment, so set `agent_executable` to
-  the main process (`codex` or `claude`) rather than matching every inherited process:
-
-  ```bash
-  target_role=build1
-  agent_executable=codex
-  project_am_root="${AM_ROOT:?run inside the project AMQ session}"
-  ps eww -axo pid=,time=,comm=,command= | awk \
-    -v executable="$agent_executable" \
-    -v target="$target_role" \
-    -v role="AM_ME=$target_role" \
-    -v root="AM_ROOT=$project_am_root" '
-      {
-        executable_name = $3
-        sub(/^.*\//, "", executable_name)
-        if (executable_name != executable) next
-        has_role = has_root = 0
-        for (field = 4; field <= NF; field++) {
-          if ($field == role) has_role = 1
-          if ($field == root) has_root = 1
-        }
-        if (has_role && has_root) {
-          count++
-          agent_pid = $1
-          agent_time = $2
-        }
-      }
-      END {
-        if (count != 1) {
-          printf "expected exactly one %s agent process for role %s under %s; found %d\n", \
-            executable, target, root, count > "/dev/stderr"
-          exit 1
-        }
-        print agent_pid, agent_time
-      }'
-  # Repeat after a short interval and compare TIME; use this with commit age and dirty files.
-  ```
+See [Multi-Agent Coordination](docs/multi-agent-coordination.md) for the gate-routing examples, full heartbeat, and fail-closed CPU recipes.
 
 ## Build & Test Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Scripts should be safe and deterministic. Any new or modified script must:
 - Keep guards in build phases or the scripts themselves, never only in Git hooks, because API
   commits bypass hooks.
 
-## Multi-agent coordination
+## Multi-Agent Coordination
 
 - **Human interaction routes via the planner.** The maintainer speaks through the planner session.
   Never post `gate/*` approval requests to the AMQ `user` mailbox and wait. On the agent's normal
@@ -78,6 +78,21 @@ Scripts should be safe and deterministic. Any new or modified script must:
 - **Never end a turn announcing future work.** If a turn must end mid-task, the final message states
   exactly what remains so the planner can re-prompt. The planner's heartbeat verifies work through
   commit age, dirty files, and CPU delta; message recency is not evidence of work.
+
+  To measure CPU delta, resolve the role's tmux pane through the managed fleet and sample its
+  cumulative CPU time twice. Set `target_role` to the quiet agent; if the terminal is not already
+  pinned to the fleet, set `fleet_session` to its `agentctl status --json` session name:
+
+  ```bash
+  fleet_session="${AGENTCTL_SESSION:?set the managed fleet session}"
+  target_role=build1
+  status_json=$(agentctl status --session "$fleet_session" --json)
+  pane_id=$(jq -r --arg role "$target_role" \
+    '.agents[] | select(.role == $role) | .pane_id' <<<"$status_json")
+  pane_pid=$(tmux display-message -p -t "$pane_id" '#{pane_pid}')
+  ps -o pid=,time= -p "$pane_pid"
+  # Repeat after a short interval and compare TIME; use this with commit age and dirty files.
+  ```
 
 ## Build & Test Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ Scripts should be safe and deterministic. Any new or modified script must:
   status_json=$(agentctl status --session "$fleet_session" --json)
   pane_id=$(jq -r --arg role "$target_role" \
     '.agents[] | select(.role == $role) | .pane_id' <<<"$status_json")
+  [ -n "$pane_id" ] || { echo "no pane for role $target_role" >&2; exit 1; }
   pane_pid=$(tmux display-message -p -t "$pane_id" '#{pane_pid}')
   ps -o pid=,time= -p "$pane_pid"
   # Repeat after a short interval and compare TIME; use this with commit age and dirty files.

--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.27;
+				MARKETING_VERSION = 2.0.28;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.27;
+				MARKETING_VERSION = 2.0.28;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.27;
+				MARKETING_VERSION = 2.0.28;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.27;
+				MARKETING_VERSION = 2.0.28;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.27;
+				MARKETING_VERSION = 2.0.28;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.27;
+				MARKETING_VERSION = 2.0.28;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.27;
+				MARKETING_VERSION = 2.0.28;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.27;
+				MARKETING_VERSION = 2.0.28;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.27;
+				MARKETING_VERSION = 2.0.28;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.27;
+				MARKETING_VERSION = 2.0.28;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.27;
+				MARKETING_VERSION = 2.0.28;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.27;
+				MARKETING_VERSION = 2.0.28;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 44;
+				CURRENT_PROJECT_VERSION = 45;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.25;
+				MARKETING_VERSION = 2.0.26;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/docs/app-modes-and-locking.md
+++ b/docs/app-modes-and-locking.md
@@ -1,0 +1,45 @@
+# App Modes and Locking
+
+## Mode Matrix
+
+| Mode | Lock Code | Can Create Unlocked Items | Can Create Locked Items | Blocked by Locked Items |
+|---|---|---|---|---|
+| **Individual** | None possible | Yes | No | No |
+| **Parent** | Can set code | Yes | Yes | No (full access) |
+| **Child** | Synced from parent | Yes | No | Yes (requires code) |
+
+## Individual-to-Parent Promotion
+
+An Individual device can set a lock code through the Family Controls Dashboard. This is the only
+user-initiated path to Parent because `ModeSelectionView` offers only Individual and Child. Setting
+the code promotes the device to Parent in the same action, so an Individual device never persists
+with a lock code and never creates locked items.
+
+The `setLockCode` guard therefore remains `!= .child`, not `== .parent`; the latter would deadlock
+the promotion by requiring Parent mode before the action that creates it.
+
+## Lock Checks
+
+Only Child mode is restricted by lock codes:
+
+```swift
+// Correct
+appModeManager.currentMode == .child
+
+// Wrong: also matches Individual
+appModeManager.currentMode != .parent
+```
+
+## Lock-Related UI
+
+Show lock toggles, which create locked items, only in Parent mode with a configured code:
+
+```swift
+appModeManager.currentMode == .parent && lockCodeManager.hasAnyLockCode
+```
+
+Prompt to edit or delete an existing locked item only in Child mode:
+
+```swift
+item.isLocked && appModeManager.currentMode == .child
+```

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -17,8 +17,9 @@ slot.
 
 ## Warm Git Credentials
 
-At session start, while the human is present, every implementation stream runs this in its clean
-assigned feature worktree:
+At fleet/session startup, while the human is present, the planner dispatches this warm-up to every
+implementation stream. Each stream runs it in its clean assigned feature worktree before taking
+implementation work:
 
 ```bash
 scripts/warm-git-credentials.sh

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -1,0 +1,112 @@
+# Development Workflow
+
+The root `AGENTS.md` carries the common-case commands and non-negotiable invariants. This runbook
+explains credential preparation, implementation isolation, simulator ownership, safe scripts, and
+build/test/format behavior.
+
+## Keep Changes Small and Reviewable
+
+Keep implementations DRY and KISS and, in general, apply YAGNI. Never force-push or amend a
+commit. Create a new signed commit for each fix; use Git revert when history must be undone.
+Always obtain independent code review before merge.
+
+Implementation streams use separate feature branches/worktrees and disjoint files. The simulator
+gate supports up to three Xcode streams, but Git isolation does not excuse overlapping edits.
+Read-only investigation/review may run concurrently from its own working copy and consumes no gate
+slot.
+
+## Warm Git Credentials
+
+At session start, while the human is present, every implementation stream runs this in its clean
+assigned feature worktree:
+
+```bash
+scripts/warm-git-credentials.sh
+```
+
+The script fails closed unless the worktree is clean, the current branch is a named feature branch,
+and `origin` has an SSH push URL. It creates a unique scratch branch, makes a signed empty scratch
+commit, performs an SSH push dry-run, restores the starting branch, deletes the scratch branch, and
+verifies the final branch/tree. The dry run creates no remote ref.
+
+If signing or SSH approval expires, rerun the script while the human can touch the biometric
+sensor. If the human is absent, commit-only work may use the authorized GitHub
+`createCommitOnBranch` API when one server-side commit exactly represents the change; otherwise
+wait. Never disable signing, create an unsigned production commit, amend, or force-push to evade a
+prompt. The separate `op` prompt uses #365's service-account path, not this Git warm-up.
+
+## Simulator Ownership
+
+Every simulator build, test, and screenshot process tree enters through `scripts/xcode-stream.sh`.
+The machine-wide gate assigns a distinct simulator UUID, DerivedData directory, and capacity slot
+to each exact `(project, agent, session)` owner. Give every stream a stable agent name and optional
+session; later runs by the same owner reuse its registered UUID.
+
+UUID destinations only. Never pass a device-name destination: it can create a simulator under
+`~/Library/Developer/XCTestDevices/` on every invocation and consume about 16 GB. Never pass a
+destination or DerivedData path yourself. Do not boot, clone, erase, or delete a gate-owned
+simulator outside the wrapper. The wrapper injects `-parallel-testing-enabled NO` and
+`-disable-concurrent-destination-testing` to prevent XCTestDevices clones.
+
+Set `IOS_SIM_GATE_DEVICE_TYPE` or `IOS_SIM_GATE_RUNTIME` only when the task requires an override.
+Always put `xcodebuild` directly after the wrapper's `--`; do not mediate it through `xcrun`, `env`,
+`bundle`, or a shell command. Wrapper-owned formatting preserves the exact child status without
+depending on caller shell options.
+
+## Build and Clean
+
+```bash
+scripts/xcode-stream.sh --agent <agent> --session <session> --xcpretty -- \
+  xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -configuration Debug build
+
+scripts/xcode-stream.sh --agent <agent> --session <session> -- \
+  scripts/clean-build.sh
+```
+
+The clean command removes only the current owner's gate-assigned DerivedData.
+
+## Test
+
+The unit tests are in `FoqosTests`. The first run may spend several minutes booting the registered
+simulator; later runs reuse it.
+
+```bash
+scripts/xcode-stream.sh --agent <agent> --session <session> -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos
+
+scripts/xcode-stream.sh --agent <agent> --session <session> -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -only-testing:FoqosTests/ClassName
+```
+
+## Screenshots, Archives, and Uploads
+
+The screenshots lane boots a simulator, so gate its entire process tree:
+
+```bash
+scripts/xcode-stream.sh --agent <agent> --session <session> -- \
+  scripts/fastlane.sh screenshots
+```
+
+Archive and upload lanes do not boot simulators. Run them through `scripts/fastlane.sh` without the
+simulator gate.
+
+## Format Swift
+
+Configuration lives in `.swift-format`; the pre-commit hook formats staged Swift files.
+
+```bash
+brew install swift-format ripgrep
+swift-format --in-place --recursive .
+swift-format lint --recursive .
+```
+
+## Script Safety
+
+New or modified scripts must validate external dependencies with `command -v` and a named nonzero
+failure before touching shared state. They fail closed when a check cannot run, input is unreadable,
+or output is unparseable. They propagate the exact child status through pipelines and wrappers,
+verify effects rather than text forms for important invariants such as simulator-clone census, and
+put mandatory guards in build phases or scripts rather than only Git hooks because API commits
+bypass hooks.

--- a/docs/multi-agent-coordination.md
+++ b/docs/multi-agent-coordination.md
@@ -4,6 +4,14 @@ The root `AGENTS.md` carries the six common-case rules. This runbook contains th
 procedure, rationale, and diagnostics a planner needs when a gate is blocked or an agent goes
 quiet.
 
+## Warm Git Credentials at Fleet Startup
+
+At fleet/session startup, while the human is present, the planner dispatches
+`scripts/warm-git-credentials.sh` to every implementation stream. Each stream runs it in its clean
+assigned feature worktree before taking implementation work. If signing or SSH approval expires
+mid-session, the planner dispatches a rerun only while the human is present; see Development
+Workflow for the AFK commit fallback.
+
 ## Route Human Gates Through the Planner
 
 The maintainer speaks through the planner session. Never post a real `gate/*` approval request to

--- a/docs/multi-agent-coordination.md
+++ b/docs/multi-agent-coordination.md
@@ -1,0 +1,126 @@
+# Multi-Agent Coordination
+
+The root `AGENTS.md` carries the six common-case rules. This runbook contains the operational
+procedure, rationale, and diagnostics a planner needs when a gate is blocked or an agent goes
+quiet.
+
+## Route Human Gates Through the Planner
+
+The maintainer speaks through the planner session. Never post a real `gate/*` approval request to
+the AMQ `user` mailbox and wait. On the agent's normal planner thread, announce the block when it
+starts:
+
+```text
+blocked on human gate: <what>
+```
+
+The planner relays authority already supplied by the maintainer or obtains it. A user-mailbox sweep
+is part of every quiet-agent heartbeat because a parked request may otherwise remain unread even
+after the same decision is resolved through the planner.
+
+## Heartbeat a Quiet Agent
+
+If an agent with in-flight work has sent no message for 30 minutes, the planner performs all five
+steps in order:
+
+1. Drain the planner inbox.
+2. Inspect the target agent's `inbox/new` to determine whether instructions were consumed.
+3. Sweep the AMQ `user` mailbox for parked gates.
+4. Inspect commit age, dirty files, and CPU delta as work evidence.
+5. Ping the agent directly.
+
+`notifier_live` is only wake-process evidence. Message recency and presence flags do not prove that
+the agent is working. A heartbeat combines repository state with CPU delta, and its ping asks the
+agent to report either evidence of work or an explicit blocker.
+
+### Measure CPU Delta
+
+Use the ownership path that actually launched the target agent and sample its cumulative CPU time
+twice. Never borrow a fleet session from another project merely because it contains the same role
+name; that process is not this project's agent.
+
+For an `agentctl`-managed agent, resolve the role's tmux pane through that project's managed fleet.
+Set `target_role` to the quiet agent and `fleet_session` to the session that owns it:
+
+```bash
+fleet_session="${AGENTCTL_SESSION:?set the managed fleet session}"
+target_role=build1
+status_json=$(agentctl status --session "$fleet_session" --json)
+pane_id=$(jq -r --arg role "$target_role" \
+  '.agents[] | select(.role == $role) | .pane_id' <<<"$status_json")
+[ -n "$pane_id" ] || { echo "no pane for role $target_role" >&2; exit 1; }
+pane_pid=$(tmux display-message -p -t "$pane_id" '#{pane_pid}')
+ps -o pid=,time= -p "$pane_pid"
+# Repeat after a short interval and compare TIME; use this with commit age and dirty files.
+```
+
+For an agent not managed by `agentctl`, match its main executable, `AM_ME` role, and this project's
+exact `AM_ROOT`. Descendants inherit the AMQ environment, so set `agent_executable` to the main
+process (`codex` or `claude`) rather than matching every inherited process:
+
+```bash
+target_role=build1
+agent_executable=codex
+project_am_root="${AM_ROOT:?run inside the project AMQ session}"
+ps eww -axo pid=,time=,comm=,command= | awk \
+  -v executable="$agent_executable" \
+  -v target="$target_role" \
+  -v role="AM_ME=$target_role" \
+  -v root="AM_ROOT=$project_am_root" '
+    {
+      executable_name = $3
+      sub(/^.*\//, "", executable_name)
+      if (executable_name != executable) next
+      has_role = has_root = 0
+      for (field = 4; field <= NF; field++) {
+        if ($field == role) has_role = 1
+        if ($field == root) has_root = 1
+      }
+      if (has_role && has_root) {
+        count++
+        agent_pid = $1
+        agent_time = $2
+      }
+    }
+    END {
+      if (count != 1) {
+        printf "expected exactly one %s agent process for role %s under %s; found %d\n", \
+          executable, target, root, count > "/dev/stderr"
+        exit 1
+      }
+      print agent_pid, agent_time
+    }'
+# Repeat after a short interval and compare TIME; use this with commit age and dirty files.
+```
+
+Both paths fail closed: an unknown role, wrong executable, wrong project root, missing fleet, or
+ambiguous process count is a diagnostic, never a healthy sample.
+
+## Announce Blockers When They Begin
+
+An agent entering any wait for a gate, review, or dependency sends a status immediately. Include
+the exact condition and what becomes possible after it clears. Do not stay silent until a later
+heartbeat discovers the wait.
+
+For a human gate, use the required prefix. For other waits, keep the state equally explicit:
+
+```text
+blocked on review gate: independent exact-head review is pending
+```
+
+## Report Merge Readiness Literally
+
+Before reporting a PR approved or merge-ready, verify that it is already ready for review and not a
+draft. Include the exact head/base, check state, and independent review decision in the handoff.
+Only the role authorized by the current workflow performs the merge.
+
+## End Turns With the Exact Remainder
+
+Never end a turn merely announcing future work. If work remains, name the concrete remaining gate
+or action so the planner can re-prompt without reconstructing state:
+
+```text
+Exact remainder: receive maintainer final-diff sign-off, then send the merge-ready packet to the planner.
+```
+
+Once no work remains, report the completed outcome instead of promising another action.

--- a/docs/multi-agent-coordination.md
+++ b/docs/multi-agent-coordination.md
@@ -114,6 +114,17 @@ Before reporting a PR approved or merge-ready, verify that it is already ready f
 draft. Include the exact head/base, check state, and independent review decision in the handoff.
 Only the role authorized by the current workflow performs the merge.
 
+### Calibrate Operator-Document Sign-Off
+
+New or restructured operator flows require blocking reviewer approval, an executable walkthrough
+where applicable, and a maintainer final read. A tiny delta does not make the maintainer a blocking
+gate: `tiny` means prose-only, with no new or changed flow step and no new command. The planner
+classifies the delta; the reviewer may escalate that classification to the full gates.
+
+Tiny deltas still require reviewer approval, green checks, and planner merge. Name the delta in the
+planner's next maintainer-facing report. That notice, plus a cheap revert by new commit, provides a
+retroactive veto; there is no wall-clock veto window.
+
 ## End Turns With the Exact Remainder
 
 Never end a turn merely announcing future work. If work remains, name the concrete remaining gate

--- a/docs/superpowers/plans/2026-08-13-issue-387-multi-agent-coordination.md
+++ b/docs/superpowers/plans/2026-08-13-issue-387-multi-agent-coordination.md
@@ -218,3 +218,81 @@ OPEN, `isDraft=false`, MERGEABLE/CLEAN with green checks.
 Obtain reviewer delta approval and a cheap re-read confirming the six one-liners and reference are
 followable. Then ask the maintainer to read the final diff and explicitly sign off. Only after that
 sign-off send the merge-ready packet to the planner; build1 does not merge.
+
+### Task 5: Rewrite the full developer guide as an invariant index
+
+**Files:**
+- Modify: `AGENTS.md`
+- Create: `docs/development-workflow.md`
+- Create: `docs/swift-style-guide.md`
+- Create: `docs/app-modes-and-locking.md`
+- Modify: `docs/multi-agent-coordination.md`
+- Create: `scripts/warm-git-credentials.sh`
+- Create: `scripts/test-warm-git-credentials.sh`
+
+**Interfaces:**
+- Consumes: every normative statement, table, example, and command in `AGENTS.md@669f202`.
+- Produces: a root invariant/index file of at most 100 physical lines, four focused durable docs,
+  and a tested `scripts/warm-git-credentials.sh` entrypoint.
+
+**Losslessness ledger:**
+
+| Current content | Root keeps | Detail destination |
+|---|---|---|
+| never amend/force; review before merge | both prohibitions | `docs/development-workflow.md` rationale |
+| biometric warm-up transaction/fallback | required script invocation | script + `docs/development-workflow.md` |
+| simulator ownership and concurrency | wrapper/UUID/direct-child prohibitions | `docs/development-workflow.md` |
+| five script-safety rules | all five terse rules | `docs/development-workflow.md` examples |
+| six coordination rules | all six one-liners | `docs/multi-agent-coordination.md` |
+| build/test/clean/screenshots/archive/format commands | one-line commands | `docs/development-workflow.md` explanations |
+| formatting/imports/naming/SwiftUI/SwiftData/SafeQuery/protocol/error/logging/control-flow/computed/closures/comments/previews/architecture/files | high-risk `@SafeQuery`, save, and Log/privacy invariants | `docs/swift-style-guide.md`, including every example |
+| testing best practices | one-Date-per-test invariant | `docs/swift-style-guide.md` |
+| app-mode matrix/promotion/lock checks/UI predicates | mode summary and exact predicates/guard | `docs/app-modes-and-locking.md` |
+| duplicated Build Output example | canonical wrapper command | `docs/development-workflow.md` |
+
+- [ ] **Step 1: Write the failing root inventory audit**
+
+Create an ad hoc Ruby audit that requires `AGENTS.md` to be at most 100 lines; contain the critical
+Git, credential, simulator, script-safety, coordination, SwiftData/logging/testing, and lock-mode
+invariants plus canonical one-line commands; link exactly once to each of the four durable docs;
+and contain none of the moved example headings, tables, or fenced code blocks. Run it against
+`669f202`; expect failure on line budget and missing three detail links.
+
+- [ ] **Step 2: Write the failing warm-up regression harness**
+
+Create `scripts/test-warm-git-credentials.sh` with isolated fake-Git cases for success, dirty tree,
+detached/unnamed branch, default branch, non-SSH push URL, signed-commit failure, dry-run failure,
+branch restoration, scratch deletion, final clean state, and exact child exit propagation. Run it;
+expect failure because `scripts/warm-git-credentials.sh` does not exist.
+
+- [ ] **Step 3: Implement the warm-up script minimally**
+
+Create a Bash entrypoint with `set -euo pipefail`, dependency/precondition diagnostics, unique
+scratch branch, cleanup trap, signed empty commit, SSH dry-run, and postcondition checks. Run the
+harness; expect every case to pass. Run `shellcheck` on both scripts.
+
+- [ ] **Step 4: Relocate all guide detail using the ledger**
+
+Rewrite root `AGENTS.md` as a self-sufficient invariant/index file of at most 100 lines. Create the
+three new focused docs, preserve the existing coordination runbook, and copy every ledger item to
+its root/detail destination without semantic deletion. Add the calibrated sign-off contract:
+`tiny` means prose-only with no new/changed flow step and no new command; planner classifies and
+reviewer may escalate; reviewer approval, green checks, and planner merge remain blocking; name the
+delta in the next maintainer report for retroactive veto/revert by new commit; all other operator
+changes keep full reviewer/walkthrough/maintainer gates.
+
+- [ ] **Step 5: Run relocation and executable verification**
+
+Run the root inventory/link audit, warm-up harness, shellcheck, `scripts/test-xcode-stream.sh`, both
+CPU recipes extracted from `docs/multi-agent-coordination.md`, version/C2/sync/privacy/whitespace
+guards, and verify all 12 version settings remain 2.0.26 (45). Compare the ledger with the final
+diff and record a destination for every row.
+
+- [ ] **Step 6: Commit, push, and run operator gates**
+
+Create new signed commits without amend, update PR #415 title/body for the full rewrite, and verify
+OPEN/non-draft/MERGEABLE-CLEAN exact-head checks. Obtain a full independent reviewer pass using the
+losslessness ledger. Ask the planner to stage the real warm-up walkthrough while the maintainer is
+physically present; verify the assigned branch/tree are restored. Exercise wrapper entrypoints via
+existing tests without launching unnecessary Xcode. Then obtain maintainer final read of the new
+root `AGENTS.md` and hand off to the planner for merge.

--- a/docs/superpowers/plans/2026-08-13-issue-387-multi-agent-coordination.md
+++ b/docs/superpowers/plans/2026-08-13-issue-387-multi-agent-coordination.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add the six field-tested coordination rules from issue #387 to the operator-facing developer guidelines.
 
-**Architecture:** Treat issue #387 as the authoritative specification and add one focused `Multi-Agent Coordination` section to `AGENTS.md`. Verify the rules by exact text audit, independent review, and a planner-led live walkthrough that includes both the safe path and a deliberately induced parked-gate failure.
+**Architecture:** Treat issue #387 as the authoritative specification. Keep its six common-case actions as self-sufficient one-line rules in `AGENTS.md`, then link once to `docs/multi-agent-coordination.md` for rationale, examples, the full heartbeat, and executable CPU recipes. Verify the rules by exact text audit, independent review, and a planner-led live walkthrough that includes both the safe path and a deliberately induced parked-gate failure.
 
 **Tech Stack:** Markdown, AMQ CLI, GitHub pull-request metadata, repository version gate.
 
@@ -13,6 +13,8 @@
 - Work only on `docs/387-multi-agent-coordination`, forked from `main@4a4f512e198de0b50b5da695c11f9f25a7569a5e`.
 - Issue #387 is the authoritative spec; create no redundant design document.
 - Preserve all six issue rules and their operational details without weakening them.
+- Apply progressive disclosure: exactly six one-line rules and one detail reference in `AGENTS.md`;
+  durable procedure belongs in `docs/multi-agent-coordination.md`, not this historical plan.
 - Do not post real human approval requests to the AMQ `user` mailbox; the only exception is the explicitly authorized harmless walkthrough-test message, which the planner must detect and drain immediately.
 - Obtain independent reviewer approval before the operator walkthrough.
 - Mark the PR ready for review before reporting it merge-ready.
@@ -27,11 +29,13 @@
 
 **Files:**
 - Modify: `AGENTS.md`
+- Create: `docs/multi-agent-coordination.md`
 - Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
 
 **Interfaces:**
 - Consumes: the six numbered requirements in GitHub issue #387.
-- Produces: one `## Multi-Agent Coordination` section and release 2.0.26 (45) in all configurations.
+- Produces: one concise `## Multi-Agent Coordination` index, one durable detail runbook, and
+  release 2.0.26 (45) in all configurations.
 
 - [ ] **Step 1: Add the focused guideline section**
 
@@ -169,3 +173,48 @@ read-along session. Do not hand off for merge until the planner reports the sign
 
 Send the PR URL, exact head/base SHAs, independent review decision, green checks, walkthrough
 evidence, and maintainer sign-off. The planner merges; build1 does not.
+
+### Task 4: Apply maintainer-requested progressive disclosure
+
+**Files:**
+- Modify: `AGENTS.md`
+- Create: `docs/multi-agent-coordination.md`
+- Modify: `docs/superpowers/plans/2026-08-13-issue-387-multi-agent-coordination.md`
+
+**Interfaces:**
+- Consumes: the six walkthrough-tested rules and both verified CPU-delta recipes at `2d22c5c`.
+- Produces: six common-case one-liners plus one resolvable detail link in `AGENTS.md`; a durable
+  runbook containing all relocated detail with no behavioral change.
+
+- [ ] **Step 1: Write and run a failing structure audit**
+
+The audit must require exactly six bullets between `## Multi-Agent Coordination` and the next
+level-two heading, exactly one reference to `docs/multi-agent-coordination.md`, no fenced code in
+that root section, all six common-case actions, and a present link target. It must fail against
+`2d22c5c` because the section contains multi-line procedures and no durable detail link.
+
+- [ ] **Step 2: Relocate detail without weakening the one-liners**
+
+Make each root bullet one physical Markdown line and independently actionable. Move the safe gate
+example, five-step heartbeat, progress-evidence rationale, fleet CPU recipe, standalone CPU recipe,
+foreign-fleet warning, wait announcement, non-draft check, and exact-remainder examples into
+`docs/multi-agent-coordination.md`. Add one reference line after the six bullets.
+
+- [ ] **Step 3: Verify the moved operator text**
+
+Run the structure/link audit. Extract and execute both Bash blocks from their new file: verify the
+managed-fleet block still fails closed for an unknown role, and verify the standalone block resolves
+this project's build1 process twice with a nondecreasing CPU time and exits 1 for a missing role.
+Run the repository version, C2, sync, privacy, and whitespace guards.
+
+- [ ] **Step 4: Commit and publish the relocation**
+
+Create one new signed commit; never amend. Push PR #415, update its walkthrough transcript to say
+the walkthrough-tested content moved without behavior change, and confirm the exact final head is
+OPEN, `isDraft=false`, MERGEABLE/CLEAN with green checks.
+
+- [ ] **Step 5: Repeat the operator-document gates**
+
+Obtain reviewer delta approval and a cheap re-read confirming the six one-liners and reference are
+followable. Then ask the maintainer to read the final diff and explicitly sign off. Only after that
+sign-off send the merge-ready packet to the planner; build1 does not merge.

--- a/docs/superpowers/plans/2026-08-13-issue-387-multi-agent-coordination.md
+++ b/docs/superpowers/plans/2026-08-13-issue-387-multi-agent-coordination.md
@@ -239,6 +239,7 @@ sign-off send the merge-ready packet to the planner; build1 does not merge.
 
 | Current content | Root keeps | Detail destination |
 |---|---|---|
+| maintainer-added implementation principle | DRY, KISS, and generally YAGNI | `docs/development-workflow.md` rationale |
 | never amend/force; review before merge | both prohibitions | `docs/development-workflow.md` rationale |
 | biometric warm-up transaction/fallback | required script invocation | script + `docs/development-workflow.md` |
 | simulator ownership and concurrency | wrapper/UUID/direct-child prohibitions | `docs/development-workflow.md` |
@@ -252,7 +253,8 @@ sign-off send the merge-ready packet to the planner; build1 does not merge.
 
 - [ ] **Step 1: Write the failing root inventory audit**
 
-Create an ad hoc Ruby audit that requires `AGENTS.md` to be at most 100 lines; contain the critical
+Create an ad hoc Ruby audit that requires `AGENTS.md` to be at most 100 lines; contain
+DRY/KISS/YAGNI and the critical
 Git, credential, simulator, script-safety, coordination, SwiftData/logging/testing, and lock-mode
 invariants plus canonical one-line commands; link exactly once to each of the four durable docs;
 and contain none of the moved example headings, tables, or fenced code blocks. Run it against

--- a/docs/superpowers/plans/2026-08-13-issue-387-multi-agent-coordination.md
+++ b/docs/superpowers/plans/2026-08-13-issue-387-multi-agent-coordination.md
@@ -1,0 +1,169 @@
+# Multi-Agent Coordination Rules Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the six field-tested coordination rules from issue #387 to the operator-facing developer guidelines.
+
+**Architecture:** Treat issue #387 as the authoritative specification and add one focused `Multi-agent coordination` section to `AGENTS.md`. Verify the rules by exact text audit, independent review, and a planner-led live walkthrough that includes both the safe path and a deliberately induced parked-gate failure.
+
+**Tech Stack:** Markdown, AMQ CLI, GitHub pull-request metadata, repository version gate.
+
+## Global Constraints
+
+- Work only on `docs/387-multi-agent-coordination`, forked from `main@4a4f512e198de0b50b5da695c11f9f25a7569a5e`.
+- Issue #387 is the authoritative spec; create no redundant design document.
+- Preserve all six issue rules and their operational details without weakening them.
+- Do not post real human approval requests to the AMQ `user` mailbox; the only exception is the explicitly authorized harmless walkthrough-test message, which the planner must detect and drain immediately.
+- Obtain independent reviewer approval before the operator walkthrough.
+- Mark the PR ready for review before reporting it merge-ready.
+- Obtain explicit maintainer sign-off after they read the final diff and after the walkthrough passes.
+- Do not merge; the planner owns merge.
+- Advance all 12 configurations from 2.0.25 (44) to 2.0.26 (45), refreshing from live `main` and re-bumping if another PR lands first.
+- Do not run Xcode or simulator work; this is an operator-documentation and release-metadata change.
+
+---
+
+### Task 1: Add the six coordination rules and release bump
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+- Consumes: the six numbered requirements in GitHub issue #387.
+- Produces: one `## Multi-agent coordination` section and release 2.0.26 (45) in all configurations.
+
+- [ ] **Step 1: Add the focused guideline section**
+
+Place the section beside the repository's other always-on operational policies. Cover exactly:
+
+1. Human interaction routes through the planner; agents never park real `gate/*` approvals in the `user` mailbox and instead send `blocked on human gate: <what>` on their normal planner thread.
+2. At 30 minutes of silence from an agent with in-flight work, the planner drains its own inbox, checks the agent's `inbox/new`, sweeps the `user` mailbox for parked gates, inspects work evidence, and pings the agent directly.
+3. `notifier_live` proves only the wake process is alive and is never evidence of progress.
+4. An agent announces every waiting state when it begins, including gates, reviews, and dependencies.
+5. A merge-ready PR is already ready for review, never draft.
+6. A turn never ends with only promised future work; if work remains, the final message names the exact remainder. Planner heartbeat uses commit age, dirty files, and CPU delta rather than message recency as work evidence.
+
+- [ ] **Step 2: Bump every configuration**
+
+Change every `CURRENT_PROJECT_VERSION = 44;` to `45` and every
+`MARKETING_VERSION = 2.0.25;` to `2.0.26`. Do not change other project settings.
+
+- [ ] **Step 3: Run static verification**
+
+Run:
+
+```bash
+rg -n '^## Multi-agent coordination|blocked on human gate|30 minutes|inbox/new|notifier_live|waiting state|draft|future work|commit age|dirty files|CPU delta' AGENTS.md
+test "$(rg -c 'CURRENT_PROJECT_VERSION = 45;' FamilyFoqos.xcodeproj/project.pbxproj)" -eq 12
+test "$(rg -c 'MARKETING_VERSION = 2.0.26;' FamilyFoqos.xcodeproj/project.pbxproj)" -eq 12
+scripts/test-check-version-increment.sh
+git diff --check
+```
+
+Expected: the text audit finds one section and every required operational phrase; both counts are
+12; the version gate and diff check pass.
+
+- [ ] **Step 4: Commit the implementation**
+
+```bash
+git add AGENTS.md FamilyFoqos.xcodeproj/project.pbxproj
+git commit -S -m "docs: add multi-agent coordination rules"
+```
+
+### Task 2: Verify and obtain independent review
+
+**Files:**
+- Verify only: `AGENTS.md`, `FamilyFoqos.xcodeproj/project.pbxproj`.
+
+**Interfaces:**
+- Consumes: the exact committed Task 1 head.
+- Produces: a clean evidence packet and reviewer READY decision before operator testing.
+
+- [ ] **Step 1: Verify the exact committed head**
+
+Run the Task 1 static checks again, plus:
+
+```bash
+scripts/check-c2-guards.sh
+scripts/check-sync-guards.sh
+/usr/bin/ruby scripts/check-log-privacy.rb --root .
+git merge-base --is-ancestor origin/main HEAD
+test -z "$(git status --porcelain)"
+```
+
+Expected: every command returns zero; no Xcode or simulator command runs.
+
+- [ ] **Step 2: Request independent read-only review**
+
+Send the reviewer issue URL, exact base/head SHAs, final diff, six-rule mapping, version evidence,
+and planned operator walkthrough. Ask for Critical/Important/Minor findings and READY yes/no. The
+reviewer must not mutate files or run Xcode.
+
+- [ ] **Step 3: Address findings with new commits**
+
+Fix all Critical and Important findings without amend or force-push, rerun proportionate checks,
+and obtain READY on the new exact head.
+
+### Task 3: Publish an undrafted PR and run the operator walkthrough
+
+**Files:**
+- No source changes unless the walkthrough exposes a documentation defect.
+
+**Interfaces:**
+- Consumes: independently approved exact head.
+- Produces: a ready-for-review PR, live evidence for all testable coordination rules, and maintainer sign-off.
+
+- [ ] **Step 1: Refresh, push, and open the PR ready for review**
+
+Refresh `origin/main`, preserve ancestry, resolve any version collision in a new signed commit,
+push the branch, and open a non-draft PR titled `Document multi-agent coordination rules (#387)`
+with `Closes #387`. Require green GitHub checks and verify `isDraft=false`, `mergeable=MERGEABLE`,
+the reviewed head SHA, and base `main` before calling it merge-ready.
+
+- [ ] **Step 2: Run the safe human-gate and blocker-announcement demonstration**
+
+On the #387 planner thread, send this harmless status at the moment the simulated wait begins:
+
+```text
+blocked on human gate: walkthrough-only confirmation; no real work is blocked
+```
+
+The planner confirms it was drained on the normal thread and that the `user` mailbox has no new
+message from this safe-path demonstration.
+
+- [ ] **Step 3: Induce and detect the documented parked-gate failure**
+
+Send one clearly labeled harmless walkthrough-test message to the `user` mailbox on a stable
+`gate/387-walkthrough-test` thread. The planner then performs the documented sweep, finds and
+drains it, and confirms no test gate remains parked. This is the only authorized exception to the
+new no-`user`-mailbox rule.
+
+- [ ] **Step 4: Demonstrate the full quiet-agent heartbeat**
+
+Without waiting 30 minutes, the planner runs the sequence on a live agent:
+
+1. drain the planner inbox;
+2. inspect the target agent's `inbox/new` to see whether instructions were consumed;
+3. inspect the `user` mailbox for parked gates;
+4. inspect commit age, dirty files, and CPU delta as work evidence; and
+5. ping the agent directly.
+
+Record that `notifier_live` was treated only as wake-process evidence, not progress evidence.
+
+- [ ] **Step 5: Audit PR readiness and turn-ending text**
+
+Show `isDraft=false` in PR metadata. Inspect the implementer's current handoff: if work remains,
+it names the exact remainder; once nothing remains, it says the work is complete rather than
+announcing a future action.
+
+- [ ] **Step 6: Obtain maintainer sign-off**
+
+After the reviewer is READY and every walkthrough step passes, ask the planner to have the
+maintainer read the final PR diff and explicitly sign off. Do not ask the maintainer to join a
+read-along session. Do not hand off for merge until the planner reports the sign-off.
+
+- [ ] **Step 7: Hand off to the planner for merge**
+
+Send the PR URL, exact head/base SHAs, independent review decision, green checks, walkthrough
+evidence, and maintainer sign-off. The planner merges; build1 does not.

--- a/docs/superpowers/plans/2026-08-13-issue-387-multi-agent-coordination.md
+++ b/docs/superpowers/plans/2026-08-13-issue-387-multi-agent-coordination.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add the six field-tested coordination rules from issue #387 to the operator-facing developer guidelines.
 
-**Architecture:** Treat issue #387 as the authoritative specification and add one focused `Multi-agent coordination` section to `AGENTS.md`. Verify the rules by exact text audit, independent review, and a planner-led live walkthrough that includes both the safe path and a deliberately induced parked-gate failure.
+**Architecture:** Treat issue #387 as the authoritative specification and add one focused `Multi-Agent Coordination` section to `AGENTS.md`. Verify the rules by exact text audit, independent review, and a planner-led live walkthrough that includes both the safe path and a deliberately induced parked-gate failure.
 
 **Tech Stack:** Markdown, AMQ CLI, GitHub pull-request metadata, repository version gate.
 
@@ -31,7 +31,7 @@
 
 **Interfaces:**
 - Consumes: the six numbered requirements in GitHub issue #387.
-- Produces: one `## Multi-agent coordination` section and release 2.0.26 (45) in all configurations.
+- Produces: one `## Multi-Agent Coordination` section and release 2.0.26 (45) in all configurations.
 
 - [ ] **Step 1: Add the focused guideline section**
 
@@ -54,7 +54,7 @@ Change every `CURRENT_PROJECT_VERSION = 44;` to `45` and every
 Run:
 
 ```bash
-rg -n '^## Multi-agent coordination|blocked on human gate|30 minutes|inbox/new|notifier_live|waiting state|draft|future work|commit age|dirty files|CPU delta' AGENTS.md
+rg -n '^## Multi-Agent Coordination|blocked on human gate|30 minutes|inbox/new|notifier_live|waiting state|draft|future work|commit age|dirty files|CPU delta' AGENTS.md
 test "$(rg -c 'CURRENT_PROJECT_VERSION = 45;' FamilyFoqos.xcodeproj/project.pbxproj)" -eq 12
 test "$(rg -c 'MARKETING_VERSION = 2.0.26;' FamilyFoqos.xcodeproj/project.pbxproj)" -eq 12
 scripts/test-check-version-increment.sh
@@ -150,6 +150,8 @@ Without waiting 30 minutes, the planner runs the sequence on a live agent:
 5. ping the agent directly.
 
 Record that `notifier_live` was treated only as wake-process evidence, not progress evidence.
+The walkthrough transcript must state that this accelerated demonstration validates the five-step
+response sequence but does not validate detection of the 30-minute trigger itself.
 
 - [ ] **Step 5: Audit PR readiness and turn-ending text**
 

--- a/docs/swift-style-guide.md
+++ b/docs/swift-style-guide.md
@@ -1,0 +1,208 @@
+# Swift Style Guide
+
+The root `AGENTS.md` carries the highest-risk invariants. Apply the complete conventions below to
+Swift implementation and tests.
+
+## Formatting and Imports
+
+- Indent with 2 spaces, never tabs.
+- Prefer 100–120 characters maximum line width.
+- Remove trailing whitespace.
+- Use one blank line between functions and two between major sections.
+- Put imports at the top, group alphabetically with system frameworks before third-party modules,
+  separate groups with a blank line, and remove unused imports.
+
+```swift
+import DeviceActivity
+import FamilyControls
+import SwiftUI
+import WidgetKit
+```
+
+## Naming
+
+- Types use PascalCase. Views end in `View`, managers in `Manager`, and utilities in `Util`.
+- Models use descriptive PascalCase names such as `BlockedProfiles`.
+- Functions and methods use verb-based camelCase such as `startBlocking`.
+- Variables, properties, and constants use camelCase, not upper snake case.
+- Boolean names begin with `is`, `has`, `enable`, or `allow`.
+- Private properties have no underscore prefix.
+- Static properties use camelCase or PascalCase according to their role.
+- UserDefaults keys use the `family_foqos_` prefix.
+
+## SwiftUI
+
+- Use `@State` for local view state and `@Binding` for parent-child data flow.
+- Use `@Environment(\.keyPath)` for environment values and `@EnvironmentObject` for shared
+  managers.
+- Prefer trailing-closure syntax for view modifiers.
+- Use `@SafeQuery`, never raw `@Query`.
+
+```swift
+@State private var isPresenting = false
+@Environment(\.modelContext) private var context
+@EnvironmentObject var strategyManager: StrategyManager
+@SafeQuery(sort: \BlockedProfiles.order) private var profiles: [BlockedProfiles]
+```
+
+## SwiftData
+
+- Mark models with `@Model`.
+- Use `@Attribute(.unique)` for unique identifiers and `@Relationship` for relationships.
+- Use `#Predicate` for complex queries.
+- Call `context.save()` after modifications and report descriptive failures.
+
+```swift
+@Model
+class BlockedProfiles {
+  @Attribute(.unique) var id: UUID
+  @Relationship var sessions: [BlockedProfileSession] = []
+}
+```
+
+### SafeQuery and Deleted Models
+
+`@SafeQuery` is a `DynamicProperty` wrapper in `Foqos/Utils/SafeQuery.swift`. It mirrors the Query
+initializers used by this codebase, except `animation:` and `transaction:`, and filters deleted
+SwiftData models to prevent zombie-object `EXC_BREAKPOINT` crashes.
+
+```swift
+// Correct
+@SafeQuery(sort: \BlockedProfiles.order) private var profiles: [BlockedProfiles]
+
+// Wrong and rejected by the pre-commit hook
+@Query(sort: \BlockedProfiles.order) private var profiles: [BlockedProfiles]
+```
+
+Use underscore initialization for dynamic predicates:
+
+```swift
+_sessions = SafeQuery(
+  filter: #Predicate<BlockedProfileSession> { $0.blockedProfile.id == profileId },
+  sort: \BlockedProfileSession.startTime,
+  order: .reverse
+)
+```
+
+Components that receive persistent-model arrays instead of querying use `.valid`:
+
+```swift
+ForEach(profiles.valid) { profile in
+  ProfileCard(profile: profile)
+}
+```
+
+## Protocols and Strategy Pattern
+
+Define focused protocols with minimal methods. Use associated types or generic constraints when
+appropriate. Strategy implementations may return optional views for custom UI.
+
+```swift
+protocol BlockingStrategy {
+  static var id: String { get }
+  var name: String { get }
+  func startBlocking(
+    context: ModelContext,
+    profile: BlockedProfiles,
+    forceStart: Bool?
+  ) -> (any View)?
+  func stopBlocking(context: ModelContext, session: BlockedProfileSession) -> (any View)?
+}
+```
+
+## Error Handling
+
+Use `try`/`catch` for throwing functions and give users descriptive error messages. Reserve
+`fatalError()` for unrecoverable initialization such as ModelContainer creation. Use `Log`, never
+`print()`, for diagnostics.
+
+```swift
+do {
+  try context.save()
+} catch {
+  errorMessage = "Failed to save changes: \(error.localizedDescription)"
+}
+```
+
+## Privacy-Focused Logging
+
+Use the global custom `Log` framework with the narrowest appropriate level and category:
+
+```swift
+Log.debug("Button tapped", category: .ui)
+Log.info("Session started for profile: \(profileId)", category: .session)
+Log.warning("Sync conflict detected", category: .sync)
+Log.error("Failed to save: \(error.localizedDescription)", category: .cloudKit)
+```
+
+Levels are `debug` (hidden in production), `info` (normal noteworthy operation), `warning`
+(potential issue), and `error` (failure requiring attention).
+
+Categories are `.app`, `.cloudKit`, `.sync`, `.strategy`, `.session`, `.ui`, `.location`, `.nfc`,
+`.timer`, `.authorization`, `.liveActivity`, and `.familyControls`.
+
+Never log passwords, lock codes, or personal identifiers. User-defined profile names are allowed;
+UUIDs and timestamps are allowed. Users export logs through Home → version footer “Debug mode” →
+Export Logs when a profile is active, or Settings → Diagnostics → Debug Mode → Export Logs.
+
+## Control Flow and Properties
+
+- Prefer `guard` and early returns over nested conditions.
+- Use optional chaining and `??` for defaults.
+- Use lightweight computed properties instead of parameterless functions; computed properties have
+  no side effects.
+
+```swift
+guard let profile = try? BlockedProfiles.findProfile(byID: id, in: context) else {
+  errorMessage = "Profile not found"
+  return
+}
+
+var isBlocking: Bool {
+  return activeSession?.isActive == true
+}
+```
+
+## Closures
+
+Prefer trailing-closure syntax, mark stored closures `@escaping`, and use weak references where a
+class closure would otherwise retain its owner.
+
+```swift
+strategy.onSessionCreation = { [weak self] status in
+  self?.handleSessionStatus(status)
+}
+```
+
+## Comments and Previews
+
+Keep comments minimal and explain why rather than what. Document complex business rules and
+workarounds. Include realistic `#Preview` blocks and isolate preview defaults.
+
+```swift
+#Preview {
+  HomeView()
+    .environmentObject(RequestAuthorizer())
+    .defaultAppStorage(UserDefaults(suiteName: "preview")!)
+}
+```
+
+## Architecture and Files
+
+- Shared managers use `static let shared` when singleton ownership is intended.
+- Inject shared managers through environment objects.
+- Models expose repository-like static data methods.
+- `StrategyManager` coordinates complex flows.
+- Group files under `Views/`, `Models/`, `Components/`, and `Utils/`.
+- Prefer one public type per file. Private related types may remain together; group extensions
+  logically or place them in separate files.
+
+## Testing
+
+- Test public interfaces rather than private implementation.
+- Use async/await for asynchronous behavior.
+- Mock dependencies when isolation requires it.
+- Cover success and failure paths.
+- Use descriptive names such as `testGivenX_WhenY_ThenZ()`.
+- Pin time: call `Date()` once per test, capture `let now = Date()`, derive all other dates from it,
+  and inject `now:` into the method under test. Independent clock reads create flaky drift.

--- a/scripts/test-warm-git-credentials.sh
+++ b/scripts/test-warm-git-credentials.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+subject="$repo_root/scripts/warm-git-credentials.sh"
+test_root=$(mktemp -d)
+trap 'rm -rf -- "$test_root"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+mkdir -p "$test_root/bin"
+cat >"$test_root/bin/git" <<'FAKE_GIT'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >>"$WARM_TEST_LOG"
+command_name=${1:-}
+shift || true
+case "$command_name ${1:-}" in
+  "rev-parse --is-inside-work-tree") echo true ;;
+  "status --porcelain")
+    [[ ${WARM_TEST_SCENARIO:-} == dirty ]] && echo ' M user-file'
+    exit 0
+    ;;
+  "branch --show-current") cat "$WARM_TEST_BRANCH" ;;
+  "remote get-url") echo "${WARM_TEST_REMOTE:-git@github.com:mnbf9rca/family-foqos.git}" ;;
+  "switch -c")
+    [[ ${WARM_TEST_SCENARIO:-} == switch_create_fail ]] && exit 41
+    printf '%s\n' "$2" >"$WARM_TEST_BRANCH"
+    printf '%s\n' "$2" >"$WARM_TEST_SCRATCH"
+    ;;
+  "switch "*)
+    [[ ${WARM_TEST_SCENARIO:-} == switch_restore_fail ]] && exit 44
+    printf '%s\n' "$1" >"$WARM_TEST_BRANCH"
+    ;;
+  "commit -S")
+    [[ ${WARM_TEST_SCENARIO:-} == commit_fail ]] && exit 42
+    exit 0
+    ;;
+  "push --dry-run")
+    [[ ${WARM_TEST_SCENARIO:-} == push_fail ]] && exit 43
+    exit 0
+    ;;
+  "show-ref --verify") [[ -s "$WARM_TEST_SCRATCH" ]] || exit 1 ;;
+  "branch -D") : >"$WARM_TEST_SCRATCH" ;;
+  *) echo "unexpected fake git call: $command_name $*" >&2; exit 90 ;;
+esac
+FAKE_GIT
+chmod +x "$test_root/bin/git"
+
+run_case() {
+  local scenario=$1
+  local branch=${2-feature/387}
+  local remote=${3-git@github.com:mnbf9rca/family-foqos.git}
+  case_root="$test_root/$scenario"
+  mkdir -p "$case_root"
+  printf '%s\n' "$branch" >"$case_root/branch"
+  : >"$case_root/scratch"
+  : >"$case_root/log"
+  set +e
+  output=$(
+    PATH="$test_root/bin:/usr/bin:/bin" \
+      WARM_TEST_SCENARIO="$scenario" \
+      WARM_TEST_REMOTE="$remote" \
+      WARM_TEST_BRANCH="$case_root/branch" \
+      WARM_TEST_SCRATCH="$case_root/scratch" \
+      WARM_TEST_LOG="$case_root/log" \
+      "$subject" 2>&1
+  )
+  result=$?
+  set -e
+}
+
+[[ -x "$subject" ]] || fail "warm-up script is missing or not executable"
+
+run_case success
+[[ $result -eq 0 ]] || fail "success returned $result: $output; calls: $(tr '\n' ';' <"$case_root/log")"
+[[ $(cat "$case_root/branch") == feature/387 ]] || fail "success did not restore branch"
+[[ ! -s "$case_root/scratch" ]] || fail "success did not delete scratch branch"
+rg -q '^commit -S --allow-empty -m chore: biometric warm-up \(discard\)$' "$case_root/log" || fail "signed scratch commit missing"
+rg -q '^push --dry-run origin HEAD:refs/heads/scratch/biometric-warmup/' "$case_root/log" || fail "SSH dry-run missing"
+
+run_case dirty
+[[ $result -eq 1 && $output == *"worktree must be clean"* ]] || fail "dirty tree did not fail closed"
+
+run_case success ''
+[[ $result -eq 1 && $output == *"named feature branch"* ]] || fail "unnamed branch did not fail closed"
+
+run_case success main
+[[ $result -eq 1 && $output == *"feature branch, not main"* ]] || fail "default branch did not fail closed"
+
+run_case success feature/387 https://github.com/mnbf9rca/family-foqos.git
+[[ $result -eq 1 && $output == *"SSH push URL"* ]] || fail "HTTPS remote did not fail closed"
+
+run_case switch_create_fail
+[[ $result -eq 41 ]] || fail "scratch creation failure status was $result, expected 41"
+[[ $(cat "$case_root/branch") == feature/387 && ! -s "$case_root/scratch" ]] || fail "scratch creation failure changed worktree state"
+
+run_case commit_fail
+[[ $result -eq 42 ]] || fail "commit failure status was $result, expected 42"
+[[ $(cat "$case_root/branch") == feature/387 && ! -s "$case_root/scratch" ]] || fail "commit failure did not clean up"
+
+run_case push_fail
+[[ $result -eq 43 ]] || fail "push failure status was $result, expected 43"
+[[ $(cat "$case_root/branch") == feature/387 && ! -s "$case_root/scratch" ]] || fail "push failure did not clean up"
+
+run_case switch_restore_fail
+[[ $result -eq 44 ]] || fail "cleanup failure status was $result, expected 44"
+
+echo "PASS: Git credential warm-up fails closed and restores its worktree"

--- a/scripts/warm-git-credentials.sh
+++ b/scripts/warm-git-credentials.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "warm-git-credentials: $*" >&2
+  exit 1
+}
+
+command -v git >/dev/null 2>&1 || fail "git is required"
+[[ $(git rev-parse --is-inside-work-tree 2>/dev/null) == true ]] || fail "run inside a Git worktree"
+[[ -z $(git status --porcelain) ]] || fail "worktree must be clean"
+
+start_branch=$(git branch --show-current)
+[[ -n $start_branch ]] || fail "run from a named feature branch"
+case "$start_branch" in
+  main | master | release/v1) fail "run from a feature branch, not $start_branch" ;;
+esac
+
+push_url=$(git remote get-url --push origin)
+case "$push_url" in
+  git@* | ssh://*) ;;
+  *) fail "origin must use an SSH push URL" ;;
+esac
+
+scratch="scratch/biometric-warmup/$(date -u +%Y%m%dT%H%M%SZ)-$$"
+
+cleanup() {
+  local result=$?
+  local cleanup_result=0
+  local current_branch
+  trap - EXIT
+  set +e
+
+  current_branch=$(git branch --show-current)
+  if [[ $current_branch != "$start_branch" ]]; then
+    git switch "$start_branch"
+    cleanup_result=$?
+  fi
+  if git show-ref --verify --quiet "refs/heads/$scratch"; then
+    git branch -D "$scratch"
+    branch_result=$?
+    if [[ $cleanup_result -eq 0 && $branch_result -ne 0 ]]; then
+      cleanup_result=$branch_result
+    fi
+  fi
+  if [[ $cleanup_result -eq 0 ]]; then
+    [[ $(git branch --show-current) == "$start_branch" ]] || cleanup_result=1
+    [[ -z $(git status --porcelain) ]] || cleanup_result=1
+  fi
+
+  [[ $result -ne 0 ]] || result=$cleanup_result
+  exit "$result"
+}
+trap cleanup EXIT
+
+git switch -c "$scratch"
+git commit -S --allow-empty -m "chore: biometric warm-up (discard)"
+git push --dry-run origin "HEAD:refs/heads/$scratch"


### PR DESCRIPTION
## Summary

- rewrite root `AGENTS.md` from 426 lines to a 63-line self-sufficient invariant index
- move all detail losslessly into four focused runbooks
- replace the inline biometric transaction with tested `scripts/warm-git-credentials.sh`
- make fleet/session credential warm-up planner-dispatched before streams take implementation work
- retain the six multi-agent coordination rules and add calibrated operator-doc sign-off
- merge live `main` and bump all configurations to 2.0.28 (47)

## Why

The always-loaded agent guide had mixed Git operations, simulator workflow, Swift style, domain
rules, and coordination procedures into one oversized file. The root now carries only common-case
commands and load-bearing invariants; investigation detail lives behind descriptive links.

## Losslessness ledger

| Original content | Root invariant | Durable detail |
|---|---|---|
| Git history and review rules | new signed commits; review before merge | `docs/development-workflow.md` |
| biometric transaction and fallback | required script invocation | script + workflow doc |
| simulator ownership/concurrency | capacity, wrapper, UUID, no-clone flags | workflow doc |
| five script-safety rules | all five retained inline | workflow doc rationale |
| six coordination rules | all six retained inline | `docs/multi-agent-coordination.md` |
| build/test/clean/screenshots/archive/format | canonical one-line commands | workflow doc explanations |
| full Swift conventions/examples | SafeQuery/save/log/privacy/time invariants | `docs/swift-style-guide.md` |
| mode matrix/promotion/lock predicates | exact mode and predicate invariants | `docs/app-modes-and-locking.md` |

Maintainer-added invariant: implementations stay DRY and KISS and generally apply YAGNI.

## Validation at `ba79e65eb968016cadb2e68a0ec56f3c38e47581`

- root inventory audit: PASS, 63 lines (limit 100), four resolvable links, no fenced detail
- `scripts/test-warm-git-credentials.sh`: PASS across success, precondition, exact failure-status,
  restoration, and cleanup cases
- shellcheck: PASS for warm-up script and harness
- `scripts/test-xcode-stream.sh`: PASS; wrapper allocation/enforcement/doc contract preserved
- `scripts/test-report-cloudkit-schema-drift.sh`: PASS after merging live main
- version increment, C2, sync, privacy, and whitespace guards: PASS
- version gate: 2.0.27 (46) -> 2.0.28 (47); all 12/12 configurations match
- signed live-main merge `76a2b49` and final correction/version commit `ba79e65` verify with the configured key
- live base `e5e00d488adfccae4bd856e0da64369aceef1854` is an ancestor
- relocated CPU blocks execute from committed Markdown: managed fake `9987 00:42.17`, unknown role
  exits 1; standalone PID 77920 `13:46.81` to `13:46.83`, unknown role exits 1

## Coordination walkthrough already completed

This accelerated run validated the five-step response sequence, not detection of the real
30-minute trigger:

1. Build1 announced `blocked on human gate: walkthrough-only confirmation; no real work is blocked`
   on the planner thread. No new safe-path message was parked in `user`.
2. Build1 deliberately planted harmless test gate `dcc5a176`. The planner sweep distinguished it
   from six historical real `gate/*` approvals, drained all seven, and verified `user` was empty.
   The planner corrected an initial historical count of three to six; both statements remain in the
   record because stale memory demonstrates why the sweep exists.
3. The planner ran all five heartbeat steps: drained planner inbox, inspected build1 `inbox/new`,
   swept `user`, inspected clean worktree/commit age/CPU delta, and pinged build1 directly.
   `notifier_live` was treated only as wake-process evidence.
4. The first fleet-only CPU recipe failed closed because this project uses standalone agents. The
   walkthrough caught that text defect; follow-up `2d22c5c` added project-scoped standalone
   matching. Reviewer execution proved the relocated CPU blocks are byte-identical after indentation
   normalization, so moving them to `docs/multi-agent-coordination.md` does not require rerunning
   this coordination walkthrough.

## Maintainer-present biometric walkthrough

The first live attempt created scratch branch
`scratch/biometric-warmup/20260813T145654Z-26646`, passed the C2 guards, then failed closed before
push because the 1Password SSH-agent socket was unavailable. Cleanup restored
`docs/387-multi-agent-coordination` at unchanged head `069e325`, left a clean tree, and deleted the
scratch branch. This was an environment failure, not a script defect; the script already uses
`set -euo pipefail` and did not reach its push command.

After the maintainer started and unlocked 1Password, the verbatim rerun succeeded:

- scratch branch: `scratch/biometric-warmup/20260813T150135Z-27711`
- signed discard commit: `4710801338dafa349b1a4d817c25e9d0d9257712`; `git show` reported a good
  ED25519 signature and `%G? = G`
- `git push --dry-run` authenticated over SSH and reported the simulated new branch
- cleanup restored `docs/387-multi-agent-coordination`, deleted the local scratch branch, kept the
  tree clean, and left HEAD unchanged at `069e325`
- `git ls-remote --heads origin scratch/biometric-warmup/20260813T150135Z-27711` exited 0 with empty
  output, proving that no remote ref was created

## Full-rewrite operator gates

- Independent reviewer: READY at `069e325`, with no Critical or Important findings after a
  fact-level losslessness audit and warm-up harness mutation tests.
- Maintainer-present biometric walkthrough: PASSED, with the transcript above.
- Maintainer final read: SIGNED OFF on the 63-line root and the planner-coordinated startup wording
  applied to root plus both durable guides.
- Build/test/screenshot entrypoints were exercised through the existing fake-backed wrapper suite;
  no unnecessary Xcode launch is required to validate relocated prose.
- Pending: reviewer revalidates exact head `ba79e65`; Build1 does not merge, and planner merges only
  after reviewer READY.

Closes #387
