### PR TITLE
Bind revocation notices to their CloudKit account

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.47;
+				MARKETING_VERSION = 2.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.47;
+				MARKETING_VERSION = 2.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.47;
+				MARKETING_VERSION = 2.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.47;
+				MARKETING_VERSION = 2.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.47;
+				MARKETING_VERSION = 2.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.47;
+				MARKETING_VERSION = 2.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.47;
+				MARKETING_VERSION = 2.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.47;
+				MARKETING_VERSION = 2.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.47;
+				MARKETING_VERSION = 2.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.47;
+				MARKETING_VERSION = 2.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.47;
+				MARKETING_VERSION = 2.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.47;
+				MARKETING_VERSION = 2.0.48;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -24,6 +24,14 @@ enum AccountAvailability: Equatable {
 }
 
 struct FamilyRevocationNoticeStore {
+  enum Resolution {
+    case none
+    case deferred
+    case surface
+    case surfaceOnce
+    case clear
+  }
+
   private static let pendingKey = "family_foqos_pending_family_revocation_notice"
   private static let accountRecordNameKey =
     "family_foqos_pending_family_revocation_notice_account_record_name"
@@ -38,22 +46,22 @@ struct FamilyRevocationNoticeStore {
     defaults.bool(forKey: Self.pendingKey)
   }
 
-  func markPending(for accountRecordID: CKRecord.ID) {
-    defaults.set(accountRecordID.recordName, forKey: Self.accountRecordNameKey)
+  func markPending(for accountRecordID: CKRecord.ID?) {
+    if let accountRecordID {
+      defaults.set(accountRecordID.recordName, forKey: Self.accountRecordNameKey)
+    } else {
+      defaults.removeObject(forKey: Self.accountRecordNameKey)
+    }
     defaults.set(true, forKey: Self.pendingKey)
   }
 
-  func shouldSurface(for currentUserRecordID: CKRecord.ID?) -> Bool {
-    guard isPending else { return false }
-    guard
-      let currentRecordName = currentUserRecordID?.recordName,
-      let pendingRecordName = defaults.string(forKey: Self.accountRecordNameKey),
-      currentRecordName == pendingRecordName
-    else {
-      clearPending()
-      return false
+  func resolution(for currentUserRecordID: CKRecord.ID?) -> Resolution {
+    guard isPending else { return .none }
+    guard let currentRecordName = currentUserRecordID?.recordName else { return .deferred }
+    guard let pendingRecordName = defaults.string(forKey: Self.accountRecordNameKey) else {
+      return .surfaceOnce
     }
-    return true
+    return currentRecordName == pendingRecordName ? .surface : .clear
   }
 
   func clearPending() {
@@ -76,13 +84,7 @@ class CloudKitManager: ObservableObject {
   private let familyRevocationNoticeStore: FamilyRevocationNoticeStore
 
   // Published state
-  @Published var currentUserRecordID: CKRecord.ID? {
-    didSet {
-      familyRevocationMessage = Self.initialFamilyRevocationMessage(
-        pendingNoticeStore: familyRevocationNoticeStore,
-        currentUserRecordID: currentUserRecordID)
-    }
-  }
+  @Published var currentUserRecordID: CKRecord.ID?
   @Published var isSignedIn = false
   @Published var familyMembers: [FamilyMember] = []
   @Published var lockCodes: [FamilyLockCode] = []
@@ -112,8 +114,24 @@ class CloudKitManager: ObservableObject {
     pendingNoticeStore: FamilyRevocationNoticeStore,
     currentUserRecordID: CKRecord.ID?
   ) -> String? {
-    pendingNoticeStore.shouldSurface(for: currentUserRecordID)
-      ? familyRevocationAlertMessage : nil
+    switch pendingNoticeStore.resolution(for: currentUserRecordID) {
+    case .none, .deferred:
+      return nil
+    case .surface:
+      return familyRevocationAlertMessage
+    case .surfaceOnce:
+      pendingNoticeStore.clearPending()
+      return familyRevocationAlertMessage
+    case .clear:
+      pendingNoticeStore.clearPending()
+      return nil
+    }
+  }
+
+  private func resolvePendingFamilyRevocationMessage() {
+    familyRevocationMessage = Self.initialFamilyRevocationMessage(
+      pendingNoticeStore: familyRevocationNoticeStore,
+      currentUserRecordID: currentUserRecordID)
   }
 
   #if DEBUG
@@ -123,6 +141,7 @@ class CloudKitManager: ObservableObject {
     ) -> CloudKitManager {
       let manager = CloudKitManager(familyRevocationNoticeStore: pendingNoticeStore)
       manager.currentUserRecordID = currentUserRecordID
+      manager.resolvePendingFamilyRevocationMessage()
       return manager
     }
   #endif
@@ -138,6 +157,7 @@ class CloudKitManager: ObservableObject {
     } else {
       self.currentUserRecordID = nil
     }
+    resolvePendingFamilyRevocationMessage()
   }
 
   func accountAvailability() async -> AccountAvailability {
@@ -149,9 +169,11 @@ class CloudKitManager: ObservableObject {
     case .available(let id):
       isSignedIn = true
       if let id { currentUserRecordID = id }
+      resolvePendingFamilyRevocationMessage()
     case .noAccount:
       isSignedIn = false
       currentUserRecordID = nil
+      resolvePendingFamilyRevocationMessage()
     case .ambiguous:
       break
     }
@@ -165,6 +187,7 @@ class CloudKitManager: ObservableObject {
     let recordID = try await networkService.ensureUserRecordID(cached: currentUserRecordID)
     self.currentUserRecordID = recordID
     self.isSignedIn = true
+    resolvePendingFamilyRevocationMessage()
     return recordID
   }
 
@@ -341,16 +364,12 @@ class CloudKitManager: ObservableObject {
     cleanup: () -> Void = {
       AuthorizationVerifier.shared.handleConfirmedCloudKitRevocation()
     },
-    markNoticePending: ((CKRecord.ID) -> Void)? = nil
+    markNoticePending: ((CKRecord.ID?) -> Void)? = nil
   ) {
     let revokingAccountID = currentUserRecordID
     // Cleanup intentionally precedes persistence: a crash between them loses the notice instead
     // of replaying a revocation claim whose state transition never completed.
     cleanup()
-    guard let revokingAccountID else {
-      familyRevocationMessage = nil
-      return
-    }
     if let markNoticePending {
       markNoticePending(revokingAccountID)
     } else {
@@ -389,6 +408,7 @@ class CloudKitManager: ObservableObject {
     if let isSignedIn = result.isSignedIn {
       self.isSignedIn = isSignedIn
     }
+    resolvePendingFamilyRevocationMessage()
     // In a disconnected result, enforced .individual is the confirmed-revocation signal. Only
     // CloudKitNetworkService+Verification may produce this overload, and only for Child mode.
     if !result.isConnected, result.enforcedMode == .individual {

--- a/Foqos/CloudKit/CloudKitManager.swift
+++ b/Foqos/CloudKit/CloudKitManager.swift
@@ -25,6 +25,8 @@ enum AccountAvailability: Equatable {
 
 struct FamilyRevocationNoticeStore {
   private static let pendingKey = "family_foqos_pending_family_revocation_notice"
+  private static let accountRecordNameKey =
+    "family_foqos_pending_family_revocation_notice_account_record_name"
 
   private let defaults: UserDefaults
 
@@ -36,12 +38,27 @@ struct FamilyRevocationNoticeStore {
     defaults.bool(forKey: Self.pendingKey)
   }
 
-  func markPending() {
+  func markPending(for accountRecordID: CKRecord.ID) {
+    defaults.set(accountRecordID.recordName, forKey: Self.accountRecordNameKey)
     defaults.set(true, forKey: Self.pendingKey)
+  }
+
+  func shouldSurface(for currentUserRecordID: CKRecord.ID?) -> Bool {
+    guard isPending else { return false }
+    guard
+      let currentRecordName = currentUserRecordID?.recordName,
+      let pendingRecordName = defaults.string(forKey: Self.accountRecordNameKey),
+      currentRecordName == pendingRecordName
+    else {
+      clearPending()
+      return false
+    }
+    return true
   }
 
   func clearPending() {
     defaults.removeObject(forKey: Self.pendingKey)
+    defaults.removeObject(forKey: Self.accountRecordNameKey)
   }
 }
 
@@ -53,13 +70,19 @@ class CloudKitManager: ObservableObject {
   static let shared = CloudKitManager()
   static let familyRevocationAlertTitle = "Family Connection Removed"
   static let familyRevocationAlertMessage =
-    "This device is no longer connected to its Family Foqos family in iCloud, so it switched to Individual mode. To reconnect, ask a parent to send a new invitation."
+    "This device is no longer connected to its Family Foqos family in iCloud. To reconnect, ask a parent to send a new invitation."
 
   private let networkService = CloudKitNetworkService()
   private let familyRevocationNoticeStore: FamilyRevocationNoticeStore
 
   // Published state
-  @Published var currentUserRecordID: CKRecord.ID?
+  @Published var currentUserRecordID: CKRecord.ID? {
+    didSet {
+      familyRevocationMessage = Self.initialFamilyRevocationMessage(
+        pendingNoticeStore: familyRevocationNoticeStore,
+        currentUserRecordID: currentUserRecordID)
+    }
+  }
   @Published var isSignedIn = false
   @Published var familyMembers: [FamilyMember] = []
   @Published var lockCodes: [FamilyLockCode] = []
@@ -80,23 +103,27 @@ class CloudKitManager: ObservableObject {
     familyRevocationNoticeStore: FamilyRevocationNoticeStore = FamilyRevocationNoticeStore()
   ) {
     self.familyRevocationNoticeStore = familyRevocationNoticeStore
-    self.familyRevocationMessage = Self.initialFamilyRevocationMessage(
-      pendingNoticeStore: familyRevocationNoticeStore)
+    self.familyRevocationMessage = nil
     // Account status is checked lazily when needed (e.g., first ensureUserRecordID call),
     // not eagerly at init time. This avoids blocking the main actor during app startup.
   }
 
   static func initialFamilyRevocationMessage(
-    pendingNoticeStore: FamilyRevocationNoticeStore
+    pendingNoticeStore: FamilyRevocationNoticeStore,
+    currentUserRecordID: CKRecord.ID?
   ) -> String? {
-    pendingNoticeStore.isPending ? familyRevocationAlertMessage : nil
+    pendingNoticeStore.shouldSurface(for: currentUserRecordID)
+      ? familyRevocationAlertMessage : nil
   }
 
   #if DEBUG
     static func makeForTesting(
-      pendingNoticeStore: FamilyRevocationNoticeStore
+      pendingNoticeStore: FamilyRevocationNoticeStore,
+      currentUserRecordID: CKRecord.ID?
     ) -> CloudKitManager {
-      CloudKitManager(familyRevocationNoticeStore: pendingNoticeStore)
+      let manager = CloudKitManager(familyRevocationNoticeStore: pendingNoticeStore)
+      manager.currentUserRecordID = currentUserRecordID
+      return manager
     }
   #endif
 
@@ -314,13 +341,20 @@ class CloudKitManager: ObservableObject {
     cleanup: () -> Void = {
       AuthorizationVerifier.shared.handleConfirmedCloudKitRevocation()
     },
-    markNoticePending: (() -> Void)? = nil
+    markNoticePending: ((CKRecord.ID) -> Void)? = nil
   ) {
+    let revokingAccountID = currentUserRecordID
+    // Cleanup intentionally precedes persistence: a crash between them loses the notice instead
+    // of replaying a revocation claim whose state transition never completed.
     cleanup()
+    guard let revokingAccountID else {
+      familyRevocationMessage = nil
+      return
+    }
     if let markNoticePending {
-      markNoticePending()
+      markNoticePending(revokingAccountID)
     } else {
-      familyRevocationNoticeStore.markPending()
+      familyRevocationNoticeStore.markPending(for: revokingAccountID)
     }
     familyRevocationMessage = Self.familyRevocationAlertMessage
   }

--- a/Foqos/Utils/EmergencyUnblockManager.swift
+++ b/Foqos/Utils/EmergencyUnblockManager.swift
@@ -260,6 +260,7 @@ class EmergencyUnblockManager: ObservableObject {
   }
 
   func resetAllStateForAccountSwitch() {
+    CloudKitManager.shared.dismissFamilyRevocationMessage()
     emergencyUnblocksResetPeriodInDays = 28
     lastEmergencyUnblocksResetDateTimestamp = 0
     emergencySettingsLockedStorage = false

--- a/FoqosTests/ChildRevocationTests.swift
+++ b/FoqosTests/ChildRevocationTests.swift
@@ -181,6 +181,41 @@ final class ChildRevocationTests: XCTestCase {
     XCTAssertFalse(restoredStore.isPending)
   }
 
+  func testGivenPendingNoticeWhileCurrentAccountIsUnknown_WhenResolvingStartupMessage_ThenNoticeIsDeferredWithoutClearing() {
+    let suiteName = "ChildRevocationTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = FamilyRevocationNoticeStore(defaults: defaults)
+    store.markPending(for: CKRecord.ID(recordName: "pending-account"))
+
+    let manager = CloudKitManager.makeForTesting(
+      pendingNoticeStore: store,
+      currentUserRecordID: nil)
+
+    XCTAssertNil(manager.familyRevocationMessage)
+    XCTAssertTrue(store.isPending)
+  }
+
+  func testGivenOwnerlessPendingNoticeWhenCurrentAccountBecomesKnown_WhenResolvingStartupMessage_ThenNoticeSurfacesOnceAndClears() {
+    let suiteName = "ChildRevocationTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = FamilyRevocationNoticeStore(defaults: defaults)
+    store.markPending(for: nil)
+    let currentAccountID = CKRecord.ID(recordName: "resolved-account")
+
+    XCTAssertEqual(
+      CloudKitManager.initialFamilyRevocationMessage(
+        pendingNoticeStore: store,
+        currentUserRecordID: currentAccountID),
+      CloudKitManager.familyRevocationAlertMessage)
+    XCTAssertFalse(store.isPending)
+    XCTAssertNil(
+      CloudKitManager.initialFamilyRevocationMessage(
+        pendingNoticeStore: store,
+        currentUserRecordID: currentAccountID))
+  }
+
   func testGivenMatchingPendingNoticeAfterModeChanged_WhenResolvingStartupMessage_ThenCopyDoesNotClaimIndividualMode() {
     let suiteName = "ChildRevocationTests-\(UUID().uuidString)"
     let defaults = UserDefaults(suiteName: suiteName)!
@@ -281,6 +316,28 @@ final class ChildRevocationTests: XCTestCase {
 
     XCTAssertFalse(store.isPending)
     XCTAssertNil(manager.familyRevocationMessage)
+  }
+
+  func testGivenConfirmedRevocationWhileAccountIDIsUnresolved_WhenHandlingTransition_ThenOwnerlessNoticeIsPersistedAndPublished() {
+    let manager = CloudKitManager.shared
+    let store = FamilyRevocationNoticeStore()
+    let originalRecordID = manager.currentUserRecordID
+    let originalMessage = manager.familyRevocationMessage
+    store.clearPending()
+    defer {
+      store.clearPending()
+      manager.currentUserRecordID = originalRecordID
+      manager.familyRevocationMessage = originalMessage
+    }
+    manager.currentUserRecordID = nil
+    manager.familyRevocationMessage = nil
+
+    manager.handleConfirmedFamilyRevocation(cleanup: {})
+
+    XCTAssertTrue(store.isPending)
+    XCTAssertEqual(
+      manager.familyRevocationMessage,
+      CloudKitManager.familyRevocationAlertMessage)
   }
 
   func testGivenForegroundVerifierConfirmsRevocation_WhenHandlingTransition_ThenPublishesDedicatedNoticeAfterCleanup() {

--- a/FoqosTests/ChildRevocationTests.swift
+++ b/FoqosTests/ChildRevocationTests.swift
@@ -136,18 +136,21 @@ final class ChildRevocationTests: XCTestCase {
         currentMode: .child))
   }
 
-  func testGivenPendingRevocationNotice_WhenStoreIsRecreated_ThenStartupMessageIsRestoredUntilCleared() {
+  func testGivenPendingRevocationNoticeForCurrentAccount_WhenStoreIsRecreated_ThenStartupMessageIsRestoredUntilCleared() {
     let suiteName = "ChildRevocationTests-\(UUID().uuidString)"
     let defaults = UserDefaults(suiteName: suiteName)!
     defer { defaults.removePersistentDomain(forName: suiteName) }
+    let accountID = CKRecord.ID(recordName: "current-account")
 
     let backgroundStore = FamilyRevocationNoticeStore(defaults: defaults)
-    backgroundStore.markPending()
+    backgroundStore.markPending(for: accountID)
 
     let relaunchedStore = FamilyRevocationNoticeStore(defaults: defaults)
     XCTAssertTrue(relaunchedStore.isPending)
     XCTAssertEqual(
-      CloudKitManager.initialFamilyRevocationMessage(pendingNoticeStore: relaunchedStore),
+      CloudKitManager.initialFamilyRevocationMessage(
+        pendingNoticeStore: relaunchedStore,
+        currentUserRecordID: accountID),
       CloudKitManager.familyRevocationAlertMessage)
 
     relaunchedStore.clearPending()
@@ -155,16 +158,56 @@ final class ChildRevocationTests: XCTestCase {
     let dismissedStore = FamilyRevocationNoticeStore(defaults: defaults)
     XCTAssertFalse(dismissedStore.isPending)
     XCTAssertNil(
-      CloudKitManager.initialFamilyRevocationMessage(pendingNoticeStore: dismissedStore))
+      CloudKitManager.initialFamilyRevocationMessage(
+        pendingNoticeStore: dismissedStore,
+        currentUserRecordID: accountID))
+  }
+
+  func testGivenRestoredPendingNoticeForDifferentAccount_WhenResolvingStartupMessage_ThenNoticeIsClearedWithoutSurfacing() {
+    let suiteName = "ChildRevocationTests-\(UUID().uuidString)"
+    let restoredDefaults = UserDefaults(suiteName: suiteName)!
+    defer { restoredDefaults.removePersistentDomain(forName: suiteName) }
+    let backedUpAccountID = CKRecord.ID(recordName: "backed-up-account")
+    let restoredDeviceAccountID = CKRecord.ID(recordName: "restored-device-account")
+
+    FamilyRevocationNoticeStore(defaults: restoredDefaults).markPending(
+      for: backedUpAccountID)
+
+    let restoredStore = FamilyRevocationNoticeStore(defaults: restoredDefaults)
+    XCTAssertNil(
+      CloudKitManager.initialFamilyRevocationMessage(
+        pendingNoticeStore: restoredStore,
+        currentUserRecordID: restoredDeviceAccountID))
+    XCTAssertFalse(restoredStore.isPending)
+  }
+
+  func testGivenMatchingPendingNoticeAfterModeChanged_WhenResolvingStartupMessage_ThenCopyDoesNotClaimIndividualMode() {
+    let suiteName = "ChildRevocationTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let accountID = CKRecord.ID(recordName: "current-account")
+    let store = FamilyRevocationNoticeStore(defaults: defaults)
+    store.markPending(for: accountID)
+
+    let message = CloudKitManager.initialFamilyRevocationMessage(
+      pendingNoticeStore: store,
+      currentUserRecordID: accountID)
+
+    XCTAssertNotNil(message)
+    XCTAssertFalse(message?.contains("Individual") == true)
+    XCTAssertTrue(message?.contains("new invitation") == true)
   }
 
   func testGivenPendingRevocationNotice_WhenShareAcceptanceCompletes_ThenNextLaunchHasNoRevocationAlert() {
     let suiteName = "ChildRevocationTests-\(UUID().uuidString)"
     let defaults = UserDefaults(suiteName: suiteName)!
     defer { defaults.removePersistentDomain(forName: suiteName) }
+    let accountID = CKRecord.ID(recordName: "current-account")
     let store = FamilyRevocationNoticeStore(defaults: defaults)
-    store.markPending()
-    let manager = CloudKitManager.makeForTesting(pendingNoticeStore: store)
+    store.markPending(for: accountID)
+    let manager = CloudKitManager.makeForTesting(
+      pendingNoticeStore: store,
+      currentUserRecordID: accountID)
     XCTAssertEqual(
       manager.familyRevocationMessage,
       CloudKitManager.familyRevocationAlertMessage)
@@ -186,8 +229,58 @@ final class ChildRevocationTests: XCTestCase {
     XCTAssertNil(manager.familyRevocationMessage)
     let nextLaunchStore = FamilyRevocationNoticeStore(defaults: defaults)
     let nextLaunchManager = CloudKitManager.makeForTesting(
-      pendingNoticeStore: nextLaunchStore)
+      pendingNoticeStore: nextLaunchStore,
+      currentUserRecordID: accountID)
     XCTAssertNil(nextLaunchManager.familyRevocationMessage)
+  }
+
+  func testGivenPendingRevocationNotice_WhenApplyingAcceptedModeWithDefaultClear_ThenRealManagerClearsIt() {
+    let manager = CloudKitManager.shared
+    let store = FamilyRevocationNoticeStore()
+    let originalRecordID = manager.currentUserRecordID
+    let originalMessage = manager.familyRevocationMessage
+    defer {
+      store.clearPending()
+      manager.currentUserRecordID = originalRecordID
+      manager.familyRevocationMessage = originalMessage
+    }
+    let accountID = CKRecord.ID(recordName: "default-clear-account")
+    manager.currentUserRecordID = accountID
+    store.markPending(for: accountID)
+    manager.familyRevocationMessage = CloudKitManager.familyRevocationAlertMessage
+
+    let mode = applyAcceptedFamilyMode(
+      role: .child,
+      selectMode: { XCTAssertEqual($0, .child) })
+
+    XCTAssertEqual(mode, .child)
+    XCTAssertFalse(store.isPending)
+    XCTAssertNil(manager.familyRevocationMessage)
+  }
+
+  func testGivenPendingRevocationNotice_WhenAccountSwitchStateResets_ThenNoticeIsCleared() {
+    let suiteName = "ChildRevocationTests-\(UUID().uuidString)"
+    let emergencyDefaults = UserDefaults(suiteName: suiteName)!
+    defer { emergencyDefaults.removePersistentDomain(forName: suiteName) }
+    let manager = CloudKitManager.shared
+    let store = FamilyRevocationNoticeStore()
+    let originalRecordID = manager.currentUserRecordID
+    let originalMessage = manager.familyRevocationMessage
+    defer {
+      store.clearPending()
+      manager.currentUserRecordID = originalRecordID
+      manager.familyRevocationMessage = originalMessage
+    }
+    let accountID = CKRecord.ID(recordName: "account-before-switch")
+    manager.currentUserRecordID = accountID
+    store.markPending(for: accountID)
+    manager.familyRevocationMessage = CloudKitManager.familyRevocationAlertMessage
+    let emergencyManager = EmergencyUnblockManager(defaults: emergencyDefaults)
+
+    emergencyManager.resetAllStateForAccountSwitch()
+
+    XCTAssertFalse(store.isPending)
+    XCTAssertNil(manager.familyRevocationMessage)
   }
 
   func testGivenForegroundVerifierConfirmsRevocation_WhenHandlingTransition_ThenPublishesDedicatedNoticeAfterCleanup() {
@@ -195,12 +288,16 @@ final class ChildRevocationTests: XCTestCase {
     let originalRevocationMessage = manager.familyRevocationMessage
     let originalShareMessage = manager.shareAcceptedMessage
     let originalShareError = manager.shareAcceptanceIsError
+    let originalRecordID = manager.currentUserRecordID
     defer {
       manager.familyRevocationMessage = originalRevocationMessage
       manager.shareAcceptedMessage = originalShareMessage
       manager.shareAcceptanceIsError = originalShareError
+      manager.currentUserRecordID = originalRecordID
     }
 
+    let accountID = CKRecord.ID(recordName: "revoked-account")
+    manager.currentUserRecordID = accountID
     manager.familyRevocationMessage = nil
     manager.shareAcceptedMessage = "existing share state"
     manager.shareAcceptanceIsError = true
@@ -210,9 +307,11 @@ final class ChildRevocationTests: XCTestCase {
       cleanup: {
         XCTAssertNil(manager.familyRevocationMessage)
         steps.append("cleanup")
+        manager.currentUserRecordID = nil
       },
-      markNoticePending: {
+      markNoticePending: { persistedAccountID in
         XCTAssertNil(manager.familyRevocationMessage)
+        XCTAssertEqual(persistedAccountID, accountID)
         steps.append("persist")
       })
 
@@ -220,14 +319,14 @@ final class ChildRevocationTests: XCTestCase {
     XCTAssertEqual(CloudKitManager.familyRevocationAlertTitle, "Family Connection Removed")
     XCTAssertEqual(
       manager.familyRevocationMessage,
-      "This device is no longer connected to its Family Foqos family in iCloud, so it switched to Individual mode. To reconnect, ask a parent to send a new invitation."
+      "This device is no longer connected to its Family Foqos family in iCloud. To reconnect, ask a parent to send a new invitation."
     )
     XCTAssertEqual(manager.shareAcceptedMessage, "existing share state")
     XCTAssertTrue(manager.shareAcceptanceIsError)
 
     let message = manager.familyRevocationMessage ?? ""
     XCTAssertTrue(message.contains("iCloud"))
-    XCTAssertTrue(message.contains("Individual"))
+    XCTAssertFalse(message.contains("Individual"))
     XCTAssertTrue(message.contains("new invitation"))
     XCTAssertFalse(message.contains("Screen Time"))
     XCTAssertFalse(message.contains("Family Sharing"))

--- a/FoqosTests/ChildSharedRefreshTests.swift
+++ b/FoqosTests/ChildSharedRefreshTests.swift
@@ -252,7 +252,11 @@ final class ChildSharedRefreshTests: XCTestCase {
   {
     let manager = CloudKitManager.shared
     let originalMessage = manager.familyRevocationMessage
-    defer { manager.familyRevocationMessage = originalMessage }
+    let originalRecordID = manager.currentUserRecordID
+    defer {
+      manager.currentUserRecordID = originalRecordID
+      manager.familyRevocationMessage = originalMessage
+    }
     manager.familyRevocationMessage = nil
     var steps: [String] = []
     var didRefreshSharedData = false
@@ -260,13 +264,14 @@ final class ChildSharedRefreshTests: XCTestCase {
     let result = await AppDelegate.refreshChildSharedDataAfterMembershipVerification(
       refreshAccountStatus: {
         steps.append("account")
+        manager.currentUserRecordID = CKRecord.ID(recordName: "background-account")
       },
       verifyMembership: {
         XCTAssertEqual(steps, ["account"])
         steps.append("membership")
         manager.handleConfirmedFamilyRevocation(
           cleanup: {},
-          markNoticePending: {})
+          markNoticePending: { _ in })
         return true
       },
       refreshSharedData: {


### PR DESCRIPTION
## Summary

- persist the revoking CloudKit account with each pending family-revocation notice
- surface only for the matching current account and clear restored/switched-account notices
- remove the stale Individual-mode claim from delayed notice copy
- clear pending revocation notices during account-switch state reset
- document the cleanup-before-persistence fail-safe ordering
- pin the real share-acceptance clearer with a mutation-verified regression test
- advance the coordinated release version to 2.0.48 (66), ahead of #447 at 2.0.49 (67)

This is the fix-don't-file follow-up to the independent adversarial pattern review of #446. The corrected context-bound pattern is the prerequisite for #447's startup recovery notice.

## Validation

- TDD RED: account-bound API absent (compile failures at all new contract points)
- TDD RED/GREEN: revocation-time account capture survives cleanup clearing the cached ID
- mutation RED/GREEN: replacing `applyAcceptedFamilyMode`'s default real clearer with `{}` produces two dedicated assertion failures; restoring it passes
- focused regressions: 71 tests, 0 failures
- full suite: 1,307 tests, 0 failures
- Debug build succeeded
- `scripts/check-version-increment.sh origin/main HEAD`
- `scripts/test-check-version-increment.sh`
- changed-file `swift-format lint`
- `git diff --check origin/main...HEAD`
- verified all 12 `MARKETING_VERSION` settings are 2.0.48 and all 12 `CURRENT_PROJECT_VERSION` settings are 66
- verified exact head has a good ED25519 signature