### PR TITLE
Persist confirmed family revocation notice

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 63;
+				CURRENT_PROJECT_VERSION = 64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.44;
+				MARKETING_VERSION = 2.0.45;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 63;
+				CURRENT_PROJECT_VERSION = 64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.44;
+				MARKETING_VERSION = 2.0.45;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 63;
+				CURRENT_PROJECT_VERSION = 64;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.44;
+				MARKETING_VERSION = 2.0.45;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 63;
+				CURRENT_PROJECT_VERSION = 64;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.44;
+				MARKETING_VERSION = 2.0.45;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 63;
+				CURRENT_PROJECT_VERSION = 64;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.44;
+				MARKETING_VERSION = 2.0.45;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 63;
+				CURRENT_PROJECT_VERSION = 64;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.44;
+				MARKETING_VERSION = 2.0.45;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 63;
+				CURRENT_PROJECT_VERSION = 64;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.44;
+				MARKETING_VERSION = 2.0.45;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 63;
+				CURRENT_PROJECT_VERSION = 64;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.44;
+				MARKETING_VERSION = 2.0.45;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 63;
+				CURRENT_PROJECT_VERSION = 64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.44;
+				MARKETING_VERSION = 2.0.45;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 63;
+				CURRENT_PROJECT_VERSION = 64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.44;
+				MARKETING_VERSION = 2.0.45;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 63;
+				CURRENT_PROJECT_VERSION = 64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.44;
+				MARKETING_VERSION = 2.0.45;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 63;
+				CURRENT_PROJECT_VERSION = 64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.44;
+				MARKETING_VERSION = 2.0.45;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -92,6 +92,14 @@ class CloudKitManager: ObservableObject {
     pendingNoticeStore.isPending ? familyRevocationAlertMessage : nil
   }
 
+  #if DEBUG
+    static func makeForTesting(
+      pendingNoticeStore: FamilyRevocationNoticeStore
+    ) -> CloudKitManager {
+      CloudKitManager(familyRevocationNoticeStore: pendingNoticeStore)
+    }
+  #endif
+
   // MARK: - Account Status
 
   func checkAccountStatus() async {

--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -23,6 +23,28 @@ enum AccountAvailability: Equatable {
   }
 }
 
+struct FamilyRevocationNoticeStore {
+  private static let pendingKey = "family_foqos_pending_family_revocation_notice"
+
+  private let defaults: UserDefaults
+
+  init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+  }
+
+  var isPending: Bool {
+    defaults.bool(forKey: Self.pendingKey)
+  }
+
+  func markPending() {
+    defaults.set(true, forKey: Self.pendingKey)
+  }
+
+  func clearPending() {
+    defaults.removeObject(forKey: Self.pendingKey)
+  }
+}
+
 /// Thin @MainActor state layer for CloudKit operations.
 /// All network I/O is delegated to CloudKitNetworkService (a background actor, not @MainActor),
 /// keeping the main thread free from CloudKit IPC.
@@ -34,6 +56,7 @@ class CloudKitManager: ObservableObject {
     "This device is no longer connected to its Family Foqos family in iCloud, so it switched to Individual mode. To reconnect, ask a parent to send a new invitation."
 
   private let networkService = CloudKitNetworkService()
+  private let familyRevocationNoticeStore: FamilyRevocationNoticeStore
 
   // Published state
   @Published var currentUserRecordID: CKRecord.ID?
@@ -53,9 +76,20 @@ class CloudKitManager: ObservableObject {
 
   // MARK: - Initialization
 
-  private init() {
+  private init(
+    familyRevocationNoticeStore: FamilyRevocationNoticeStore = FamilyRevocationNoticeStore()
+  ) {
+    self.familyRevocationNoticeStore = familyRevocationNoticeStore
+    self.familyRevocationMessage = Self.initialFamilyRevocationMessage(
+      pendingNoticeStore: familyRevocationNoticeStore)
     // Account status is checked lazily when needed (e.g., first ensureUserRecordID call),
     // not eagerly at init time. This avoids blocking the main actor during app startup.
+  }
+
+  static func initialFamilyRevocationMessage(
+    pendingNoticeStore: FamilyRevocationNoticeStore
+  ) -> String? {
+    pendingNoticeStore.isPending ? familyRevocationAlertMessage : nil
   }
 
   // MARK: - Account Status
@@ -271,13 +305,26 @@ class CloudKitManager: ObservableObject {
   func handleConfirmedFamilyRevocation(
     cleanup: () -> Void = {
       AuthorizationVerifier.shared.handleConfirmedCloudKitRevocation()
-    }
+    },
+    markNoticePending: (() -> Void)? = nil
   ) {
     cleanup()
+    if let markNoticePending {
+      markNoticePending()
+    } else {
+      familyRevocationNoticeStore.markPending()
+    }
     familyRevocationMessage = Self.familyRevocationAlertMessage
   }
 
-  func dismissFamilyRevocationMessage() {
+  func dismissFamilyRevocationMessage(
+    clearPending: (() -> Void)? = nil
+  ) {
+    if let clearPending {
+      clearPending()
+    } else {
+      familyRevocationNoticeStore.clearPending()
+    }
     familyRevocationMessage = nil
   }
 

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -625,6 +625,20 @@ func acceptCloudKitShare(_ metadata: CKShare.Metadata) {
   }
 }
 
+@MainActor
+func applyAcceptedFamilyMode(
+  role: FamilyRole,
+  selectMode: (AppMode) -> Void = { AppModeManager.shared.selectMode($0) },
+  clearFamilyRevocationNotice: () -> Void = {
+    CloudKitManager.shared.dismissFamilyRevocationMessage()
+  }
+) -> AppMode {
+  let appMode: AppMode = role == .parent ? .parent : .child
+  selectMode(appMode)
+  clearFamilyRevocationNotice()
+  return appMode
+}
+
 /// Called from confirmation alert "Continue" — accepts share and sets up role
 func completeShareAcceptance(metadata: CKShare.Metadata, role: FamilyRole) {
   Task { @MainActor in
@@ -641,8 +655,7 @@ func completeShareAcceptance(metadata: CKShare.Metadata, role: FamilyRole) {
     }
 
     // 2. Switch app mode immediately after successful share acceptance
-    let appMode: AppMode = role == .parent ? .parent : .child
-    AppModeManager.shared.selectMode(appMode)
+    let appMode = applyAcceptedFamilyMode(role: role)
 
     // 3. Best-effort: register self as family member
     do {

--- a/Foqos/Utils/LockCodeManager.swift
+++ b/Foqos/Utils/LockCodeManager.swift
@@ -204,6 +204,11 @@ class LockCodeManager: ObservableObject {
     func seedForScreenshots(_ codes: [FamilyLockCode]) {
       lockCodes = codes
     }
+
+    /// Test assertion seam for the private child verification cache.
+    var cachedChildLockCodeCount: Int {
+      cachedLockCodes.count
+    }
   #endif
 
   // MARK: - Child Operations

--- a/FoqosTests/ChildRevocationCacheTests.swift
+++ b/FoqosTests/ChildRevocationCacheTests.swift
@@ -18,9 +18,11 @@ final class ChildRevocationCacheTests: XCTestCase {
       defaults.removePersistentDomain(forName: suiteName)
     }
     XCTAssertNotNil(defaults.data(forKey: Self.cacheKey))
+    XCTAssertEqual(LockCodeManager.shared.cachedChildLockCodeCount, 1)
 
     LockCodeManager.shared.handleConfirmedCloudKitRevocation()
 
     XCTAssertNil(defaults.data(forKey: Self.cacheKey))
+    XCTAssertEqual(LockCodeManager.shared.cachedChildLockCodeCount, 0)
   }
 }

--- a/FoqosTests/ChildRevocationTests.swift
+++ b/FoqosTests/ChildRevocationTests.swift
@@ -136,6 +136,28 @@ final class ChildRevocationTests: XCTestCase {
         currentMode: .child))
   }
 
+  func testGivenPendingRevocationNotice_WhenStoreIsRecreated_ThenStartupMessageIsRestoredUntilCleared() {
+    let suiteName = "ChildRevocationTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    let backgroundStore = FamilyRevocationNoticeStore(defaults: defaults)
+    backgroundStore.markPending()
+
+    let relaunchedStore = FamilyRevocationNoticeStore(defaults: defaults)
+    XCTAssertTrue(relaunchedStore.isPending)
+    XCTAssertEqual(
+      CloudKitManager.initialFamilyRevocationMessage(pendingNoticeStore: relaunchedStore),
+      CloudKitManager.familyRevocationAlertMessage)
+
+    relaunchedStore.clearPending()
+
+    let dismissedStore = FamilyRevocationNoticeStore(defaults: defaults)
+    XCTAssertFalse(dismissedStore.isPending)
+    XCTAssertNil(
+      CloudKitManager.initialFamilyRevocationMessage(pendingNoticeStore: dismissedStore))
+  }
+
   func testGivenForegroundVerifierConfirmsRevocation_WhenHandlingTransition_ThenPublishesDedicatedNoticeAfterCleanup() {
     let manager = CloudKitManager.shared
     let originalRevocationMessage = manager.familyRevocationMessage
@@ -150,14 +172,19 @@ final class ChildRevocationTests: XCTestCase {
     manager.familyRevocationMessage = nil
     manager.shareAcceptedMessage = "existing share state"
     manager.shareAcceptanceIsError = true
-    var didCleanup = false
+    var steps: [String] = []
 
-    manager.handleConfirmedFamilyRevocation {
-      XCTAssertNil(manager.familyRevocationMessage)
-      didCleanup = true
-    }
+    manager.handleConfirmedFamilyRevocation(
+      cleanup: {
+        XCTAssertNil(manager.familyRevocationMessage)
+        steps.append("cleanup")
+      },
+      markNoticePending: {
+        XCTAssertNil(manager.familyRevocationMessage)
+        steps.append("persist")
+      })
 
-    XCTAssertTrue(didCleanup)
+    XCTAssertEqual(steps, ["cleanup", "persist"])
     XCTAssertEqual(CloudKitManager.familyRevocationAlertTitle, "Family Connection Removed")
     XCTAssertEqual(
       manager.familyRevocationMessage,
@@ -173,7 +200,11 @@ final class ChildRevocationTests: XCTestCase {
     XCTAssertFalse(message.contains("Screen Time"))
     XCTAssertFalse(message.contains("Family Sharing"))
 
-    manager.dismissFamilyRevocationMessage()
+    manager.dismissFamilyRevocationMessage {
+      XCTAssertNotNil(manager.familyRevocationMessage)
+      steps.append("clear")
+    }
     XCTAssertNil(manager.familyRevocationMessage)
+    XCTAssertEqual(steps, ["cleanup", "persist", "clear"])
   }
 }

--- a/FoqosTests/ChildRevocationTests.swift
+++ b/FoqosTests/ChildRevocationTests.swift
@@ -158,6 +158,38 @@ final class ChildRevocationTests: XCTestCase {
       CloudKitManager.initialFamilyRevocationMessage(pendingNoticeStore: dismissedStore))
   }
 
+  func testGivenPendingRevocationNotice_WhenShareAcceptanceCompletes_ThenNextLaunchHasNoRevocationAlert() {
+    let suiteName = "ChildRevocationTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = FamilyRevocationNoticeStore(defaults: defaults)
+    store.markPending()
+    let manager = CloudKitManager.makeForTesting(pendingNoticeStore: store)
+    XCTAssertEqual(
+      manager.familyRevocationMessage,
+      CloudKitManager.familyRevocationAlertMessage)
+    var steps: [String] = []
+
+    let mode = applyAcceptedFamilyMode(
+      role: .child,
+      selectMode: {
+        XCTAssertEqual($0, .child)
+        steps.append("mode")
+      },
+      clearFamilyRevocationNotice: {
+        manager.dismissFamilyRevocationMessage()
+        steps.append("clear")
+      })
+
+    XCTAssertEqual(mode, .child)
+    XCTAssertEqual(steps, ["mode", "clear"])
+    XCTAssertNil(manager.familyRevocationMessage)
+    let nextLaunchStore = FamilyRevocationNoticeStore(defaults: defaults)
+    let nextLaunchManager = CloudKitManager.makeForTesting(
+      pendingNoticeStore: nextLaunchStore)
+    XCTAssertNil(nextLaunchManager.familyRevocationMessage)
+  }
+
   func testGivenForegroundVerifierConfirmsRevocation_WhenHandlingTransition_ThenPublishesDedicatedNoticeAfterCleanup() {
     let manager = CloudKitManager.shared
     let originalRevocationMessage = manager.familyRevocationMessage

--- a/FoqosTests/ChildSharedRefreshTests.swift
+++ b/FoqosTests/ChildSharedRefreshTests.swift
@@ -264,7 +264,9 @@ final class ChildSharedRefreshTests: XCTestCase {
       verifyMembership: {
         XCTAssertEqual(steps, ["account"])
         steps.append("membership")
-        manager.handleConfirmedFamilyRevocation {}
+        manager.handleConfirmedFamilyRevocation(
+          cleanup: {},
+          markNoticePending: {})
         return true
       },
       refreshSharedData: {

--- a/docs/superpowers/plans/2026-08-14-revocation-notice-persistence.md
+++ b/docs/superpowers/plans/2026-08-14-revocation-notice-persistence.md
@@ -1,0 +1,62 @@
+# Family Revocation Notice Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this
+> plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the existing confirmed-revocation alert after termination and pin both child PIN
+cache representations without global mode state.
+
+**Architecture:** A tiny injected-`UserDefaults` store owns one pending Bool. The common
+revocation transition orders cleanup, flag persistence, then publication; startup and dismissal
+map the flag to the existing alert state. A DEBUG-only count accessor observes the private child
+PIN cache in tests.
+
+**Tech Stack:** Swift 6, SwiftUI, CloudKit, XCTest, UserDefaults, Xcode simulator gate.
+
+## Constraints
+
+- Work only in `.worktrees/build1-revocation-persistence` on
+  `fix/revocation-notice-persistence`, based on main `312a773`.
+- Preserve the exact title, message, and root alert introduced by #445.
+- Persist only after confirmed cleanup/mode persistence; clear on alert dismissal.
+- Do not read or mutate `AppModeManager` from `ChildRevocationCacheTests`.
+- Publish reserved version 2.0.45 (64) using only new signed commits; the planner merges.
+
+### Task 1: Add failing persistence and cache tests
+
+**Files:**
+- Modify: `FoqosTests/ChildRevocationTests.swift`
+- Modify: `FoqosTests/ChildRevocationCacheTests.swift`
+
+- [ ] Simulate process termination with two notice-store instances backed by one isolated suite.
+- [ ] Pin startup restoration, transition ordering, and dismissal clearing.
+- [ ] Pin the child cache count before and after confirmed revocation alongside the persisted key.
+- [ ] Run the focused tests and confirm RED from missing production APIs.
+
+### Task 2: Implement the minimal persistence path
+
+**Files:**
+- Modify: `Foqos/CloudKit/CloudKitManager.swift`
+- Modify: `Foqos/Utils/LockCodeManager.swift`
+
+- [ ] Add the pending-notice store with production and isolated-suite construction.
+- [ ] Restore the existing alert message at manager initialization when pending.
+- [ ] Order confirmed cleanup, pending persistence, and message publication.
+- [ ] Clear pending persistence and the message on dismissal.
+- [ ] Add the DEBUG-only cached child lock-code count accessor.
+- [ ] Run focused tests until GREEN and format changed Swift files.
+
+### Task 3: Version, verify, review, and deliver
+
+**Files:**
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+
+- [ ] Set all `MARKETING_VERSION` values to 2.0.45 and all
+  `CURRENT_PROJECT_VERSION` values to 64.
+- [ ] Run focused and full tests, Debug build, recursive format lint, diff checks, and project
+  structural/version/sync/privacy guards.
+- [ ] Verify exact-head signatures and a clean worktree.
+- [ ] Obtain independent exact-head review and address Critical/Important findings with new signed
+  commits and proportionate reruns.
+- [ ] Push without force, open a ready PR linked to #445/#435, confirm version gate and
+  mergeability, then send exact-SHA evidence to the workflow reviewer and planner.

--- a/docs/superpowers/specs/2026-08-14-revocation-notice-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-14-revocation-notice-persistence-design.md
@@ -1,0 +1,45 @@
+# Family Revocation Notice Persistence Design
+
+## Goal
+
+Preserve the existing confirmed-family-revocation explanation across process termination. If a
+silent push demotes a Child device and the app terminates before foregrounding, the next launch
+must present the same **Family Connection Removed** alert with no new UX or copy.
+
+## Root cause
+
+`CloudKitManager.familyRevocationMessage` is only in memory. Background verification correctly
+cleans family state and selects Individual before publishing that message, but termination loses
+the message while the persisted mode remains Individual. The next launch therefore cannot explain
+why the mode changed.
+
+The revocation cache test also checks only the persisted lock-code key. It no longer proves that
+`LockCodeManager.cachedLockCodes` is emptied because the public verification probe reads that cache
+only in Child mode and would reintroduce process-global mode mutation.
+
+## Approved design
+
+Add a small `UserDefaults`-backed pending-notice store. Confirmed revocation performs cleanup and
+persists the mode first, marks the notice pending second, and publishes the existing in-memory
+message last. This ordering never claims a demotion that did not happen. On construction,
+`CloudKitManager` maps a pending flag to the existing exact alert message. Dismissing the alert
+clears both the persisted flag and in-memory message.
+
+Keep the store independently constructible with an injected defaults suite so tests can simulate
+termination by discarding one instance and creating another. Keep production on
+`UserDefaults.standard`; do not persist the message text or introduce another presentation path.
+
+Under `#if DEBUG`, expose only the child lock-code cache count from `LockCodeManager`. The cache
+test uses that mode-independent assertion seam to pin both persisted-key removal and in-memory
+cache clearing without touching `AppModeManager`.
+
+## Testing and delivery
+
+Use TDD for pending-flag survival across store reconstruction, startup message restoration,
+cleanup-before-persistence-before-publication ordering, dismissal clearing, and both lock-code
+cache representations. Run focused tests, all tests, a standalone Debug build, recursive format
+lint, project guards, version/sync/privacy checks, and independent exact-head review.
+
+Work from main `312a773` on `fix/revocation-notice-persistence`. Set every target configuration to
+the planner-reserved version 2.0.45 (64), publish a ready PR as the immediate follow-up to #445,
+and leave merge ownership with the planner.


### PR DESCRIPTION
## Summary

- persist the existing confirmed family-revocation notice after cleanup and restore it on next launch
- clear the pending notice when the unchanged alert is dismissed
- pin both persisted and in-memory child PIN cache clearing through a mode-independent DEBUG seam
- bump every target configuration to 2.0.45 (64)

Immediate follow-up to #445 and #435.

## Verification

- focused revocation/cache/background tests: 40 passed, 0 failed
- full simulator suite: 1,302 passed, 0 failed
- standalone Debug build
- recursive swift-format lint and git diff check
- version, sync, C2, and log-privacy gates
- independent exact-head review: no findings, Ready to publish YES