### PR TITLE
Fix recurring establishment save conflict

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.43;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/CloudKit/SyncEngine/RecordProvider.swift
+++ b/Foqos/CloudKit/SyncEngine/RecordProvider.swift
@@ -60,8 +60,14 @@ final class RecordProvider {
   }
 
   func establishmentRecord() -> CKRecord {
-    SyncedEstablishment(generation: store.establishmentGeneration, establishedAt: Date())
-      .toCKRecord(in: zoneID)
+    let synced = SyncedEstablishment(
+      generation: store.establishmentGeneration, establishedAt: Date())
+    let record = materialize(
+      recordName: SyncedEstablishment.recordName,
+      recordType: SyncedEstablishment.recordType,
+      freshRecordID: CKRecord.ID(recordName: SyncedEstablishment.recordName, zoneID: zoneID))
+    synced.updateCKRecord(record)
+    return record
   }
 
   private func profileRecord(_ profile: BlockedProfiles) -> CKRecord? {

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -256,8 +256,8 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       if !saved.isEmpty { self?.reset?.handleZoneSaveConfirmed() }
     }
     resetCommandSaveDidSucceed = { [weak self] _ in self?.reset?.handleCommandSaveResult(.saved) }
-    resetEstablishmentSaveDidSucceed = { [weak self] _ in
-      self?.reset?.handleEstablishmentSaveResult(.saved)
+    resetEstablishmentSaveDidSucceed = { [weak self] record in
+      self?.handleEstablishmentSaveSucceeded(record)
     }
     // Fix 2 (§8.1 step 5): forward the SERVER record, not the device's own failed record —
     // the local record always carries the device's own requestId (fixed name), so
@@ -274,12 +274,7 @@ final class SyncEngineController: SyncEngineDriverDelegate {
       // else transient/other: keep the intent — do NOT clear or abandon.
     }
     resetEstablishmentSaveDidFail = { [weak self] _, error in
-      guard let self, let reset = self.reset else { return }
-      if error.code == .serverRecordChanged, let server = error.serverRecord {
-        if let winningRecord = reset.handleEstablishmentSaveResult(.serverRecordChanged(server)) {
-          self.onFetchedEstablishment?(winningRecord)
-        }
-      }
+      self?.handleEstablishmentSaveFailed(error)
     }
     onResumeReset = { [weak self] _ in
       self?.resetTask = Task { [weak self] in
@@ -804,6 +799,43 @@ final class SyncEngineController: SyncEngineDriverDelegate {
         resolveSeedName(name)  // I11 observable-clear (Fix 5): terminal, dropped
       }
     }
+  }
+
+  /// Reconciles the fixed-name establishment record after CloudKit accepts a save. A wipe reset
+  /// still owns its intent transition; the controller owns change-tag caching and I11 seed
+  /// completion for both reset and ordinary seed traffic.
+  private func handleEstablishmentSaveSucceeded(_ record: CKRecord) {
+    reset?.handleEstablishmentSaveResult(.saved)
+    store.setSystemFields(
+      CKRecordSystemFieldsCodec.encode(record), for: SyncedEstablishment.recordName)
+    resolveSeedName(SyncedEstablishment.recordName)
+  }
+
+  /// Resolves fixed-name establishment CAS conflicts by generation. The existing reset machine
+  /// gets first refusal so a live wiping intent retains its established semantics. Outside that
+  /// path, a higher server generation enters adoption, an equal generation accepts the server's
+  /// metadata as terminal, and a lower generation retries the local winner with the server tag.
+  private func handleEstablishmentSaveFailed(_ error: CKError) {
+    guard error.code == .serverRecordChanged, let server = error.serverRecord else { return }
+    if let winningRecord = reset?.handleEstablishmentSaveResult(.serverRecordChanged(server)) {
+      onFetchedEstablishment?(winningRecord)
+      return
+    }
+    guard let serverEstablishment = SyncedEstablishment(from: server) else { return }
+    if serverEstablishment.generation > store.establishmentGeneration {
+      onFetchedEstablishment?(server)
+      return
+    }
+
+    store.setSystemFields(
+      CKRecordSystemFieldsCodec.encode(server), for: SyncedEstablishment.recordName)
+    if serverEstablishment.generation == store.establishmentGeneration {
+      resolveSeedName(SyncedEstablishment.recordName)
+      return
+    }
+
+    markQueueDrainNeeded(after: error)
+    driver.add(pendingRecordZoneChanges: [.saveRecord(recordID(SyncedEstablishment.recordName))])
   }
 
   /// §5.3 failed-delete branches: U-delete (`.unknownItem`, done), Z (recreate + re-add),

--- a/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
+++ b/Foqos/CloudKit/SyncEngine/SyncEngineController.swift
@@ -817,11 +817,18 @@ final class SyncEngineController: SyncEngineDriverDelegate {
   /// metadata as terminal, and a lower generation retries the local winner with the server tag.
   private func handleEstablishmentSaveFailed(_ error: CKError) {
     guard error.code == .serverRecordChanged, let server = error.serverRecord else { return }
+    let hadLiveWipingIntent = store.resetIntent?.stage == .wiping
     if let winningRecord = reset?.handleEstablishmentSaveResult(.serverRecordChanged(server)) {
       onFetchedEstablishment?(winningRecord)
       return
     }
-    guard let serverEstablishment = SyncedEstablishment(from: server) else { return }
+    guard !hadLiveWipingIntent else { return }
+    guard let serverEstablishment = SyncedEstablishment(from: server) else {
+      Log.warning(
+        "Establishment save conflict returned an undecodable server record; seed retained",
+        category: .sync)
+      return
+    }
     if serverEstablishment.generation > store.establishmentGeneration {
       onFetchedEstablishment?(server)
       return

--- a/FoqosTests/RecordProviderTests.swift
+++ b/FoqosTests/RecordProviderTests.swift
@@ -180,6 +180,21 @@ final class RecordProviderTests: XCTestCase {
     XCTAssertEqual(record?[SyncedEstablishment.FieldKey.generation.rawValue] as? Int, 4)
   }
 
+  func testGivenCachedEstablishmentFields_WhenMaterialized_ThenReusesServerRecordID() throws {
+    let sentinelZone = CKRecordZone.ID(zoneName: "DeviceSync", ownerName: "sentinel-owner")
+    let cached = SyncedEstablishment(generation: 1, establishedAt: Date())
+      .toCKRecord(in: sentinelZone)
+    store.setSystemFields(
+      CKRecordSystemFieldsCodec.encode(cached), for: SyncedEstablishment.recordName)
+    store.establishmentGeneration = 2
+
+    let record = try XCTUnwrap(
+      makeProvider().record(forRecordName: SyncedEstablishment.recordName))
+
+    XCTAssertEqual(record.recordID.zoneID.ownerName, "sentinel-owner")
+    XCTAssertEqual(record[SyncedEstablishment.FieldKey.generation.rawValue] as? Int, 2)
+  }
+
   func testGivenEmergencyUnblockEventRecordName_WhenMaterialized_ThenBuildsEventRecord() {
     let now = Date()
     emergencyManager.seedForTesting(epoch: 2)

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -619,6 +619,138 @@ final class SyncEngineControllerTests: XCTestCase {
       "relaunch enqueues no zone save")
   }
 
+  func testGivenPostAdoptionEqualEstablishmentConflict_WhenRelaunched_ThenSeedDoesNotRecur()
+    async throws
+  {
+    store.engineState = nil
+    store.establishmentGeneration = 1
+
+    let controller = makeController()
+    controller.start()
+    await controller.startupTask?.value
+
+    let batch = try XCTUnwrap(controller.nextRecordZoneChangeBatch(scope: nil))
+    let sentEstablishment = try XCTUnwrap(
+      batch.first { $0.recordID.recordName == SyncedEstablishment.recordName })
+    let savedRecords = batch.filter {
+      $0.recordID.recordName != SyncedEstablishment.recordName
+    }
+    let serverEstablishment = SyncedEstablishment(generation: 1, establishedAt: Date())
+      .toCKRecord(in: zoneID)
+    let conflict = makeCKError(
+      .serverRecordChanged,
+      userInfo: [CKRecordChangedErrorServerRecordKey: serverEstablishment])
+
+    controller.handle(
+      .sentRecordZoneChanges(
+        savedRecords: savedRecords,
+        failedRecordSaves: [(record: sentEstablishment, error: conflict)],
+        deletedRecordIDs: [],
+        failedRecordDeletes: []))
+    controller.handle(
+      .sentDatabaseChanges(
+        savedZones: [zoneID], failedZoneSaves: [], deletedZoneIDs: [], failedZoneDeletes: []))
+
+    XCTAssertNotNil(
+      store.systemFields(for: SyncedEstablishment.recordName),
+      "equal-generation server metadata must become the fixed record's change-tag base")
+    XCTAssertFalse(
+      store.pendingSeedIntent,
+      "equal-generation conflict is a terminal seed outcome after adoption")
+
+    controller.handle(.stateUpdate(serialization: Data([0x01])))
+    let relaunchDriver = MockSyncEngineDriver()
+    let relaunchController = SyncEngineController(
+      modelContext: context,
+      store: store,
+      driverFactory: { _ in relaunchDriver },
+      apply: apply,
+      provider: provider,
+      sessionSync: sessionSync,
+      deviceId: deviceId)
+    relaunchController.start()
+    await relaunchController.startupTask?.value
+
+    XCTAssertFalse(
+      relaunchDriver.pendingRecordZoneChanges.contains {
+        if case .saveRecord(let id) = $0 {
+          return id.recordName == SyncedEstablishment.recordName
+        }
+        return false
+      },
+      "ordinary relaunch must not repeat the establishment seed")
+  }
+
+  func testGivenLowerServerEstablishmentConflict_WhenRetrySucceeds_ThenSeedResolves()
+    async throws
+  {
+    store.engineState = nil
+    store.establishmentGeneration = 2
+
+    let controller = makeController()
+    controller.start()
+    await controller.startupTask?.value
+
+    let batch = try XCTUnwrap(controller.nextRecordZoneChangeBatch(scope: nil))
+    let sentEstablishment = try XCTUnwrap(
+      batch.first { $0.recordID.recordName == SyncedEstablishment.recordName })
+    let savedRecords = batch.filter {
+      $0.recordID.recordName != SyncedEstablishment.recordName
+    }
+    driver.setPendingRecordZoneChangesForTest([])
+    let serverEstablishment = SyncedEstablishment(generation: 1, establishedAt: Date())
+      .toCKRecord(in: zoneID)
+    let conflict = makeCKError(
+      .serverRecordChanged,
+      userInfo: [CKRecordChangedErrorServerRecordKey: serverEstablishment])
+
+    controller.handle(
+      .sentRecordZoneChanges(
+        savedRecords: savedRecords,
+        failedRecordSaves: [(record: sentEstablishment, error: conflict)],
+        deletedRecordIDs: [],
+        failedRecordDeletes: []))
+    controller.handle(
+      .sentDatabaseChanges(
+        savedZones: [zoneID], failedZoneSaves: [], deletedZoneIDs: [], failedZoneDeletes: []))
+
+    XCTAssertNotNil(store.systemFields(for: SyncedEstablishment.recordName))
+    XCTAssertEqual(countPendingSaves(named: SyncedEstablishment.recordName), 1)
+    XCTAssertTrue(store.pendingSeedIntent, "local winner remains pending until retry succeeds")
+
+    let retry = try XCTUnwrap(provider.record(forRecordName: SyncedEstablishment.recordName))
+    controller.handle(
+      .sentRecordZoneChanges(
+        savedRecords: [retry], failedRecordSaves: [], deletedRecordIDs: [],
+        failedRecordDeletes: []))
+
+    XCTAssertFalse(store.pendingSeedIntent, "successful local-winner retry resolves the seed")
+  }
+
+  func testGivenHigherServerEstablishmentConflictWithoutReset_WhenHandled_ThenAdoptsOnce() {
+    store.engineState = Data([0x01])
+    store.establishmentGeneration = 1
+    let controller = makeController()
+    controller.start()
+    controller.startupTask?.cancel()
+    let sent = SyncedEstablishment(generation: 1, establishedAt: Date()).toCKRecord(in: zoneID)
+    let server = SyncedEstablishment(generation: 2, establishedAt: Date()).toCKRecord(in: zoneID)
+    let conflict = makeCKError(
+      .serverRecordChanged, userInfo: [CKRecordChangedErrorServerRecordKey: server])
+    var adoptedRecords: [CKRecord] = []
+    controller.onFetchedEstablishment = { adoptedRecords.append($0) }
+
+    controller.handle(
+      .sentRecordZoneChanges(
+        savedRecords: [], failedRecordSaves: [(record: sent, error: conflict)],
+        deletedRecordIDs: [], failedRecordDeletes: []))
+
+    XCTAssertEqual(adoptedRecords.count, 1)
+    XCTAssertEqual(
+      adoptedRecords.first?[SyncedEstablishment.FieldKey.generation.rawValue] as? Int,
+      2)
+  }
+
   // MARK: - I12 delete-intent recovery (S-29, S-33, CRA-5)
 
   func testGivenTombstoneEntityPresent_WhenRecover_ThenAbortAndClear() async {

--- a/FoqosTests/SyncEngineControllerTests.swift
+++ b/FoqosTests/SyncEngineControllerTests.swift
@@ -751,6 +751,40 @@ final class SyncEngineControllerTests: XCTestCase {
       2)
   }
 
+  func testGivenLiveWipingResetAndNonHigherEstablishmentConflict_WhenHandled_ThenDoesNotFallThrough() {
+    store.engineState = Data([0x01])
+    store.establishmentGeneration = 2
+    let controller = makeController()
+    controller.start()
+    controller.startupTask?.cancel()
+    let sent = SyncedEstablishment(generation: 2, establishedAt: Date()).toCKRecord(in: zoneID)
+
+    for serverGeneration in [2, 1] {
+      store.resetIntent = ResetIntent(
+        id: UUID(), clear: false, wipe: true, stage: .wiping, priorCommandId: nil)
+      store.setSystemFields(nil, for: SyncedEstablishment.recordName)
+      driver.setPendingRecordZoneChangesForTest([])
+      let server = SyncedEstablishment(
+        generation: serverGeneration, establishedAt: Date()
+      ).toCKRecord(in: zoneID)
+      let conflict = makeCKError(
+        .serverRecordChanged, userInfo: [CKRecordChangedErrorServerRecordKey: server])
+
+      controller.handle(
+        .sentRecordZoneChanges(
+          savedRecords: [], failedRecordSaves: [(record: sent, error: conflict)],
+          deletedRecordIDs: [], failedRecordDeletes: []))
+
+      XCTAssertNil(store.resetIntent, "live wiping intent is consumed")
+      XCTAssertNil(
+        store.systemFields(for: SyncedEstablishment.recordName),
+        "live reset keeps its existing no-cache conflict semantics")
+      XCTAssertEqual(
+        countPendingSaves(named: SyncedEstablishment.recordName), 0,
+        "consumed live reset must not trigger an unowned follow-on write")
+    }
+  }
+
   // MARK: - I12 delete-intent recovery (S-29, S-33, CRA-5)
 
   func testGivenTombstoneEntityPresent_WhenRecover_ThenAbortAndClear() async {

--- a/docs/superpowers/plans/2026-08-14-issue-442-establishment-conflict.md
+++ b/docs/superpowers/plans/2026-08-14-issue-442-establishment-conflict.md
@@ -1,0 +1,55 @@
+# Issue #442 Establishment Conflict Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make fixed-name establishment conflicts converge instead of leaving a pending seed that fails again on every launch.
+
+**Architecture:** Give `SyncEngineController` a narrow reconciliation path based on server/local generation ordering, preserve `ResetController` semantics for live resets, and let `RecordProvider` materialize the server change tag for local-winner retries.
+
+**Tech Stack:** Swift 6, CloudKit, CKSyncEngine, XCTest, Xcode simulator gate.
+
+## Global Constraints
+
+- Work only in `.worktrees/build2-442` on `fix/442-establishment-conflict`.
+- Base is main `3410b5d`; publish reserved version 2.0.43 (62) across all 12 configurations.
+- Use synthetic fixtures only; never include private diagnostics or real family data.
+- Preserve higher-generation adoption and existing live-reset semantics.
+- Do not broaden this fixed-name lifecycle into generic entity conflict handling.
+- Use new signed commits; request independent exact-head review; the planner merges.
+
+### Task 1: Capture the recurrence and metadata contract
+
+**Files:**
+- Modify: `FoqosTests/SyncEngineControllerTests.swift`
+- Modify: `FoqosTests/RecordProviderTests.swift`
+
+- [ ] Add an equal-generation, no-reset conflict test proving server system fields are cached, the
+  pending seed resolves, and a simulated relaunch does not enqueue `SyncEstablishment` again.
+- [ ] Run only that test and confirm RED for the unresolved seed or missing metadata.
+- [ ] Add focused tests for lower-generation retry, higher-generation adoption, and provider
+  materialization from cached system fields.
+
+### Task 2: Implement minimal reconciliation
+
+**Files:**
+- Modify: `Foqos/CloudKit/SyncEngine/SyncEngineController.swift`
+- Modify: `Foqos/CloudKit/SyncEngine/RecordProvider.swift`
+
+- [ ] Route establishment success through reset handling, then cache fields and resolve a normal
+  seed when no reset remains.
+- [ ] Route `serverRecordChanged` through reset handling first, decode the server establishment,
+  and compare generations: adopt higher, reconcile equal, or cache/re-enqueue lower.
+- [ ] Materialize cached establishment fields before updating current payload values.
+- [ ] Run the new focused tests and existing controller/provider/reset suites until GREEN.
+
+### Task 3: Version and delivery verification
+
+**Files:**
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+
+- [ ] Set every `MARKETING_VERSION` to 2.0.43 and every `CURRENT_PROJECT_VERSION` to 62.
+- [ ] Format touched Swift files and run recursive format lint plus `git diff --check`.
+- [ ] Run the complete simulator-gated test suite and standalone Debug build using agent `build2`,
+  session `implement_beta_fixes`.
+- [ ] Commit with signing, push the branch, open a ready-for-review PR closing #442, verify checks,
+  request independent exact-head review through AMQ, and report the result to the planner.

--- a/docs/superpowers/specs/2026-08-14-issue-442-establishment-conflict-design.md
+++ b/docs/superpowers/specs/2026-08-14-issue-442-establishment-conflict-design.md
@@ -1,0 +1,61 @@
+# Issue #442 Establishment Conflict Reconciliation Design
+
+## Goal
+
+Stop a fixed-name `SyncEstablishment` save conflict from recurring on every launch after a device
+has already adopted the current establishment generation. A conflict without a live reset intent
+must either adopt a newer generation or reconcile CloudKit metadata and finish the pending seed.
+
+## Root cause
+
+`SyncEngineController` routes every establishment save conflict only through `ResetController`.
+That controller deliberately ignores the result unless a reset is currently in `.wiping`, so a
+post-adoption conflict stores no server system fields and never resolves the pending seed intent.
+The next launch purges and seeds again, reproducing the same `serverRecordChanged` failure.
+
+`RecordProvider.establishmentRecord()` also creates a fresh record instead of materializing cached
+system fields, so a legitimate retry cannot carry the server change tag.
+
+## Design
+
+Keep reset ownership unchanged, but add controller-owned establishment reconciliation for normal
+seeding:
+
+- A higher server generation is authoritative and enters the existing fetched-establishment
+  adoption path.
+- An equal server generation is the same establishment. Cache its authoritative system fields and
+  resolve the establishment seed without another save.
+- A lower server generation loses to the local generation. Cache its system fields, re-enqueue the
+  establishment with the server change tag, and keep the seed pending until that retry succeeds.
+- A successful establishment save outside reset caches system fields and resolves the seed.
+- Malformed server records remain pending and are not treated as success.
+
+For a live wiping reset, call the existing reset result handler first. Its higher-generation winner
+still enters adoption; equal/lower results retain the reset controller's existing intent cleanup,
+then use the same metadata reconciliation rules. Normal seeding must not manufacture reset intent.
+
+`RecordProvider` will materialize the establishment record from cached system fields when present,
+then set the current generation and established date. This is narrowly scoped to the fixed-name
+record rather than adding it to generic entity conflict behavior.
+
+## Testing
+
+Use only synthetic CloudKit records:
+
+- equal-generation conflict after adoption caches server fields, resolves the seed, and does not
+  enqueue establishment again after relaunch;
+- lower-generation conflict caches fields and re-enqueues, with a later successful save resolving
+  the seed;
+- higher-generation conflict without reset routes to adoption exactly once;
+- the provider materializes cached establishment system fields; and
+- existing live-reset establishment tests remain green.
+
+Run focused controller/provider/reset tests, the full simulator-gated suite, a standalone Debug
+build, recursive format lint, project version guards, `git diff --check`, and independent exact-head
+review.
+
+## Delivery
+
+Work in `.worktrees/build2-442` on `fix/442-establishment-conflict`, based on main `3410b5d`.
+Publish all 12 configurations as version 2.0.43 (62), use new signed commits, open a ready-for-review
+PR closing #442, and leave merge ownership with the planner.


### PR DESCRIPTION
Closes #442

## Summary
- reconcile fixed-name establishment conflicts by generation outside live resets
- cache server system fields so local-winner retries carry the CloudKit change tag
- resolve equal-generation seeds so ordinary relaunches do not repeat the failed save
- bump all target configurations to 2.0.43 (62)

## Verification
- focused RED reproduced missing metadata, pending seed, and relaunch recurrence
- focused establishment reconciliation tests: 4 passed
- controller/provider/reset/wipe suites: 131 passed
- full suite: 1,297 passed
- standalone Debug build: succeeded
- swift-format lint --recursive .
- git diff --check
- scripts/check-version-increment.sh origin/main HEAD