### PR TITLE
fix: keep family-member reads side-effect free

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 58;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.37;
+				MARKETING_VERSION = 2.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 58;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.37;
+				MARKETING_VERSION = 2.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 58;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.37;
+				MARKETING_VERSION = 2.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 58;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.37;
+				MARKETING_VERSION = 2.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 58;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.37;
+				MARKETING_VERSION = 2.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 58;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.37;
+				MARKETING_VERSION = 2.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 58;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.37;
+				MARKETING_VERSION = 2.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 58;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.37;
+				MARKETING_VERSION = 2.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 58;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.37;
+				MARKETING_VERSION = 2.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 58;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.37;
+				MARKETING_VERSION = 2.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 58;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.37;
+				MARKETING_VERSION = 2.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 58;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.37;
+				MARKETING_VERSION = 2.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/CloudKit/CloudKitNetworkService+FamilyMembers.swift
+++ b/Foqos/CloudKit/CloudKitNetworkService+FamilyMembers.swift
@@ -107,8 +107,6 @@ extension CloudKitNetworkService {
   }
 
   func fetchFamilyMembers() async throws -> [FamilyMember] {
-    try await createPolicyZoneIfNeeded()
-
     let query = CKQuery(
       recordType: FamilyMember.recordType,
       predicate: NSPredicate(value: true)

--- a/Foqos/Models/AppMode.swift
+++ b/Foqos/Models/AppMode.swift
@@ -91,6 +91,12 @@ class AppModeManager: ObservableObject {
     currentMode == .individual ? .parent : nil
   }
 
+  /// Returns whether a mode may create the private records used for family policies.
+  /// Individual creates them during first lock-code setup; Child must never create them.
+  nonisolated static func allowsFamilyPolicyCreation(mode: AppMode) -> Bool {
+    mode != .child
+  }
+
   /// Returns true if the current mode allows creating/editing personal profiles
   var canCreateProfiles: Bool {
     currentMode == .individual || currentMode == .parent
@@ -101,8 +107,8 @@ class AppModeManager: ObservableObject {
     currentMode == .child
   }
 
-  /// Returns true if the current mode can create policies for others
+  /// Returns true if the current mode may create private family-policy storage.
   var canCreateFamilyPolicies: Bool {
-    currentMode == .parent
+    Self.allowsFamilyPolicyCreation(mode: currentMode)
   }
 }

--- a/FoqosTests/FamilyMemberReadPolicyTests.swift
+++ b/FoqosTests/FamilyMemberReadPolicyTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import XCTest
+
+@testable import FamilyFoqos
+
+final class FamilyMemberReadPolicyTests: XCTestCase {
+  func testGivenFamilyMemberRead_WhenInspectingImplementation_ThenItDoesNotCreatePolicyZone()
+    throws
+  {
+    let source = try familyMemberSource()
+    let body = try functionBody(named: "fetchFamilyMembers", in: source)
+
+    XCTAssertFalse(
+      body.contains("createPolicyZoneIfNeeded"),
+      "Family-member reads must never create participant-owned private CloudKit state"
+    )
+  }
+
+  func testGivenFamilyMemberWrite_WhenInspectingImplementation_ThenItCreatesPolicyZone()
+    throws
+  {
+    let source = try familyMemberSource()
+    let body = try functionBody(named: "saveFamilyMember", in: source)
+
+    XCTAssertTrue(
+      body.contains("createPolicyZoneIfNeeded"),
+      "Family-member writes must retain policy-zone setup"
+    )
+  }
+
+  func testGivenEveryAppMode_WhenCheckingFamilyPolicyCreation_ThenOnlyChildIsDenied() {
+    let fixtures: [(mode: AppMode, isAllowed: Bool)] = [
+      (.individual, true),
+      (.parent, true),
+      (.child, false),
+    ]
+
+    for fixture in fixtures {
+      XCTAssertEqual(
+        AppModeManager.allowsFamilyPolicyCreation(mode: fixture.mode),
+        fixture.isAllowed,
+        "Unexpected family-policy creation rule for \(fixture.mode)"
+      )
+    }
+  }
+
+  private func functionBody(named name: String, in source: String) throws -> Substring {
+    guard let signature = source.range(of: "func \(name)(") else {
+      throw TestError.missingFunction(name)
+    }
+    guard let openingBrace = source[signature.lowerBound...].firstIndex(of: "{") else {
+      throw TestError.missingFunctionBody(name)
+    }
+
+    var depth = 0
+    var index = openingBrace
+    while index < source.endIndex {
+      switch source[index] {
+      case "{":
+        depth += 1
+      case "}":
+        depth -= 1
+        if depth == 0 {
+          return source[source.index(after: openingBrace)..<index]
+        }
+      default:
+        break
+      }
+      index = source.index(after: index)
+    }
+
+    throw TestError.missingFunctionBody(name)
+  }
+
+  private func familyMemberSource() throws -> String {
+    let repositoryRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let sourceURL =
+      repositoryRoot
+      .appendingPathComponent("Foqos/CloudKit/CloudKitNetworkService+FamilyMembers.swift")
+    return try String(contentsOf: sourceURL, encoding: .utf8)
+  }
+
+  private enum TestError: Error {
+    case missingFunction(String)
+    case missingFunctionBody(String)
+  }
+}


### PR DESCRIPTION
Closes #439

## Summary
- stop fetchFamilyMembers from creating the private FamilyPolicies zone before a read
- preserve policy-zone creation for family-member writes
- correct the family-policy creation rule so Individual and Parent are allowed while Child is denied
- reserve version 2.0.39 (58)

## Verification
- Red: targeted FamilyMemberReadPolicyTests failed before production changes because the corrected exhaustive mode policy did not exist
- Green: FamilyMemberReadPolicyTests — 3 passed, 0 failed
- Full suite — 1,283 passed, 0 failed
- Debug build — succeeded through scripts/xcode-stream.sh
- swift-format lint --recursive . — passed
- git diff --check — passed

## Scope
Implementation avoids build1-owned #431 files. The CloudKit read change is confined to CloudKitNetworkService+FamilyMembers.swift; write/setup zone creation remains intact.