### PR TITLE
Fix child CloudKit push refresh (#428)

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 55;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.36;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 55;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.36;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 55;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.36;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 55;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.36;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 55;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.36;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 55;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.36;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 55;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.36;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 55;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.36;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 55;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.36;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 55;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.36;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 55;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.36;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 55;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.34;
+				MARKETING_VERSION = 2.0.36;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -101,6 +101,10 @@ class CloudKitManager: ObservableObject {
     try await networkService.createPolicyZoneIfNeeded()
   }
 
+  func ensureSharedDatabaseSubscription() async throws {
+    try await networkService.ensureSharedDatabaseSubscription()
+  }
+
   // MARK: - Family Member Management
 
   func saveFamilyMember(_ member: FamilyMember) async throws {
@@ -169,7 +173,9 @@ class CloudKitManager: ObservableObject {
     try await networkService.commandIsPending(command)
   }
 
-  func fetchPendingCommands() async throws -> [FamilyCommand] {
+  func fetchPendingCommands() async throws -> (
+    commands: [FamilyCommand], isConnected: Bool
+  ) {
     return try await networkService.fetchPendingCommands(currentUserRecordID: currentUserRecordID)
   }
 

--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -176,7 +176,20 @@ class CloudKitManager: ObservableObject {
   func fetchPendingCommands() async throws -> (
     commands: [FamilyCommand], isConnected: Bool
   ) {
-    return try await networkService.fetchPendingCommands(currentUserRecordID: currentUserRecordID)
+    let userRecordID = try await Self.resolvePendingCommandUserRecordID(
+      cached: currentUserRecordID
+    ) {
+      try await self.ensureUserRecordID()
+    }
+    return try await networkService.fetchPendingCommands(currentUserRecordID: userRecordID)
+  }
+
+  static func resolvePendingCommandUserRecordID(
+    cached: CKRecord.ID?,
+    fetch: () async throws -> CKRecord.ID
+  ) async rethrows -> CKRecord.ID {
+    if let cached { return cached }
+    return try await fetch()
   }
 
   func deleteCommand(_ command: FamilyCommand) async throws {

--- a/Foqos/CloudKit/CloudKitNetworkService+Commands.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Commands.swift
@@ -16,6 +16,13 @@ extension CloudKitNetworkService {
     return .failed
   }
 
+  static func resolvePendingCommandFetch(
+    commands: [FamilyCommand],
+    hasFailures: Bool
+  ) -> (commands: [FamilyCommand], isConnected: Bool) {
+    (commands: commands, isConnected: !hasFailures)
+  }
+
   func sendCommand(_ command: FamilyCommand) async throws {
     Log.info("Sending command: \(command.commandType.rawValue) to child", category: .cloudKit)
 
@@ -61,14 +68,17 @@ extension CloudKitNetworkService {
     }
   }
 
-  func fetchPendingCommands(currentUserRecordID: CKRecord.ID?) async throws -> [FamilyCommand] {
+  func fetchPendingCommands(
+    currentUserRecordID: CKRecord.ID?
+  ) async throws -> (commands: [FamilyCommand], isConnected: Bool) {
     let zones = try await sharedDatabase.allRecordZones()
 
     var allCommands: [FamilyCommand] = []
+    var hasFailures = false
 
     guard let userRecordID = currentUserRecordID else {
       Log.debug("No user record ID, skipping command fetch", category: .cloudKit)
-      return []
+      return Self.resolvePendingCommandFetch(commands: [], hasFailures: false)
     }
     let currentUserRecordName = userRecordID.recordName
 
@@ -85,19 +95,31 @@ extension CloudKitNetworkService {
         )
 
         for (_, result) in results {
-          if case .success(let record) = result,
-            let command = FamilyCommand(from: record)
-          {
+          switch result {
+          case .success(let record):
+            guard let command = FamilyCommand(from: record) else {
+              hasFailures = true
+              Log.error("Failed to decode pending command", category: .cloudKit)
+              continue
+            }
             allCommands.append(command)
+          case .failure(let error):
+            hasFailures = true
+            Log.error(
+              "Failed to fetch pending command: \(redactedErrorForLog(error))",
+              category: .cloudKit)
           }
         }
       } catch {
+        hasFailures = true
         Log.error(
           "Failed to fetch commands from zone \(zone.zoneID): \(redactedErrorForLog(error))", category: .cloudKit)
       }
     }
 
-    return allCommands
+    return Self.resolvePendingCommandFetch(
+      commands: allCommands,
+      hasFailures: hasFailures)
   }
 
   func deleteCommand(_ command: FamilyCommand) async throws {

--- a/Foqos/CloudKit/CloudKitNetworkService+Commands.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Commands.swift
@@ -18,9 +18,10 @@ extension CloudKitNetworkService {
 
   static func resolvePendingCommandFetch(
     commands: [FamilyCommand],
-    hasFailures: Bool
+    hasFailures: Bool,
+    hasUserRecordID: Bool = true
   ) -> (commands: [FamilyCommand], isConnected: Bool) {
-    (commands: commands, isConnected: !hasFailures)
+    (commands: commands, isConnected: hasUserRecordID && !hasFailures)
   }
 
   func sendCommand(_ command: FamilyCommand) async throws {
@@ -77,8 +78,11 @@ extension CloudKitNetworkService {
     var hasFailures = false
 
     guard let userRecordID = currentUserRecordID else {
-      Log.debug("No user record ID, skipping command fetch", category: .cloudKit)
-      return Self.resolvePendingCommandFetch(commands: [], hasFailures: false)
+      Log.error("No user record ID available for command fetch", category: .cloudKit)
+      return Self.resolvePendingCommandFetch(
+        commands: [],
+        hasFailures: false,
+        hasUserRecordID: false)
     }
     let currentUserRecordName = userRecordID.recordName
 

--- a/Foqos/CloudKit/CloudKitNetworkService+Subscriptions.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Subscriptions.swift
@@ -31,8 +31,21 @@ extension CloudKitNetworkService {
       notificationInfo.shouldSendContentAvailable,
       notificationInfo.alertBody == nil,
       notificationInfo.alertLocalizationKey == nil,
+      notificationInfo.alertLocalizationArgs == nil,
+      notificationInfo.title == nil,
+      notificationInfo.titleLocalizationKey == nil,
+      notificationInfo.titleLocalizationArgs == nil,
+      notificationInfo.subtitle == nil,
+      notificationInfo.subtitleLocalizationKey == nil,
+      notificationInfo.subtitleLocalizationArgs == nil,
+      notificationInfo.alertActionLocalizationKey == nil,
+      notificationInfo.alertLaunchImage == nil,
       notificationInfo.soundName == nil,
-      !notificationInfo.shouldBadge
+      notificationInfo.desiredKeys == nil,
+      !notificationInfo.shouldBadge,
+      !notificationInfo.shouldSendMutableContent,
+      notificationInfo.category == nil,
+      notificationInfo.collapseIDKey == nil
     else {
       return .replace
     }

--- a/Foqos/CloudKit/CloudKitNetworkService+Subscriptions.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+Subscriptions.swift
@@ -1,0 +1,76 @@
+import CloudKit
+
+extension CloudKitNetworkService {
+  static let sharedDatabaseSubscriptionID = "family-foqos-shared-database-v1"
+
+  enum SharedDatabaseSubscriptionAction: Equatable {
+    case keep
+    case create
+    case replace
+  }
+
+  private enum SharedDatabaseSubscriptionError: Error {
+    case missingSaveResult
+  }
+
+  static func makeSharedDatabaseSubscription() -> CKDatabaseSubscription {
+    let subscription = CKDatabaseSubscription(subscriptionID: sharedDatabaseSubscriptionID)
+    let notificationInfo = CKSubscription.NotificationInfo()
+    notificationInfo.shouldSendContentAvailable = true
+    subscription.notificationInfo = notificationInfo
+    return subscription
+  }
+
+  static func sharedDatabaseSubscriptionAction(
+    existing: CKSubscription?
+  ) -> SharedDatabaseSubscriptionAction {
+    guard let existing else { return .create }
+    guard let databaseSubscription = existing as? CKDatabaseSubscription,
+      databaseSubscription.subscriptionID == sharedDatabaseSubscriptionID,
+      let notificationInfo = databaseSubscription.notificationInfo,
+      notificationInfo.shouldSendContentAvailable,
+      notificationInfo.alertBody == nil,
+      notificationInfo.alertLocalizationKey == nil,
+      notificationInfo.soundName == nil,
+      !notificationInfo.shouldBadge
+    else {
+      return .replace
+    }
+    return .keep
+  }
+
+  /// Establishes the one shared-database subscription owned by the child data path.
+  /// The stable ID makes repeated startup/foreground repair calls idempotent.
+  func ensureSharedDatabaseSubscription() async throws {
+    let database = sharedDatabase
+    let existing: CKSubscription?
+    do {
+      existing = try await database.subscription(for: Self.sharedDatabaseSubscriptionID)
+    } catch let error as CKError where error.code == .unknownItem {
+      existing = nil
+    }
+
+    switch Self.sharedDatabaseSubscriptionAction(existing: existing) {
+    case .keep:
+      return
+    case .replace:
+      do {
+        try await database.deleteSubscription(withID: Self.sharedDatabaseSubscriptionID)
+      } catch let error as CKError where error.code == .unknownItem {
+        // The subscription disappeared between fetch and repair; continue with creation.
+      }
+    case .create:
+      break
+    }
+
+    let subscription = Self.makeSharedDatabaseSubscription()
+    let results = try await database.modifySubscriptions(
+      saving: [subscription],
+      deleting: [])
+    guard let saveResult = results.saveResults[Self.sharedDatabaseSubscriptionID] else {
+      throw SharedDatabaseSubscriptionError.missingSaveResult
+    }
+    _ = try saveResult.get()
+    Log.info("Shared database subscription established", category: .cloudKit)
+  }
+}

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -153,7 +153,14 @@ struct FoqosApp: App {
                 // Verify child authorization when app becomes active
                 verifyChildAuthorizationIfNeeded()
                 if AppModeManager.shared.currentMode == .child {
-                  await LockCodeManager.shared.processPendingCommands()
+                  do {
+                    try await CloudKitManager.shared.ensureSharedDatabaseSubscription()
+                  } catch {
+                    Log.error(
+                      "Failed to establish shared database subscription: \(redactedErrorForLog(error))",
+                      category: .cloudKit)
+                  }
+                  await LockCodeManager.shared.refreshSharedLockCodesForVerification()
                 }
               }
               // #201: re-drive persisted session-stop retries so a remote device doesn't see a
@@ -396,6 +403,13 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
   // MARK: - Remote Notification Handling
 
+  static func shouldRefreshChildSharedData(
+    databaseScope: CKDatabase.Scope?,
+    mode: AppMode
+  ) -> Bool {
+    mode == .child && databaseScope == .shared
+  }
+
   func application(
     _: UIApplication,
     didRegisterForRemoteNotificationsWithDeviceToken _: Data
@@ -421,9 +435,22 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     if let ckNotification = CKNotification(fromRemoteNotificationDictionary: userInfo) {
       Log.info("CloudKit notification received - type: \(ckNotification.notificationType.rawValue)", category: .cloudKit)
 
+      let databaseScope = (ckNotification as? CKDatabaseNotification)?.databaseScope
+      let shouldRefreshChildSharedData = Self.shouldRefreshChildSharedData(
+        databaseScope: databaseScope,
+        mode: AppModeManager.shared.currentMode)
+
       // Route the CloudKit push to the engine (schedules a fetch+send); the engine
       // also owns its own database subscription. Preserve heartbeat refresh (#190).
       Task { @MainActor in
+        let childRefreshResult: UIBackgroundFetchResult?
+        if shouldRefreshChildSharedData {
+          childRefreshResult =
+            await LockCodeManager.shared.refreshSharedLockCodesForVerification()
+            .backgroundFetchResult
+        } else {
+          childRefreshResult = nil
+        }
         if ProfileSyncManager.shared.isEnabled {
           do {
             try ProfileSyncManager.shared.syncNow()
@@ -434,10 +461,23 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         if AppModeManager.shared.currentMode == .parent {
           await HeartbeatManager.shared.refreshHeartbeats()
         }
-        completionHandler(.newData)
+        completionHandler(childRefreshResult ?? .newData)
       }
     } else {
       completionHandler(.noData)
+    }
+  }
+}
+
+extension ChildSharedDataRefreshResult {
+  var backgroundFetchResult: UIBackgroundFetchResult {
+    switch self {
+    case .newData:
+      return .newData
+    case .noData:
+      return .noData
+    case .failed:
+      return .failed
     }
   }
 }
@@ -589,6 +629,13 @@ func completeShareAcceptance(metadata: CKShare.Metadata, role: FamilyRole) {
 
     // 4. Best-effort: fetch shared lock codes
     if appMode == .child {
+      do {
+        try await CloudKitManager.shared.ensureSharedDatabaseSubscription()
+      } catch {
+        Log.error(
+          "Failed to establish shared database subscription after share acceptance: \(redactedErrorForLog(error))",
+          category: .cloudKit)
+      }
       await LockCodeManager.shared.refreshSharedLockCodesForVerification()
     }
 

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -151,7 +151,7 @@ struct FoqosApp: App {
                 // Enforce CloudKit FamilyMember role as local app mode (must complete before auth check)
                 await CloudKitManager.shared.verifySelfFamilyMemberRecord()
                 // Verify child authorization when app becomes active
-                verifyChildAuthorizationIfNeeded()
+                await verifyChildAuthorizationIfNeeded()
                 if AppModeManager.shared.currentMode == .child {
                   do {
                     try await CloudKitManager.shared.ensureSharedDatabaseSubscription()
@@ -653,11 +653,10 @@ func completeShareAcceptance(metadata: CKShare.Metadata, role: FamilyRole) {
 
 /// Verify child authorization when app becomes active (if in child mode)
 /// If authorization is lost, clear shared data and switch to individual mode
-func verifyChildAuthorizationIfNeeded() {
-  Task { @MainActor in
-    if let message = await AuthorizationVerifier.shared.verifyIfNeeded() {
-      CloudKitManager.shared.shareAcceptanceIsError = true
-      CloudKitManager.shared.shareAcceptedMessage = message
-    }
+@MainActor
+func verifyChildAuthorizationIfNeeded() async {
+  if let message = await AuthorizationVerifier.shared.verifyIfNeeded() {
+    CloudKitManager.shared.shareAcceptanceIsError = true
+    CloudKitManager.shared.shareAcceptedMessage = message
   }
 }

--- a/Foqos/Utils/AuthorizationVerifier.swift
+++ b/Foqos/Utils/AuthorizationVerifier.swift
@@ -63,6 +63,25 @@ class AuthorizationVerifier: ObservableObject {
     }
   }
 
+  enum VerificationDisposition: Equatable {
+    case authorized
+    case confirmedLoss
+    case indeterminate
+  }
+
+  static func verificationDisposition(
+    for result: VerificationResult
+  ) -> VerificationDisposition {
+    switch result {
+    case .authorized:
+      return .authorized
+    case .notChildDevice, .notAuthorized:
+      return .confirmedLoss
+    case .networkError, .unknownError:
+      return .indeterminate
+    }
+  }
+
   @Published private(set) var lastVerificationDate: Date?
   @Published private(set) var currentAuthorizationType: AuthorizationType = .none
 
@@ -183,11 +202,16 @@ class AuthorizationVerifier: ObservableObject {
     }
 
     let result = await verifyChildAuthorization()
-
-    if !result.isAuthorized {
+    switch Self.verificationDisposition(for: result) {
+    case .authorized:
+      return nil
+    case .confirmedLoss:
       return await handleAuthorizationLoss()
+    case .indeterminate:
+      Log.warning(
+        "Child authorization verification was indeterminate; preserving family state",
+        category: .authorization)
+      return nil
     }
-
-    return nil
   }
 }

--- a/Foqos/Utils/LockCodeManager.swift
+++ b/Foqos/Utils/LockCodeManager.swift
@@ -3,6 +3,25 @@ import FamilyControls
 import Foundation
 import SwiftUI
 
+enum ChildSharedDataRefreshResult: Equatable {
+  case newData
+  case noData
+  case failed
+
+  static func combine(
+    _ lockCodes: ChildSharedDataRefreshResult,
+    _ commands: ChildSharedDataRefreshResult
+  ) -> ChildSharedDataRefreshResult {
+    if lockCodes == .failed || commands == .failed {
+      return .failed
+    }
+    if lockCodes == .newData || commands == .newData {
+      return .newData
+    }
+    return .noData
+  }
+}
+
 /// Manages lock codes for parent-controlled (managed) profiles.
 /// - Parents: Can create, view, and update lock codes
 /// - Children: Can only verify codes (cannot see them)
@@ -191,9 +210,10 @@ class LockCodeManager: ObservableObject {
 
   /// Fetch shared lock codes for verification (child operation)
   /// Verifies child authorization before fetching to ensure security
-  func refreshSharedLockCodesForVerification() async {
-    guard !ScreenshotDemoMode.isActive else { return }
-    guard appModeManager.currentMode == .child else { return }
+  @discardableResult
+  func refreshSharedLockCodesForVerification() async -> ChildSharedDataRefreshResult {
+    guard !ScreenshotDemoMode.isActive else { return .noData }
+    guard appModeManager.currentMode == .child else { return .noData }
 
     isLoading = true
     defer { isLoading = false }
@@ -206,9 +226,15 @@ class LockCodeManager: ObservableObject {
         self.cachedLockCodes = []
         self.error = message
       }
-      return
+      return .failed
     }
 
+    let lockCodeResult = await refreshSharedLockCodes()
+    let commandResult = await processPendingCommands()
+    return ChildSharedDataRefreshResult.combine(lockCodeResult, commandResult)
+  }
+
+  private func refreshSharedLockCodes() async -> ChildSharedDataRefreshResult {
     do {
       let result = try await cloudKitManager.fetchSharedLockCodes()
       // Fail-closed-with-cache (#197): trust a CONNECTED result (even empty = parent cleared)
@@ -219,18 +245,38 @@ class LockCodeManager: ObservableObject {
         isConnected: result.isConnected,
         persisted: loadPersistedLockCodes()
       )
+      let refreshResult = Self.lockCodeRefreshResult(
+        previous: cachedLockCodes,
+        refreshed: resolved.cache,
+        isConnected: result.isConnected)
       self.cachedLockCodes = resolved.cache
       persistLockCodes(resolved.persist)
       self.error = nil
-
-      // Also check for pending commands from parent
-      await processPendingCommands()
+      return refreshResult
     } catch {
       // Defensive: the network layer returns empty without throwing for offline/CKError, but
       // if it ever does throw, keep the last-synced codes rather than falling back to empty.
       self.cachedLockCodes = loadPersistedLockCodes()
       self.error = error.localizedDescription
+      return .failed
     }
+  }
+
+  nonisolated static func lockCodeRefreshResult(
+    previous: [FamilyLockCode],
+    refreshed: [FamilyLockCode],
+    isConnected: Bool
+  ) -> ChildSharedDataRefreshResult {
+    guard isConnected else { return .failed }
+    return previous == refreshed ? .noData : .newData
+  }
+
+  nonisolated static func commandRefreshResult(
+    didApplyCommand: Bool,
+    isConnected: Bool
+  ) -> ChildSharedDataRefreshResult {
+    guard isConnected else { return .failed }
+    return didApplyCommand ? .newData : .noData
   }
 
   /// Resolve the verification cache and the persisted store after a fetch (#197).
@@ -325,10 +371,13 @@ class LockCodeManager: ObservableObject {
 
   /// Check for and process any pending commands from parent.
   /// Called from child lock-code refresh, the PIN-dialog poll, and child foreground.
-  func processPendingCommands(cleanupStale: Bool = true) async {
-    guard !ScreenshotDemoMode.isActive else { return }
+  @discardableResult
+  func processPendingCommands(
+    cleanupStale: Bool = true
+  ) async -> ChildSharedDataRefreshResult {
+    guard !ScreenshotDemoMode.isActive else { return .noData }
     guard appModeManager.currentMode == .child else {
-      return
+      return .noData
     }
 
     if cleanupStale {
@@ -337,13 +386,18 @@ class LockCodeManager: ObservableObject {
     }
 
     do {
-      let commands = try await cloudKitManager.fetchPendingCommands()
+      let result = try await cloudKitManager.fetchPendingCommands()
+      var didApplyCommand = false
 
-      for command in commands {
-        await processCommand(command)
+      for command in result.commands {
+        didApplyCommand = await processCommand(command) || didApplyCommand
       }
+      return Self.commandRefreshResult(
+        didApplyCommand: didApplyCommand,
+        isConnected: result.isConnected)
     } catch {
       Log.error("Failed to fetch pending commands: \(redactedErrorForLog(error))", category: .cloudKit)
+      return .failed
     }
   }
 
@@ -379,7 +433,7 @@ class LockCodeManager: ObservableObject {
     return true
   }
 
-  private func processCommand(_ command: FamilyCommand) async {
+  private func processCommand(_ command: FamilyCommand) async -> Bool {
     let didApply = applyCommandIfNeeded(command)
     if !didApply {
       Log.info("Skipping already processed command: \(command.commandType.rawValue)", category: .cloudKit)
@@ -391,6 +445,7 @@ class LockCodeManager: ObservableObject {
     } catch {
       Log.error("Failed to delete processed command: \(redactedErrorForLog(error))", category: .cloudKit)
     }
+    return didApply
   }
 
   // MARK: - Temporary Unlock Session

--- a/Foqos/Utils/LockCodeManager.swift
+++ b/Foqos/Utils/LockCodeManager.swift
@@ -268,14 +268,17 @@ class LockCodeManager: ObservableObject {
     isConnected: Bool
   ) -> ChildSharedDataRefreshResult {
     guard isConnected else { return .failed }
-    return previous == refreshed ? .noData : .newData
+    let previousByID = previous.sorted { $0.id.uuidString < $1.id.uuidString }
+    let refreshedByID = refreshed.sorted { $0.id.uuidString < $1.id.uuidString }
+    return previousByID == refreshedByID ? .noData : .newData
   }
 
   nonisolated static func commandRefreshResult(
     didApplyCommand: Bool,
-    isConnected: Bool
+    isConnected: Bool,
+    hasProcessingFailures: Bool = false
   ) -> ChildSharedDataRefreshResult {
-    guard isConnected else { return .failed }
+    guard isConnected, !hasProcessingFailures else { return .failed }
     return didApplyCommand ? .newData : .noData
   }
 
@@ -388,13 +391,17 @@ class LockCodeManager: ObservableObject {
     do {
       let result = try await cloudKitManager.fetchPendingCommands()
       var didApplyCommand = false
+      var hasProcessingFailures = false
 
       for command in result.commands {
-        didApplyCommand = await processCommand(command) || didApplyCommand
+        let outcome = await processCommand(command)
+        didApplyCommand = outcome.didApply || didApplyCommand
+        hasProcessingFailures = outcome.didFail || hasProcessingFailures
       }
       return Self.commandRefreshResult(
         didApplyCommand: didApplyCommand,
-        isConnected: result.isConnected)
+        isConnected: result.isConnected,
+        hasProcessingFailures: hasProcessingFailures)
     } catch {
       Log.error("Failed to fetch pending commands: \(redactedErrorForLog(error))", category: .cloudKit)
       return .failed
@@ -433,7 +440,9 @@ class LockCodeManager: ObservableObject {
     return true
   }
 
-  private func processCommand(_ command: FamilyCommand) async -> Bool {
+  private func processCommand(_ command: FamilyCommand) async -> (
+    didApply: Bool, didFail: Bool
+  ) {
     let didApply = applyCommandIfNeeded(command)
     if !didApply {
       Log.info("Skipping already processed command: \(command.commandType.rawValue)", category: .cloudKit)
@@ -442,10 +451,11 @@ class LockCodeManager: ObservableObject {
     // Delete the command after processing
     do {
       try await cloudKitManager.deleteCommand(command)
+      return (didApply: didApply, didFail: false)
     } catch {
       Log.error("Failed to delete processed command: \(redactedErrorForLog(error))", category: .cloudKit)
+      return (didApply: didApply, didFail: true)
     }
-    return didApply
   }
 
   // MARK: - Temporary Unlock Session

--- a/Foqos/Utils/LockCodeManager.swift
+++ b/Foqos/Utils/LockCodeManager.swift
@@ -208,8 +208,8 @@ class LockCodeManager: ObservableObject {
 
   // MARK: - Child Operations
 
-  /// Fetch shared lock codes for verification (child operation)
-  /// Verifies child authorization before fetching to ensure security
+  /// Fetch shared lock codes for verification (child operation).
+  /// Reuses persisted child authorization, verifying once only when bootstrap state is absent.
   @discardableResult
   func refreshSharedLockCodesForVerification() async -> ChildSharedDataRefreshResult {
     guard !ScreenshotDemoMode.isActive else { return .noData }
@@ -218,20 +218,34 @@ class LockCodeManager: ObservableObject {
     isLoading = true
     defer { isLoading = false }
 
-    // Use centralized authorization verification
-    let result = await AuthorizationVerifier.shared.verifyChildAuthorization()
-    guard result.isAuthorized else {
-      // Let the centralized handler deal with authorization loss
-      if let message = await AuthorizationVerifier.shared.verifyIfNeeded() {
-        self.cachedLockCodes = []
-        self.error = message
-      }
+    let authorizationDisposition = await Self.sharedRefreshAuthorizationDisposition(
+      persisted: AuthorizationVerifier.shared.currentAuthorizationType
+    ) {
+      await AuthorizationVerifier.shared.verifyChildAuthorization()
+    }
+    switch authorizationDisposition {
+    case .authorized:
+      break
+    case .confirmedLoss:
+      self.cachedLockCodes = []
+      self.error = await AuthorizationVerifier.shared.handleAuthorizationLoss()
+      return .failed
+    case .indeterminate:
+      self.error = "Child authorization has not been verified."
       return .failed
     }
 
     let lockCodeResult = await refreshSharedLockCodes()
     let commandResult = await processPendingCommands()
     return ChildSharedDataRefreshResult.combine(lockCodeResult, commandResult)
+  }
+
+  static func sharedRefreshAuthorizationDisposition(
+    persisted authorizationType: AuthorizationVerifier.AuthorizationType,
+    verify: () async -> AuthorizationVerifier.VerificationResult
+  ) async -> AuthorizationVerifier.VerificationDisposition {
+    guard authorizationType != .child else { return .authorized }
+    return AuthorizationVerifier.verificationDisposition(for: await verify())
   }
 
   private func refreshSharedLockCodes() async -> ChildSharedDataRefreshResult {

--- a/Foqos/Views/Child/ChildDashboardView.swift
+++ b/Foqos/Views/Child/ChildDashboardView.swift
@@ -72,11 +72,6 @@ struct ChildDashboardView: View {
       .refreshable {
         await fetchLockCodesIfNeeded()
       }
-      .onAppear {
-        Task {
-          await fetchLockCodesIfNeeded()
-        }
-      }
       .sheet(isPresented: $showSettings) {
         ChildSettingsView()
       }

--- a/Foqos/Views/Child/ChildDashboardView.swift
+++ b/Foqos/Views/Child/ChildDashboardView.swift
@@ -139,7 +139,7 @@ struct ChildDashboardView: View {
 
     let result = await AuthorizationVerifier.shared.verifyChildAuthorization()
 
-    if !result.isAuthorized {
+    if AuthorizationVerifier.verificationDisposition(for: result) == .confirmedLoss {
       showAuthorizationLostAlert = true
     }
   }

--- a/FoqosTests/ChildSharedRefreshTests.swift
+++ b/FoqosTests/ChildSharedRefreshTests.swift
@@ -10,11 +10,11 @@ final class ChildSharedRefreshTests: XCTestCase {
     FamilyLockCode(id: id, code: code, scope: .allChildren)
   }
 
-  func testGivenColdBackgroundCommandFetch_WhenResolvingIdentity_ThenFetchesUserRecordID() async throws {
+  func testGivenColdBackgroundCommandFetch_WhenResolvingIdentity_ThenFetchesUserRecordID() async {
     let expected = CKRecord.ID(recordName: "child")
     var didResolve = false
 
-    let resolved = try await CloudKitManager.resolvePendingCommandUserRecordID(cached: nil) {
+    let resolved = await CloudKitManager.resolvePendingCommandUserRecordID(cached: nil) {
       didResolve = true
       return expected
     }

--- a/FoqosTests/ChildSharedRefreshTests.swift
+++ b/FoqosTests/ChildSharedRefreshTests.swift
@@ -10,6 +10,28 @@ final class ChildSharedRefreshTests: XCTestCase {
     FamilyLockCode(id: id, code: code, scope: .allChildren)
   }
 
+  func testGivenColdBackgroundCommandFetch_WhenResolvingIdentity_ThenFetchesUserRecordID() async throws {
+    let expected = CKRecord.ID(recordName: "child")
+    var didResolve = false
+
+    let resolved = try await CloudKitManager.resolvePendingCommandUserRecordID(cached: nil) {
+      didResolve = true
+      return expected
+    }
+
+    XCTAssertTrue(didResolve)
+    XCTAssertEqual(resolved, expected)
+  }
+
+  func testGivenMissingCommandIdentity_WhenResolvingFetch_ThenReportsDisconnected() {
+    let result = CloudKitNetworkService.resolvePendingCommandFetch(
+      commands: [],
+      hasFailures: false,
+      hasUserRecordID: false)
+
+    XCTAssertFalse(result.isConnected)
+  }
+
   func testGivenConnectedChangedLockCodes_WhenClassifying_ThenReportsNewData() {
     XCTAssertEqual(
       LockCodeManager.lockCodeRefreshResult(
@@ -26,6 +48,18 @@ final class ChildSharedRefreshTests: XCTestCase {
       LockCodeManager.lockCodeRefreshResult(
         previous: [code],
         refreshed: [code],
+        isConnected: true),
+      .noData)
+  }
+
+  func testGivenConnectedReorderedLockCodes_WhenClassifying_ThenReportsNoData() {
+    let first = makeCode()
+    let second = makeCode()
+
+    XCTAssertEqual(
+      LockCodeManager.lockCodeRefreshResult(
+        previous: [first, second],
+        refreshed: [second, first],
         isConnected: true),
       .noData)
   }
@@ -60,6 +94,15 @@ final class ChildSharedRefreshTests: XCTestCase {
       LockCodeManager.commandRefreshResult(
         didApplyCommand: true,
         isConnected: false),
+      .failed)
+  }
+
+  func testGivenCommandDeletionFailure_WhenClassifying_ThenReportsFailure() {
+    XCTAssertEqual(
+      LockCodeManager.commandRefreshResult(
+        didApplyCommand: true,
+        isConnected: true,
+        hasProcessingFailures: true),
       .failed)
   }
 

--- a/FoqosTests/ChildSharedRefreshTests.swift
+++ b/FoqosTests/ChildSharedRefreshTests.swift
@@ -1,0 +1,122 @@
+import CloudKit
+import UIKit
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class ChildSharedRefreshTests: XCTestCase {
+  private func makeCode(id: UUID = UUID(), code: String = "1234") -> FamilyLockCode {
+    FamilyLockCode(id: id, code: code, scope: .allChildren)
+  }
+
+  func testGivenConnectedChangedLockCodes_WhenClassifying_ThenReportsNewData() {
+    XCTAssertEqual(
+      LockCodeManager.lockCodeRefreshResult(
+        previous: [],
+        refreshed: [makeCode()],
+        isConnected: true),
+      .newData)
+  }
+
+  func testGivenConnectedUnchangedLockCodes_WhenClassifying_ThenReportsNoData() {
+    let code = makeCode()
+
+    XCTAssertEqual(
+      LockCodeManager.lockCodeRefreshResult(
+        previous: [code],
+        refreshed: [code],
+        isConnected: true),
+      .noData)
+  }
+
+  func testGivenDisconnectedLockCodeFetch_WhenClassifying_ThenReportsFailure() {
+    XCTAssertEqual(
+      LockCodeManager.lockCodeRefreshResult(
+        previous: [],
+        refreshed: [],
+        isConnected: false),
+      .failed)
+  }
+
+  func testGivenConnectedAppliedCommand_WhenClassifying_ThenReportsNewData() {
+    XCTAssertEqual(
+      LockCodeManager.commandRefreshResult(
+        didApplyCommand: true,
+        isConnected: true),
+      .newData)
+  }
+
+  func testGivenConnectedNoCommand_WhenClassifying_ThenReportsNoData() {
+    XCTAssertEqual(
+      LockCodeManager.commandRefreshResult(
+        didApplyCommand: false,
+        isConnected: true),
+      .noData)
+  }
+
+  func testGivenPartialCommandFetchFailure_WhenClassifying_ThenReportsFailure() {
+    XCTAssertEqual(
+      LockCodeManager.commandRefreshResult(
+        didApplyCommand: true,
+        isConnected: false),
+      .failed)
+  }
+
+  func testGivenCommandRecordFailure_WhenResolvingFetch_ThenReportsDisconnected() {
+    let result = CloudKitNetworkService.resolvePendingCommandFetch(
+      commands: [],
+      hasFailures: true)
+
+    XCTAssertFalse(result.isConnected)
+  }
+
+  func testGivenLockCodesChangedAndNoCommands_WhenCombining_ThenReportsNewData() {
+    XCTAssertEqual(
+      ChildSharedDataRefreshResult.combine(.newData, .noData),
+      .newData)
+  }
+
+  func testGivenNoChanges_WhenCombining_ThenReportsNoData() {
+    XCTAssertEqual(
+      ChildSharedDataRefreshResult.combine(.noData, .noData),
+      .noData)
+  }
+
+  func testGivenEitherFetchFailed_WhenCombining_ThenReportsFailure() {
+    XCTAssertEqual(
+      ChildSharedDataRefreshResult.combine(.newData, .failed),
+      .failed)
+    XCTAssertEqual(
+      ChildSharedDataRefreshResult.combine(.failed, .noData),
+      .failed)
+  }
+
+  func testGivenRefreshOutcome_WhenMappingBackgroundResult_ThenPreservesMeaning() {
+    XCTAssertEqual(ChildSharedDataRefreshResult.newData.backgroundFetchResult, .newData)
+    XCTAssertEqual(ChildSharedDataRefreshResult.noData.backgroundFetchResult, .noData)
+    XCTAssertEqual(ChildSharedDataRefreshResult.failed.backgroundFetchResult, .failed)
+  }
+
+  func testGivenSharedDatabasePushInChildMode_WhenRouting_ThenRefreshesSharedData() {
+    XCTAssertTrue(
+      AppDelegate.shouldRefreshChildSharedData(
+        databaseScope: .shared,
+        mode: .child))
+  }
+
+  func testGivenPrivatePushOrNonChildMode_WhenRouting_ThenDoesNotRefreshSharedData() {
+    XCTAssertFalse(
+      AppDelegate.shouldRefreshChildSharedData(
+        databaseScope: .private,
+        mode: .child))
+    XCTAssertFalse(
+      AppDelegate.shouldRefreshChildSharedData(
+        databaseScope: .shared,
+        mode: .parent))
+    XCTAssertFalse(
+      AppDelegate.shouldRefreshChildSharedData(
+        databaseScope: nil,
+        mode: .child))
+  }
+}

--- a/FoqosTests/ChildSharedRefreshTests.swift
+++ b/FoqosTests/ChildSharedRefreshTests.swift
@@ -10,6 +10,57 @@ final class ChildSharedRefreshTests: XCTestCase {
     FamilyLockCode(id: id, code: code, scope: .allChildren)
   }
 
+  func testGivenTransientAuthorizationFailure_WhenClassifying_ThenResultIsIndeterminate() {
+    let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+    let unknownError = NSError(domain: "test", code: 1)
+
+    XCTAssertEqual(
+      AuthorizationVerifier.verificationDisposition(for: .networkError(networkError)),
+      .indeterminate)
+    XCTAssertEqual(
+      AuthorizationVerifier.verificationDisposition(for: .unknownError(unknownError)),
+      .indeterminate)
+  }
+
+  func testGivenDefinitiveAuthorizationFailure_WhenClassifying_ThenLossIsConfirmed() {
+    XCTAssertEqual(
+      AuthorizationVerifier.verificationDisposition(for: .notChildDevice),
+      .confirmedLoss)
+    XCTAssertEqual(
+      AuthorizationVerifier.verificationDisposition(for: .notAuthorized),
+      .confirmedLoss)
+  }
+
+  func testGivenPersistedChildAuthorization_WhenResolvingSharedRefresh_ThenSkipsVerification()
+    async
+  {
+    var didVerify = false
+
+    let disposition = await LockCodeManager.sharedRefreshAuthorizationDisposition(
+      persisted: .child
+    ) {
+      didVerify = true
+      return .notAuthorized
+    }
+
+    XCTAssertFalse(didVerify)
+    XCTAssertEqual(disposition, .authorized)
+  }
+
+  func testGivenMissingPersistedAuthorization_WhenResolvingSharedRefresh_ThenVerifiesOnce() async {
+    var verificationCount = 0
+
+    let disposition = await LockCodeManager.sharedRefreshAuthorizationDisposition(
+      persisted: .none
+    ) {
+      verificationCount += 1
+      return .authorized
+    }
+
+    XCTAssertEqual(verificationCount, 1)
+    XCTAssertEqual(disposition, .authorized)
+  }
+
   func testGivenColdBackgroundCommandFetch_WhenResolvingIdentity_ThenFetchesUserRecordID() async {
     let expected = CKRecord.ID(recordName: "child")
     var didResolve = false

--- a/FoqosTests/SharedDatabaseSubscriptionTests.swift
+++ b/FoqosTests/SharedDatabaseSubscriptionTests.swift
@@ -1,0 +1,42 @@
+import CloudKit
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class SharedDatabaseSubscriptionTests: XCTestCase {
+  func testGivenMissingSubscription_WhenResolvingRegistration_ThenCreatesIt() {
+    XCTAssertEqual(
+      CloudKitNetworkService.sharedDatabaseSubscriptionAction(existing: nil),
+      .create)
+  }
+
+  func testGivenCurrentSubscription_WhenResolvingRegistration_ThenKeepsIt() {
+    let subscription = CloudKitNetworkService.makeSharedDatabaseSubscription()
+
+    XCTAssertEqual(
+      CloudKitNetworkService.sharedDatabaseSubscriptionAction(existing: subscription),
+      .keep)
+  }
+
+  func testGivenStaleSubscription_WhenResolvingRegistration_ThenReplacesIt() {
+    let subscription = CKDatabaseSubscription(
+      subscriptionID: CloudKitNetworkService.sharedDatabaseSubscriptionID)
+
+    XCTAssertEqual(
+      CloudKitNetworkService.sharedDatabaseSubscriptionAction(existing: subscription),
+      .replace)
+  }
+
+  func testGivenSharedSubscription_WhenConfigured_ThenDeliveryIsSilent() {
+    let subscription = CloudKitNetworkService.makeSharedDatabaseSubscription()
+
+    XCTAssertEqual(
+      subscription.subscriptionID,
+      CloudKitNetworkService.sharedDatabaseSubscriptionID)
+    XCTAssertEqual(subscription.notificationInfo?.shouldSendContentAvailable, true)
+    XCTAssertNil(subscription.notificationInfo?.alertBody)
+    XCTAssertNil(subscription.notificationInfo?.soundName)
+    XCTAssertEqual(subscription.notificationInfo?.shouldBadge, false)
+  }
+}

--- a/FoqosTests/SharedDatabaseSubscriptionTests.swift
+++ b/FoqosTests/SharedDatabaseSubscriptionTests.swift
@@ -28,6 +28,20 @@ final class SharedDatabaseSubscriptionTests: XCTestCase {
       .replace)
   }
 
+  func testGivenVisibleTitleOrSubtitle_WhenResolvingRegistration_ThenReplacesIt() {
+    let titled = CloudKitNetworkService.makeSharedDatabaseSubscription()
+    titled.notificationInfo?.title = "Visible title"
+    let subtitled = CloudKitNetworkService.makeSharedDatabaseSubscription()
+    subtitled.notificationInfo?.subtitle = "Visible subtitle"
+
+    XCTAssertEqual(
+      CloudKitNetworkService.sharedDatabaseSubscriptionAction(existing: titled),
+      .replace)
+    XCTAssertEqual(
+      CloudKitNetworkService.sharedDatabaseSubscriptionAction(existing: subtitled),
+      .replace)
+  }
+
   func testGivenSharedSubscription_WhenConfigured_ThenDeliveryIsSilent() {
     let subscription = CloudKitNetworkService.makeSharedDatabaseSubscription()
 
@@ -36,7 +50,21 @@ final class SharedDatabaseSubscriptionTests: XCTestCase {
       CloudKitNetworkService.sharedDatabaseSubscriptionID)
     XCTAssertEqual(subscription.notificationInfo?.shouldSendContentAvailable, true)
     XCTAssertNil(subscription.notificationInfo?.alertBody)
+    XCTAssertNil(subscription.notificationInfo?.alertLocalizationKey)
+    XCTAssertNil(subscription.notificationInfo?.alertLocalizationArgs)
+    XCTAssertNil(subscription.notificationInfo?.title)
+    XCTAssertNil(subscription.notificationInfo?.titleLocalizationKey)
+    XCTAssertNil(subscription.notificationInfo?.titleLocalizationArgs)
+    XCTAssertNil(subscription.notificationInfo?.subtitle)
+    XCTAssertNil(subscription.notificationInfo?.subtitleLocalizationKey)
+    XCTAssertNil(subscription.notificationInfo?.subtitleLocalizationArgs)
+    XCTAssertNil(subscription.notificationInfo?.alertActionLocalizationKey)
+    XCTAssertNil(subscription.notificationInfo?.alertLaunchImage)
     XCTAssertNil(subscription.notificationInfo?.soundName)
+    XCTAssertNil(subscription.notificationInfo?.desiredKeys)
     XCTAssertEqual(subscription.notificationInfo?.shouldBadge, false)
+    XCTAssertEqual(subscription.notificationInfo?.shouldSendMutableContent, false)
+    XCTAssertNil(subscription.notificationInfo?.category)
+    XCTAssertNil(subscription.notificationInfo?.collapseIDKey)
   }
 }


### PR DESCRIPTION
## Summary

- register and repair one silent shared-database CloudKit subscription for child devices
- refresh shared lock codes and pending family commands when that subscription invalidates local data
- retain foreground, share-acceptance, manual-pull, emergency-screen, and PIN-dialog recovery paths while removing the redundant dashboard `onAppear` fetch
- report truthful background fetch results, including partial command-fetch failures
- bump all targets to version 2.0.36 (55) per the coordinated merge order

## Root cause

Child devices read family policy records from CloudKit's shared database, but only the private CKSyncEngine path owned a database subscription. Parent lock-code mutations therefore had no shared-database push trigger, and the existing notification handler always returned `.newData` without fetching child policy data. Foreground activation fetched commands but did not unconditionally refresh lock codes.

## User impact

When CloudKit delivers the silent shared-database push, child devices now refresh lock codes and commands immediately. If delivery is missed, the next foreground activation repairs the subscription and performs the same refresh; manual pull remains the final recovery path.

## Validation

- `scripts/xcode-stream.sh --agent build1 --session implement_beta_fixes --xcbeautify -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos` — 1,279 tests, 0 failures
- focused authorization, revocation-cache, and child-refresh regression tests — 36 tests, 0 failures
- `scripts/xcode-stream.sh --agent build1 --session implement_beta_fixes --xcbeautify -- xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -configuration Debug build` — succeeded
- `swift-format lint` on every changed Swift file — passed
- `git diff --check` — passed

Closes #428
