### PR TITLE
Fix duplicate cold-launch schedule registration

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.35;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.35;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.35;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.35;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.35;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.35;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.35;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.35;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.35;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.35;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.35;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.35;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -92,9 +92,8 @@ struct FoqosApp: App {
   /// Sync upgrade notice (shown when legacy session records are cleaned up)
   @State private var showSyncUpgradeAlert = false
 
-  /// Tracks whether .onAppear has run, to skip duplicate schedule work
-  /// when scenePhase fires .active on initial launch.
-  @State private var hasPerformedInitialSetup = false
+  /// Coalesces cold-launch and warm-foreground schedule refreshes.
+  @State private var scheduleRefreshState = AppScheduleRefreshState()
 
   /// CloudKit share acceptance
   @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
@@ -143,6 +142,7 @@ struct FoqosApp: App {
         }
         .onChange(of: scenePhase) { oldPhase, newPhase in
           Log.debug("scenePhase changed", category: .app)
+          let shouldRefreshSchedules = scheduleRefreshState.shouldRefresh(for: newPhase)
           if newPhase == .active {
             if !ScreenshotDemoMode.isActive {
               Task {
@@ -168,15 +168,8 @@ struct FoqosApp: App {
                 }
               }
             }
-            // Only reschedule on warm returns — .onAppear handles cold launch
-            if hasPerformedInitialSetup && !ScreenshotDemoMode.isActive {
-              PreActivationReminderScheduler.mergeExtensionScheduleSuppression(
-                context: container.mainContext)
-              PreActivationReminderScheduler.reconcileMissingSnapshots(
-                context: container.mainContext)
-              PreActivationReminderScheduler.reconcileScheduleRegistrations(
-                context: container.mainContext)
-              PreActivationReminderScheduler.catchUpMissedScheduleStarts(context: container.mainContext)
+            if shouldRefreshSchedules && !ScreenshotDemoMode.isActive {
+              reconcileSchedulesForCurrentState()
             }
           }
         }
@@ -286,8 +279,11 @@ struct FoqosApp: App {
         .environmentObject(cloudKitManager)
         .environmentObject(profileSyncManager)
         .onAppear {
-          // Migrate profiles to V2 trigger system if needed
-          ProfileMigrationUtil.migrateProfilesIfNeeded(context: container.mainContext)
+          let shouldPerformInitialRefresh = scheduleRefreshState.shouldPerformInitialRefresh()
+          if shouldPerformInitialRefresh {
+            // Migration must precede the single coalesced cold-launch refresh.
+            ProfileMigrationUtil.migrateProfilesIfNeeded(context: container.mainContext)
+          }
           // Construct + wire the sync engine with the live ModelContext (I10).
           // Skipped under the XCTest host so hosted unit tests own `attachEngine`'s
           // one-shot idempotency guard themselves.
@@ -298,18 +294,9 @@ struct FoqosApp: App {
                 emergencyManager: emergencyManager)
             }
           }
-          if !ScreenshotDemoMode.isActive {
-            // Reschedule pre-activation reminders for today
-            PreActivationReminderScheduler.mergeExtensionScheduleSuppression(
-              context: container.mainContext)
-            PreActivationReminderScheduler.reconcileMissingSnapshots(
-              context: container.mainContext)
-            PreActivationReminderScheduler.reconcileScheduleRegistrations(
-              context: container.mainContext)
-            // Catch up any missed schedule starts
-            PreActivationReminderScheduler.catchUpMissedScheduleStarts(context: container.mainContext)
+          if shouldPerformInitialRefresh && !ScreenshotDemoMode.isActive {
+            reconcileSchedulesForCurrentState()
           }
-          hasPerformedInitialSetup = true
         }
     }
     .handlesExternalEvents(matching: ["*"])  // Handle all external events including CloudKit shares
@@ -322,6 +309,16 @@ struct FoqosApp: App {
     // Parent dashboard is accessible from settings (parent mode)
     // Child parental controls info is accessible from settings (child mode)
     HomeView()
+  }
+
+  private func reconcileSchedulesForCurrentState() {
+    PreActivationReminderScheduler.mergeExtensionScheduleSuppression(
+      context: container.mainContext)
+    PreActivationReminderScheduler.reconcileMissingSnapshots(
+      context: container.mainContext)
+    PreActivationReminderScheduler.reconcileScheduleRegistrations(
+      context: container.mainContext)
+    PreActivationReminderScheduler.catchUpMissedScheduleStarts(context: container.mainContext)
   }
 
   // MARK: - Share Acceptance Alerts

--- a/Foqos/Utils/AppScheduleRefreshState.swift
+++ b/Foqos/Utils/AppScheduleRefreshState.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct AppScheduleRefreshState {
+  private var didPerformInitialRefresh = false
+  private var becameNonActiveAfterInitialRefresh = false
+
+  mutating func shouldPerformInitialRefresh() -> Bool {
+    guard !didPerformInitialRefresh else { return false }
+    didPerformInitialRefresh = true
+    return true
+  }
+
+  mutating func shouldRefresh(for scenePhase: ScenePhase) -> Bool {
+    guard didPerformInitialRefresh else { return false }
+
+    switch scenePhase {
+    case .active:
+      guard becameNonActiveAfterInitialRefresh else { return false }
+      becameNonActiveAfterInitialRefresh = false
+      return true
+    case .background, .inactive:
+      becameNonActiveAfterInitialRefresh = true
+      return false
+    @unknown default:
+      return false
+    }
+  }
+}

--- a/Foqos/Utils/ProfileMigrationUtil.swift
+++ b/Foqos/Utils/ProfileMigrationUtil.swift
@@ -3,7 +3,8 @@ import SwiftData
 enum ProfileMigrationUtil {
   /// Migrates V1 profiles to V2 trigger system if needed.
   /// Defers profiles with active sessions. Safe to call as a no-op when nothing needs migration.
-  static func migrateProfilesIfNeeded(context: ModelContext) {
+  @discardableResult
+  static func migrateProfilesIfNeeded(context: ModelContext) -> Int {
     do {
       let profiles = try BlockedProfiles.fetchProfiles(in: context)
 
@@ -40,8 +41,10 @@ enum ProfileMigrationUtil {
           category: .app
         )
       }
+      return migratedCount
     } catch {
       Log.error("Failed to migrate profiles: \(error.localizedDescription)", category: .app)
+      return 0
     }
   }
 }

--- a/Foqos/Utils/ProfileMigrationUtil.swift
+++ b/Foqos/Utils/ProfileMigrationUtil.swift
@@ -28,9 +28,9 @@ enum ProfileMigrationUtil {
       if migratedCount > 0 {
         try context.save()
         Log.info("Migrated \(migratedCount) profiles to schema V2", category: .app)
-        // Register schedules with DeviceActivityCenter for migrated profiles
+        // Refresh shared snapshots before the centralized launch reconciliation registers
+        // DeviceActivity schedules. Registering here would duplicate the launch refresh.
         for profile in migratedProfiles {
-          DeviceActivityCenterUtil.scheduleTimerActivity(for: profile)
           BlockedProfiles.updateSnapshot(for: profile)
         }
       }

--- a/Foqos/Utils/StrategyManager.swift
+++ b/Foqos/Utils/StrategyManager.swift
@@ -32,6 +32,7 @@ class StrategyManager: ObservableObject {
   private let timersUtil: TimersUtilScheduling
   private let appBlocker: RestrictionApplying
   private let backstopRegistrar: BackstopRegistering
+  private let scheduleReconciler: @MainActor (ModelContext) -> Void
 
   init(
     geofenceEvaluator: GeofenceEvaluator = .shared,
@@ -43,7 +44,10 @@ class StrategyManager: ObservableObject {
     appBlocker: RestrictionApplying = AppBlockerUtil(),
     backstopRegistrar: BackstopRegistering = DeviceActivityBackstopRegistrar(),
     timersUtil: TimersUtilScheduling = TimersUtil(),
-    remoteActiveDefaults: UserDefaults = .standard
+    remoteActiveDefaults: UserDefaults = .standard,
+    scheduleReconciler: @escaping @MainActor (ModelContext) -> Void = {
+      PreActivationReminderScheduler.reconcileScheduleRegistrations(context: $0)
+    }
   ) {
     self.geofenceEvaluator = geofenceEvaluator
     self.emergencyUnblockManager = emergencyUnblockManager
@@ -55,6 +59,7 @@ class StrategyManager: ObservableObject {
     self.appBlocker = appBlocker
     self.backstopRegistrar = backstopRegistrar
     self.timersUtil = timersUtil
+    self.scheduleReconciler = scheduleReconciler
     self.remotelyActiveProfileIds = RemotelyActiveStore.load(defaults: remoteActiveDefaults)
   }
 
@@ -139,7 +144,9 @@ class StrategyManager: ObservableObject {
       // Close live activity if no session is active and a scheduled session might have ended
       liveActivityManager.endSessionActivity()
       // Re-attempt migration for profiles deferred due to active sessions
-      ProfileMigrationUtil.migrateProfilesIfNeeded(context: context)
+      if ProfileMigrationUtil.migrateProfilesIfNeeded(context: context) > 0 {
+        scheduleReconciler(context)
+      }
     }
   }
 

--- a/FoqosTests/AppScheduleRefreshStateTests.swift
+++ b/FoqosTests/AppScheduleRefreshStateTests.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+import XCTest
+
+@testable import FamilyFoqos
+
+final class AppScheduleRefreshStateTests: XCTestCase {
+  func testGivenInitialSetupCompleted_WhenInitialActiveArrives_ThenRefreshIsSkipped() {
+    var state = AppScheduleRefreshState()
+    XCTAssertTrue(state.shouldPerformInitialRefresh())
+
+    XCTAssertFalse(state.shouldRefresh(for: .active))
+  }
+
+  func testGivenInitialInactiveArrivesBeforeSetup_WhenInitialActiveArrives_ThenRefreshIsSkipped() {
+    var state = AppScheduleRefreshState()
+    XCTAssertFalse(state.shouldRefresh(for: .inactive))
+    XCTAssertTrue(state.shouldPerformInitialRefresh())
+
+    XCTAssertFalse(state.shouldRefresh(for: .active))
+  }
+
+  func testGivenInitialSetupCompleted_WhenAppReturnsFromInactive_ThenRefreshRunsOnce() {
+    var state = AppScheduleRefreshState()
+    XCTAssertTrue(state.shouldPerformInitialRefresh())
+
+    XCTAssertFalse(state.shouldRefresh(for: .inactive))
+    XCTAssertTrue(state.shouldRefresh(for: .active))
+    XCTAssertFalse(state.shouldRefresh(for: .active))
+  }
+
+  func testGivenInitialSetupCompleted_WhenAppReturnsFromBackground_ThenRefreshRunsOnce() {
+    var state = AppScheduleRefreshState()
+    XCTAssertTrue(state.shouldPerformInitialRefresh())
+
+    XCTAssertFalse(state.shouldRefresh(for: .background))
+    XCTAssertFalse(state.shouldRefresh(for: .inactive))
+    XCTAssertTrue(state.shouldRefresh(for: .active))
+  }
+
+  func testGivenInitialRefreshAlreadyPerformed_WhenRootAppearsAgain_ThenRefreshIsSkipped() {
+    var state = AppScheduleRefreshState()
+
+    XCTAssertTrue(state.shouldPerformInitialRefresh())
+    XCTAssertFalse(state.shouldPerformInitialRefresh())
+  }
+}

--- a/FoqosTests/StrategyManagerReconcileTests.swift
+++ b/FoqosTests/StrategyManagerReconcileTests.swift
@@ -25,6 +25,53 @@ final class StrategyManagerReconcileTests: XCTestCase {
     try await super.tearDown()
   }
 
+  func testGivenDeferredProfileMigration_WhenLoadingWithoutActiveSession_ThenScheduleReconciled()
+    throws
+  {
+    let now = Date()
+    let profile = BlockedProfiles(
+      name: "School",
+      blockingStrategyId: ManualBlockingStrategy.id,
+      schedule: BlockedProfileSchedule(
+        days: [.monday],
+        startHour: 9,
+        startMinute: 0,
+        endHour: 15,
+        endMinute: 30,
+        updatedAt: now
+      )
+    )
+    profile.profileSchemaVersion = 1
+    context.insert(profile)
+    try context.save()
+
+    var registeredProfileIds: [UUID] = []
+    manager = StrategyManager(
+      scheduleReconciler: { context in
+        PreActivationReminderScheduler.reconcileScheduleRegistrations(
+          context: context,
+          notificationCenter: NotificationCenter(),
+          register: { registeredProfileIds.append($0.id) }
+        )
+      })
+
+    try manager.loadActiveSession(context: context)
+
+    XCTAssertFalse(profile.needsMigration)
+    XCTAssertEqual(registeredProfileIds, [profile.id])
+  }
+
+  func testGivenNoProfileMigration_WhenLoadingWithoutActiveSession_ThenScheduleNotReconciled()
+    throws
+  {
+    var reconciliationCount = 0
+    manager = StrategyManager(scheduleReconciler: { _ in reconciliationCount += 1 })
+
+    try manager.loadActiveSession(context: context)
+
+    XCTAssertEqual(reconciliationCount, 0)
+  }
+
   // #237 / Design Q1: tapping Stop while the shared active session was swapped by the extension
   // must NOT end the stale on-screen session -- it reloads and surfaces instead.
   func testGivenSharedSessionSwapped_WhenToggleStop_ThenStaleSessionNotEndedAndSurfaced() throws {


### PR DESCRIPTION
## Summary
- coalesce initial and warm-foreground schedule refreshes with an explicit lifecycle state
- centralize DeviceActivity registration after launch and deferred profile migrations
- register only eligible migrated schedules (`hasActiveSchedule && !needsAppSelection`), matching the existing reconciliation policy
- bump all configurations to 2.0.35 (54)

## Verification
- `swift-format lint --recursive .`
- focused launch/migration/deferred-path tests passed
- full suite: 1,253 passed, 0 failures
- Debug build succeeded through `scripts/xcode-stream.sh --agent build2 --session implement_beta_fixes`
- `git diff --check`

Closes #425