### PR TITLE
Fix child recovery after family share revocation

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.33;
+				MARKETING_VERSION = 2.0.34;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.33;
+				MARKETING_VERSION = 2.0.34;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.33;
+				MARKETING_VERSION = 2.0.34;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.33;
+				MARKETING_VERSION = 2.0.34;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.33;
+				MARKETING_VERSION = 2.0.34;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.33;
+				MARKETING_VERSION = 2.0.34;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.33;
+				MARKETING_VERSION = 2.0.34;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.33;
+				MARKETING_VERSION = 2.0.34;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.33;
+				MARKETING_VERSION = 2.0.34;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.33;
+				MARKETING_VERSION = 2.0.34;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.33;
+				MARKETING_VERSION = 2.0.34;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.33;
+				MARKETING_VERSION = 2.0.34;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.32;
+				MARKETING_VERSION = 2.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.32;
+				MARKETING_VERSION = 2.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.32;
+				MARKETING_VERSION = 2.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.32;
+				MARKETING_VERSION = 2.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.32;
+				MARKETING_VERSION = 2.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.32;
+				MARKETING_VERSION = 2.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.32;
+				MARKETING_VERSION = 2.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.32;
+				MARKETING_VERSION = 2.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.32;
+				MARKETING_VERSION = 2.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.32;
+				MARKETING_VERSION = 2.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.32;
+				MARKETING_VERSION = 2.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.32;
+				MARKETING_VERSION = 2.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.31;
+				MARKETING_VERSION = 2.0.32;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -235,10 +235,12 @@ class CloudKitManager: ObservableObject {
 
   nonisolated static func confirmedRevocationTrigger(
     isConnected: Bool,
+    isSignedIn: Bool,
     enforcedMode: AppMode?,
     currentMode: AppMode
   ) -> FamilyAuthorizationLossTrigger? {
     guard !isConnected,
+      isSignedIn,
       enforcedMode == .individual,
       currentMode == .child
     else {
@@ -250,9 +252,11 @@ class CloudKitManager: ObservableObject {
   func verifySelfFamilyMemberRecord() async {
     guard !ScreenshotDemoMode.isActive else { return }
     let localMode = AppModeManager.shared.currentMode
+    let accountIsSignedIn = self.isSignedIn
     let result = await networkService.verifySelfFamilyMember(
       cachedUserRecordID: currentUserRecordID,
-      localMode: localMode
+      localMode: localMode,
+      accountIsSignedIn: accountIsSignedIn
     )
 
     self.isConnectedToFamily = result.isConnected
@@ -264,12 +268,15 @@ class CloudKitManager: ObservableObject {
     }
     // In a disconnected result, enforced .individual is the confirmed-revocation signal. Only
     // CloudKitNetworkService+Verification may produce this overload, and only for Child mode.
-    if let trigger = Self.confirmedRevocationTrigger(
-      isConnected: result.isConnected,
-      enforcedMode: result.enforcedMode,
-      currentMode: AppModeManager.shared.currentMode
-    ) {
-      _ = await AuthorizationVerifier.shared.handleAuthorizationLoss(trigger: trigger)
+    if !result.isConnected, result.enforcedMode == .individual {
+      if let trigger = Self.confirmedRevocationTrigger(
+        isConnected: result.isConnected,
+        isSignedIn: self.isSignedIn,
+        enforcedMode: result.enforcedMode,
+        currentMode: AppModeManager.shared.currentMode
+      ) {
+        _ = await AuthorizationVerifier.shared.handleAuthorizationLoss(trigger: trigger)
+      }
       return
     }
     if let mode = result.enforcedMode {

--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -233,11 +233,26 @@ class CloudKitManager: ObservableObject {
 
   // MARK: - Verification
 
+  nonisolated static func confirmedRevocationTrigger(
+    isConnected: Bool,
+    enforcedMode: AppMode?,
+    currentMode: AppMode
+  ) -> FamilyAuthorizationLossTrigger? {
+    guard !isConnected,
+      enforcedMode == .individual,
+      currentMode == .child
+    else {
+      return nil
+    }
+    return .confirmedCloudKitRevocation
+  }
+
   func verifySelfFamilyMemberRecord() async {
     guard !ScreenshotDemoMode.isActive else { return }
+    let localMode = AppModeManager.shared.currentMode
     let result = await networkService.verifySelfFamilyMember(
       cachedUserRecordID: currentUserRecordID,
-      localMode: AppModeManager.shared.currentMode
+      localMode: localMode
     )
 
     self.isConnectedToFamily = result.isConnected
@@ -246,6 +261,16 @@ class CloudKitManager: ObservableObject {
     }
     if let isSignedIn = result.isSignedIn {
       self.isSignedIn = isSignedIn
+    }
+    // In a disconnected result, enforced .individual is the confirmed-revocation signal. Only
+    // CloudKitNetworkService+Verification may produce this overload, and only for Child mode.
+    if let trigger = Self.confirmedRevocationTrigger(
+      isConnected: result.isConnected,
+      enforcedMode: result.enforcedMode,
+      currentMode: AppModeManager.shared.currentMode
+    ) {
+      _ = await AuthorizationVerifier.shared.handleAuthorizationLoss(trigger: trigger)
+      return
     }
     if let mode = result.enforcedMode {
       AppModeManager.shared.selectMode(mode)

--- a/Foqos/CloudKit/CloudKitNetworkService+Verification.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Verification.swift
@@ -9,15 +9,13 @@ extension CloudKitNetworkService {
     case indeterminate
   }
 
-  private static let verificationPolicyZoneName = "FamilyPolicies"
-
   static func resolveSharedPolicyZoneLookup(
     zoneIDsFromSuccessfulLookup zoneIDs: [CKRecordZone.ID]?
   ) -> SharedPolicyZoneLookup {
     guard let zoneIDs else { return .indeterminate }
     guard
       let policyZoneID = zoneIDs.first(where: {
-        $0.zoneName == verificationPolicyZoneName
+        $0.zoneName == CloudKitConstants.policyZoneName
       })
     else {
       return .confirmedAbsent
@@ -27,9 +25,15 @@ extension CloudKitNetworkService {
 
   static func enforcedMode(
     for lookup: SharedPolicyZoneLookup,
-    localMode: AppMode
+    localMode: AppMode,
+    accountIsSignedIn: Bool
   ) -> AppMode? {
-    guard case .confirmedAbsent = lookup, localMode == .child else { return nil }
+    guard case .confirmedAbsent = lookup,
+      localMode == .child,
+      accountIsSignedIn
+    else {
+      return nil
+    }
     return .individual
   }
 
@@ -102,14 +106,18 @@ extension CloudKitNetworkService {
 
   func verifySelfFamilyMember(
     cachedUserRecordID: CKRecord.ID?,
-    localMode: AppMode
+    localMode: AppMode,
+    accountIsSignedIn: Bool
   ) async -> VerificationResult {
     let start = CFAbsoluteTimeGetCurrent()
     Log.info("verifySelfFamilyMember: starting", category: .cloudKit)
 
     let zoneLookup = await lookupSharedPolicyZoneForVerification()
     guard case .present(let zoneID) = zoneLookup else {
-      let enforcedMode = Self.enforcedMode(for: zoneLookup, localMode: localMode)
+      let enforcedMode = Self.enforcedMode(
+        for: zoneLookup,
+        localMode: localMode,
+        accountIsSignedIn: accountIsSignedIn)
       if enforcedMode == .individual {
         Log.info(
           "verifySelfFamilyMember: shared zone revocation confirmed",

--- a/Foqos/CloudKit/CloudKitNetworkService+Verification.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Verification.swift
@@ -3,6 +3,49 @@ import Foundation
 
 extension CloudKitNetworkService {
 
+  enum SharedPolicyZoneLookup: Equatable, Sendable {
+    case present(CKRecordZone.ID)
+    case confirmedAbsent
+    case indeterminate
+  }
+
+  private static let verificationPolicyZoneName = "FamilyPolicies"
+
+  static func resolveSharedPolicyZoneLookup(
+    zoneIDsFromSuccessfulLookup zoneIDs: [CKRecordZone.ID]?
+  ) -> SharedPolicyZoneLookup {
+    guard let zoneIDs else { return .indeterminate }
+    guard
+      let policyZoneID = zoneIDs.first(where: {
+        $0.zoneName == verificationPolicyZoneName
+      })
+    else {
+      return .confirmedAbsent
+    }
+    return .present(policyZoneID)
+  }
+
+  static func enforcedMode(
+    for lookup: SharedPolicyZoneLookup,
+    localMode: AppMode
+  ) -> AppMode? {
+    guard case .confirmedAbsent = lookup, localMode == .child else { return nil }
+    return .individual
+  }
+
+  private func lookupSharedPolicyZoneForVerification() async -> SharedPolicyZoneLookup {
+    do {
+      let zones = try await sharedDatabase.allRecordZones()
+      return Self.resolveSharedPolicyZoneLookup(
+        zoneIDsFromSuccessfulLookup: zones.map(\.zoneID))
+    } catch {
+      Log.error(
+        "Failed to fetch shared zones during verification: \(redactedErrorForLog(error))",
+        category: .cloudKit)
+      return .indeterminate
+    }
+  }
+
   // MARK: - Self Registration
 
   func registerSelfAsFamilyMember(role: FamilyRole, userRecordID: CKRecord.ID) async {
@@ -64,12 +107,23 @@ extension CloudKitNetworkService {
     let start = CFAbsoluteTimeGetCurrent()
     Log.info("verifySelfFamilyMember: starting", category: .cloudKit)
 
-    guard let zone = await findSharedZoneByName() else {
-      Log.info(
-        "verifySelfFamilyMember: no shared zone (\(String(format: "%.2f", CFAbsoluteTimeGetCurrent() - start))s)",
-        category: .cloudKit)
+    let zoneLookup = await lookupSharedPolicyZoneForVerification()
+    guard case .present(let zoneID) = zoneLookup else {
+      let enforcedMode = Self.enforcedMode(for: zoneLookup, localMode: localMode)
+      if enforcedMode == .individual {
+        Log.info(
+          "verifySelfFamilyMember: shared zone revocation confirmed",
+          category: .cloudKit)
+      } else {
+        Log.info(
+          "verifySelfFamilyMember: shared zone unavailable",
+          category: .cloudKit)
+      }
       return VerificationResult(
-        isConnected: false, userRecordID: cachedUserRecordID, isSignedIn: nil, enforcedMode: nil)
+        isConnected: false,
+        userRecordID: cachedUserRecordID,
+        isSignedIn: nil,
+        enforcedMode: enforcedMode)
     }
     Log.info(
       "verifySelfFamilyMember: found zone (\(String(format: "%.2f", CFAbsoluteTimeGetCurrent() - start))s)",
@@ -106,7 +160,7 @@ extension CloudKitNetworkService {
     do {
       let (results, _) = try await sharedDatabase.records(
         matching: query,
-        inZoneWith: zone.zoneID
+        inZoneWith: zoneID
       )
       Log.info(
         "verifySelfFamilyMember: queried FamilyMember (\(String(format: "%.2f", CFAbsoluteTimeGetCurrent() - start))s)",

--- a/Foqos/CloudKit/CloudKitNetworkService.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService.swift
@@ -34,10 +34,10 @@ actor CloudKitNetworkService {
     container.sharedCloudDatabase
   }
 
-  private let policyZoneName = "FamilyPolicies"
-
   var policyZoneID: CKRecordZone.ID {
-    CKRecordZone.ID(zoneName: policyZoneName, ownerName: CKCurrentUserDefaultName)
+    CKRecordZone.ID(
+      zoneName: CloudKitConstants.policyZoneName,
+      ownerName: CKCurrentUserDefaultName)
   }
 
   var policyZoneVerified = false
@@ -52,7 +52,7 @@ actor CloudKitNetworkService {
   func findSharedZoneByName() async -> CKRecordZone? {
     do {
       let zones = try await sharedDatabase.allRecordZones()
-      return zones.first { $0.zoneID.zoneName == policyZoneName }
+      return zones.first { $0.zoneID.zoneName == CloudKitConstants.policyZoneName }
     } catch {
       Log.error("Failed to fetch shared zones: \(redactedErrorForLog(error))", category: .cloudKit)
       return nil

--- a/Foqos/CloudKit/SyncModels.swift
+++ b/Foqos/CloudKit/SyncModels.swift
@@ -7,6 +7,7 @@ import Foundation
 /// Shared CloudKit configuration used across all sync services
 enum CloudKitConstants {
   static let containerIdentifier = "iCloud.com.cynexia.family-foqos"
+  static let policyZoneName = "FamilyPolicies"
   static let syncZoneName = "DeviceSync"
   static let defaultUserRecordName = "__default_user__"
 }

--- a/Foqos/Utils/AuthorizationVerifier.swift
+++ b/Foqos/Utils/AuthorizationVerifier.swift
@@ -1,6 +1,11 @@
 import FamilyControls
 import Foundation
 
+enum FamilyAuthorizationLossTrigger: Equatable {
+  case familyControls
+  case confirmedCloudKitRevocation
+}
+
 /// Centralized service for verifying Apple Family Sharing authorization.
 /// Used to ensure children accepting CloudKit shares are actually set up as
 /// children in Apple Family Sharing (not just adults pretending to be children).
@@ -141,11 +146,15 @@ class AuthorizationVerifier: ObservableObject {
   /// Handle authorization loss for a child device.
   /// This is the single entry point for all authorization loss scenarios.
   /// Clears shared state, switches to individual mode, and returns a user message.
-  func handleAuthorizationLoss() async -> String {
+  func handleAuthorizationLoss(
+    trigger: FamilyAuthorizationLossTrigger = .familyControls
+  ) async -> String {
     let cloudKitManager = CloudKitManager.shared
     let appModeManager = AppModeManager.shared
 
     Log.info("Handling authorization loss", category: .authorization)
+
+    LockCodeManager.shared.handleFamilyAuthorizationLoss(trigger)
 
     // Clear CloudKit shared state first
     cloudKitManager.clearSharedState()

--- a/Foqos/Utils/LockCodeManager.swift
+++ b/Foqos/Utils/LockCodeManager.swift
@@ -247,6 +247,12 @@ class LockCodeManager: ObservableObject {
     isConnected ? (cache: fetched, persist: fetched) : (cache: persisted, persist: persisted)
   }
 
+  func handleFamilyAuthorizationLoss(_ trigger: FamilyAuthorizationLossTrigger) {
+    guard trigger == .confirmedCloudKitRevocation else { return }
+    cachedLockCodes = []
+    throttleDefaults.removeObject(forKey: CacheKey.childLockCodes)
+  }
+
   /// Pure verification logic - all inputs explicit, no instance state.
   /// Used directly by tests; the instance method below is a thin wrapper.
   static func verifyCode(

--- a/FoqosTests/ChildRevocationCacheTests.swift
+++ b/FoqosTests/ChildRevocationCacheTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class ChildRevocationCacheTests: XCTestCase {
+  private static let cacheKey = "family_foqos_child_lock_codes"
+
+  private var defaults: UserDefaults!
+  private var originalMode: AppMode!
+  private var suiteName: String!
+
+  override func setUp() {
+    super.setUp()
+    originalMode = AppModeManager.shared.currentMode
+    AppModeManager.shared.selectMode(.child)
+
+    suiteName = "ChildRevocationCacheTests-\(UUID().uuidString)"
+    defaults = UserDefaults(suiteName: suiteName)!
+    let codes = [FamilyLockCode(code: "test-code", scope: .allChildren)]
+    defaults.set(try! JSONEncoder().encode(codes), forKey: Self.cacheKey)
+    LockCodeManager.shared.overrideDefaults(defaults)
+  }
+
+  override func tearDown() {
+    LockCodeManager.shared.overrideDefaults(nil)
+    defaults.removePersistentDomain(forName: suiteName)
+    AppModeManager.shared.selectMode(originalMode)
+    defaults = nil
+    originalMode = nil
+    suiteName = nil
+    super.tearDown()
+  }
+
+  func testGivenFamilyControlsLoss_WhenHandlingCache_ThenPINRemainsAvailable() {
+    XCTAssertTrue(LockCodeManager.shared.canVerifyCode)
+
+    LockCodeManager.shared.handleFamilyAuthorizationLoss(.familyControls)
+
+    XCTAssertTrue(LockCodeManager.shared.canVerifyCode)
+    XCTAssertNotNil(defaults.data(forKey: Self.cacheKey))
+  }
+
+  func testGivenConfirmedCloudKitRevocation_WhenHandlingCache_ThenPINErased() {
+    XCTAssertTrue(LockCodeManager.shared.canVerifyCode)
+
+    LockCodeManager.shared.handleFamilyAuthorizationLoss(.confirmedCloudKitRevocation)
+
+    XCTAssertFalse(LockCodeManager.shared.canVerifyCode)
+    XCTAssertNil(defaults.data(forKey: Self.cacheKey))
+  }
+}

--- a/FoqosTests/ChildRevocationTests.swift
+++ b/FoqosTests/ChildRevocationTests.swift
@@ -1,0 +1,61 @@
+import CloudKit
+import XCTest
+
+@testable import FamilyFoqos
+
+final class ChildRevocationTests: XCTestCase {
+  private func zoneID(_ name: String) -> CKRecordZone.ID {
+    CKRecordZone.ID(zoneName: name, ownerName: "test-owner")
+  }
+
+  func testGivenSuccessfulEmptyLookup_WhenResolvingZone_ThenRevocationIsConfirmed() {
+    XCTAssertEqual(
+      CloudKitNetworkService.resolveSharedPolicyZoneLookup(
+        zoneIDsFromSuccessfulLookup: []),
+      .confirmedAbsent)
+  }
+
+  func testGivenFailedLookup_WhenResolvingZone_ThenResultIsIndeterminate() {
+    XCTAssertEqual(
+      CloudKitNetworkService.resolveSharedPolicyZoneLookup(
+        zoneIDsFromSuccessfulLookup: nil),
+      .indeterminate)
+  }
+
+  func testGivenExactPolicyZoneAmongOtherZones_WhenResolving_ThenExactZoneIsPresent() {
+    let exact = zoneID("FamilyPolicies")
+    let fixture = [zoneID("OtherZone"), zoneID("FamilyPolicies-Renamed"), exact]
+
+    XCTAssertEqual(
+      CloudKitNetworkService.resolveSharedPolicyZoneLookup(
+        zoneIDsFromSuccessfulLookup: fixture),
+      .present(exact))
+  }
+
+  func testGivenOnlyMutatedPolicyName_WhenResolving_ThenRevocationIsConfirmed() {
+    let mutatedFixture = [zoneID("FamilyPolicies-Renamed"), zoneID("OtherZone")]
+
+    XCTAssertEqual(
+      CloudKitNetworkService.resolveSharedPolicyZoneLookup(
+        zoneIDsFromSuccessfulLookup: mutatedFixture),
+      .confirmedAbsent)
+  }
+
+  func testGivenConfirmedAbsenceInChildMode_WhenResolvingMode_ThenEnforcesIndividual() {
+    XCTAssertEqual(
+      CloudKitNetworkService.enforcedMode(for: .confirmedAbsent, localMode: .child),
+      .individual)
+  }
+
+  func testGivenConfirmedAbsenceOutsideChildMode_WhenResolvingMode_ThenDoesNotChangeMode() {
+    XCTAssertNil(
+      CloudKitNetworkService.enforcedMode(for: .confirmedAbsent, localMode: .parent))
+    XCTAssertNil(
+      CloudKitNetworkService.enforcedMode(for: .confirmedAbsent, localMode: .individual))
+  }
+
+  func testGivenIndeterminateLookupInChildMode_WhenResolvingMode_ThenDoesNotChangeMode() {
+    XCTAssertNil(
+      CloudKitNetworkService.enforcedMode(for: .indeterminate, localMode: .child))
+  }
+}

--- a/FoqosTests/ChildRevocationTests.swift
+++ b/FoqosTests/ChildRevocationTests.swift
@@ -58,4 +58,34 @@ final class ChildRevocationTests: XCTestCase {
     XCTAssertNil(
       CloudKitNetworkService.enforcedMode(for: .indeterminate, localMode: .child))
   }
+
+  func testGivenDisconnectedIndividualSignalInChildMode_WhenResolvingTrigger_ThenRevocationIsConfirmed() {
+    XCTAssertEqual(
+      CloudKitManager.confirmedRevocationTrigger(
+        isConnected: false,
+        enforcedMode: .individual,
+        currentMode: .child),
+      .confirmedCloudKitRevocation)
+  }
+
+  func testGivenDisconnectedIndividualSignalOutsideChildMode_WhenResolvingTrigger_ThenNoRevocation() {
+    XCTAssertNil(
+      CloudKitManager.confirmedRevocationTrigger(
+        isConnected: false,
+        enforcedMode: .individual,
+        currentMode: .parent))
+    XCTAssertNil(
+      CloudKitManager.confirmedRevocationTrigger(
+        isConnected: false,
+        enforcedMode: .individual,
+        currentMode: .individual))
+  }
+
+  func testGivenConnectedIndividualSignalInChildMode_WhenResolvingTrigger_ThenNoRevocation() {
+    XCTAssertNil(
+      CloudKitManager.confirmedRevocationTrigger(
+        isConnected: true,
+        enforcedMode: .individual,
+        currentMode: .child))
+  }
 }

--- a/FoqosTests/ChildRevocationTests.swift
+++ b/FoqosTests/ChildRevocationTests.swift
@@ -23,8 +23,12 @@ final class ChildRevocationTests: XCTestCase {
   }
 
   func testGivenExactPolicyZoneAmongOtherZones_WhenResolving_ThenExactZoneIsPresent() {
-    let exact = zoneID("FamilyPolicies")
-    let fixture = [zoneID("OtherZone"), zoneID("FamilyPolicies-Renamed"), exact]
+    let exact = zoneID(CloudKitConstants.policyZoneName)
+    let fixture = [
+      zoneID("OtherZone"),
+      zoneID("\(CloudKitConstants.policyZoneName)-Renamed"),
+      exact,
+    ]
 
     XCTAssertEqual(
       CloudKitNetworkService.resolveSharedPolicyZoneLookup(
@@ -33,7 +37,10 @@ final class ChildRevocationTests: XCTestCase {
   }
 
   func testGivenOnlyMutatedPolicyName_WhenResolving_ThenRevocationIsConfirmed() {
-    let mutatedFixture = [zoneID("FamilyPolicies-Renamed"), zoneID("OtherZone")]
+    let mutatedFixture = [
+      zoneID("\(CloudKitConstants.policyZoneName)-Renamed"),
+      zoneID("OtherZone"),
+    ]
 
     XCTAssertEqual(
       CloudKitNetworkService.resolveSharedPolicyZoneLookup(
@@ -43,26 +50,47 @@ final class ChildRevocationTests: XCTestCase {
 
   func testGivenConfirmedAbsenceInChildMode_WhenResolvingMode_ThenEnforcesIndividual() {
     XCTAssertEqual(
-      CloudKitNetworkService.enforcedMode(for: .confirmedAbsent, localMode: .child),
+      CloudKitNetworkService.enforcedMode(
+        for: .confirmedAbsent,
+        localMode: .child,
+        accountIsSignedIn: true),
       .individual)
   }
 
   func testGivenConfirmedAbsenceOutsideChildMode_WhenResolvingMode_ThenDoesNotChangeMode() {
     XCTAssertNil(
-      CloudKitNetworkService.enforcedMode(for: .confirmedAbsent, localMode: .parent))
+      CloudKitNetworkService.enforcedMode(
+        for: .confirmedAbsent,
+        localMode: .parent,
+        accountIsSignedIn: true))
     XCTAssertNil(
-      CloudKitNetworkService.enforcedMode(for: .confirmedAbsent, localMode: .individual))
+      CloudKitNetworkService.enforcedMode(
+        for: .confirmedAbsent,
+        localMode: .individual,
+        accountIsSignedIn: true))
   }
 
   func testGivenIndeterminateLookupInChildMode_WhenResolvingMode_ThenDoesNotChangeMode() {
     XCTAssertNil(
-      CloudKitNetworkService.enforcedMode(for: .indeterminate, localMode: .child))
+      CloudKitNetworkService.enforcedMode(
+        for: .indeterminate,
+        localMode: .child,
+        accountIsSignedIn: true))
+  }
+
+  func testGivenConfirmedAbsenceWhileSignedOut_WhenResolvingMode_ThenDoesNotChangeMode() {
+    XCTAssertNil(
+      CloudKitNetworkService.enforcedMode(
+        for: .confirmedAbsent,
+        localMode: .child,
+        accountIsSignedIn: false))
   }
 
   func testGivenDisconnectedIndividualSignalInChildMode_WhenResolvingTrigger_ThenRevocationIsConfirmed() {
     XCTAssertEqual(
       CloudKitManager.confirmedRevocationTrigger(
         isConnected: false,
+        isSignedIn: true,
         enforcedMode: .individual,
         currentMode: .child),
       .confirmedCloudKitRevocation)
@@ -72,11 +100,13 @@ final class ChildRevocationTests: XCTestCase {
     XCTAssertNil(
       CloudKitManager.confirmedRevocationTrigger(
         isConnected: false,
+        isSignedIn: true,
         enforcedMode: .individual,
         currentMode: .parent))
     XCTAssertNil(
       CloudKitManager.confirmedRevocationTrigger(
         isConnected: false,
+        isSignedIn: true,
         enforcedMode: .individual,
         currentMode: .individual))
   }
@@ -85,6 +115,16 @@ final class ChildRevocationTests: XCTestCase {
     XCTAssertNil(
       CloudKitManager.confirmedRevocationTrigger(
         isConnected: true,
+        isSignedIn: true,
+        enforcedMode: .individual,
+        currentMode: .child))
+  }
+
+  func testGivenSignedOutIndividualSignalInChildMode_WhenResolvingTrigger_ThenNoRevocation() {
+    XCTAssertNil(
+      CloudKitManager.confirmedRevocationTrigger(
+        isConnected: false,
+        isSignedIn: false,
         enforcedMode: .individual,
         currentMode: .child))
   }

--- a/FoqosTests/ChildRevocationTests.swift
+++ b/FoqosTests/ChildRevocationTests.swift
@@ -8,6 +8,13 @@ final class ChildRevocationTests: XCTestCase {
     CKRecordZone.ID(zoneName: name, ownerName: "test-owner")
   }
 
+  func testPolicyZoneNameMatchesShippedWireValue() {
+    XCTAssertEqual(
+      CloudKitConstants.policyZoneName,
+      "FamilyPolicies",
+      "Live CloudKit data contract; renaming orphans existing shared zones")
+  }
+
   func testGivenSuccessfulEmptyLookup_WhenResolvingZone_ThenRevocationIsConfirmed() {
     XCTAssertEqual(
       CloudKitNetworkService.resolveSharedPolicyZoneLookup(

--- a/docs/superpowers/plans/2026-08-14-issue-427-child-revocation.md
+++ b/docs/superpowers/plans/2026-08-14-issue-427-child-revocation.md
@@ -1,0 +1,629 @@
+# Issue #427 Child Revocation Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect authoritative CloudKit share revocation on a Child-mode device, erase only the
+revoked family's stale PIN authority, and transition the device to Individual mode without
+weakening offline fail-closed behavior.
+
+**Architecture:** A verification-local tri-state classifier distinguishes an exact shared policy
+zone, a successful lookup with no exact zone, and an indeterminate failed lookup. The existing
+`VerificationResult.enforcedMode` field carries the Child-only confirmed-revocation signal to
+`CloudKitManager`, which invokes trigger-keyed centralized cleanup. `LockCodeManager` erases its
+child cache only for the confirmed CloudKit trigger.
+
+**Tech Stack:** Swift 6, CloudKit, Combine/ObservableObject, UserDefaults, XCTest, Xcode simulator
+gate.
+
+## Global Constraints
+
+- Work only in `/Users/rob/git/family-foqos/.worktrees/build2-427` on
+  `fix/427-child-revocation`.
+- Do not edit `Foqos/CloudKit/CloudKitNetworkService.swift`; the planner granted ownership only of
+  `Foqos/CloudKit/CloudKitNetworkService+Verification.swift` and
+  `Foqos/Utils/LockCodeManager.swift` among build1-overlapping files.
+- Use 2-space Swift indentation, privacy-focused `Log`, and no personal identifiers or PINs in
+  logs.
+- Keep every offline/transient lookup indeterminate and preserve #197's persisted child PIN cache.
+- Only successful CloudKit lookup plus absent exact `FamilyPolicies` zone plus current Child mode
+  may erase the child PIN cache and select Individual mode.
+- Keep Family Controls-driven authorization loss separate: issue #431's transient error path must
+  not erase either PIN cache.
+- Run every build/test through
+  `scripts/xcode-stream.sh --agent build2 --session implement_beta_fixes`; never provide a
+  destination or DerivedData path.
+- If main stays at `2.0.31 (50)`, set every configuration to `2.0.32 (51)`; otherwise recompute both
+  version values strictly above main before publication.
+- Every commit is signed. Never amend, force-push, or merge; the planner merges after independent
+  review.
+
+---
+
+### Task 1: Classify the shared policy zone without conflating errors
+
+**Files:**
+
+- Create: `FoqosTests/ChildRevocationTests.swift`
+- Modify: `Foqos/CloudKit/CloudKitNetworkService+Verification.swift`
+
+**Interfaces:**
+
+- Consumes: `CKDatabase.allRecordZones()`, `CKRecordZone.ID`, `AppMode`, and the existing
+  `VerificationResult` initializer.
+- Produces: `CloudKitNetworkService.SharedPolicyZoneLookup`,
+  `resolveSharedPolicyZoneLookup(zoneIDsFromSuccessfulLookup:)`, and
+  `enforcedMode(for:localMode:)`.
+
+- [ ] **Step 1: Write failing tri-state and Child-only decision tests**
+
+Create `FoqosTests/ChildRevocationTests.swift` with literals whose expected values are independent
+of the production classifier:
+
+```swift
+import CloudKit
+import XCTest
+
+@testable import FamilyFoqos
+
+final class ChildRevocationTests: XCTestCase {
+  private func zoneID(_ name: String) -> CKRecordZone.ID {
+    CKRecordZone.ID(zoneName: name, ownerName: "test-owner")
+  }
+
+  func testGivenSuccessfulEmptyLookup_WhenResolvingZone_ThenRevocationIsConfirmed() {
+    XCTAssertEqual(
+      CloudKitNetworkService.resolveSharedPolicyZoneLookup(
+        zoneIDsFromSuccessfulLookup: []),
+      .confirmedAbsent)
+  }
+
+  func testGivenFailedLookup_WhenResolvingZone_ThenResultIsIndeterminate() {
+    XCTAssertEqual(
+      CloudKitNetworkService.resolveSharedPolicyZoneLookup(
+        zoneIDsFromSuccessfulLookup: nil),
+      .indeterminate)
+  }
+
+  func testGivenExactPolicyZoneAmongOtherZones_WhenResolving_ThenExactZoneIsPresent() {
+    let exact = zoneID("FamilyPolicies")
+    let fixture = [zoneID("OtherZone"), zoneID("FamilyPolicies-Renamed"), exact]
+
+    XCTAssertEqual(
+      CloudKitNetworkService.resolveSharedPolicyZoneLookup(
+        zoneIDsFromSuccessfulLookup: fixture),
+      .present(exact))
+  }
+
+  func testGivenOnlyMutatedPolicyName_WhenResolving_ThenRevocationIsConfirmed() {
+    let mutatedFixture = [zoneID("FamilyPolicies-Renamed"), zoneID("OtherZone")]
+
+    XCTAssertEqual(
+      CloudKitNetworkService.resolveSharedPolicyZoneLookup(
+        zoneIDsFromSuccessfulLookup: mutatedFixture),
+      .confirmedAbsent)
+  }
+
+  func testGivenConfirmedAbsenceInChildMode_WhenResolvingMode_ThenEnforcesIndividual() {
+    XCTAssertEqual(
+      CloudKitNetworkService.enforcedMode(for: .confirmedAbsent, localMode: .child),
+      .individual)
+  }
+
+  func testGivenConfirmedAbsenceOutsideChildMode_WhenResolvingMode_ThenDoesNotChangeMode() {
+    XCTAssertNil(
+      CloudKitNetworkService.enforcedMode(for: .confirmedAbsent, localMode: .parent))
+    XCTAssertNil(
+      CloudKitNetworkService.enforcedMode(for: .confirmedAbsent, localMode: .individual))
+  }
+
+  func testGivenIndeterminateLookupInChildMode_WhenResolvingMode_ThenDoesNotChangeMode() {
+    XCTAssertNil(
+      CloudKitNetworkService.enforcedMode(for: .indeterminate, localMode: .child))
+  }
+}
+```
+
+Mutation check: renaming the exact string, accepting prefix matches, treating `nil` as absence, or
+returning `.individual` for any non-Child mode must fail at least one test.
+
+- [ ] **Step 2: Run the focused class and verify RED**
+
+Run:
+
+```bash
+scripts/xcode-stream.sh --agent build2 --session implement_beta_fixes -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -only-testing:FoqosTests/ChildRevocationTests
+```
+
+Expected: build failure because `SharedPolicyZoneLookup`,
+`resolveSharedPolicyZoneLookup(zoneIDsFromSuccessfulLookup:)`, and `enforcedMode(for:localMode:)`
+do not exist. This is the intended RED, not a fixture or syntax failure.
+
+- [ ] **Step 3: Add the minimal tri-state classifier and lookup**
+
+At the top of the verification extension, add:
+
+```swift
+enum SharedPolicyZoneLookup: Equatable, Sendable {
+  case present(CKRecordZone.ID)
+  case confirmedAbsent
+  case indeterminate
+}
+
+private static let verificationPolicyZoneName = "FamilyPolicies"
+
+static func resolveSharedPolicyZoneLookup(
+  zoneIDsFromSuccessfulLookup zoneIDs: [CKRecordZone.ID]?
+) -> SharedPolicyZoneLookup {
+  guard let zoneIDs else { return .indeterminate }
+  guard
+    let policyZoneID = zoneIDs.first(where: {
+      $0.zoneName == verificationPolicyZoneName
+    })
+  else {
+    return .confirmedAbsent
+  }
+  return .present(policyZoneID)
+}
+
+static func enforcedMode(
+  for lookup: SharedPolicyZoneLookup,
+  localMode: AppMode
+) -> AppMode? {
+  guard case .confirmedAbsent = lookup, localMode == .child else { return nil }
+  return .individual
+}
+
+private func lookupSharedPolicyZoneForVerification() async -> SharedPolicyZoneLookup {
+  do {
+    let zones = try await sharedDatabase.allRecordZones()
+    return Self.resolveSharedPolicyZoneLookup(
+      zoneIDsFromSuccessfulLookup: zones.map(\.zoneID))
+  } catch {
+    Log.error(
+      "Failed to fetch shared zones during verification: \(redactedErrorForLog(error))",
+      category: .cloudKit)
+    return .indeterminate
+  }
+}
+```
+
+Replace `verifySelfFamilyMember`'s optional-zone guard with one lookup and switch:
+
+```swift
+let zoneLookup = await lookupSharedPolicyZoneForVerification()
+guard case .present(let zoneID) = zoneLookup else {
+  let enforcedMode = Self.enforcedMode(for: zoneLookup, localMode: localMode)
+  Log.info(
+    enforcedMode == .individual
+      ? "verifySelfFamilyMember: shared zone revocation confirmed"
+      : "verifySelfFamilyMember: shared zone unavailable",
+    category: .cloudKit)
+  return VerificationResult(
+    isConnected: false,
+    userRecordID: cachedUserRecordID,
+    isSignedIn: nil,
+    enforcedMode: enforcedMode)
+}
+```
+
+Within that method only, replace both uses of `zone.zoneID` with `zoneID`. Do not change
+`registerSelfAsFamilyMember` or the core optional shared-zone helper.
+
+- [ ] **Step 4: Run the focused class and verify GREEN**
+
+Run the exact Step 2 command. Expected: all seven `ChildRevocationTests` pass, including the
+mutated rename fixture and indeterminate Child-mode case.
+
+- [ ] **Step 5: Format, inspect scope, and create a signed classifier commit**
+
+Run:
+
+```bash
+swift-format --in-place \
+  Foqos/CloudKit/CloudKitNetworkService+Verification.swift \
+  FoqosTests/ChildRevocationTests.swift
+git diff --check
+git diff -- Foqos/CloudKit/CloudKitNetworkService+Verification.swift \
+  FoqosTests/ChildRevocationTests.swift
+git add Foqos/CloudKit/CloudKitNetworkService+Verification.swift \
+  FoqosTests/ChildRevocationTests.swift
+git commit -S -m "fix: distinguish child share revocation"
+```
+
+Expected: only the two owned files are committed; signature verification succeeds with
+`git log -1 --show-signature`.
+
+---
+
+### Task 2: Key PIN erasure to confirmed CloudKit revocation
+
+**Files:**
+
+- Create: `FoqosTests/ChildRevocationCacheTests.swift`
+- Modify: `Foqos/Utils/AuthorizationVerifier.swift`
+- Modify: `Foqos/Utils/LockCodeManager.swift`
+- Modify: `Foqos/CloudKit/CloudKitManager.swift`
+
+**Interfaces:**
+
+- Consumes: Task 1's disconnected plus enforced `.individual` signal and the existing
+  `handleAuthorizationLoss()` cleanup.
+- Produces: `FamilyAuthorizationLossTrigger`,
+  `LockCodeManager.handleFamilyAuthorizationLoss(_:)`, and
+  `CloudKitManager.confirmedRevocationTrigger(isConnected:enforcedMode:currentMode:)`.
+
+- [ ] **Step 1: Add failing manager-signal and real cache-policy tests**
+
+Append to `ChildRevocationTests`:
+
+```swift
+func testGivenDisconnectedIndividualSignalInChildMode_WhenResolving_ThenRevocationIsConfirmed() {
+  XCTAssertEqual(
+    CloudKitManager.confirmedRevocationTrigger(
+      isConnected: false, enforcedMode: .individual, currentMode: .child),
+    .confirmedCloudKitRevocation)
+}
+
+func testGivenRevocationSignalOutsideChildMode_WhenResolving_ThenNoLossIsApplied() {
+  XCTAssertNil(
+    CloudKitManager.confirmedRevocationTrigger(
+      isConnected: false, enforcedMode: .individual, currentMode: .parent))
+  XCTAssertNil(
+    CloudKitManager.confirmedRevocationTrigger(
+      isConnected: false, enforcedMode: .individual, currentMode: .individual))
+}
+
+func testGivenConnectedIndividualSignalInChildMode_WhenResolving_ThenNoLossIsApplied() {
+  XCTAssertNil(
+    CloudKitManager.confirmedRevocationTrigger(
+      isConnected: true, enforcedMode: .individual, currentMode: .child))
+}
+```
+
+Create `FoqosTests/ChildRevocationCacheTests.swift`:
+
+```swift
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class ChildRevocationCacheTests: XCTestCase {
+  private let cacheKey = "family_foqos_child_lock_codes"
+
+  private func withSeededCache(
+    _ body: (LockCodeManager, UserDefaults) throws -> Void
+  ) throws {
+    let suiteName = "ChildRevocationCacheTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    let manager = LockCodeManager.shared
+    let originalMode = AppModeManager.shared.currentMode
+    defer {
+      manager.overrideDefaults(nil)
+      AppModeManager.shared.currentMode = originalMode
+      defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    AppModeManager.shared.currentMode = .child
+    let code = FamilyLockCode(code: "test-code", scope: .allChildren)
+    defaults.set(try JSONEncoder().encode([code]), forKey: cacheKey)
+    manager.overrideDefaults(defaults)
+    XCTAssertTrue(manager.canVerifyCode)
+
+    try body(manager, defaults)
+  }
+
+  func testGivenFamilyControlsLoss_WhenApplyingCachePolicy_ThenPINCacheIsPreserved() throws {
+    try withSeededCache { manager, defaults in
+      manager.handleFamilyAuthorizationLoss(.familyControls)
+
+      XCTAssertTrue(manager.canVerifyCode)
+      XCTAssertNotNil(defaults.data(forKey: cacheKey))
+    }
+  }
+
+  func testGivenConfirmedCloudKitRevocation_WhenApplyingCachePolicy_ThenPINCacheIsErased() throws {
+    try withSeededCache { manager, defaults in
+      manager.handleFamilyAuthorizationLoss(.confirmedCloudKitRevocation)
+
+      XCTAssertFalse(manager.canVerifyCode)
+      XCTAssertNil(defaults.data(forKey: cacheKey))
+    }
+  }
+}
+```
+
+These tests exercise the real singleton cache and isolated UserDefaults. They do not mock or alter
+CloudKit. Mutation check: removing the trigger guard, erasing only persisted state, erasing only
+in-memory state, accepting the overloaded signal while connected, or dropping the Child-only gate
+must fail.
+
+- [ ] **Step 2: Run both focused classes and verify RED**
+
+Run:
+
+```bash
+scripts/xcode-stream.sh --agent build2 --session implement_beta_fixes -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -only-testing:FoqosTests/ChildRevocationTests \
+  -only-testing:FoqosTests/ChildRevocationCacheTests
+```
+
+Expected: build failure for missing `FamilyAuthorizationLossTrigger`,
+`handleFamilyAuthorizationLoss(_:)`, and `confirmedRevocationTrigger(...)`. The already-green Task
+1 tests remain syntactically valid.
+
+- [ ] **Step 3: Add trigger-keyed cache behavior**
+
+Add above `AuthorizationVerifier`:
+
+```swift
+enum FamilyAuthorizationLossTrigger: Equatable {
+  case familyControls
+  case confirmedCloudKitRevocation
+}
+```
+
+Change the handler signature and route the trigger before existing cleanup:
+
+```swift
+func handleAuthorizationLoss(
+  trigger: FamilyAuthorizationLossTrigger = .familyControls
+) async -> String {
+  let cloudKitManager = CloudKitManager.shared
+  let appModeManager = AppModeManager.shared
+
+  Log.info("Handling authorization loss", category: .authorization)
+
+  LockCodeManager.shared.handleFamilyAuthorizationLoss(trigger)
+  cloudKitManager.clearSharedState()
+  clearAuthorizationState()
+  appModeManager.selectMode(.individual)
+
+  return
+    "Your child account authorization was revoked (the device may have been removed from Apple Family Sharing). You've been switched to individual mode. To reconnect, ask a parent to re-add this device and send a new invitation."
+}
+```
+
+Existing call sites keep the default `.familyControls` trigger. In `LockCodeManager`, add beside
+the child cache resolver:
+
+```swift
+func handleFamilyAuthorizationLoss(_ trigger: FamilyAuthorizationLossTrigger) {
+  guard trigger == .confirmedCloudKitRevocation else { return }
+  cachedLockCodes = []
+  throttleDefaults.removeObject(forKey: CacheKey.childLockCodes)
+}
+```
+
+- [ ] **Step 4: Interpret the overloaded verification signal in CloudKitManager**
+
+Add the pure decision:
+
+```swift
+nonisolated static func confirmedRevocationTrigger(
+  isConnected: Bool,
+  enforcedMode: AppMode?,
+  currentMode: AppMode
+) -> FamilyAuthorizationLossTrigger? {
+  guard !isConnected, enforcedMode == .individual, currentMode == .child else { return nil }
+  return .confirmedCloudKitRevocation
+}
+```
+
+In `verifySelfFamilyMemberRecord()`, capture `localMode` before the await, pass it to verification,
+then interpret the returned signal before the existing general enforced-mode branch:
+
+```swift
+let localMode = AppModeManager.shared.currentMode
+let result = await networkService.verifySelfFamilyMember(
+  cachedUserRecordID: currentUserRecordID,
+  localMode: localMode
+)
+
+// In a disconnected result, enforced .individual is the confirmed-revocation signal. Only
+// CloudKitNetworkService+Verification may produce this overload, and only for Child mode.
+if let trigger = Self.confirmedRevocationTrigger(
+  isConnected: result.isConnected,
+  enforcedMode: result.enforcedMode,
+  currentMode: AppModeManager.shared.currentMode
+) {
+  _ = await AuthorizationVerifier.shared.handleAuthorizationLoss(trigger: trigger)
+  return
+}
+
+if let mode = result.enforcedMode {
+  AppModeManager.shared.selectMode(mode)
+}
+```
+
+Keep the existing published connection, user-record, and sign-in updates before this branch. The
+decision rechecks the current mode after the await so a concurrent user mode change cannot be
+overwritten by stale verification.
+
+- [ ] **Step 5: Run both focused classes and the #197 regression class; verify GREEN**
+
+Run:
+
+```bash
+scripts/xcode-stream.sh --agent build2 --session implement_beta_fixes -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -only-testing:FoqosTests/ChildRevocationTests \
+  -only-testing:FoqosTests/ChildRevocationCacheTests \
+  -only-testing:FoqosTests/LockCodeFailClosedTests
+```
+
+Expected: every selected test passes. In particular, the existing offline fetch retains the
+persisted cache, the Family Controls trigger retains both caches, and only confirmed CloudKit
+revocation erases both.
+
+- [ ] **Step 6: Format, inspect scope, and create a signed cleanup commit**
+
+Run:
+
+```bash
+swift-format --in-place \
+  Foqos/CloudKit/CloudKitManager.swift \
+  Foqos/Utils/AuthorizationVerifier.swift \
+  Foqos/Utils/LockCodeManager.swift \
+  FoqosTests/ChildRevocationTests.swift \
+  FoqosTests/ChildRevocationCacheTests.swift
+git diff --check
+git diff --stat
+git add Foqos/CloudKit/CloudKitManager.swift \
+  Foqos/Utils/AuthorizationVerifier.swift \
+  Foqos/Utils/LockCodeManager.swift \
+  FoqosTests/ChildRevocationTests.swift \
+  FoqosTests/ChildRevocationCacheTests.swift
+git commit -S -m "fix: clear stale PIN after confirmed revocation"
+```
+
+Expected: no `CloudKitNetworkService.swift`, UI file, #428 subscription work, or unrelated cleanup
+is present. Verify the signature with `git log -1 --show-signature`.
+
+---
+
+### Task 3: Version and verify the complete #427 change
+
+**Files:**
+
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+- Verify: every Swift and test file changed in Tasks 1–2
+
+**Interfaces:**
+
+- Consumes: the complete verified behavior from Tasks 1–2 and current `main` version values.
+- Produces: a branch whose marketing/build versions are strictly above main and whose focused,
+  full-suite, build, formatting, and repository gates pass.
+
+- [ ] **Step 1: Re-read issue #427 and compare every done criterion to the diff**
+
+Fetch/re-read the complete issue body. Confirm the diff shows: automatic foreground detection,
+confirmed-absence versus error separation, Child-only transition, in-memory and persisted PIN
+erasure, unchanged offline preservation, and focused tests for both branches. Remove any unrelated
+change rather than documenting it.
+
+- [ ] **Step 2: Re-read main's version and bump every configuration strictly above it**
+
+Run:
+
+```bash
+git show main:FamilyFoqos.xcodeproj/project.pbxproj | \
+  rg "MARKETING_VERSION|CURRENT_PROJECT_VERSION"
+rg -n "MARKETING_VERSION|CURRENT_PROJECT_VERSION" \
+  FamilyFoqos.xcodeproj/project.pbxproj
+```
+
+If main remains `2.0.31 (50)`, use `apply_patch` to replace every
+`MARKETING_VERSION = 2.0.31;` with `MARKETING_VERSION = 2.0.32;` and every
+`CURRENT_PROJECT_VERSION = 50;` with `CURRENT_PROJECT_VERSION = 51;`. Verify no old values remain
+and every configuration reports the same new pair. If main advanced, use the next marketing patch
+and integer build above its maxima instead.
+
+- [ ] **Step 3: Run focused regression tests**
+
+Run the exact Task 2 Step 5 command. Expected: all selected tests pass with zero failures.
+
+- [ ] **Step 4: Run the complete test suite**
+
+Run:
+
+```bash
+scripts/xcode-stream.sh --agent build2 --session implement_beta_fixes -- \
+  xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos
+```
+
+Expected: `** TEST SUCCEEDED **` and zero failures.
+
+- [ ] **Step 5: Run a formatted Debug build**
+
+First validate the formatter dependency with `command -v xcbeautify`. Then run:
+
+```bash
+scripts/xcode-stream.sh --agent build2 --session implement_beta_fixes --xcbeautify -- \
+  xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos \
+  -configuration Debug build
+```
+
+Expected: wrapper exit `0` and a successful build.
+
+- [ ] **Step 6: Run formatting and repository guards**
+
+Validate `swift-format` and `rg` with `command -v`, then run:
+
+```bash
+swift-format --in-place \
+  Foqos/CloudKit/CloudKitManager.swift \
+  Foqos/CloudKit/CloudKitNetworkService+Verification.swift \
+  Foqos/Utils/AuthorizationVerifier.swift \
+  Foqos/Utils/LockCodeManager.swift \
+  FoqosTests/ChildRevocationTests.swift \
+  FoqosTests/ChildRevocationCacheTests.swift
+swift-format lint --recursive .
+scripts/check-c2-guards.sh
+scripts/check-sync-guards.sh
+scripts/run-log-privacy-lint.sh "$PWD"
+git diff --check
+```
+
+Expected: formatter lint, C2 guards, I2/I5 sync guards, and privacy lint all exit `0`.
+
+- [ ] **Step 7: Inspect the complete uncommitted version delta**
+
+Run:
+
+```bash
+git status --short --branch
+git diff main...HEAD --stat
+git diff --stat
+git diff --check
+```
+
+Expected: only #427 implementation/tests/docs/version files are present and no worktree is dirty
+except the intentional version change.
+
+- [ ] **Step 8: Commit the version bump as a new signed commit**
+
+Run:
+
+```bash
+git add FamilyFoqos.xcodeproj/project.pbxproj
+git commit -S -m "chore: bump version for child revocation fix"
+git log -1 --show-signature
+git status --short --branch
+```
+
+Expected: a good signature and a clean feature worktree.
+
+- [ ] **Step 9: Run the strict version gate against the committed head**
+
+Run:
+
+```bash
+scripts/check-version-increment.sh main HEAD
+```
+
+Expected: exit `0` with exactly
+`Version gate passed: MARKETING_VERSION 2.0.31 -> 2.0.32; CURRENT_PROJECT_VERSION 50 -> 51.`
+when main has not advanced. If main advanced and the values were recomputed, require the same
+message shape with the actual strictly increasing pairs.
+
+- [ ] **Step 10: Publish a ready-for-review PR and request independent AMQ review**
+
+Use the `github:yeet` publish workflow: confirm the exact commit/file scope, push
+`fix/427-child-revocation`, open one PR against `main` that closes #427, and mark it ready for
+review (not draft). The PR body must summarize the tri-state semantics, Child-only trigger,
+#197/#431 cache boundary, versions, and exact verification evidence.
+
+Send the reviewer a self-contained AMQ `review_request` with repository, PR number, exact head SHA,
+issue acceptance criteria, ownership constraint, and commands/results. Announce the review wait
+when it begins. Address findings with new signed commits only, rerun proportionate verification,
+and obtain review of the exact final head.
+
+- [ ] **Step 11: Report the literal PR/review state to the planner**
+
+Report PR number and URL, head/base SHAs, draft=false, check state, independent review decision,
+version pair, and any exact remaining gate. Do not merge. #425 begins only after the planner's #427
+handoff permits the strict sequential transition.

--- a/docs/superpowers/specs/2026-08-14-issue-427-child-revocation-design.md
+++ b/docs/superpowers/specs/2026-08-14-issue-427-child-revocation-design.md
@@ -81,13 +81,13 @@ an inline comment documenting the field's dual meaning and the invariant that on
 The Child-only gate is mandatory. A parent owns its policy zone in the private database, so an
 empty shared database is not evidence that Parent mode should be removed.
 
-`LockCodeManager` will gain one focused cleanup operation that clears both `cachedLockCodes` and
-the persisted `family_foqos_child_lock_codes` value. A distinct confirmed-CloudKit-revocation
-cleanup entry point in `AuthorizationVerifier` will call that operation and then compose with the
-existing `handleAuthorizationLoss()` cleanup before selecting Individual mode. Existing Family
-Controls-driven callers continue to call `handleAuthorizationLoss()` and must not erase either PIN
-cache. The cache operation performs no network I/O and does not clear parent/individual lock-code
-state.
+`LockCodeManager` will gain one focused cleanup operation keyed by an authorization-loss trigger.
+It clears both `cachedLockCodes` and the persisted `family_foqos_child_lock_codes` value only for
+confirmed CloudKit revocation. `AuthorizationVerifier.handleAuthorizationLoss(trigger:)` will pass
+that trigger through before performing its existing cleanup and selecting Individual mode.
+Existing Family Controls-driven callers use the non-revocation trigger and must not erase either
+PIN cache. The cache operation performs no network I/O and does not clear parent/individual
+lock-code state.
 
 This separation is also a compatibility boundary for issue #431. Family Controls error code 4 can
 currently reach `handleAuthorizationLoss()` after a transient authorization failure. Until #431

--- a/docs/superpowers/specs/2026-08-14-issue-427-child-revocation-design.md
+++ b/docs/superpowers/specs/2026-08-14-issue-427-child-revocation-design.md
@@ -74,13 +74,26 @@ Existing connected verification behavior remains unchanged.
 - confirmed absent in Parent or Individual mode: report disconnected without changing mode; and
 - indeterminate in every mode: preserve local mode and shared authority.
 
+The `CloudKitManager` branch that interprets disconnected plus enforced `.individual` will carry
+an inline comment documenting the field's dual meaning and the invariant that only
+`CloudKitNetworkService+Verification.swift` may produce this revocation signal.
+
 The Child-only gate is mandatory. A parent owns its policy zone in the private database, so an
 empty shared database is not evidence that Parent mode should be removed.
 
 `LockCodeManager` will gain one focused cleanup operation that clears both `cachedLockCodes` and
-the persisted `family_foqos_child_lock_codes` value. `AuthorizationVerifier.handleAuthorizationLoss()`
-will call it alongside the existing CloudKit and authorization cleanup before selecting Individual
-mode. The operation performs no network I/O and does not clear parent/individual lock-code state.
+the persisted `family_foqos_child_lock_codes` value. A distinct confirmed-CloudKit-revocation
+cleanup entry point in `AuthorizationVerifier` will call that operation and then compose with the
+existing `handleAuthorizationLoss()` cleanup before selecting Individual mode. Existing Family
+Controls-driven callers continue to call `handleAuthorizationLoss()` and must not erase either PIN
+cache. The cache operation performs no network I/O and does not clear parent/individual lock-code
+state.
+
+This separation is also a compatibility boundary for issue #431. Family Controls error code 4 can
+currently reach `handleAuthorizationLoss()` after a transient authorization failure. Until #431
+corrects that classification, the ordinary authorization-loss path must preserve the fail-closed
+PIN cache. Only a successful CloudKit zone-list lookup proving the shared policy zone absent may
+call the confirmed-revocation entry point.
 
 No lock-code fetch semantics change. In particular, `LockCodeManager.resolveLockCodes` continues
 to preserve the persisted cache whenever `isConnected` is false. Only the separate authoritative
@@ -94,9 +107,11 @@ revocation signal may erase it.
 3. A present zone continues through FamilyMember verification.
 4. A thrown lookup produces an indeterminate result; no mode or PIN cache changes occur.
 5. A successful lookup without the exact policy zone produces confirmed absence.
-6. If and only if local mode is Child, centralized authorization-loss cleanup clears published
-   shared state, authorization state, the in-memory child PIN cache, and its persisted copy, then
-   selects Individual mode.
+6. If and only if local mode is Child, the confirmed-revocation cleanup clears the in-memory child
+   PIN cache and its persisted copy, composes with the existing cleanup of published shared and
+   authorization state, then selects Individual mode.
+7. Family Controls-driven authorization loss continues through the existing cleanup path without
+   erasing either child PIN cache.
 
 ## Error handling and privacy
 
@@ -116,7 +131,9 @@ Use TDD and first demonstrate failures for:
   classifying as confirmed absence;
 - only Child mode turning confirmed absence into authorization-loss handling;
 - Parent and Individual modes preserving their modes for the same shared-database absence;
-- child PIN cleanup removing both the in-memory verification cache and persisted value; and
+- child PIN cleanup removing both the in-memory verification cache and persisted value;
+- a Family Controls-driven authorization loss preserving both PIN caches while the confirmed
+  CloudKit-revocation path erases them; and
 - the existing offline `resolveLockCodes` test continuing to preserve the cached PIN.
 
 Run focused tests through

--- a/docs/superpowers/specs/2026-08-14-issue-427-child-revocation-design.md
+++ b/docs/superpowers/specs/2026-08-14-issue-427-child-revocation-design.md
@@ -1,0 +1,136 @@
+# Issue #427 Child Revocation Recovery Design
+
+## Goal
+
+When CloudKit authoritatively reports that a Child-mode device no longer has the family shared
+zone, transition the device to Individual mode and erase the obsolete child PIN cache. Preserve
+the existing fail-closed PIN cache for every offline, network, or otherwise indeterminate lookup.
+
+## Root cause
+
+`CloudKitNetworkService.findSharedZoneByName()` returns `nil` for two materially different
+outcomes:
+
+- `sharedDatabase.allRecordZones()` succeeds and contains no `FamilyPolicies` zone. For a
+  persistently Child-mode device, this is confirmed share revocation.
+- `allRecordZones()` throws because CloudKit cannot answer. This is an indeterminate transient
+  failure.
+
+`verifySelfFamilyMember` consequently returns the same disconnected result for both outcomes,
+and `CloudKitManager` has no signal that permits automatic unenrolment. The centralized
+`AuthorizationVerifier.handleAuthorizationLoss()` cleanup also clears published CloudKit state,
+authorization state, and app mode, but it leaves `LockCodeManager`'s in-memory and persisted child
+PIN cache intact.
+
+## Considered approaches
+
+### A. Tri-state verification lookup and centralized cleanup (approved)
+
+Add a verification-local shared-zone lookup with `present`, `confirmedAbsent`, and
+`indeterminate` outcomes. Carry confirmed absence through `VerificationResult`; only a Child-mode
+caller may turn that signal into authorization-loss cleanup. Extend the existing centralized
+cleanup to erase the child PIN cache.
+
+This directly models the CloudKit evidence, recovers immediately after revocation, and leaves the
+#197 offline fail-closed path unchanged.
+
+### B. Treat a missing zone as a connected empty lock-code fetch (rejected)
+
+This would clear the PIN when a zone lookup fails for network or service reasons, reopening the
+#197 airplane-mode bypass.
+
+### C. Require repeated absence or a time threshold (rejected)
+
+This adds persistent state and delays recovery even though a successful zone-list response is
+already authoritative. It does not make transient failures safer than the tri-state result.
+
+## Design
+
+Keep the new lookup in `CloudKitNetworkService+Verification.swift`; do not change the shared
+optional helper in `CloudKitNetworkService.swift`. This limits #427 to verification and avoids
+broadly changing unrelated shared-zone consumers.
+
+The verification extension will classify a zone-list attempt as:
+
+- `present(zoneID)` when a zone whose name is exactly `FamilyPolicies` is returned;
+- `confirmedAbsent` when the request succeeds but no exact-name match exists; or
+- `indeterminate` when the request throws.
+
+The classifier will be independently testable from a list of zone IDs plus an explicit lookup
+success/failure signal. The positive fixture will include unrelated zones and a mutated
+`FamilyPolicies` rename variant so an incidental non-empty list cannot make the test pass. Only an
+exact zone-name match is connected.
+
+To honor the ownership boundary without editing `CloudKitNetworkService.swift`, the verification
+extension will resolve the tri-state result against `localMode` before constructing the existing
+`VerificationResult`. Confirmed absence in Child mode will use the existing `enforcedMode` field
+with `.individual`; every other absent or indeterminate result will keep `enforcedMode` nil.
+Existing connected verification behavior remains unchanged.
+`CloudKitManager.verifySelfFamilyMemberRecord()` will interpret the result as follows:
+
+- connected: update connection state and apply any CloudKit-enforced role as today;
+- disconnected with `.individual` enforced while the current local mode is Child: invoke
+  centralized authorization-loss cleanup;
+- confirmed absent in Parent or Individual mode: report disconnected without changing mode; and
+- indeterminate in every mode: preserve local mode and shared authority.
+
+The Child-only gate is mandatory. A parent owns its policy zone in the private database, so an
+empty shared database is not evidence that Parent mode should be removed.
+
+`LockCodeManager` will gain one focused cleanup operation that clears both `cachedLockCodes` and
+the persisted `family_foqos_child_lock_codes` value. `AuthorizationVerifier.handleAuthorizationLoss()`
+will call it alongside the existing CloudKit and authorization cleanup before selecting Individual
+mode. The operation performs no network I/O and does not clear parent/individual lock-code state.
+
+No lock-code fetch semantics change. In particular, `LockCodeManager.resolveLockCodes` continues
+to preserve the persisted cache whenever `isConnected` is false. Only the separate authoritative
+revocation signal may erase it.
+
+## Data flow
+
+1. On foreground activation, the app calls `verifySelfFamilyMemberRecord()` as it does today.
+2. Verification lists shared zones and produces one tri-state lookup result, then resolves it
+   against the supplied local mode without changing the core result type.
+3. A present zone continues through FamilyMember verification.
+4. A thrown lookup produces an indeterminate result; no mode or PIN cache changes occur.
+5. A successful lookup without the exact policy zone produces confirmed absence.
+6. If and only if local mode is Child, centralized authorization-loss cleanup clears published
+   shared state, authorization state, the in-memory child PIN cache, and its persisted copy, then
+   selects Individual mode.
+
+## Error handling and privacy
+
+CloudKit lookup errors remain privacy-safe logs and map to `indeterminate`. No error text, record
+identifier, lock code, or personal identifier is persisted or logged. Cleanup is synchronous local
+state mutation apart from the existing async wrapper, so a confirmed revocation does not depend on
+another network request.
+
+## Testing
+
+Use TDD and first demonstrate failures for:
+
+- a successful empty zone list classifying as confirmed absence;
+- a thrown zone lookup classifying as indeterminate;
+- an exact `FamilyPolicies` match classifying as present even alongside unrelated zones;
+- a non-empty fixture containing a rename/mutation variant such as `FamilyPolicies-Renamed`
+  classifying as confirmed absence;
+- only Child mode turning confirmed absence into authorization-loss handling;
+- Parent and Individual modes preserving their modes for the same shared-database absence;
+- child PIN cleanup removing both the in-memory verification cache and persisted value; and
+- the existing offline `resolveLockCodes` test continuing to preserve the cached PIN.
+
+Run focused tests through
+`scripts/xcode-stream.sh --agent build2 --session implement_beta_fixes`, then the full required
+test/build/format/guard suite. Do not use a device-name destination.
+
+## Delivery and ownership
+
+Work only in `.worktrees/build2-427` on `fix/427-child-revocation`. The planner granted this stream
+temporary ownership of `LockCodeManager.swift` and `CloudKitNetworkService+Verification.swift`;
+build1 will defer #428 until #427 merges. Do not edit `CloudKitNetworkService.swift` without a new
+planner gate.
+
+If `main` remains at `2.0.31 (50)`, set every configuration of `MARKETING_VERSION` to `2.0.32` and
+every configuration of `CURRENT_PROJECT_VERSION` to `51`. If `main` advances before publication,
+recompute both values so they remain strictly above main. Deliver one signed commit series and one
+ready-for-review PR for #427; the planner merges after independent AMQ review.


### PR DESCRIPTION
## Summary

- distinguish a confirmed missing shared `FamilyPolicies` zone from transient CloudKit lookup failure
- require a confirmed signed-in account before producing or honoring the revocation signal
- transition only a currently enrolled Child device to Individual mode on confirmed revocation
- clear the stale in-memory and persisted shared PIN only for confirmed CloudKit revocation
- preserve the #197 fail-closed PIN cache for offline/transient CloudKit and ordinary Family Controls authorization loss
- centralize and pin the shipped shared policy-zone wire value
- bump the release to 2.0.34 (53), strictly above current `main`

## Root cause

Verification collapsed a successful empty shared-zone lookup and a failed lookup into the same disconnected result. The fail-closed resolver correctly retained the persisted PIN for disconnected fetches, but that meant a genuinely removed child could remain in Child mode with a PIN the former parent could no longer clear.

## Validation

- focused revocation/cache/fail-closed coverage: 21 tests
- policy-zone value mutation: exactly the wire-contract assertion failed; the other 12 revocation tests passed
- full post-merge test suite: 1,246 passed, 0 failed
- post-merge Debug build: succeeded
- `swift-format lint --recursive .`
- C2 and sync guards
- log privacy lint: 232/232 files, 502 sites, 0 annotations
- version gate: main 2.0.33 (52) → head 2.0.34 (53)
- all branch commits signed and verified

Closes #427