### PR TITLE
Test CloudKit code-to-schema drift

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.26;
+				MARKETING_VERSION = 2.0.27;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/FoqosTests/CloudKitCodeSchemaDriftTests.swift
+++ b/FoqosTests/CloudKitCodeSchemaDriftTests.swift
@@ -1,0 +1,457 @@
+import Foundation
+import XCTest
+
+final class CloudKitCodeSchemaDriftTests: XCTestCase {
+  func testGivenEverySupportedPattern_WhenValidating_ThenDiscoversLiteralWireKeys() throws {
+    let root = try makeFixtureRoot(
+      sources: [
+        "CloudKit/FieldRecord.swift": """
+        struct FieldRecord {
+          static let recordType = "FieldRecord"
+          enum FieldKey: String {
+            case implicitName
+            case swiftName = "wireName"
+          }
+        }
+        """,
+        "Models/ConstantRecord.swift": """
+        struct ConstantRecord {
+          static let recordType = "ConstantRecord"
+          enum RecordKey {
+            static let swiftName = "constantWire"
+          }
+        }
+        """,
+        "CloudKit/LiteralRecord.swift": """
+        func makeRecord() {
+          let record = CKRecord(recordType: "LiteralRecord", recordID: recordID)
+          record["literalWire"] = true
+        }
+        """,
+      ],
+      schema: """
+        RECORD TYPE FieldRecord (
+          implicitName STRING,
+          wireName STRING,
+        );
+        RECORD TYPE ConstantRecord (
+          constantWire STRING,
+        );
+        RECORD TYPE LiteralRecord (
+          literalWire INT64,
+        );
+        """)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let fields = try CloudKitSchemaDriftValidator.validate(repoRoot: root)
+
+    XCTAssertEqual(fields["FieldRecord"], ["implicitName", "wireName"])
+    XCTAssertEqual(fields["ConstantRecord"], ["constantWire"])
+    XCTAssertEqual(fields["LiteralRecord"], ["literalWire"])
+  }
+
+  func testGivenUnsupportedDeclarationInNestedPlantedFile_WhenValidating_ThenFailsClosed() throws {
+    let root = try makeFixtureRoot(
+      sources: [
+        "Nested/Planted.swift": """
+        struct Planted {
+          static let recordType = "Planted"
+          enum FieldKey: String {
+            case dynamic = generatedKey
+          }
+        }
+        """
+      ],
+      schema: """
+        RECORD TYPE Planted (
+          dynamic STRING,
+        );
+        """)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    XCTAssertThrowsError(try CloudKitSchemaDriftValidator.validate(repoRoot: root)) { error in
+      guard case .unsupportedDeclaration(let file, let line) = error as? CloudKitSchemaDriftError
+      else {
+        return XCTFail("Expected unsupportedDeclaration, got \(error)")
+      }
+      XCTAssertTrue(file.hasSuffix("Foqos/Nested/Planted.swift"))
+      XCTAssertEqual(line, "case dynamic = generatedKey")
+    }
+  }
+
+  func testGivenCodeFieldMissingFromSchema_WhenValidating_ThenReportsField() throws {
+    let root = try makeFixtureRoot(
+      sources: [
+        "CloudKit/MissingField.swift": """
+        struct MissingField {
+          static let recordType = "MissingField"
+          enum FieldKey: String {
+            case absent
+          }
+        }
+        """
+      ],
+      schema: """
+        RECORD TYPE MissingField (
+          retained STRING,
+        );
+        """)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    XCTAssertThrowsError(try CloudKitSchemaDriftValidator.validate(repoRoot: root)) { error in
+      XCTAssertEqual(
+        error as? CloudKitSchemaDriftError,
+        .missingField(recordType: "MissingField", field: "absent"))
+    }
+  }
+
+  func testGivenWrittenRecordTypeMissingFromSchema_WhenValidating_ThenReportsType() throws {
+    let root = try makeFixtureRoot(
+      sources: [
+        "CloudKit/MissingType.swift": """
+        struct MissingType {
+          static let recordType = "MissingType"
+          enum FieldKey: String {
+            case field
+          }
+        }
+        """
+      ],
+      schema: """
+        RECORD TYPE OtherType (
+          field STRING,
+        );
+        """)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    XCTAssertThrowsError(try CloudKitSchemaDriftValidator.validate(repoRoot: root)) { error in
+      XCTAssertEqual(error as? CloudKitSchemaDriftError, .missingRecordType("MissingType"))
+    }
+  }
+
+  func testGivenRepositorySources_WhenValidating_ThenMatchesPinnedBaseline() throws {
+    let repositoryRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let expectedCounts = [
+      "SyncedProfile": 39,
+      "ProfileSession": 10,
+      "SyncedLocation": 8,
+      "EmergencySettings": 7,
+      "EmergencyUnblockEvent": 5,
+      "SyncResetRequest": 4,
+      "EmergencyResetEpoch": 2,
+      "SyncEstablishment": 2,
+      "DeviceHeartbeat": 5,
+      "FamilyCommand": 5,
+      "FamilyLockCode": 7,
+      "FamilyMember": 6,
+      "FamilyRoot": 1,
+    ]
+
+    let fields = try CloudKitSchemaDriftValidator.validate(repoRoot: repositoryRoot)
+
+    XCTAssertEqual(fields.mapValues(\.count), expectedCounts)
+    XCTAssertEqual(fields.count, 13)
+    XCTAssertEqual(fields.values.reduce(0) { $0 + $1.count }, 101)
+    XCTAssertEqual(fields["FamilyRoot"], ["createdAt"])
+  }
+
+  private func makeFixtureRoot(sources: [String: String], schema: String) throws -> URL {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("CloudKitCodeSchemaDriftTests-\(UUID().uuidString)")
+    let sourceRoot = root.appendingPathComponent("Foqos")
+    let schemaURL = sourceRoot.appendingPathComponent("CloudKit/cloudkit-schema.ckdb")
+    try FileManager.default.createDirectory(
+      at: schemaURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try schema.write(to: schemaURL, atomically: true, encoding: .utf8)
+
+    for (relativePath, contents) in sources {
+      let fileURL = sourceRoot.appendingPathComponent(relativePath)
+      try FileManager.default.createDirectory(
+        at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+    }
+    return root
+  }
+}
+
+private enum CloudKitSchemaDriftError: Error, Equatable, CustomStringConvertible {
+  case unreadableInput(String)
+  case unsupportedDeclaration(file: String, line: String)
+  case unableToEnumerate(recordType: String)
+  case ambiguousLiteralVariable(file: String, variable: String)
+  case missingRecordType(String)
+  case missingField(recordType: String, field: String)
+
+  var description: String {
+    switch self {
+    case .unreadableInput(let path):
+      return "Unreadable CloudKit schema input: \(path)"
+    case .unsupportedDeclaration(let file, let line):
+      return "Unsupported CloudKit field declaration in \(file): \(line)"
+    case .unableToEnumerate(let recordType):
+      return "Unable to enumerate CloudKit fields for record type: \(recordType)"
+    case .ambiguousLiteralVariable(let file, let variable):
+      return "Literal CKRecord variable \(variable) maps to multiple record types in \(file)"
+    case .missingRecordType(let recordType):
+      return "CloudKit schema is missing RECORD TYPE \(recordType)"
+    case .missingField(let recordType, let field):
+      return "CloudKit schema is missing \(recordType).\(field)"
+    }
+  }
+}
+
+private struct CloudKitSchemaDriftValidator {
+  private static let ignoredFieldlessRecordTypes: Set<String> = ["SyncedSession"]
+
+  static func validate(repoRoot: URL) throws -> [String: Set<String>] {
+    let sourceRoot = repoRoot.appendingPathComponent("Foqos")
+    let schemaURL = sourceRoot.appendingPathComponent("CloudKit/cloudkit-schema.ckdb")
+    let sourceURLs = try swiftSourceURLs(below: sourceRoot)
+    guard let schema = try? String(contentsOf: schemaURL, encoding: .utf8), !schema.isEmpty else {
+      throw CloudKitSchemaDriftError.unreadableInput(schemaURL.path)
+    }
+
+    var codeFields: [String: Set<String>] = [:]
+    for sourceURL in sourceURLs {
+      guard let source = try? String(contentsOf: sourceURL, encoding: .utf8) else {
+        throw CloudKitSchemaDriftError.unreadableInput(sourceURL.path)
+      }
+      merge(try keyedFields(in: source, file: sourceURL.path), into: &codeFields)
+      merge(try literalFields(in: source, file: sourceURL.path), into: &codeFields)
+    }
+
+    let schemaFields = try parsedSchemaFields(from: schema, file: schemaURL.path)
+    for recordType in codeFields.keys.sorted() {
+      guard let availableFields = schemaFields[recordType] else {
+        throw CloudKitSchemaDriftError.missingRecordType(recordType)
+      }
+      for field in (codeFields[recordType] ?? []).sorted() where !availableFields.contains(field) {
+        throw CloudKitSchemaDriftError.missingField(recordType: recordType, field: field)
+      }
+    }
+    return codeFields
+  }
+
+  private static func swiftSourceURLs(below sourceRoot: URL) throws -> [URL] {
+    guard
+      let enumerator = FileManager.default.enumerator(
+        at: sourceRoot,
+        includingPropertiesForKeys: [.isRegularFileKey],
+        options: [.skipsHiddenFiles])
+    else {
+      throw CloudKitSchemaDriftError.unreadableInput(sourceRoot.path)
+    }
+
+    var sourceURLs: [URL] = []
+    for case let url as URL in enumerator where url.pathExtension == "swift" {
+      sourceURLs.append(url)
+    }
+    guard !sourceURLs.isEmpty else {
+      throw CloudKitSchemaDriftError.unreadableInput(sourceRoot.path)
+    }
+    return sourceURLs.sorted { $0.path < $1.path }
+  }
+
+  private static func keyedFields(in source: String, file: String) throws
+    -> [String: Set<String>]
+  {
+    let text = source as NSString
+    let recordMatches = try matches(
+      #"static\s+let\s+recordType\s*=\s*"([^"]+)""#, in: source)
+    let enumMatches = try matches(
+      #"(?:private\s+)?enum\s+(FieldKey|RecordKey)\s*(?::\s*String)?\s*\{"#,
+      in: source)
+    var fieldsByRecordType: [String: Set<String>] = [:]
+
+    for (index, recordMatch) in recordMatches.enumerated() {
+      guard let recordType = capture(1, from: recordMatch, in: text) else { continue }
+      let nextRecordLocation =
+        index + 1 < recordMatches.count ? recordMatches[index + 1].range.location : text.length
+      let candidates = enumMatches.filter {
+        $0.range.location > recordMatch.range.location && $0.range.location < nextRecordLocation
+      }
+
+      if candidates.isEmpty, ignoredFieldlessRecordTypes.contains(recordType) {
+        continue
+      }
+      guard candidates.count == 1, let keyKind = capture(1, from: candidates[0], in: text)
+      else {
+        throw CloudKitSchemaDriftError.unableToEnumerate(recordType: recordType)
+      }
+
+      let enumMatch = candidates[0]
+      let openingBrace = enumMatch.range.location + enumMatch.range.length - 1
+      let bodyRange = try balancedBodyRange(
+        in: text, openingBrace: openingBrace, file: file, declaration: "enum \(keyKind)")
+      let body = text.substring(with: bodyRange)
+      let fields = try parseKeyBody(body, kind: keyKind, file: file)
+      guard !fields.isEmpty else {
+        throw CloudKitSchemaDriftError.unableToEnumerate(recordType: recordType)
+      }
+      fieldsByRecordType[recordType, default: []].formUnion(fields)
+    }
+    return fieldsByRecordType
+  }
+
+  private static func parseKeyBody(_ body: String, kind: String, file: String) throws -> Set<String> {
+    let pattern =
+      kind == "FieldKey"
+      ? #"^case\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*=\s*"([^"]+)")?\s*$"#
+      : #"^static\s+let\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*"([^"]+)"\s*$"#
+    let regex = try NSRegularExpression(pattern: pattern)
+    var fields: Set<String> = []
+
+    for rawLine in body.components(separatedBy: .newlines) {
+      let line = rawLine.components(separatedBy: "//")[0]
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !line.isEmpty else { continue }
+      let text = line as NSString
+      let fullRange = NSRange(location: 0, length: text.length)
+      guard let match = regex.firstMatch(in: line, range: fullRange) else {
+        throw CloudKitSchemaDriftError.unsupportedDeclaration(file: file, line: line)
+      }
+
+      if kind == "FieldKey" {
+        guard let implicitName = capture(1, from: match, in: text) else {
+          throw CloudKitSchemaDriftError.unsupportedDeclaration(file: file, line: line)
+        }
+        fields.insert(capture(2, from: match, in: text) ?? implicitName)
+      } else if let wireName = capture(1, from: match, in: text) {
+        fields.insert(wireName)
+      }
+    }
+    return fields
+  }
+
+  private static func literalFields(in source: String, file: String) throws
+    -> [String: Set<String>]
+  {
+    let text = source as NSString
+    let assignments = try matches(
+      #"(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*CKRecord\s*\(\s*recordType:\s*"([^"]+)""#,
+      in: source)
+    var typesByVariable: [String: Set<String>] = [:]
+    for assignment in assignments {
+      guard let variable = capture(1, from: assignment, in: text),
+        let recordType = capture(2, from: assignment, in: text)
+      else { continue }
+      typesByVariable[variable, default: []].insert(recordType)
+    }
+
+    var fieldsByRecordType: [String: Set<String>] = [:]
+    for variable in typesByVariable.keys.sorted() {
+      guard let recordTypes = typesByVariable[variable], recordTypes.count == 1,
+        let recordType = recordTypes.first
+      else {
+        throw CloudKitSchemaDriftError.ambiguousLiteralVariable(file: file, variable: variable)
+      }
+      fieldsByRecordType[recordType, default: []] = []
+
+      let escapedVariable = NSRegularExpression.escapedPattern(for: variable)
+      let writes = try matches(
+        escapedVariable + #"\s*\[\s*([^\]]+)\s*\]\s*="#,
+        in: source)
+      for write in writes {
+        guard let keyExpression = capture(1, from: write, in: text) else { continue }
+        let keyText = keyExpression.trimmingCharacters(in: .whitespacesAndNewlines) as NSString
+        let stringLiteral = try NSRegularExpression(pattern: #"^"([^"]+)"$"#)
+        let range = NSRange(location: 0, length: keyText.length)
+        guard let literalMatch = stringLiteral.firstMatch(in: keyText as String, range: range),
+          let field = capture(1, from: literalMatch, in: keyText)
+        else {
+          throw CloudKitSchemaDriftError.unsupportedDeclaration(
+            file: file, line: "\(variable)[\(keyExpression)]")
+        }
+        fieldsByRecordType[recordType, default: []].insert(field)
+      }
+    }
+    return fieldsByRecordType
+  }
+
+  private static func parsedSchemaFields(from schema: String, file: String) throws
+    -> [String: Set<String>]
+  {
+    let header = try NSRegularExpression(
+      pattern: #"^RECORD TYPE\s+(?:"([^"]+)"|([A-Za-z_][A-Za-z0-9_]*))\s*\($"#)
+    var fieldsByRecordType: [String: Set<String>] = [:]
+    var currentRecordType: String?
+
+    for rawLine in schema.components(separatedBy: .newlines) {
+      let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+      if currentRecordType == nil {
+        let text = line as NSString
+        let range = NSRange(location: 0, length: text.length)
+        if let match = header.firstMatch(in: line, range: range),
+          let recordType = capture(1, from: match, in: text) ?? capture(2, from: match, in: text)
+        {
+          currentRecordType = recordType
+          fieldsByRecordType[recordType, default: []] = []
+        }
+        continue
+      }
+
+      if line == ");" {
+        currentRecordType = nil
+        continue
+      }
+      guard !line.isEmpty, !line.hasPrefix("//"), !line.hasPrefix("GRANT "),
+        let recordType = currentRecordType,
+        let firstToken = line.split(whereSeparator: { $0.isWhitespace }).first
+      else { continue }
+
+      let field = String(firstToken).trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+      guard !field.hasPrefix("___") else { continue }
+      fieldsByRecordType[recordType, default: []].insert(field)
+    }
+
+    guard currentRecordType == nil, !fieldsByRecordType.isEmpty else {
+      throw CloudKitSchemaDriftError.unreadableInput(file)
+    }
+    return fieldsByRecordType
+  }
+
+  private static func balancedBodyRange(
+    in text: NSString, openingBrace: Int, file: String, declaration: String
+  ) throws -> NSRange {
+    var depth = 0
+    for location in openingBrace..<text.length {
+      switch text.substring(with: NSRange(location: location, length: 1)) {
+      case "{":
+        depth += 1
+      case "}":
+        depth -= 1
+        if depth == 0 {
+          return NSRange(location: openingBrace + 1, length: location - openingBrace - 1)
+        }
+      default:
+        continue
+      }
+    }
+    throw CloudKitSchemaDriftError.unsupportedDeclaration(file: file, line: "unclosed \(declaration)")
+  }
+
+  private static func matches(_ pattern: String, in text: String) throws
+    -> [NSTextCheckingResult]
+  {
+    let regex = try NSRegularExpression(pattern: pattern)
+    return regex.matches(in: text, range: NSRange(location: 0, length: (text as NSString).length))
+  }
+
+  private static func capture(
+    _ index: Int, from match: NSTextCheckingResult, in text: NSString
+  ) -> String? {
+    let range = match.range(at: index)
+    guard range.location != NSNotFound else { return nil }
+    return text.substring(with: range)
+  }
+
+  private static func merge(
+    _ additions: [String: Set<String>], into fields: inout [String: Set<String>]
+  ) {
+    for (recordType, newFields) in additions {
+      fields[recordType, default: []].formUnion(newFields)
+    }
+  }
+}

--- a/docs/superpowers/plans/2026-08-13-cloudkit-code-schema-drift-test.md
+++ b/docs/superpowers/plans/2026-08-13-cloudkit-code-schema-drift-test.md
@@ -1,0 +1,180 @@
+# CloudKit Code-to-Schema Drift Test Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an XCTest gate that fails closed when CloudKit fields written by Swift drift from the checked-in `.ckdb` schema.
+
+**Architecture:** A test-only validator recursively derives every Swift file below `Foqos`, discovers the three supported write-key shapes, and parses checked-in `RECORD TYPE` blocks. It compares code fields as a subset of schema fields, treats `SyncedSession` as the sole pinned read/delete-only exception, and exposes deterministic errors for unsupported declarations, missing fields, and missing record types.
+
+**Tech Stack:** Swift, XCTest, Foundation file enumeration and regular expressions, Xcode simulator tests.
+
+## Global Constraints
+
+- Keep the implementation in one new `FoqosTests/CloudKitCodeSchemaDriftTests.swift` file; do not add production API.
+- Derive source files recursively from `Foqos`; do not maintain a hand-written source-file list.
+- Fail closed on every non-enumerable active record declaration; only `SyncedSession` may be fieldless.
+- Treat code fields as a subset of schema fields; additive schema-only fields remain valid.
+- Pin 13 active record types and 101 fields with the exact per-type counts from issue #383.
+- Use the repository Xcode stream wrapper and simulator UUID injection; never pass a simulator name or caller destination.
+- Bump all build settings from marketing version `2.0.26` / build `45` to `2.0.27` / `46`.
+
+---
+
+### Task 1: Prove the test contract RED
+
+**Files:**
+- Create: `FoqosTests/CloudKitCodeSchemaDriftTests.swift`
+
+**Interfaces:**
+- Consumes: temporary fixture roots containing `Foqos/**/*.swift` and `Foqos/CloudKit/cloudkit-schema.ckdb`.
+- Produces: tests for `CloudKitSchemaDriftValidator.validate(repoRoot:) -> [String: Set<String>]` and deterministic `CloudKitSchemaDriftError` cases.
+
+- [ ] **Step 1: Add focused tests before the validator exists**
+
+Add XCTest cases that:
+
+```swift
+func testGivenEverySupportedPattern_WhenValidating_ThenDiscoversLiteralWireKeys()
+func testGivenUnsupportedDeclarationInNestedPlantedFile_WhenValidating_ThenFailsClosed()
+func testGivenCodeFieldMissingFromSchema_WhenValidating_ThenReportsField()
+func testGivenWrittenRecordTypeMissingFromSchema_WhenValidating_ThenReportsType()
+func testGivenRepositorySources_WhenValidating_ThenMatchesPinnedBaseline()
+```
+
+The positive fixture must contain a `FieldKey: String` enum with implicit and explicit raw values, a `RecordKey` constants enum, and a literal `CKRecord(recordType:)` variable with a string-subscript write. The planted-file fixture must place an unsupported `FieldKey` declaration below a nested `Foqos` directory so the failure proves recursive discovery is live.
+
+- [ ] **Step 2: Run the focused class and verify RED**
+
+Run:
+
+```bash
+./scripts/xcode-stream.sh --agent build2 --session collab --xcpretty -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -only-testing:FoqosTests/CloudKitCodeSchemaDriftTests
+```
+
+Expected: compile failure because `CloudKitSchemaDriftValidator` and `CloudKitSchemaDriftError` do not exist.
+
+### Task 2: Implement the minimal fail-closed validator GREEN
+
+**Files:**
+- Modify: `FoqosTests/CloudKitCodeSchemaDriftTests.swift`
+
+**Interfaces:**
+- Consumes: repository root URL, recursively derived Swift source URLs, and `.ckdb` text.
+- Produces: `[recordType: Set<fieldName>]` or a typed error identifying the unsupported declaration or missing schema entry.
+
+- [ ] **Step 1: Add deterministic error and validator types below the test class**
+
+Use private test-only types with these responsibilities:
+
+```swift
+private enum CloudKitSchemaDriftError: Error, Equatable {
+  case unreadableInput(String)
+  case unsupportedDeclaration(file: String, line: String)
+  case unableToEnumerate(recordType: String)
+  case ambiguousLiteralVariable(file: String, variable: String)
+  case missingRecordType(String)
+  case missingField(recordType: String, field: String)
+}
+
+private struct CloudKitSchemaDriftValidator {
+  static func validate(repoRoot: URL) throws -> [String: Set<String>]
+}
+```
+
+- [ ] **Step 2: Derive source files and parse keyed declarations**
+
+Enumerate readable `.swift` files recursively below `repoRoot/Foqos`, sorted by path. Associate each `static let recordType = "…"` with the following `FieldKey` or `RecordKey` block before the next record type. Accept only these current declaration forms:
+
+```swift
+case implicitName
+case swiftName = "wireName"
+static let swiftName = "wireName"
+```
+
+Reject every other non-comment line in a key block. Require at least one key for every static record type except the exact `SyncedSession` pin.
+
+- [ ] **Step 3: Parse literal record writes and checked-in schema blocks**
+
+Discover literal assignments shaped like:
+
+```swift
+let rootRecord = CKRecord(recordType: "FamilyRoot", recordID: rootRecordID)
+rootRecord["createdAt"] = Date()
+```
+
+Map a literal variable to exactly one record type per source file and fail if it is ambiguous. Parse all `.ckdb` `RECORD TYPE` blocks into type/field sets, retaining record types even when their field set is empty and ignoring CloudKit system fields prefixed with `___`.
+
+- [ ] **Step 4: Compare code to schema fail-closed**
+
+For every code record type in sorted order, first require a matching schema block and then require every code field in sorted order. Throw `missingRecordType` or `missingField` at the first drift. Never reject schema-only record types or fields.
+
+- [ ] **Step 5: Run the focused class and verify GREEN**
+
+Run the Task 1 command. Expected: all five tests pass, including the live planted-file discovery failure.
+
+- [ ] **Step 6: Mutation-check every discovery control**
+
+Temporarily disable each of the three parser paths one at a time—`FieldKey`, `RecordKey`, and literal writes—and rerun the positive fixture. Each mutation must fail. Restore the implementation and rerun the focused class green.
+
+### Task 3: Pin release version and verify the branch
+
+**Files:**
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+- Test: `FoqosTests/CloudKitCodeSchemaDriftTests.swift`
+
+**Interfaces:**
+- Consumes: version-gate policy and the complete XCTest target.
+- Produces: release versions `2.0.27` / `46` and a review-ready branch.
+
+- [ ] **Step 1: Bump every target/configuration version setting**
+
+Change all 12 occurrences each:
+
+```text
+MARKETING_VERSION = 2.0.27;
+CURRENT_PROJECT_VERSION = 46;
+```
+
+- [ ] **Step 2: Run formatting and project/version checks**
+
+Run:
+
+```bash
+swift-format --in-place FoqosTests/CloudKitCodeSchemaDriftTests.swift
+swift-format lint FoqosTests/CloudKitCodeSchemaDriftTests.swift
+plutil -lint FamilyFoqos.xcodeproj/project.pbxproj
+./scripts/test-check-version-increment.sh
+rg -c 'MARKETING_VERSION = 2\.0\.27;' FamilyFoqos.xcodeproj/project.pbxproj
+rg -c 'CURRENT_PROJECT_VERSION = 46;' FamilyFoqos.xcodeproj/project.pbxproj
+git diff --check
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 3: Run focused and full XCTest verification**
+
+Run the focused command from Task 1, then:
+
+```bash
+./scripts/xcode-stream.sh --agent build2 --session collab --xcpretty -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos
+```
+
+Expected: the focused class and full suite pass with zero failures.
+
+- [ ] **Step 4: Commit without amending**
+
+```bash
+git add FoqosTests/CloudKitCodeSchemaDriftTests.swift \
+  FamilyFoqos.xcodeproj/project.pbxproj \
+  docs/superpowers/plans/2026-08-13-cloudkit-code-schema-drift-test.md
+git commit -S -m "Test CloudKit code schema drift"
+./scripts/check-version-increment.sh 8780bfb HEAD
+git verify-commit HEAD
+```
+
+- [ ] **Step 5: Request code review before merge**
+
+Push the branch, open a draft PR that closes #383 and records RED/GREEN plus mutation evidence, then request reviewer inspection through AMQ. Undraft only after a `READY` verdict; the maintainer owns merge.


### PR DESCRIPTION
## Summary

- add an in-language XCTest gate that recursively derives every `Foqos/**/*.swift` source file
- discover CloudKit fields from `FieldKey: String`, `RecordKey` constants, and literal `CKRecord` subscript writes
- fail closed on unsupported declarations, missing schema fields, and missing `RECORD TYPE` blocks
- pin the active baseline at 13 record types / 101 fields with the exact per-type counts from #383
- keep additive schema-only fields valid and retain `SyncedSession` as the sole read/delete-only exception
- bump all targets to marketing version 2.0.27 and build 46

## Why

The existing zero-Xcode reporter guards the checked-in manifest, but issue #383 requires a Swift/XCTest gate that directly checks source declarations and literal writes against `Foqos/CloudKit/cloudkit-schema.ckdb`. Constructing records and reading `allKeys()` was rejected because conditional or nil writes can silently under-enumerate coverage.

## Implementation

`CloudKitCodeSchemaDriftTests` contains a test-only validator; no production API was added. It:

1. recursively enumerates Swift files below `Foqos`
2. associates each static `recordType` with its supported key declaration and rejects non-enumerable forms
3. maps literal `CKRecord(recordType:)` variables to literal subscript writes and rejects dynamic keys
4. parses checked-in `.ckdb` record blocks
5. checks code fields as a subset of schema fields in deterministic type/field order

The nested planted-file fixture proves recursive file derivation is live rather than relying on a hand-maintained file list.

## TDD evidence

RED before implementation:

```text
cannot find 'CloudKitSchemaDriftValidator' in scope
cannot find type 'CloudKitSchemaDriftError' in scope
```

GREEN after implementation:

```text
Executed 5 tests, with 0 failures (0 unexpected)
Test Succeeded
```

Mutation controls independently turned RED:

- disabled `FieldKey` discovery: `Unable to enumerate ... FieldRecord`
- disabled `RecordKey` discovery: `Unable to enumerate ... ConstantRecord`
- disabled literal `CKRecord` discovery: `LiteralRecord` was absent
- disabled recursive traversal: the nested planted unsupported declaration was not reached

All mutations were restored before final verification.

## Verification

```text
Focused CloudKitCodeSchemaDriftTests: 5 tests, 0 failures
Full XCTest suite: 1228 tests, 0 failures
swift-format lint: passed
plutil project lint: OK
version increment harness: PASS
version gate: 2.0.26 -> 2.0.27; 45 -> 46
Bash CloudKit drift reporter: OK: no CloudKit schema drift.
git diff --check: passed
signed commit verification: passed
```

Closes #383
