### PR TITLE
Explain confirmed family revocation

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 63;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.44;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 63;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.44;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 63;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.44;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 63;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.44;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 63;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.44;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 63;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.44;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 63;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.44;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 63;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.44;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 63;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.44;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 63;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.44;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 63;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.44;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 63;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.42;
+				MARKETING_VERSION = 2.0.44;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -29,6 +29,9 @@ enum AccountAvailability: Equatable {
 @MainActor
 class CloudKitManager: ObservableObject {
   static let shared = CloudKitManager()
+  static let familyRevocationAlertTitle = "Family Connection Removed"
+  static let familyRevocationAlertMessage =
+    "This device is no longer connected to its Family Foqos family in iCloud, so it switched to Individual mode. To reconnect, ask a parent to send a new invitation."
 
   private let networkService = CloudKitNetworkService()
 
@@ -44,6 +47,7 @@ class CloudKitManager: ObservableObject {
   @Published var error: CloudKitError?
   @Published var shareAcceptedMessage: String?
   @Published var shareAcceptanceIsError = false
+  @Published var familyRevocationMessage: String?
   @Published var pendingParticipants: [CKShare.Participant] = []
   @Published var isShareOwner = false
 
@@ -252,24 +256,35 @@ class CloudKitManager: ObservableObject {
 
   // MARK: - Verification
 
-  nonisolated static func confirmedRevocationTrigger(
+  nonisolated static func isConfirmedRevocation(
     isConnected: Bool,
     isSignedIn: Bool,
     enforcedMode: AppMode?,
     currentMode: AppMode
-  ) -> ConfirmedCloudKitRevocationTrigger? {
-    guard !isConnected,
-      isSignedIn,
-      enforcedMode == .individual,
-      currentMode == .child
-    else {
-      return nil
-    }
-    return .confirmedCloudKitRevocation
+  ) -> Bool {
+    !isConnected
+      && isSignedIn
+      && enforcedMode == .individual
+      && currentMode == .child
   }
 
-  func verifySelfFamilyMemberRecord() async {
-    guard !ScreenshotDemoMode.isActive else { return }
+  func handleConfirmedFamilyRevocation(
+    cleanup: () -> Void = {
+      AuthorizationVerifier.shared.handleConfirmedCloudKitRevocation()
+    }
+  ) {
+    cleanup()
+    familyRevocationMessage = Self.familyRevocationAlertMessage
+  }
+
+  func dismissFamilyRevocationMessage() {
+    familyRevocationMessage = nil
+  }
+
+  /// Returns true only when this verification handled a confirmed Child-family revocation.
+  @discardableResult
+  func verifySelfFamilyMemberRecord() async -> Bool {
+    guard !ScreenshotDemoMode.isActive else { return false }
     let localMode = AppModeManager.shared.currentMode
     let accountIsSignedIn = self.isSignedIn
     let result = await networkService.verifySelfFamilyMember(
@@ -288,19 +303,21 @@ class CloudKitManager: ObservableObject {
     // In a disconnected result, enforced .individual is the confirmed-revocation signal. Only
     // CloudKitNetworkService+Verification may produce this overload, and only for Child mode.
     if !result.isConnected, result.enforcedMode == .individual {
-      if Self.confirmedRevocationTrigger(
+      if Self.isConfirmedRevocation(
         isConnected: result.isConnected,
         isSignedIn: self.isSignedIn,
         enforcedMode: result.enforcedMode,
         currentMode: AppModeManager.shared.currentMode
-      ) != nil {
-        _ = await AuthorizationVerifier.shared.handleConfirmedCloudKitRevocation()
+      ) {
+        handleConfirmedFamilyRevocation()
+        return true
       }
-      return
+      return false
     }
     if let mode = result.enforcedMode {
       AppModeManager.shared.selectMode(mode)
     }
+    return false
   }
 
   // MARK: - Share Participant Sync

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -426,9 +426,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
   @MainActor
   static func refreshChildSharedDataAfterMembershipVerification(
+    refreshAccountStatus: () async -> Void,
     verifyMembership: () async -> Bool,
     refreshSharedData: () async -> ChildSharedDataRefreshResult
   ) async -> ChildSharedDataRefreshResult {
+    await refreshAccountStatus()
     let didHandleConfirmedRevocation = await verifyMembership()
     guard !didHandleConfirmedRevocation else { return .newData }
     return await refreshSharedData()
@@ -471,6 +473,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         if shouldRefreshChildSharedData {
           childRefreshResult =
             await Self.refreshChildSharedDataAfterMembershipVerification(
+              refreshAccountStatus: {
+                await CloudKitManager.shared.checkAccountStatus()
+              },
               verifyMembership: {
                 await CloudKitManager.shared.verifySelfFamilyMemberRecord()
               },

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -191,6 +191,23 @@ struct FoqosApp: App {
           }
           handleURL(url)
         }
+        .alert(
+          CloudKitManager.familyRevocationAlertTitle,
+          isPresented: Binding(
+            get: { cloudKitManager.familyRevocationMessage != nil },
+            set: {
+              if !$0 {
+                cloudKitManager.dismissFamilyRevocationMessage()
+              }
+            }
+          )
+        ) {
+          Button("OK") {
+            cloudKitManager.dismissFamilyRevocationMessage()
+          }
+        } message: {
+          Text(cloudKitManager.familyRevocationMessage ?? "")
+        }
         // Share acceptance result alert (success or error)
         .alert(
           cloudKitManager.shareAcceptanceIsError ? "Unable to Join Family" : shareAcceptanceTitle,
@@ -407,6 +424,16 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     mode == .child && databaseScope == .shared
   }
 
+  @MainActor
+  static func refreshChildSharedDataAfterMembershipVerification(
+    verifyMembership: () async -> Bool,
+    refreshSharedData: () async -> ChildSharedDataRefreshResult
+  ) async -> ChildSharedDataRefreshResult {
+    let didHandleConfirmedRevocation = await verifyMembership()
+    guard !didHandleConfirmedRevocation else { return .newData }
+    return await refreshSharedData()
+  }
+
   func application(
     _: UIApplication,
     didRegisterForRemoteNotificationsWithDeviceToken _: Data
@@ -443,7 +470,14 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         let childRefreshResult: UIBackgroundFetchResult?
         if shouldRefreshChildSharedData {
           childRefreshResult =
-            await LockCodeManager.shared.refreshSharedLockCodesForVerification()
+            await Self.refreshChildSharedDataAfterMembershipVerification(
+              verifyMembership: {
+                await CloudKitManager.shared.verifySelfFamilyMemberRecord()
+              },
+              refreshSharedData: {
+                await LockCodeManager.shared.refreshSharedLockCodesForVerification()
+              }
+            )
             .backgroundFetchResult
         } else {
           childRefreshResult = nil

--- a/Foqos/Utils/AuthorizationVerifier.swift
+++ b/Foqos/Utils/AuthorizationVerifier.swift
@@ -1,10 +1,6 @@
 import FamilyControls
 import Foundation
 
-enum ConfirmedCloudKitRevocationTrigger: Equatable {
-  case confirmedCloudKitRevocation
-}
-
 /// Centralized service for verifying Apple Family Sharing authorization.
 /// Used to ensure children accepting CloudKit shares are actually set up as
 /// children in Apple Family Sharing (not just adults pretending to be children).
@@ -106,10 +102,6 @@ class AuthorizationVerifier: ObservableObject {
       return error.domain == NSURLErrorDomain ? .networkError(error) : .unknownError(error)
     }
 
-    if #available(iOS 26.4, *), familyControlsError == .unauthorized {
-      return .notAuthorized
-    }
-
     switch familyControlsError {
     case .invalidAccountType:
       return .notChildDevice
@@ -198,8 +190,8 @@ class AuthorizationVerifier: ObservableObject {
 
   /// Handle a CloudKit-confirmed family revocation for a child device.
   /// Family Controls errors must never reach this destructive path.
-  /// Clears shared state, switches to individual mode, and returns a user message.
-  func handleConfirmedCloudKitRevocation() async -> String {
+  /// Clears shared state and switches to individual mode.
+  func handleConfirmedCloudKitRevocation() {
     let cloudKitManager = CloudKitManager.shared
     let appModeManager = AppModeManager.shared
 
@@ -216,8 +208,6 @@ class AuthorizationVerifier: ObservableObject {
     // Switch to individual mode
     appModeManager.selectMode(.individual)
 
-    return
-      "Your child account authorization was revoked (the device may have been removed from Apple Family Sharing). You've been switched to individual mode. To reconnect, ask a parent to re-add this device and send a new invitation."
   }
 
   /// Verify child authorization if in child mode and connected to family.

--- a/FoqosTests/ChildRevocationCacheTests.swift
+++ b/FoqosTests/ChildRevocationCacheTests.swift
@@ -3,42 +3,24 @@ import XCTest
 
 @testable import FamilyFoqos
 
-@MainActor
 final class ChildRevocationCacheTests: XCTestCase {
   private static let cacheKey = "family_foqos_child_lock_codes"
 
-  private var defaults: UserDefaults!
-  private var originalMode: AppMode!
-  private var suiteName: String!
-
-  override func setUp() {
-    super.setUp()
-    originalMode = AppModeManager.shared.currentMode
-    AppModeManager.shared.selectMode(.child)
-
-    suiteName = "ChildRevocationCacheTests-\(UUID().uuidString)"
-    defaults = UserDefaults(suiteName: suiteName)!
+  @MainActor
+  func testGivenConfirmedCloudKitRevocation_WhenHandlingCache_ThenPINErased() {
+    let suiteName = "ChildRevocationCacheTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
     let codes = [FamilyLockCode(code: "test-code", scope: .allChildren)]
     defaults.set(try! JSONEncoder().encode(codes), forKey: Self.cacheKey)
     LockCodeManager.shared.overrideDefaults(defaults)
-  }
-
-  override func tearDown() {
-    LockCodeManager.shared.overrideDefaults(nil)
-    defaults.removePersistentDomain(forName: suiteName)
-    AppModeManager.shared.selectMode(originalMode)
-    defaults = nil
-    originalMode = nil
-    suiteName = nil
-    super.tearDown()
-  }
-
-  func testGivenConfirmedCloudKitRevocation_WhenHandlingCache_ThenPINErased() {
-    XCTAssertTrue(LockCodeManager.shared.canVerifyCode)
+    defer {
+      LockCodeManager.shared.overrideDefaults(nil)
+      defaults.removePersistentDomain(forName: suiteName)
+    }
+    XCTAssertNotNil(defaults.data(forKey: Self.cacheKey))
 
     LockCodeManager.shared.handleConfirmedCloudKitRevocation()
 
-    XCTAssertFalse(LockCodeManager.shared.canVerifyCode)
     XCTAssertNil(defaults.data(forKey: Self.cacheKey))
   }
 }

--- a/FoqosTests/ChildRevocationTests.swift
+++ b/FoqosTests/ChildRevocationTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 @testable import FamilyFoqos
 
+@MainActor
 final class ChildRevocationTests: XCTestCase {
   private func zoneID(_ name: String) -> CKRecordZone.ID {
     CKRecordZone.ID(zoneName: name, ownerName: "test-owner")
@@ -94,24 +95,23 @@ final class ChildRevocationTests: XCTestCase {
   }
 
   func testGivenDisconnectedIndividualSignalInChildMode_WhenResolvingTrigger_ThenRevocationIsConfirmed() {
-    XCTAssertEqual(
-      CloudKitManager.confirmedRevocationTrigger(
+    XCTAssertTrue(
+      CloudKitManager.isConfirmedRevocation(
         isConnected: false,
         isSignedIn: true,
         enforcedMode: .individual,
-        currentMode: .child),
-      .confirmedCloudKitRevocation)
+        currentMode: .child))
   }
 
   func testGivenDisconnectedIndividualSignalOutsideChildMode_WhenResolvingTrigger_ThenNoRevocation() {
-    XCTAssertNil(
-      CloudKitManager.confirmedRevocationTrigger(
+    XCTAssertFalse(
+      CloudKitManager.isConfirmedRevocation(
         isConnected: false,
         isSignedIn: true,
         enforcedMode: .individual,
         currentMode: .parent))
-    XCTAssertNil(
-      CloudKitManager.confirmedRevocationTrigger(
+    XCTAssertFalse(
+      CloudKitManager.isConfirmedRevocation(
         isConnected: false,
         isSignedIn: true,
         enforcedMode: .individual,
@@ -119,8 +119,8 @@ final class ChildRevocationTests: XCTestCase {
   }
 
   func testGivenConnectedIndividualSignalInChildMode_WhenResolvingTrigger_ThenNoRevocation() {
-    XCTAssertNil(
-      CloudKitManager.confirmedRevocationTrigger(
+    XCTAssertFalse(
+      CloudKitManager.isConfirmedRevocation(
         isConnected: true,
         isSignedIn: true,
         enforcedMode: .individual,
@@ -128,11 +128,52 @@ final class ChildRevocationTests: XCTestCase {
   }
 
   func testGivenSignedOutIndividualSignalInChildMode_WhenResolvingTrigger_ThenNoRevocation() {
-    XCTAssertNil(
-      CloudKitManager.confirmedRevocationTrigger(
+    XCTAssertFalse(
+      CloudKitManager.isConfirmedRevocation(
         isConnected: false,
         isSignedIn: false,
         enforcedMode: .individual,
         currentMode: .child))
+  }
+
+  func testGivenForegroundVerifierConfirmsRevocation_WhenHandlingTransition_ThenPublishesDedicatedNoticeAfterCleanup() {
+    let manager = CloudKitManager.shared
+    let originalRevocationMessage = manager.familyRevocationMessage
+    let originalShareMessage = manager.shareAcceptedMessage
+    let originalShareError = manager.shareAcceptanceIsError
+    defer {
+      manager.familyRevocationMessage = originalRevocationMessage
+      manager.shareAcceptedMessage = originalShareMessage
+      manager.shareAcceptanceIsError = originalShareError
+    }
+
+    manager.familyRevocationMessage = nil
+    manager.shareAcceptedMessage = "existing share state"
+    manager.shareAcceptanceIsError = true
+    var didCleanup = false
+
+    manager.handleConfirmedFamilyRevocation {
+      XCTAssertNil(manager.familyRevocationMessage)
+      didCleanup = true
+    }
+
+    XCTAssertTrue(didCleanup)
+    XCTAssertEqual(CloudKitManager.familyRevocationAlertTitle, "Family Connection Removed")
+    XCTAssertEqual(
+      manager.familyRevocationMessage,
+      "This device is no longer connected to its Family Foqos family in iCloud, so it switched to Individual mode. To reconnect, ask a parent to send a new invitation."
+    )
+    XCTAssertEqual(manager.shareAcceptedMessage, "existing share state")
+    XCTAssertTrue(manager.shareAcceptanceIsError)
+
+    let message = manager.familyRevocationMessage ?? ""
+    XCTAssertTrue(message.contains("iCloud"))
+    XCTAssertTrue(message.contains("Individual"))
+    XCTAssertTrue(message.contains("new invitation"))
+    XCTAssertFalse(message.contains("Screen Time"))
+    XCTAssertFalse(message.contains("Family Sharing"))
+
+    manager.dismissFamilyRevocationMessage()
+    XCTAssertNil(manager.familyRevocationMessage)
   }
 }

--- a/FoqosTests/ChildSharedRefreshTests.swift
+++ b/FoqosTests/ChildSharedRefreshTests.swift
@@ -247,6 +247,49 @@ final class ChildSharedRefreshTests: XCTestCase {
         mode: .child))
   }
 
+  func testGivenConfirmedRevocationDuringBackgroundRefresh_WhenRouting_ThenPublishesNoticeAndReportsNewData()
+    async
+  {
+    let manager = CloudKitManager.shared
+    let originalMessage = manager.familyRevocationMessage
+    defer { manager.familyRevocationMessage = originalMessage }
+    manager.familyRevocationMessage = nil
+    var didRefreshSharedData = false
+
+    let result = await AppDelegate.refreshChildSharedDataAfterMembershipVerification {
+      manager.handleConfirmedFamilyRevocation {}
+      return true
+    } refreshSharedData: {
+      didRefreshSharedData = true
+      return .failed
+    }
+
+    XCTAssertEqual(result, .newData)
+    XCTAssertFalse(didRefreshSharedData)
+    XCTAssertEqual(
+      manager.familyRevocationMessage,
+      CloudKitManager.familyRevocationAlertMessage)
+  }
+
+  func testGivenMembershipUnchangedDuringBackgroundRefresh_WhenRouting_ThenPreservesRefreshResult()
+    async
+  {
+    var didVerifyMembership = false
+    var didRefreshSharedData = false
+
+    let result = await AppDelegate.refreshChildSharedDataAfterMembershipVerification {
+      didVerifyMembership = true
+      return false
+    } refreshSharedData: {
+      didRefreshSharedData = true
+      return .noData
+    }
+
+    XCTAssertTrue(didVerifyMembership)
+    XCTAssertTrue(didRefreshSharedData)
+    XCTAssertEqual(result, .noData)
+  }
+
   func testGivenPrivatePushOrNonChildMode_WhenRouting_ThenDoesNotRefreshSharedData() {
     XCTAssertFalse(
       AppDelegate.shouldRefreshChildSharedData(

--- a/FoqosTests/ChildSharedRefreshTests.swift
+++ b/FoqosTests/ChildSharedRefreshTests.swift
@@ -247,24 +247,33 @@ final class ChildSharedRefreshTests: XCTestCase {
         mode: .child))
   }
 
-  func testGivenConfirmedRevocationDuringBackgroundRefresh_WhenRouting_ThenPublishesNoticeAndReportsNewData()
+  func testGivenColdLaunchConfirmedRevocationDuringBackgroundRefresh_WhenRouting_ThenRefreshesAccountAndPublishesNotice()
     async
   {
     let manager = CloudKitManager.shared
     let originalMessage = manager.familyRevocationMessage
     defer { manager.familyRevocationMessage = originalMessage }
     manager.familyRevocationMessage = nil
+    var steps: [String] = []
     var didRefreshSharedData = false
 
-    let result = await AppDelegate.refreshChildSharedDataAfterMembershipVerification {
-      manager.handleConfirmedFamilyRevocation {}
-      return true
-    } refreshSharedData: {
-      didRefreshSharedData = true
-      return .failed
-    }
+    let result = await AppDelegate.refreshChildSharedDataAfterMembershipVerification(
+      refreshAccountStatus: {
+        steps.append("account")
+      },
+      verifyMembership: {
+        XCTAssertEqual(steps, ["account"])
+        steps.append("membership")
+        manager.handleConfirmedFamilyRevocation {}
+        return true
+      },
+      refreshSharedData: {
+        didRefreshSharedData = true
+        return .failed
+      })
 
     XCTAssertEqual(result, .newData)
+    XCTAssertEqual(steps, ["account", "membership"])
     XCTAssertFalse(didRefreshSharedData)
     XCTAssertEqual(
       manager.familyRevocationMessage,
@@ -274,19 +283,22 @@ final class ChildSharedRefreshTests: XCTestCase {
   func testGivenMembershipUnchangedDuringBackgroundRefresh_WhenRouting_ThenPreservesRefreshResult()
     async
   {
-    var didVerifyMembership = false
-    var didRefreshSharedData = false
+    var steps: [String] = []
 
-    let result = await AppDelegate.refreshChildSharedDataAfterMembershipVerification {
-      didVerifyMembership = true
-      return false
-    } refreshSharedData: {
-      didRefreshSharedData = true
-      return .noData
-    }
+    let result = await AppDelegate.refreshChildSharedDataAfterMembershipVerification(
+      refreshAccountStatus: {
+        steps.append("account")
+      },
+      verifyMembership: {
+        steps.append("membership")
+        return false
+      },
+      refreshSharedData: {
+        steps.append("shared-data")
+        return .noData
+      })
 
-    XCTAssertTrue(didVerifyMembership)
-    XCTAssertTrue(didRefreshSharedData)
+    XCTAssertEqual(steps, ["account", "membership", "shared-data"])
     XCTAssertEqual(result, .noData)
   }
 

--- a/docs/superpowers/plans/2026-08-14-issue-435-cloudkit-revocation-notice.md
+++ b/docs/superpowers/plans/2026-08-14-issue-435-cloudkit-revocation-notice.md
@@ -1,0 +1,88 @@
+# Issue #435 CloudKit Revocation Notice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this
+> plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface a truthful one-shot explanation after confirmed CloudKit family removal, for
+both foreground and silent-push discovery, while isolating the revocation cache test.
+
+**Architecture:** Keep CloudKit membership verification as the sole confirmation authority. Route
+foreground and child shared-database pushes through the same verifier and one destructive
+transition, which publishes dedicated alert state after cleanup. Keep share-acceptance UI and
+Family Controls failures independent.
+
+**Tech Stack:** Swift 6, SwiftUI, CloudKit, FamilyControls, XCTest, Xcode simulator gate.
+
+## Constraints
+
+- Work only in `.worktrees/build1-435` on `fix/435-revocation-notice`.
+- Base is `3410b5d`, version 2.0.42 (61); publish reserved version 2.0.44 (63).
+- Use the planner-approved alert title and message verbatim.
+- Only confirmed CloudKit absence may clear family state or select Individual.
+- The silent shared-database push must verify membership before child-data refresh.
+- Do not reuse share-acceptance state or copy.
+- Remove all `AppModeManager` access from `ChildRevocationCacheTests`.
+- Every commit must be new and signed; the planner merges.
+
+---
+
+### Task 1: Add failing behavior and hygiene tests
+
+**Files:**
+- Modify: `FoqosTests/ChildRevocationTests.swift`
+- Modify: `FoqosTests/ChildSharedRefreshTests.swift`
+- Modify: `FoqosTests/FamilyControlsVerificationTests.swift`
+- Modify: `FoqosTests/ChildRevocationCacheTests.swift`
+
+- [ ] Rename trigger assertions to the missing Bool API and keep every positive/negative case.
+- [ ] Add tests for exact alert title/copy, forbidden `Screen Time` and `Family Sharing` wording,
+      cleanup-before-publication, and one-shot dismissal state.
+- [ ] Add background routing tests: child shared push verifies first; confirmed revocation skips
+      child refresh and reports `.newData`; unchanged membership retains the current refresh result.
+- [ ] Remove the cache test's `originalMode`, `selectMode(.child)`, and restoration.
+- [ ] Add/retain typed-mapping coverage proving `.unauthorized` and unknown cases are non-destructive.
+- [ ] Run selected tests and confirm RED from missing production APIs:
+
+```bash
+scripts/xcode-stream.sh --agent build1 --session issue_435 --xcbeautify -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -only-testing:FoqosTests/ChildRevocationTests -only-testing:FoqosTests/ChildRevocationCacheTests -only-testing:FoqosTests/ChildSharedRefreshTests -only-testing:FoqosTests/FamilyControlsVerificationTests
+```
+
+---
+
+### Task 2: Implement the common transition and alert
+
+**Files:**
+- Modify: `Foqos/CloudKit/CloudKitManager.swift`
+- Modify: `Foqos/Utils/AuthorizationVerifier.swift`
+- Modify: `Foqos/FoqosApp.swift`
+
+- [ ] Add `@Published var familyRevocationMessage: String?` plus internal title/message constants.
+- [ ] Add one confirmed-revocation transition that performs injected/production cleanup first,
+      then publishes the approved message. Make authorization cleanup synchronous `Void`.
+- [ ] Replace the optional single-case trigger with `isConfirmedRevocation(...) -> Bool`.
+- [ ] Have membership verification return whether it handled confirmed revocation so foreground can
+      ignore the result and background can skip child refresh/report `.newData` after demotion.
+- [ ] Extract the background child-refresh sequence behind injected verifier/refresh closures, use
+      it from `AppDelegate`, and preserve existing `.noData`/`.failed` results without revocation.
+- [ ] Present dedicated `Family Connection Removed` root alert and clear its state on dismissal.
+- [ ] Remove the redundant iOS 26.4 pre-check; retain `.unauthorized` and `@unknown default`.
+- [ ] Run the focused command until GREEN, then format changed Swift files and run `git diff --check`.
+- [ ] Create a new signed implementation commit.
+
+---
+
+### Task 3: Version, verify, review, and deliver
+
+**Files:**
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+
+- [ ] Set every `MARKETING_VERSION` to 2.0.44 and every `CURRENT_PROJECT_VERSION` to 63.
+- [ ] Run changed-file `swift-format lint`, `git diff --check`, focused tests, full simulator-gated
+      tests, and standalone Debug build through the `issue_435` stream.
+- [ ] Run project structural/version guards and verify all branch commits have good signatures.
+- [ ] Create a new signed version commit and confirm the worktree is clean.
+- [ ] Obtain independent review of the exact `origin/main...HEAD` diff. Address Critical/Important
+      findings only in new signed commits and rerun affected/full gates.
+- [ ] Push without force, open a ready-for-review PR closing #435, confirm exact head/version gate/
+      mergeability, then send exact-SHA evidence to the workflow reviewer and planner. The planner
+      performs the merge.

--- a/docs/superpowers/plans/2026-08-14-issue-435-cloudkit-revocation-notice.md
+++ b/docs/superpowers/plans/2026-08-14-issue-435-cloudkit-revocation-notice.md
@@ -37,8 +37,9 @@ Family Controls failures independent.
 - [ ] Rename trigger assertions to the missing Bool API and keep every positive/negative case.
 - [ ] Add tests for exact alert title/copy, forbidden `Screen Time` and `Family Sharing` wording,
       cleanup-before-publication, and one-shot dismissal state.
-- [ ] Add background routing tests: child shared push verifies first; confirmed revocation skips
-      child refresh and reports `.newData`; unchanged membership retains the current refresh result.
+- [ ] Add background routing tests: a cold child shared push refreshes account status before
+      membership verification; confirmed revocation skips child refresh and reports `.newData`;
+      unchanged membership retains the current refresh result.
 - [ ] Remove the cache test's `originalMode`, `selectMode(.child)`, and restoration.
 - [ ] Add/retain typed-mapping coverage proving `.unauthorized` and unknown cases are non-destructive.
 - [ ] Run selected tests and confirm RED from missing production APIs:
@@ -62,8 +63,9 @@ scripts/xcode-stream.sh --agent build1 --session issue_435 --xcbeautify -- xcode
 - [ ] Replace the optional single-case trigger with `isConfirmedRevocation(...) -> Bool`.
 - [ ] Have membership verification return whether it handled confirmed revocation so foreground can
       ignore the result and background can skip child refresh/report `.newData` after demotion.
-- [ ] Extract the background child-refresh sequence behind injected verifier/refresh closures, use
-      it from `AppDelegate`, and preserve existing `.noData`/`.failed` results without revocation.
+- [ ] Extract the background child-refresh sequence behind injected account-status/verifier/refresh
+      closures, use it from `AppDelegate`, and preserve existing `.noData`/`.failed` results without
+      revocation.
 - [ ] Present dedicated `Family Connection Removed` root alert and clear its state on dismissal.
 - [ ] Remove the redundant iOS 26.4 pre-check; retain `.unauthorized` and `@unknown default`.
 - [ ] Run the focused command until GREEN, then format changed Swift files and run `git diff --check`.

--- a/docs/superpowers/specs/2026-08-14-issue-435-cloudkit-revocation-notice-design.md
+++ b/docs/superpowers/specs/2026-08-14-issue-435-cloudkit-revocation-notice-design.md
@@ -31,11 +31,13 @@ The root view presents that state in its own alert titled **Family Connection Re
 OK action that clears the optional message. Do not reuse `shareAcceptedMessage` or
 `shareAcceptanceIsError`.
 
-Foreground activation continues to call `verifySelfFamilyMemberRecord()`. For a child shared-
-database notification, the background handler calls that same verifier before refreshing shared
-lock codes and commands. A confirmed removal reports new data and skips the now-inapplicable child
-refresh; an ambiguous/offline lookup remains non-destructive under #431 and proceeds with the
-existing fail-closed refresh.
+Foreground activation continues to refresh account status and call
+`verifySelfFamilyMemberRecord()`. For a child shared-database notification, the background handler
+first refreshes account status, then calls that same verifier before refreshing shared lock codes
+and commands. This ordering prevents a cold-launched singleton's default `isSignedIn == false`
+from suppressing confirmed revocation. A confirmed removal reports new data and skips the
+now-inapplicable child refresh; an ambiguous/offline lookup remains non-destructive under #431 and
+proceeds with the existing fail-closed refresh.
 
 Make the confirmation predicate a named `Bool` (`isConfirmedRevocation`) rather than a single-case
 optional enum. Make `AuthorizationVerifier.handleConfirmedCloudKitRevocation()` return `Void`, and

--- a/docs/superpowers/specs/2026-08-14-issue-435-cloudkit-revocation-notice-design.md
+++ b/docs/superpowers/specs/2026-08-14-issue-435-cloudkit-revocation-notice-design.md
@@ -1,0 +1,68 @@
+# Issue #435 CloudKit Revocation Notice Design
+
+## Goal
+
+Explain a confirmed CloudKit family removal after the app safely clears Child state and switches
+to Individual mode. The explanation must work whether foreground activation or a silent shared-
+database push discovers the removal, and it must remain separate from share-acceptance errors.
+
+## Root cause
+
+`CloudKitManager.verifySelfFamilyMemberRecord()` discards the string returned by the destructive
+revocation cleanup. Foreground activation therefore silently changes modes. The #437 background
+push path refreshes shared child data without first running the membership verifier, so it cannot
+publish the same explanation when the push is the first evidence of removal. The existing
+`shareAcceptedMessage` alert is semantically wrong for a device leaving a family.
+
+`ChildRevocationCacheTests` also changes the process-global `AppModeManager` in setup and teardown.
+That mode change launches the manager's asynchronous writer even though the cache test does not
+depend on mode, allowing work to escape the test boundary.
+
+## Approved design
+
+Add dedicated one-shot `CloudKitManager.familyRevocationMessage` state. A single confirmed-
+revocation transition clears authorization/shared/PIN state, selects Individual, and only then
+publishes this exact message:
+
+> This device is no longer connected to its Family Foqos family in iCloud, so it switched to
+> Individual mode. To reconnect, ask a parent to send a new invitation.
+
+The root view presents that state in its own alert titled **Family Connection Removed**, with an
+OK action that clears the optional message. Do not reuse `shareAcceptedMessage` or
+`shareAcceptanceIsError`.
+
+Foreground activation continues to call `verifySelfFamilyMemberRecord()`. For a child shared-
+database notification, the background handler calls that same verifier before refreshing shared
+lock codes and commands. A confirmed removal reports new data and skips the now-inapplicable child
+refresh; an ambiguous/offline lookup remains non-destructive under #431 and proceeds with the
+existing fail-closed refresh.
+
+Make the confirmation predicate a named `Bool` (`isConfirmedRevocation`) rather than a single-case
+optional enum. Make `AuthorizationVerifier.handleConfirmedCloudKitRevocation()` return `Void`, and
+remove the redundant iOS 26.4 equality check while retaining the exhaustive typed
+`FamilyControlsError` switch, its `.unauthorized` case, and `@unknown default`.
+
+## Testing
+
+Use TDD to cover:
+
+- the exact title and message, including `iCloud`, `Individual`, and reconnection guidance;
+- the CloudKit message excludes `Screen Time` and `Family Sharing`;
+- confirmed cleanup publishes the one-shot message after its cleanup dependency runs;
+- both foreground's common verifier and the child shared-database background route reach that
+  same transition, while the push skips child refresh after revocation and reports new data;
+- non-revocation background refresh behavior remains unchanged;
+- the renamed Bool predicate preserves every positive and negative fixture;
+- typed Family Controls mapping remains exhaustive without the redundant pre-check; and
+- `ChildRevocationCacheTests` erases the PIN cache without reading or mutating global app mode.
+
+Run focused revocation, cache, background-refresh, and Family Controls tests before the complete
+simulator-gated suite, standalone Debug build, changed-file format lint, `git diff --check`, project
+guards, and independent exact-head review.
+
+## Delivery
+
+Work in `.worktrees/build1-435` on `fix/435-revocation-notice`, based on main `3410b5d` at version
+2.0.42 (61). Set every target configuration to the planner-reserved version 2.0.44 (63). Use only
+new signed commits, publish a ready-for-review PR closing #435, and leave merge ownership with the
+planner.


### PR DESCRIPTION
## Summary

- publish a dedicated one-shot explanation after CloudKit-confirmed family removal switches a Child device to Individual mode
- route foreground and silent shared-database push discovery through the same confirmed-revocation transition, with account status initialized first on cold background launch
- keep revocation copy separate from share-acceptance and Family Controls messaging
- replace the single-case optional trigger with a Bool, remove the redundant Family Controls pre-check, and isolate the revocation cache test from global app-mode writers
- set every target configuration to version 2.0.44 (63)

## User impact

A removed Child device now explains why it switched to Individual mode and how to reconnect. The notice is also retained when a silent CloudKit push discovers the removal before the app next becomes active.

## Validation

- focused revocation, refresh, cache, and Family Controls tests: 48 tests, 0 failures
- full simulator-gated suite: 1,301 tests, 0 failures
- standalone Debug build: succeeded
- recursive swift-format lint, git diff check, version gate, sync guards, C2 guards, and log privacy lint: passed
- independent exact-head review: ready, no Critical, Important, or Minor findings

Closes #435
