### PR TITLE
Fix emergency settings lock placement

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/Views/Child/ChildDashboardView.swift
+++ b/Foqos/Views/Child/ChildDashboardView.swift
@@ -588,14 +588,30 @@ struct EditLockedProfilesSheet: View {
 
 // MARK: - Child Settings View
 
+struct EmergencySettingsLockChangeGate {
+  private var pendingValue: Bool?
+
+  mutating func request(_ newValue: Bool) {
+    pendingValue = newValue
+  }
+
+  mutating func resolve(verificationSucceeded: Bool) -> Bool? {
+    defer { pendingValue = nil }
+    return verificationSucceeded ? pendingValue : nil
+  }
+}
+
 struct ChildSettingsView: View {
   @Environment(\.dismiss) private var dismiss
   @ObservedObject private var appModeManager = AppModeManager.shared
   @ObservedObject private var cloudKitManager = CloudKitManager.shared
+  @ObservedObject private var emergencyManager = EmergencyUnblockManager.shared
   @ObservedObject private var lockCodeManager = LockCodeManager.shared
 
   @StateObject private var shareCoordinator = ShareCoordinator()
   @State private var showCodeEntry = false
+  @State private var showEmergencyLockCodeEntry = false
+  @State private var emergencySettingsLockChangeGate = EmergencySettingsLockChangeGate()
 
   private var hasLockCode: Bool {
     lockCodeManager.canVerifyCode
@@ -617,6 +633,27 @@ struct ChildSettingsView: View {
             Spacer()
             Text(cloudKitManager.isSignedIn ? "Connected" : "Not Connected")
               .foregroundColor(cloudKitManager.isSignedIn ? .green : .red)
+          }
+        }
+
+        if hasLockCode {
+          Section("Emergency Access") {
+            Toggle(
+              isOn: Binding(
+                get: { emergencyManager.isEmergencySettingsLocked() },
+                set: { newValue in
+                  emergencySettingsLockChangeGate.request(newValue)
+                  showEmergencyLockCodeEntry = true
+                }
+              )
+            ) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Lock Emergency Reset-Period Changes")
+                Text("Requires the parent lock code to change this setting on this device")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+              }
+            }
           }
         }
 
@@ -659,6 +696,27 @@ struct ChildSettingsView: View {
           },
           onCancel: {
             showCodeEntry = false
+          }
+        )
+      }
+      .sheet(
+        isPresented: $showEmergencyLockCodeEntry,
+        onDismiss: {
+          _ = emergencySettingsLockChangeGate.resolve(verificationSucceeded: false)
+        }
+      ) {
+        LockCodeEntrySheet(
+          onSuccess: {
+            showEmergencyLockCodeEntry = false
+            if let newValue = emergencySettingsLockChangeGate.resolve(
+              verificationSucceeded: true
+            ) {
+              emergencyManager.setEmergencySettingsLocked(newValue)
+            }
+          },
+          onCancel: {
+            showEmergencyLockCodeEntry = false
+            _ = emergencySettingsLockChangeGate.resolve(verificationSucceeded: false)
           }
         )
       }

--- a/Foqos/Views/Child/ChildDashboardView.swift
+++ b/Foqos/Views/Child/ChildDashboardView.swift
@@ -642,6 +642,7 @@ struct ChildSettingsView: View {
               isOn: Binding(
                 get: { emergencyManager.isEmergencySettingsLocked() },
                 set: { newValue in
+                  // Keep the stored setting unchanged until parent-code verification succeeds.
                   emergencySettingsLockChangeGate.request(newValue)
                   showEmergencyLockCodeEntry = true
                 }
@@ -649,7 +650,7 @@ struct ChildSettingsView: View {
             ) {
               VStack(alignment: .leading, spacing: 4) {
                 Text("Lock Emergency Reset-Period Changes")
-                Text("Requires the parent lock code to change this setting on this device")
+                Text("Requires the parent lock code to change the emergency reset period on this device")
                   .font(.caption)
                   .foregroundColor(.secondary)
               }
@@ -707,10 +708,11 @@ struct ChildSettingsView: View {
       ) {
         LockCodeEntrySheet(
           onSuccess: {
-            showEmergencyLockCodeEntry = false
-            if let newValue = emergencySettingsLockChangeGate.resolve(
+            let newValue = emergencySettingsLockChangeGate.resolve(
               verificationSucceeded: true
-            ) {
+            )
+            showEmergencyLockCodeEntry = false
+            if let newValue {
               emergencyManager.setEmergencySettingsLocked(newValue)
             }
           },

--- a/Foqos/Views/Parent/ParentDashboardView.swift
+++ b/Foqos/Views/Parent/ParentDashboardView.swift
@@ -5,23 +5,20 @@ import SwiftUI
 ///
 /// ## Child Mode Access Model (ADR 2026-02-22)
 ///
-/// When a child opens this dashboard, controls follow a three-tier model:
+/// When a child opens this dashboard, controls follow a two-tier model:
 ///
 /// | Tier | Interactivity | Computed property | Examples |
 /// |------|---------------|-------------------|----------|
 /// | 1. Read-only | Never interactive | N/A (always visible) | Info cards, member lists |
-/// | 2. Device-local | Enabled after PIN | `deviceSettingsEnabled` | Emergency settings toggle |
-/// | 3. CloudKit ops | Never interactive | `parentOperationsEnabled` | Set lock code, add/remove members |
+/// | 2. CloudKit ops | Never interactive | `parentOperationsEnabled` | Set lock code, add/remove members |
 ///
 /// The child sees the full dashboard — nothing is hidden. Only interactivity differs.
-/// Principle: device-local settings (tier 2) can be changed with PIN; CloudKit parent
-/// operations (tier 3) require parent authorization and cannot be performed by a child.
+/// CloudKit parent operations require parent authorization and cannot be performed by a child.
 struct ParentDashboardView: View {
   @ObservedObject private var cloudKitManager = CloudKitManager.shared
   @ObservedObject private var appModeManager = AppModeManager.shared
   @ObservedObject private var lockCodeManager = LockCodeManager.shared
   @ObservedObject private var strategyManager = StrategyManager.shared
-  @ObservedObject private var emergencyManager = EmergencyUnblockManager.shared
   @ObservedObject private var heartbeatManager = HeartbeatManager.shared
 
   @Environment(\.dismiss) private var dismiss
@@ -29,8 +26,6 @@ struct ParentDashboardView: View {
   @State private var showLockCodeSetup = false
   @State private var showError = false
   @State private var errorMessage = ""
-  @State private var isDashboardUnlocked = false
-  @State private var showLockCodeEntry = false
   @State private var showLeaveConfirmation = false
   @State private var showLeaveLockCodeEntry = false
   @State private var showClearLockCodeAlert = false
@@ -50,14 +45,7 @@ struct ParentDashboardView: View {
     appModeManager.currentMode == .child
   }
 
-  /// Tier 2: device-local settings enabled after PIN unlock
-  /// Controls like emergency settings toggle that are configured on this device
-  /// Independent of iCloud — PIN verification uses the last-synced lock codes cached on-device
-  private var deviceSettingsEnabled: Bool {
-    !isChildMode || isDashboardUnlocked
-  }
-
-  /// Tier 3: CloudKit parent operations — always disabled for child
+  /// Tier 2: CloudKit parent operations — always disabled for child
   /// Controls like set/change lock code, add/remove family members
   private var parentOperationsEnabled: Bool {
     isPageFunctional && !isChildMode
@@ -88,11 +76,6 @@ struct ParentDashboardView: View {
           // Header
           headerSection
 
-          // Child mode unlock banner
-          if isChildMode {
-            childUnlockBanner
-          }
-
           // iCloud status
           if !cloudKitManager.isSignedIn {
             iCloudWarning
@@ -102,13 +85,6 @@ struct ParentDashboardView: View {
           lockCodeSection
             .disabled(!parentOperationsEnabled)
             .opacity(parentOperationsEnabled ? 1.0 : 0.5)
-
-          // Emergency settings lock (only when lock code is set)
-          if lockCodeManager.hasAnyLockCode || lockCodeManager.canVerifyCode {
-            emergencyLockSection
-              .disabled(!deviceSettingsEnabled)
-              .opacity(deviceSettingsEnabled ? 1.0 : 0.5)
-          }
 
           // Co-parents section
           coParentsSection
@@ -176,18 +152,6 @@ struct ParentDashboardView: View {
                 }
               }
             }
-          }
-        )
-      }
-      .sheet(isPresented: $showLockCodeEntry) {
-        LockCodeEntryView(
-          title: "Enter Lock Code",
-          subtitle: "Enter the parent lock code to change device settings",
-          onVerify: { code in
-            lockCodeManager.validateCode(code)
-          },
-          onSuccess: {
-            isDashboardUnlocked = true
           }
         )
       }
@@ -264,54 +228,6 @@ struct ParentDashboardView: View {
         .font(.subheadline)
         .foregroundColor(.secondary)
     }
-  }
-
-  private var childUnlockBanner: some View {
-    VStack(spacing: 12) {
-      HStack(spacing: 12) {
-        Image(systemName: isDashboardUnlocked ? "lock.open.fill" : "lock.fill")
-          .font(.title2)
-          .foregroundColor(isDashboardUnlocked ? .green : .accentColor)
-
-        VStack(alignment: .leading, spacing: 4) {
-          Text(isDashboardUnlocked ? "Dashboard Unlocked" : "Dashboard Locked")
-            .font(.headline)
-          Text(
-            isDashboardUnlocked
-              ? "You can now change device settings."
-              : "Enter the lock code to change device settings."
-          )
-          .font(.caption)
-          .foregroundColor(.secondary)
-        }
-
-        Spacer()
-      }
-
-      if !isDashboardUnlocked {
-        Button {
-          showLockCodeEntry = true
-        } label: {
-          HStack {
-            Image(systemName: "lock.open")
-            Text("Unlock")
-          }
-          .font(.subheadline)
-          .fontWeight(.medium)
-        }
-        .buttonStyle(.bordered)
-        .tint(.accentColor)
-      }
-    }
-    .padding()
-    .background(
-      RoundedRectangle(cornerRadius: 12)
-        .fill(Color.accentColor.opacity(0.1))
-        .overlay(
-          RoundedRectangle(cornerRadius: 12)
-            .stroke(Color.accentColor.opacity(0.2), lineWidth: 1)
-        )
-    )
   }
 
   private var iCloudWarning: some View {
@@ -401,45 +317,6 @@ struct ParentDashboardView: View {
       }
     } message: {
       Text("Children will be able to freely edit all profiles without entering a code.")
-    }
-  }
-
-  private var emergencyLockSection: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text("Emergency Settings")
-        .font(.headline)
-
-      HStack(spacing: 16) {
-        Image(systemName: emergencyManager.isEmergencySettingsLocked() ? "lock.fill" : "lock.open")
-          .font(.title2)
-          .foregroundColor(emergencyManager.isEmergencySettingsLocked() ? .orange : .secondary)
-
-        VStack(alignment: .leading, spacing: 4) {
-          Text("Lock Emergency Settings")
-            .font(.subheadline)
-            .fontWeight(.medium)
-
-          Text("Requires lock code to change reset period on children's devices")
-            .font(.caption)
-            .foregroundColor(.secondary)
-        }
-
-        Spacer()
-
-        Toggle(
-          "",
-          isOn: Binding(
-            get: { emergencyManager.isEmergencySettingsLocked() },
-            set: { emergencyManager.setEmergencySettingsLocked($0) }
-          )
-        )
-        .labelsHidden()
-      }
-      .padding()
-      .background(
-        RoundedRectangle(cornerRadius: 12)
-          .fill(Color(.tertiarySystemBackground))
-      )
     }
   }
 

--- a/FoqosTests/ChildDashboardCopyTests.swift
+++ b/FoqosTests/ChildDashboardCopyTests.swift
@@ -12,4 +12,24 @@ final class ChildDashboardCopyTests: XCTestCase {
       "Footer must not promise that stopping is lock-gated (stopping is un-gated by design, deviation #7)"
     )
   }
+
+  func testGivenDisableRequested_WhenVerificationHasNotSucceeded_ThenChangeCannotBeApplied() {
+    var gate = EmergencySettingsLockChangeGate()
+
+    gate.request(false)
+
+    XCTAssertNil(gate.resolve(verificationSucceeded: false))
+  }
+
+  func testGivenDisableRequested_WhenVerificationSucceeds_ThenPendingValueCanBeApplied() {
+    var gate = EmergencySettingsLockChangeGate()
+
+    gate.request(false)
+
+    XCTAssertEqual(gate.resolve(verificationSucceeded: true), false)
+    XCTAssertNil(
+      gate.resolve(verificationSucceeded: true),
+      "A verified change must be consumed exactly once"
+    )
+  }
 }


### PR DESCRIPTION
## Summary

- remove the ineffective device-local emergency lock toggle from the parent dashboard
- add the toggle to child settings with parent lock-code verification before either state change
- describe the setting as locking emergency reset-period changes on this device
- bump the app version to 2.0.32 (51)

## Root cause

The parent dashboard wrote a device-local/same-user synced setting, so changing it on a parent's account did not reach a child's family-share account. The setting is only enforced in Child mode.

## Impact

A parent holding a child device can now enable or disable the setting from the child-side UI after entering the parent lock code. Dismissing or failing verification discards the pending change. Existing same-user sync and account-switch reset behavior remain unchanged.

## Validation

- `swift-format lint --recursive .`
- `scripts/xcode-stream.sh --agent build1 --session implement_beta_fixes -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos` — 1,230 tests, 0 failures
- `scripts/xcode-stream.sh --agent build1 --session implement_beta_fixes --xcbeautify -- xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -configuration Debug build` — succeeded
- `git diff --check`

Closes #429
