### PR TITLE
Recover family state before startup side effects

### DIFF
--- a/FamilyFoqos.xcodeproj/project.pbxproj
+++ b/FamilyFoqos.xcodeproj/project.pbxproj
@@ -704,7 +704,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -715,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.48;
+				MARKETING_VERSION = 2.0.49;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -736,7 +736,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosDeviceMonitor/FoqosDeviceMonitor.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosDeviceMonitor/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosDeviceMonitor;
@@ -747,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.48;
+				MARKETING_VERSION = 2.0.49;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosDeviceMonitor";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -895,7 +895,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -923,7 +923,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.48;
+				MARKETING_VERSION = 2.0.49;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -949,7 +949,7 @@
 				CODE_SIGN_ENTITLEMENTS = foqos/foqos.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"foqos/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -977,7 +977,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.48;
+				MARKETING_VERSION = 2.0.49;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -999,12 +999,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.48;
+				MARKETING_VERSION = 2.0.49;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1025,12 +1025,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.48;
+				MARKETING_VERSION = 2.0.49;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,12 +1050,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.48;
+				MARKETING_VERSION = 2.0.49;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1075,12 +1075,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
-				MARKETING_VERSION = 2.0.48;
+				MARKETING_VERSION = 2.0.49;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-FoqosUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1101,7 +1101,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1112,7 +1112,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.48;
+				MARKETING_VERSION = 2.0.49;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1133,7 +1133,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = FoqosShieldConfig/FoqosShieldConfig.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosShieldConfig/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosShieldConfig;
@@ -1144,7 +1144,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.48;
+				MARKETING_VERSION = 2.0.49;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosShieldConfig";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1168,7 +1168,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1179,7 +1179,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.48;
+				MARKETING_VERSION = 2.0.49;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1202,7 +1202,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = FoqosWidget/FoqosWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 66;
+				CURRENT_PROJECT_VERSION = 67;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FoqosWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FoqosWidget;
@@ -1213,7 +1213,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.0.48;
+				MARKETING_VERSION = 2.0.49;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cynexia.family-foqos.FoqosWidget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Foqos/CloudKit/StartupRecoveryCloudService.swift
+++ b/Foqos/CloudKit/StartupRecoveryCloudService.swift
@@ -1,0 +1,352 @@
+import CloudKit
+import Foundation
+
+enum StartupRecoveryMembershipObservation: Equatable {
+  case accountUnavailable
+  case accountIndeterminate
+  case sharedZoneAbsent
+  case sharedZoneIndeterminate
+  case recordAbsent
+  case recordFailed
+  case recordRole(String)
+}
+
+enum StartupRecoveryProfileFetchOutcome: Equatable {
+  case success
+  case zoneMissing
+  case indeterminate
+}
+
+struct StartupRecoveryProfileRecordFold: Equatable {
+  private var profileRecordNames: Set<String> = []
+
+  var profileCount: Int { profileRecordNames.count }
+
+  mutating func applyModification(recordName: String, recordType: String) {
+    guard recordType == SyncedProfile.recordType else { return }
+    profileRecordNames.insert(recordName)
+  }
+
+  mutating func applyDeletion(recordName: String, recordType: String) {
+    guard recordType == SyncedProfile.recordType else { return }
+    profileRecordNames.remove(recordName)
+  }
+}
+
+final class StartupRecoveryCloudService: @unchecked Sendable {  // SAFETY: Immutable CKContainer; each lookup keeps mutable state call-local
+  private let container: CKContainer
+
+  init(
+    container: CKContainer = CKContainer(identifier: CloudKitConstants.containerIdentifier)
+  ) {
+    self.container = container
+  }
+
+  static func resolveMembership(
+    _ observation: StartupRecoveryMembershipObservation
+  ) -> StartupRecoveryMembershipResult {
+    switch observation {
+    case .sharedZoneAbsent, .recordAbsent:
+      return .confirmedNone
+    case .recordRole(let roleValue):
+      guard let role = FamilyRole(rawValue: roleValue) else { return .indeterminate }
+      return .member(role)
+    case .accountUnavailable, .accountIndeterminate, .sharedZoneIndeterminate, .recordFailed:
+      return .indeterminate
+    }
+  }
+
+  static func resolveProfileCount(
+    fold: StartupRecoveryProfileRecordFold,
+    outcome: StartupRecoveryProfileFetchOutcome
+  ) -> StartupRecoveryProfileCountResult {
+    switch outcome {
+    case .success:
+      return .confirmed(fold.profileCount)
+    case .zoneMissing:
+      return .confirmed(0)
+    case .indeterminate:
+      return .indeterminate
+    }
+  }
+
+  func lookupMembership() async -> StartupRecoveryMembershipResult {
+    let accountStatus: CKAccountStatus
+    do {
+      accountStatus = try await container.accountStatus()
+    } catch {
+      Log.error(
+        "Startup recovery could not determine the iCloud account state: \(redactedErrorForLog(error))",
+        category: .cloudKit)
+      return Self.resolveMembership(.accountIndeterminate)
+    }
+
+    guard accountStatus == .available else {
+      return Self.resolveMembership(.accountUnavailable)
+    }
+
+    let userRecordID: CKRecord.ID
+    do {
+      userRecordID = try await container.userRecordID()
+    } catch {
+      Log.error(
+        "Startup recovery could not identify the iCloud account: \(redactedErrorForLog(error))",
+        category: .cloudKit)
+      return Self.resolveMembership(.accountIndeterminate)
+    }
+
+    let database = container.sharedCloudDatabase
+    let policyZoneID: CKRecordZone.ID
+    do {
+      let zones = try await database.allRecordZones()
+      guard
+        let matchingZone = zones.first(where: {
+          $0.zoneID.zoneName == CloudKitConstants.policyZoneName
+        })
+      else {
+        return Self.resolveMembership(.sharedZoneAbsent)
+      }
+      policyZoneID = matchingZone.zoneID
+    } catch {
+      Log.error(
+        "Startup recovery could not inspect the shared family zone: \(redactedErrorForLog(error))",
+        category: .cloudKit)
+      return Self.resolveMembership(.sharedZoneIndeterminate)
+    }
+
+    let observation = await fetchMembershipObservation(
+      in: policyZoneID,
+      userRecordName: userRecordID.recordName,
+      database: database)
+    return Self.resolveMembership(observation)
+  }
+
+  func fetchSyncedProfileCount() async -> StartupRecoveryProfileCountResult {
+    do {
+      guard try await container.accountStatus() == .available else {
+        return .indeterminate
+      }
+    } catch {
+      Log.error(
+        "Startup recovery could not determine the profile account state: \(redactedErrorForLog(error))",
+        category: .cloudKit)
+      return .indeterminate
+    }
+
+    let zoneID = CKRecordZone.ID(
+      zoneName: CloudKitConstants.syncZoneName,
+      ownerName: CKCurrentUserDefaultName)
+    let configuration = CKFetchRecordZoneChangesOperation.ZoneConfiguration()
+    configuration.previousServerChangeToken = nil
+    configuration.desiredKeys = []
+
+    let operation = CKFetchRecordZoneChangesOperation(
+      recordZoneIDs: [zoneID],
+      configurationsByRecordZoneID: [zoneID: configuration])
+    operation.fetchAllChanges = true
+    let accumulator = ProfileFetchAccumulator()
+
+    operation.recordWasChangedBlock = { _, recordResult in
+      switch recordResult {
+      case .success(let record):
+        accumulator.applyModification(
+          recordName: record.recordID.recordName,
+          recordType: record.recordType)
+      case .failure:
+        accumulator.markIndeterminate()
+      }
+    }
+    operation.recordWithIDWasDeletedBlock = { recordID, recordType in
+      accumulator.applyDeletion(recordName: recordID.recordName, recordType: recordType)
+    }
+    operation.recordZoneFetchResultBlock = { _, result in
+      if case .failure(let error) = result {
+        accumulator.recordZoneFailure(error)
+      }
+    }
+
+    let outcome = await withCheckedContinuation { continuation in
+      operation.fetchRecordZoneChangesResultBlock = { result in
+        continuation.resume(returning: accumulator.outcome(for: result))
+      }
+      container.privateCloudDatabase.add(operation)
+    }
+
+    let snapshot = accumulator.foldSnapshot()
+    return Self.resolveProfileCount(fold: snapshot, outcome: outcome)
+  }
+
+  private func fetchMembershipObservation(
+    in zoneID: CKRecordZone.ID,
+    userRecordName: String,
+    database: CKDatabase
+  ) async -> StartupRecoveryMembershipObservation {
+    let configuration = CKFetchRecordZoneChangesOperation.ZoneConfiguration()
+    configuration.previousServerChangeToken = nil
+    configuration.desiredKeys = [
+      FamilyMember.RecordKey.userRecordName,
+      FamilyMember.RecordKey.role,
+    ]
+
+    let operation = CKFetchRecordZoneChangesOperation(
+      recordZoneIDs: [zoneID],
+      configurationsByRecordZoneID: [zoneID: configuration])
+    operation.fetchAllChanges = true
+    let accumulator = MembershipFetchAccumulator(userRecordName: userRecordName)
+
+    operation.recordWasChangedBlock = { _, recordResult in
+      switch recordResult {
+      case .success(let record):
+        accumulator.apply(record)
+      case .failure:
+        accumulator.markIndeterminate()
+      }
+    }
+    operation.recordWithIDWasDeletedBlock = { recordID, _ in
+      accumulator.applyDeletion(recordID: recordID)
+    }
+    operation.recordZoneFetchResultBlock = { _, result in
+      if case .failure(let error) = result {
+        accumulator.recordZoneFailure(error)
+      }
+    }
+
+    return await withCheckedContinuation { continuation in
+      operation.fetchRecordZoneChangesResultBlock = { result in
+        continuation.resume(returning: accumulator.observation(for: result))
+      }
+      database.add(operation)
+    }
+  }
+}
+
+private final class MembershipFetchAccumulator: @unchecked Sendable {  // SAFETY: NSLock guards every mutable field access
+  private let lock = NSLock()
+  private let userRecordName: String
+  private var matchingRecordID: CKRecord.ID?
+  private var roleValue: String?
+  private var fetchFailed = false
+  private var zoneWasRemoved = false
+
+  init(userRecordName: String) {
+    self.userRecordName = userRecordName
+  }
+
+  func apply(_ record: CKRecord) {
+    guard record.recordType == FamilyMember.recordType,
+      record[FamilyMember.RecordKey.userRecordName] as? String == userRecordName
+    else { return }
+
+    lock.withLock {
+      matchingRecordID = record.recordID
+      guard let role = record[FamilyMember.RecordKey.role] as? String else {
+        fetchFailed = true
+        return
+      }
+      roleValue = role
+    }
+  }
+
+  func applyDeletion(recordID: CKRecord.ID) {
+    lock.withLock {
+      guard recordID == matchingRecordID else { return }
+      matchingRecordID = nil
+      roleValue = nil
+    }
+  }
+
+  func markIndeterminate() {
+    lock.withLock {
+      fetchFailed = true
+    }
+  }
+
+  func recordZoneFailure(_ error: Error) {
+    lock.withLock {
+      if startupRecoveryIsMissingZone(error) {
+        zoneWasRemoved = true
+      } else {
+        fetchFailed = true
+      }
+    }
+  }
+
+  func observation(
+    for operationResult: Result<Void, Error>
+  ) -> StartupRecoveryMembershipObservation {
+    lock.withLock {
+      if zoneWasRemoved { return .sharedZoneAbsent }
+      if fetchFailed { return .recordFailed }
+      if case .failure(let error) = operationResult {
+        return startupRecoveryIsMissingZone(error) ? .sharedZoneAbsent : .recordFailed
+      }
+      guard let roleValue else { return .recordAbsent }
+      return .recordRole(roleValue)
+    }
+  }
+}
+
+private final class ProfileFetchAccumulator: @unchecked Sendable {  // SAFETY: NSLock guards every mutable field access
+  private let lock = NSLock()
+  private var fold = StartupRecoveryProfileRecordFold()
+  private var zoneFailureOutcome: StartupRecoveryProfileFetchOutcome?
+  private var recordFailure = false
+
+  func applyModification(recordName: String, recordType: String) {
+    lock.withLock {
+      fold.applyModification(recordName: recordName, recordType: recordType)
+    }
+  }
+
+  func applyDeletion(recordName: String, recordType: String) {
+    lock.withLock {
+      fold.applyDeletion(recordName: recordName, recordType: recordType)
+    }
+  }
+
+  func markIndeterminate() {
+    lock.withLock {
+      recordFailure = true
+    }
+  }
+
+  func recordZoneFailure(_ error: Error) {
+    lock.withLock {
+      zoneFailureOutcome = startupRecoveryIsMissingZone(error) ? .zoneMissing : .indeterminate
+    }
+  }
+
+  func outcome(for operationResult: Result<Void, Error>) -> StartupRecoveryProfileFetchOutcome {
+    lock.withLock {
+      if recordFailure { return .indeterminate }
+      if let zoneFailureOutcome { return zoneFailureOutcome }
+      switch operationResult {
+      case .success:
+        return .success
+      case .failure(let error):
+        return startupRecoveryIsMissingZone(error) ? .zoneMissing : .indeterminate
+      }
+    }
+  }
+
+  func foldSnapshot() -> StartupRecoveryProfileRecordFold {
+    lock.withLock { fold }
+  }
+
+}
+
+private func startupRecoveryIsMissingZone(_ error: Error) -> Bool {
+  guard let cloudKitError = error as? CKError else { return false }
+  switch cloudKitError.code {
+  case .zoneNotFound, .userDeletedZone:
+    return true
+  case .partialFailure:
+    guard
+      let partialErrors = cloudKitError.partialErrorsByItemID,
+      !partialErrors.isEmpty
+    else { return false }
+    return partialErrors.values.allSatisfy(startupRecoveryIsMissingZone)
+  default:
+    return false
+  }
+}

--- a/Foqos/CloudKit/StartupRecoveryCloudService.swift
+++ b/Foqos/CloudKit/StartupRecoveryCloudService.swift
@@ -4,16 +4,18 @@ import Foundation
 enum StartupRecoveryMembershipObservation: Equatable {
   case accountUnavailable
   case accountIndeterminate
-  case sharedZoneAbsent
+  case zoneListSucceededWithoutPolicyZone(ownerUserRecordName: String)
   case sharedZoneIndeterminate
-  case recordAbsent
-  case recordFailed
-  case recordRole(String)
+  case recordAbsent(ownerUserRecordName: String)
+  case recordFetchFailed
+  case recordZoneMissing
+  case recordRole(role: String, ownerUserRecordName: String)
 }
 
 enum StartupRecoveryProfileFetchOutcome: Equatable {
   case success
-  case zoneMissing
+  case zoneListSucceededWithoutSyncZone
+  case zoneFetchReportedMissing
   case indeterminate
 }
 
@@ -46,12 +48,14 @@ final class StartupRecoveryCloudService: @unchecked Sendable {  // SAFETY: Immut
     _ observation: StartupRecoveryMembershipObservation
   ) -> StartupRecoveryMembershipResult {
     switch observation {
-    case .sharedZoneAbsent, .recordAbsent:
-      return .confirmedNone
-    case .recordRole(let roleValue):
+    case .zoneListSucceededWithoutPolicyZone(let ownerUserRecordName),
+      .recordAbsent(let ownerUserRecordName):
+      return .confirmedNone(ownerUserRecordName: ownerUserRecordName)
+    case .recordRole(let roleValue, let ownerUserRecordName):
       guard let role = FamilyRole(rawValue: roleValue) else { return .indeterminate }
-      return .member(role)
-    case .accountUnavailable, .accountIndeterminate, .sharedZoneIndeterminate, .recordFailed:
+      return .member(role: role, ownerUserRecordName: ownerUserRecordName)
+    case .accountUnavailable, .accountIndeterminate, .sharedZoneIndeterminate,
+      .recordFetchFailed, .recordZoneMissing:
       return .indeterminate
     }
   }
@@ -63,9 +67,9 @@ final class StartupRecoveryCloudService: @unchecked Sendable {  // SAFETY: Immut
     switch outcome {
     case .success:
       return .confirmed(fold.profileCount)
-    case .zoneMissing:
+    case .zoneListSucceededWithoutSyncZone:
       return .confirmed(0)
-    case .indeterminate:
+    case .zoneFetchReportedMissing, .indeterminate:
       return .indeterminate
     }
   }
@@ -104,7 +108,9 @@ final class StartupRecoveryCloudService: @unchecked Sendable {  // SAFETY: Immut
           $0.zoneID.zoneName == CloudKitConstants.policyZoneName
         })
       else {
-        return Self.resolveMembership(.sharedZoneAbsent)
+        return Self.resolveMembership(
+          .zoneListSucceededWithoutPolicyZone(
+            ownerUserRecordName: userRecordID.recordName))
       }
       policyZoneID = matchingZone.zoneID
     } catch {
@@ -114,14 +120,21 @@ final class StartupRecoveryCloudService: @unchecked Sendable {  // SAFETY: Immut
       return Self.resolveMembership(.sharedZoneIndeterminate)
     }
 
-    let observation = await fetchMembershipObservation(
+    var observation = await fetchMembershipObservation(
       in: policyZoneID,
       userRecordName: userRecordID.recordName,
       database: database)
+    if observation == .recordZoneMissing {
+      observation = await recheckPolicyZoneAfterMissingFetch(
+        ownerUserRecordName: userRecordID.recordName,
+        database: database)
+    }
     return Self.resolveMembership(observation)
   }
 
-  func fetchSyncedProfileCount() async -> StartupRecoveryProfileCountResult {
+  func fetchSyncedProfileCount(
+    expectedOwnerUserRecordName: String
+  ) async -> StartupRecoveryProfileCountResult {
     do {
       guard try await container.accountStatus() == .available else {
         return .indeterminate
@@ -129,6 +142,19 @@ final class StartupRecoveryCloudService: @unchecked Sendable {  // SAFETY: Immut
     } catch {
       Log.error(
         "Startup recovery could not determine the profile account state: \(redactedErrorForLog(error))",
+        category: .cloudKit)
+      return .indeterminate
+    }
+
+    do {
+      guard
+        try await container.userRecordID().recordName == expectedOwnerUserRecordName
+      else {
+        return .indeterminate
+      }
+    } catch {
+      Log.error(
+        "Startup recovery could not verify the profile account: \(redactedErrorForLog(error))",
         category: .cloudKit)
       return .indeterminate
     }
@@ -165,15 +191,52 @@ final class StartupRecoveryCloudService: @unchecked Sendable {  // SAFETY: Immut
       }
     }
 
-    let outcome = await withCheckedContinuation { continuation in
+    var outcome = await withCheckedContinuation { continuation in
       operation.fetchRecordZoneChangesResultBlock = { result in
         continuation.resume(returning: accumulator.outcome(for: result))
       }
       container.privateCloudDatabase.add(operation)
     }
 
+    if outcome == .zoneFetchReportedMissing {
+      do {
+        let zones = try await container.privateCloudDatabase.allRecordZones()
+        if !zones.contains(where: { $0.zoneID.zoneName == CloudKitConstants.syncZoneName }) {
+          outcome = .zoneListSucceededWithoutSyncZone
+        } else {
+          outcome = .indeterminate
+        }
+      } catch {
+        Log.error(
+          "Startup recovery could not recheck the profile zone: \(redactedErrorForLog(error))",
+          category: .cloudKit)
+        outcome = .indeterminate
+      }
+    }
+
     let snapshot = accumulator.foldSnapshot()
     return Self.resolveProfileCount(fold: snapshot, outcome: outcome)
+  }
+
+  private func recheckPolicyZoneAfterMissingFetch(
+    ownerUserRecordName: String,
+    database: CKDatabase
+  ) async -> StartupRecoveryMembershipObservation {
+    do {
+      let zones = try await database.allRecordZones()
+      guard
+        zones.contains(where: { $0.zoneID.zoneName == CloudKitConstants.policyZoneName })
+      else {
+        return .zoneListSucceededWithoutPolicyZone(
+          ownerUserRecordName: ownerUserRecordName)
+      }
+      return .recordFetchFailed
+    } catch {
+      Log.error(
+        "Startup recovery could not recheck the shared family zone: \(redactedErrorForLog(error))",
+        category: .cloudKit)
+      return .sharedZoneIndeterminate
+    }
   }
 
   private func fetchMembershipObservation(
@@ -275,13 +338,15 @@ private final class MembershipFetchAccumulator: @unchecked Sendable {  // SAFETY
     for operationResult: Result<Void, Error>
   ) -> StartupRecoveryMembershipObservation {
     lock.withLock {
-      if zoneWasRemoved { return .sharedZoneAbsent }
-      if fetchFailed { return .recordFailed }
+      if zoneWasRemoved { return .recordZoneMissing }
+      if fetchFailed { return .recordFetchFailed }
       if case .failure(let error) = operationResult {
-        return startupRecoveryIsMissingZone(error) ? .sharedZoneAbsent : .recordFailed
+        return startupRecoveryIsMissingZone(error) ? .recordZoneMissing : .recordFetchFailed
       }
-      guard let roleValue else { return .recordAbsent }
-      return .recordRole(roleValue)
+      guard let roleValue else {
+        return .recordAbsent(ownerUserRecordName: userRecordName)
+      }
+      return .recordRole(role: roleValue, ownerUserRecordName: userRecordName)
     }
   }
 }
@@ -312,7 +377,8 @@ private final class ProfileFetchAccumulator: @unchecked Sendable {  // SAFETY: N
 
   func recordZoneFailure(_ error: Error) {
     lock.withLock {
-      zoneFailureOutcome = startupRecoveryIsMissingZone(error) ? .zoneMissing : .indeterminate
+      zoneFailureOutcome =
+        startupRecoveryIsMissingZone(error) ? .zoneFetchReportedMissing : .indeterminate
     }
   }
 
@@ -324,7 +390,7 @@ private final class ProfileFetchAccumulator: @unchecked Sendable {  // SAFETY: N
       case .success:
         return .success
       case .failure(let error):
-        return startupRecoveryIsMissingZone(error) ? .zoneMissing : .indeterminate
+        return startupRecoveryIsMissingZone(error) ? .zoneFetchReportedMissing : .indeterminate
       }
     }
   }

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -792,6 +792,8 @@ func applyAcceptedFamilyMode(
 /// Called from confirmation alert "Continue" — accepts share and sets up role
 func completeShareAcceptance(metadata: CKShare.Metadata, role: FamilyRole) {
   Task { @MainActor in
+    StartupRecoveryRuntime.shared.beginShareAcceptance()
+
     // 1. Accept CloudKit share (no auth gate)
     do {
       try await CloudKitManager.shared.acceptShareDirect(metadata: metadata)
@@ -801,11 +803,13 @@ func completeShareAcceptance(metadata: CKShare.Metadata, role: FamilyRole) {
       CloudKitManager.shared.shareAcceptanceIsError = true
       CloudKitManager.shared.shareAcceptedMessage =
         "Failed to accept invitation: \(error.localizedDescription)"
+      StartupRecoveryRuntime.shared.failShareAcceptance()
       return
     }
 
     // 2. Switch app mode immediately after successful share acceptance
     let appMode = applyAcceptedFamilyMode(role: role)
+    StartupRecoveryRuntime.shared.completeShareAcceptanceAfterModeApplied()
 
     // 3. Best-effort: register self as family member
     do {

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -201,6 +201,26 @@ struct FoqosApp: App {
         } message: {
           Text(cloudKitManager.familyRevocationMessage ?? "")
         }
+        .alert(
+          StartupRecoveryCopy.roleRestoredTitle,
+          isPresented: Binding(
+            get: {
+              if case .roleRestored = startupRecoveryCoordinator.state { return true }
+              return false
+            },
+            set: { isPresented in
+              if !isPresented {
+                startupRecoveryCoordinator.dismissRoleRestoredNotice()
+              }
+            }
+          )
+        ) {
+          Button("OK") {
+            startupRecoveryCoordinator.dismissRoleRestoredNotice()
+          }
+        } message: {
+          Text(StartupRecoveryCopy.roleRestoredMessage)
+        }
         // Share acceptance result alert (success or error)
         .alert(
           cloudKitManager.shareAcceptanceIsError ? "Unable to Join Family" : shareAcceptanceTitle,
@@ -298,7 +318,7 @@ struct FoqosApp: App {
         .task {
           let classification =
             isRunningUnitTests || ScreenshotDemoMode.isActive
-            ? StartupRecoveryLocalClassification.existing
+            ? StartupRecoveryLocalClassification.localStatePresent
             : StartupRecoveryLocalState.classify(startupRecoverySnapshot)
           await startupRecoveryCoordinator.start(classification: classification)
           handleRecoveryState(startupRecoveryCoordinator.state)

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -35,15 +35,7 @@ private func redactedURLString(_ url: URL) -> String {
 
 private let container: ModelContainer = {
   do {
-    // Configure SwiftData to use local storage only (not CloudKit sync)
-    // We handle CloudKit manually for FamilyPolicy via CloudKitManager
-    let schema = Schema([BlockedProfileSession.self, BlockedProfiles.self, SavedLocation.self])
-    let modelConfiguration = ModelConfiguration(
-      schema: schema,
-      isStoredInMemoryOnly: ScreenshotDemoMode.isActive,
-      cloudKitDatabase: .none  // Disable automatic CloudKit sync for these models
-    )
-    return try ModelContainer(for: schema, configurations: [modelConfiguration])
+    return try AppModelStore.makeContainer()
   } catch {
     fatalError("Couldn't create ModelContainer: \(error)")
   }

--- a/Foqos/FoqosApp.swift
+++ b/Foqos/FoqosApp.swift
@@ -61,6 +61,9 @@ class PendingShareAcceptance: ObservableObject {
 
 @main
 struct FoqosApp: App {
+  private let startupRecoverySnapshot = StartupRecoveryLocalState.capture()
+  @StateObject private var startupRecoveryRuntime = StartupRecoveryRuntime.shared
+  @StateObject private var startupRecoveryCoordinator: StartupRecoveryCoordinator
   @StateObject private var requestAuthorizer = RequestAuthorizer()
   @StateObject private var navigationManager = NavigationManager.shared
   @StateObject private var nfcWriter = NFCWriter()
@@ -80,6 +83,7 @@ struct FoqosApp: App {
 
   // Device sync for same-user multi-device sync
   @StateObject private var profileSyncManager = ProfileSyncManager.shared
+  @StateObject private var startupRecoveryReachability = NetworkReachabilityMonitor()
 
   /// Sync upgrade notice (shown when legacy session records are cleaned up)
   @State private var showSyncUpgradeAlert = false
@@ -93,6 +97,32 @@ struct FoqosApp: App {
   @Environment(\.scenePhase) private var scenePhase
 
   init() {
+    let cloudService = StartupRecoveryCloudService()
+    let recoveryDefaults =
+      isRunningUnitTests || ScreenshotDemoMode.isActive
+      ? UserDefaults(suiteName: "StartupRecoveryBypass-\(UUID().uuidString)")!
+      : UserDefaults.standard
+    let recoveryCoordinator = StartupRecoveryCoordinator(
+      store: StartupRecoveryStore(defaults: recoveryDefaults),
+      captureLocalClassification: {
+        StartupRecoveryLocalState.classify(StartupRecoveryLocalState.capture())
+      },
+      captureOrigin: captureStartupRecoveryOrigin,
+      restoreOrigin: restoreStartupRecoveryOrigin,
+      lookupMembership: { await cloudService.lookupMembership() },
+      lookupSyncedProfileCount: { ownerUserRecordName in
+        await cloudService.fetchSyncedProfileCount(
+          expectedOwnerUserRecordName: ownerUserRecordName)
+      },
+      restoreFamilyRole: restoreRecoveredFamilyRole,
+      refreshChildLockCodes: {
+        _ = await LockCodeManager.shared.refreshSharedLockCodesForVerification()
+      },
+      setSyncEnabled: { ProfileSyncManager.shared.isEnabled = $0 },
+      releaseStartup: { StartupRecoveryRuntime.shared.release() })
+    _startupRecoveryCoordinator = StateObject(wrappedValue: recoveryCoordinator)
+    StartupRecoveryRuntime.shared.register(coordinator: recoveryCoordinator)
+
     // Migrate UserDefaults keys BEFORE any @AppStorage reads.
     // Must run here (not in .onAppear) because SwiftUI reads @AppStorage
     // when building the view hierarchy, which happens before .onAppear fires.
@@ -134,42 +164,13 @@ struct FoqosApp: App {
         }
         .onChange(of: scenePhase) { oldPhase, newPhase in
           Log.debug("scenePhase changed", category: .app)
+          guard !startupRecoveryRuntime.isHeld else {
+            return
+          }
           let shouldRefreshSchedules = scheduleRefreshState.shouldRefresh(for: newPhase)
-          if newPhase == .active {
-            if !ScreenshotDemoMode.isActive {
-              Task {
-                // Determine iCloud sign-in status (independent of family sharing)
-                await CloudKitManager.shared.checkAccountStatus()
-                // Enforce CloudKit FamilyMember role as local app mode (must complete before auth check)
-                await CloudKitManager.shared.verifySelfFamilyMemberRecord()
-                // Verify child authorization when app becomes active
-                await verifyChildAuthorizationIfNeeded()
-                if AppModeManager.shared.currentMode == .child {
-                  do {
-                    try await CloudKitManager.shared.ensureSharedDatabaseSubscription()
-                  } catch {
-                    Log.error(
-                      "Failed to establish shared database subscription: \(redactedErrorForLog(error))",
-                      category: .cloudKit)
-                  }
-                  await LockCodeManager.shared.refreshSharedLockCodesForVerification()
-                }
-              }
-              // #201: re-drive persisted session-stop retries so a remote device doesn't see a
-              // stopped session as perpetually active
-              Task { await StrategyManager.shared.drainSessionStopOutbox() }
-              // #200: pull/push on foreground instead of the deleted notification throttle
-              if profileSyncManager.isEnabled {
-                do {
-                  try profileSyncManager.syncNow()
-                } catch {
-                  Log.warning("syncNow skipped: \(error.localizedDescription)", category: .sync)
-                }
-              }
-            }
-            if shouldRefreshSchedules && !ScreenshotDemoMode.isActive {
-              reconcileSchedulesForCurrentState()
-            }
+          guard newPhase == .active else { return }
+          Task {
+            await handleActiveScene(shouldRefreshSchedules: shouldRefreshSchedules)
           }
         }
         .onOpenURL { url in
@@ -294,25 +295,25 @@ struct FoqosApp: App {
         .environmentObject(appModeManager)
         .environmentObject(cloudKitManager)
         .environmentObject(profileSyncManager)
+        .task {
+          let classification =
+            isRunningUnitTests || ScreenshotDemoMode.isActive
+            ? StartupRecoveryLocalClassification.existing
+            : StartupRecoveryLocalState.classify(startupRecoverySnapshot)
+          await startupRecoveryCoordinator.start(classification: classification)
+          handleRecoveryState(startupRecoveryCoordinator.state)
+        }
+        .onChange(of: startupRecoveryCoordinator.state) { _, state in
+          handleRecoveryState(state)
+        }
+        .onChange(of: startupRecoveryReachability.isOnline) { wasOnline, isOnline in
+          guard !wasOnline, isOnline else { return }
+          Task {
+            await startupRecoveryCoordinator.recheckIfNeeded()
+          }
+        }
         .onAppear {
-          let shouldPerformInitialRefresh = scheduleRefreshState.shouldPerformInitialRefresh()
-          if shouldPerformInitialRefresh {
-            // Migration must precede the single coalesced cold-launch refresh.
-            ProfileMigrationUtil.migrateProfilesIfNeeded(context: container.mainContext)
-          }
-          // Construct + wire the sync engine with the live ModelContext (I10).
-          // Skipped under the XCTest host so hosted unit tests own `attachEngine`'s
-          // one-shot idempotency guard themselves.
-          if !isRunningUnitTests && !ScreenshotDemoMode.isActive {
-            Task {
-              await profileSyncManager.attachEngine(
-                modelContext: container.mainContext,
-                emergencyManager: emergencyManager)
-            }
-          }
-          if shouldPerformInitialRefresh && !ScreenshotDemoMode.isActive {
-            reconcileSchedulesForCurrentState()
-          }
+          handleRecoveryState(startupRecoveryCoordinator.state)
         }
     }
     .handlesExternalEvents(matching: ["*"])  // Handle all external events including CloudKit shares
@@ -320,11 +321,84 @@ struct FoqosApp: App {
   }
 
   /// Root view that routes based on app mode
+  @ViewBuilder
   private var rootView: some View {
-    // All modes use HomeView as the default landing page
-    // Parent dashboard is accessible from settings (parent mode)
-    // Child parental controls info is accessible from settings (child mode)
-    HomeView()
+    if !startupRecoveryRuntime.isHeld {
+      // All modes use HomeView as the default landing page.
+      HomeView()
+    } else {
+      StartupRecoveryView(coordinator: startupRecoveryCoordinator)
+    }
+  }
+
+  private func handleRecoveryState(_ state: StartupRecoveryState) {
+    if case .normal(let recheckArmed) = state, recheckArmed {
+      startupRecoveryReachability.start()
+    } else {
+      startupRecoveryReachability.stop()
+    }
+
+    guard !startupRecoveryRuntime.isHeld else { return }
+
+    let shouldPerformInitialRefresh = scheduleRefreshState.shouldPerformInitialRefresh()
+    if shouldPerformInitialRefresh {
+      ProfileMigrationUtil.migrateProfilesIfNeeded(context: container.mainContext)
+    }
+    // Construct + wire the sync engine only after recovery releases startup (I10).
+    // Hosted unit tests own the one-shot idempotency guard themselves.
+    if !isRunningUnitTests && !ScreenshotDemoMode.isActive {
+      Task {
+        await profileSyncManager.attachEngine(
+          modelContext: container.mainContext,
+          emergencyManager: emergencyManager)
+      }
+    }
+    if shouldPerformInitialRefresh && !ScreenshotDemoMode.isActive {
+      reconcileSchedulesForCurrentState()
+    }
+    if scenePhase == .active {
+      Task { await handleActiveScene(shouldRefreshSchedules: false) }
+    }
+  }
+
+  @MainActor
+  private func handleActiveScene(shouldRefreshSchedules: Bool) async {
+    guard !startupRecoveryRuntime.isHeld else { return }
+    if case .normal(let recheckArmed) = startupRecoveryCoordinator.state, recheckArmed {
+      await startupRecoveryCoordinator.recheckIfNeeded()
+      guard !startupRecoveryRuntime.isHeld else { return }
+    }
+
+    if !ScreenshotDemoMode.isActive {
+      await CloudKitManager.shared.checkAccountStatus()
+      await CloudKitManager.shared.verifySelfFamilyMemberRecord()
+      await verifyChildAuthorizationIfNeeded()
+      if AppModeManager.shared.currentMode == .child {
+        do {
+          try await CloudKitManager.shared.ensureSharedDatabaseSubscription()
+        } catch {
+          Log.error(
+            "Failed to establish shared database subscription: \(redactedErrorForLog(error))",
+            category: .cloudKit)
+        }
+        await LockCodeManager.shared.refreshSharedLockCodesForVerification()
+      }
+
+      // #201: re-drive persisted session-stop retries so a remote device doesn't see a
+      // stopped session as perpetually active.
+      await StrategyManager.shared.drainSessionStopOutbox()
+      // #200: pull/push on foreground instead of the deleted notification throttle.
+      if profileSyncManager.isEnabled {
+        do {
+          try profileSyncManager.syncNow()
+        } catch {
+          Log.warning("syncNow skipped: \(error.localizedDescription)", category: .sync)
+        }
+      }
+    }
+    if shouldRefreshSchedules && !ScreenshotDemoMode.isActive {
+      reconcileSchedulesForCurrentState()
+    }
   }
 
   private func reconcileSchedulesForCurrentState() {
@@ -377,6 +451,83 @@ struct FoqosApp: App {
     // Handle as universal link for our app
     navigationManager.handleLink(url)
   }
+}
+
+@MainActor
+private func captureStartupRecoveryOrigin() -> StartupRecoveryOriginState {
+  let defaults = UserDefaults.standard
+  return StartupRecoveryOriginState(
+    modeRawValue: defaults.string(forKey: "family_foqos_app_mode"),
+    hasSelectedMode: optionalBool(
+      in: defaults,
+      forKey: "family_foqos_has_selected_mode"),
+    onboardingCompleted: optionalBool(
+      in: defaults,
+      forKey: "family_foqos_has_completed_onboarding"),
+    showIntro: optionalBool(
+      in: defaults,
+      forKey: "family_foqos_show_intro_screen"),
+    showModeSelection: optionalBool(
+      in: defaults,
+      forKey: "family_foqos_show_mode_selection"),
+    deviceSyncEnabled: ProfileSyncManager.shared.isEnabled)
+}
+
+@MainActor
+private func restoreStartupRecoveryOrigin(_ origin: StartupRecoveryOriginState) {
+  let defaults = UserDefaults.standard
+  let appModeManager = AppModeManager.shared
+
+  if let rawValue = origin.modeRawValue, let mode = AppMode(rawValue: rawValue) {
+    appModeManager.currentMode = mode
+  } else {
+    appModeManager.currentMode = .individual
+    defaults.removeObject(forKey: "family_foqos_app_mode")
+  }
+
+  appModeManager.hasSelectedMode = origin.hasSelectedMode ?? false
+  restoreOptionalBool(
+    origin.hasSelectedMode,
+    in: defaults,
+    forKey: "family_foqos_has_selected_mode")
+  restoreOptionalBool(
+    origin.onboardingCompleted,
+    in: defaults,
+    forKey: "family_foqos_has_completed_onboarding")
+  restoreOptionalBool(
+    origin.showIntro,
+    in: defaults,
+    forKey: "family_foqos_show_intro_screen")
+  restoreOptionalBool(
+    origin.showModeSelection,
+    in: defaults,
+    forKey: "family_foqos_show_mode_selection")
+  ProfileSyncManager.shared.isEnabled = origin.deviceSyncEnabled ?? false
+}
+
+private func optionalBool(in defaults: UserDefaults, forKey key: String) -> Bool? {
+  guard defaults.object(forKey: key) != nil else { return nil }
+  return defaults.bool(forKey: key)
+}
+
+private func restoreOptionalBool(
+  _ value: Bool?,
+  in defaults: UserDefaults,
+  forKey key: String
+) {
+  guard let value else {
+    defaults.removeObject(forKey: key)
+    return
+  }
+  defaults.set(value, forKey: key)
+}
+
+@MainActor
+private func restoreRecoveredFamilyRole(_ role: FamilyRole) {
+  AppModeManager.shared.selectMode(role == .parent ? .parent : .child)
+  UserDefaults.standard.set(true, forKey: "family_foqos_has_completed_onboarding")
+  UserDefaults.standard.set(false, forKey: "family_foqos_show_intro_screen")
+  UserDefaults.standard.set(false, forKey: "family_foqos_show_mode_selection")
 }
 
 // MARK: - App Delegate for CloudKit Share Handling
@@ -448,51 +599,58 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
   ) {
     Log.info("Received remote notification", category: .cloudKit)
-
-    // Check if this is a CloudKit notification
-    if let ckNotification = CKNotification(fromRemoteNotificationDictionary: userInfo) {
-      Log.info("CloudKit notification received - type: \(ckNotification.notificationType.rawValue)", category: .cloudKit)
-
-      let databaseScope = (ckNotification as? CKDatabaseNotification)?.databaseScope
-      let shouldRefreshChildSharedData = Self.shouldRefreshChildSharedData(
-        databaseScope: databaseScope,
-        mode: AppModeManager.shared.currentMode)
-
-      // Route the CloudKit push to the engine (schedules a fetch+send); the engine
-      // also owns its own database subscription. Preserve heartbeat refresh (#190).
-      Task { @MainActor in
-        let childRefreshResult: UIBackgroundFetchResult?
-        if shouldRefreshChildSharedData {
-          childRefreshResult =
-            await Self.refreshChildSharedDataAfterMembershipVerification(
-              refreshAccountStatus: {
-                await CloudKitManager.shared.checkAccountStatus()
-              },
-              verifyMembership: {
-                await CloudKitManager.shared.verifySelfFamilyMemberRecord()
-              },
-              refreshSharedData: {
-                await LockCodeManager.shared.refreshSharedLockCodesForVerification()
-              }
-            )
-            .backgroundFetchResult
-        } else {
-          childRefreshResult = nil
-        }
-        if ProfileSyncManager.shared.isEnabled {
-          do {
-            try ProfileSyncManager.shared.syncNow()
-          } catch {
-            Log.warning("syncNow skipped: \(error.localizedDescription)", category: .sync)
+    Task { @MainActor in
+      await StartupRecoveryPushRouter.route(
+        isHeld: StartupRecoveryRuntime.shared.isHeld,
+        onHeld: { completionHandler(.noData) },
+        onReleased: {
+          // Check if this is a CloudKit notification only after recovery releases startup.
+          guard let ckNotification = CKNotification(fromRemoteNotificationDictionary: userInfo)
+          else {
+            completionHandler(.noData)
+            return
           }
-        }
-        if AppModeManager.shared.currentMode == .parent {
-          await HeartbeatManager.shared.refreshHeartbeats()
-        }
-        completionHandler(childRefreshResult ?? .newData)
-      }
-    } else {
-      completionHandler(.noData)
+          Log.info(
+            "CloudKit notification received - type: \(ckNotification.notificationType.rawValue)",
+            category: .cloudKit)
+
+          let databaseScope = (ckNotification as? CKDatabaseNotification)?.databaseScope
+          let shouldRefreshChildSharedData = Self.shouldRefreshChildSharedData(
+            databaseScope: databaseScope,
+            mode: AppModeManager.shared.currentMode)
+
+          // Route the CloudKit push to the engine (schedules a fetch+send); the engine
+          // also owns its own database subscription. Preserve heartbeat refresh (#190).
+          let childRefreshResult: UIBackgroundFetchResult?
+          if shouldRefreshChildSharedData {
+            childRefreshResult =
+              await Self.refreshChildSharedDataAfterMembershipVerification(
+                refreshAccountStatus: {
+                  await CloudKitManager.shared.checkAccountStatus()
+                },
+                verifyMembership: {
+                  await CloudKitManager.shared.verifySelfFamilyMemberRecord()
+                },
+                refreshSharedData: {
+                  await LockCodeManager.shared.refreshSharedLockCodesForVerification()
+                }
+              )
+              .backgroundFetchResult
+          } else {
+            childRefreshResult = nil
+          }
+          if ProfileSyncManager.shared.isEnabled {
+            do {
+              try ProfileSyncManager.shared.syncNow()
+            } catch {
+              Log.warning("syncNow skipped: \(error.localizedDescription)", category: .sync)
+            }
+          }
+          if AppModeManager.shared.currentMode == .parent {
+            await HeartbeatManager.shared.refreshHeartbeats()
+          }
+          completionHandler(childRefreshResult ?? .newData)
+        })
     }
   }
 }

--- a/Foqos/Utils/AppModelStore.swift
+++ b/Foqos/Utils/AppModelStore.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftData
+
+enum AppModelStore {
+  static var schema: Schema {
+    Schema([BlockedProfileSession.self, BlockedProfiles.self, SavedLocation.self])
+  }
+
+  static var configuration: ModelConfiguration {
+    ModelConfiguration(
+      schema: schema,
+      isStoredInMemoryOnly: ScreenshotDemoMode.isActive,
+      cloudKitDatabase: .none)
+  }
+
+  static var storeURL: URL {
+    configuration.url
+  }
+
+  static func makeConfiguration(url: URL) -> ModelConfiguration {
+    ModelConfiguration(schema: schema, url: url, cloudKitDatabase: .none)
+  }
+
+  static func makeContainer() throws -> ModelContainer {
+    let schema = schema
+    return try ModelContainer(for: schema, configurations: [configuration])
+  }
+}

--- a/Foqos/Utils/StartupRecoveryCoordinator.swift
+++ b/Foqos/Utils/StartupRecoveryCoordinator.swift
@@ -12,10 +12,27 @@ enum StartupRecoveryProfileCountResult: Equatable {
   case indeterminate
 }
 
+enum StartupRecoveryPath: String, Codable {
+  case freshMember
+  case localStatePresentMember
+}
+
+struct StartupRecoveryOriginState: Codable, Equatable {
+  let modeRawValue: String?
+  let hasSelectedMode: Bool?
+  let onboardingCompleted: Bool?
+  let showIntro: Bool?
+  let showModeSelection: Bool?
+  let deviceSyncEnabled: Bool?
+}
+
 struct StartupRecoveryPendingOffer: Codable, Equatable {
   let ownerUserRecordName: String
   let role: FamilyRole
-  let profileCount: Int?
+  let path: StartupRecoveryPath
+  let profileCountHint: Int?
+  let profileCountConfirmedAt: Date?
+  let origin: StartupRecoveryOriginState
 }
 
 struct StartupRecoveryStore {
@@ -61,6 +78,7 @@ enum StartupRecoveryState: Equatable {
   case normal(recheckArmed: Bool)
   case checkingProfiles(role: FamilyRole)
   case offer(role: FamilyRole, profileCount: Int)
+  case roleRestored(role: FamilyRole)
 }
 
 @MainActor
@@ -68,6 +86,9 @@ final class StartupRecoveryCoordinator: ObservableObject {
   @Published private(set) var state = StartupRecoveryState.checking
 
   private let store: StartupRecoveryStore
+  private let captureLocalClassification: () -> StartupRecoveryLocalClassification
+  private let captureOrigin: () -> StartupRecoveryOriginState
+  private let restoreOrigin: (StartupRecoveryOriginState) -> Void
   private let lookupMembership: () async -> StartupRecoveryMembershipResult
   private let lookupSyncedProfileCount: (String) async -> StartupRecoveryProfileCountResult
   private let restoreFamilyRole: (FamilyRole) -> Void
@@ -75,9 +96,23 @@ final class StartupRecoveryCoordinator: ObservableObject {
   private let setSyncEnabled: (Bool) -> Void
   private let releaseStartup: () -> Void
   private var didReleaseStartup = false
+  private var membershipClassification = StartupRecoveryLocalClassification.fresh
+  private var inFlightTask: Task<Void, Never>?
+  private var inFlightID = 0
 
   init(
     store: StartupRecoveryStore,
+    captureLocalClassification: @escaping () -> StartupRecoveryLocalClassification = { .fresh },
+    captureOrigin: @escaping () -> StartupRecoveryOriginState = {
+      StartupRecoveryOriginState(
+        modeRawValue: nil,
+        hasSelectedMode: nil,
+        onboardingCompleted: nil,
+        showIntro: nil,
+        showModeSelection: nil,
+        deviceSyncEnabled: nil)
+    },
+    restoreOrigin: @escaping (StartupRecoveryOriginState) -> Void = { _ in },
     lookupMembership: @escaping () async -> StartupRecoveryMembershipResult,
     lookupSyncedProfileCount: @escaping (String) async -> StartupRecoveryProfileCountResult,
     restoreFamilyRole: @escaping (FamilyRole) -> Void,
@@ -86,6 +121,9 @@ final class StartupRecoveryCoordinator: ObservableObject {
     releaseStartup: @escaping () -> Void
   ) {
     self.store = store
+    self.captureLocalClassification = captureLocalClassification
+    self.captureOrigin = captureOrigin
+    self.restoreOrigin = restoreOrigin
     self.lookupMembership = lookupMembership
     self.lookupSyncedProfileCount = lookupSyncedProfileCount
     self.restoreFamilyRole = restoreFamilyRole
@@ -95,14 +133,16 @@ final class StartupRecoveryCoordinator: ObservableObject {
   }
 
   func start(classification: StartupRecoveryLocalClassification) async {
+    await performSingleFlight { [weak self] in
+      await self?.startWork(classification: classification)
+    }
+  }
+
+  private func startWork(classification: StartupRecoveryLocalClassification) async {
+    membershipClassification = classification
     if let pendingOffer = store.pendingOffer {
-      if let profileCount = pendingOffer.profileCount {
-        state = .offer(role: pendingOffer.role, profileCount: profileCount)
-      } else {
-        await recover(
-          role: pendingOffer.role,
-          ownerUserRecordName: pendingOffer.ownerUserRecordName)
-      }
+      state = .checking
+      await resume(pendingOffer)
       return
     }
 
@@ -115,23 +155,36 @@ final class StartupRecoveryCoordinator: ObservableObject {
     case .existing:
       showNormal(recheckArmed: false)
     case .fresh:
-      await checkMembership(canContinueAfterFailure: false, releasesStartup: true)
+      await checkMembership(
+        classification: classification,
+        canContinueAfterFailure: false,
+        releasesStartup: true)
     case .indeterminate:
       state = .retryMembership(canContinueSetup: false)
     }
   }
 
   func retry() async {
+    await performSingleFlight { [weak self] in
+      await self?.retryWork()
+    }
+  }
+
+  private func retryWork() async {
     switch state {
     case .retryMembership:
       state = .checking
-      await checkMembership(canContinueAfterFailure: true, releasesStartup: true)
-    case .retryProfiles(let role):
-      guard let ownerUserRecordName = store.pendingOffer?.ownerUserRecordName else {
-        state = .retryMembership(canContinueSetup: true)
-        return
+      if let pendingOffer = store.pendingOffer {
+        await resume(pendingOffer)
+      } else {
+        await checkMembership(
+          classification: membershipClassification,
+          canContinueAfterFailure: true,
+          releasesStartup: true)
       }
-      await checkProfiles(for: role, ownerUserRecordName: ownerUserRecordName)
+    case .retryProfiles:
+      guard let pendingOffer = store.pendingOffer else { return }
+      await resume(pendingOffer)
     default:
       break
     }
@@ -144,11 +197,23 @@ final class StartupRecoveryCoordinator: ObservableObject {
   }
 
   func recheckIfNeeded() async {
+    await performSingleFlight { [weak self] in
+      await self?.recheckWorkIfNeeded()
+    }
+  }
+
+  private func recheckWorkIfNeeded() async {
     guard store.recheckPending else { return }
+    let classification = captureLocalClassification()
+    membershipClassification = classification
+    guard classification != .indeterminate else { return }
 
     switch await lookupMembership() {
     case .member(let role, let ownerUserRecordName):
-      await recover(role: role, ownerUserRecordName: ownerUserRecordName)
+      await beginRecovery(
+        role: role,
+        ownerUserRecordName: ownerUserRecordName,
+        classification: classification)
     case .confirmedNone:
       store.clearRecheckPending()
       state = .normal(recheckArmed: false)
@@ -157,26 +222,54 @@ final class StartupRecoveryCoordinator: ObservableObject {
     }
   }
 
-  func restoreProfiles() {
+  func restoreProfiles() async {
+    await performSingleFlight { [weak self] in
+      await self?.restoreProfilesWork()
+    }
+  }
+
+  private func restoreProfilesWork() async {
     guard case .offer(_, let profileCount) = state, profileCount > 0 else { return }
+    guard await validateOffer(expectedProfileCount: profileCount) else { return }
     setSyncEnabled(true)
     completeOffer()
   }
 
-  func declineProfiles() {
+  func declineProfiles() async {
+    await performSingleFlight { [weak self] in
+      await self?.declineProfilesWork()
+    }
+  }
+
+  private func declineProfilesWork() async {
     guard case .offer(_, let profileCount) = state, profileCount > 0 else { return }
+    guard await validateOffer(expectedProfileCount: profileCount) else { return }
     completeOffer()
   }
 
-  func continueWithoutProfiles() {
+  func continueWithoutProfiles() async {
+    await performSingleFlight { [weak self] in
+      await self?.continueWithoutProfilesWork()
+    }
+  }
+
+  private func continueWithoutProfilesWork() async {
     guard case .offer(_, let profileCount) = state, profileCount == 0 else { return }
+    guard await validateOffer(expectedProfileCount: profileCount) else { return }
     completeOffer()
   }
 
-  private func checkMembership(canContinueAfterFailure: Bool, releasesStartup: Bool) async {
+  private func checkMembership(
+    classification: StartupRecoveryLocalClassification,
+    canContinueAfterFailure: Bool,
+    releasesStartup: Bool
+  ) async {
     switch await lookupMembership() {
     case .member(let role, let ownerUserRecordName):
-      await recover(role: role, ownerUserRecordName: ownerUserRecordName)
+      await beginRecovery(
+        role: role,
+        ownerUserRecordName: ownerUserRecordName,
+        classification: classification)
     case .confirmedNone:
       store.clearRecheckPending()
       state = .normal(recheckArmed: false)
@@ -186,32 +279,141 @@ final class StartupRecoveryCoordinator: ObservableObject {
     }
   }
 
-  private func recover(role: FamilyRole, ownerUserRecordName: String) async {
-    store.pendingOffer = StartupRecoveryPendingOffer(
+  private func beginRecovery(
+    role: FamilyRole,
+    ownerUserRecordName: String,
+    classification: StartupRecoveryLocalClassification
+  ) async {
+    let path: StartupRecoveryPath
+    switch classification {
+    case .fresh:
+      path = .freshMember
+    case .existing:
+      path = .localStatePresentMember
+    case .indeterminate:
+      state = .retryMembership(canContinueSetup: true)
+      return
+    }
+
+    let pendingOffer = StartupRecoveryPendingOffer(
       ownerUserRecordName: ownerUserRecordName,
       role: role,
-      profileCount: nil)
+      path: path,
+      profileCountHint: nil,
+      profileCountConfirmedAt: nil,
+      origin: captureOrigin())
+    store.pendingOffer = pendingOffer
     store.clearRecheckPending()
     restoreFamilyRole(role)
     if role == .child {
       await refreshChildLockCodes()
     }
-    await checkProfiles(for: role, ownerUserRecordName: ownerUserRecordName)
+    switch path {
+    case .freshMember:
+      await checkProfiles(for: pendingOffer)
+    case .localStatePresentMember:
+      setSyncEnabled(false)
+      state = .roleRestored(role: role)
+      releaseStartupIfNeeded()
+    }
   }
 
-  private func checkProfiles(for role: FamilyRole, ownerUserRecordName: String) async {
-    state = .checkingProfiles(role: role)
-    switch await lookupSyncedProfileCount(ownerUserRecordName) {
+  private func resume(_ pendingOffer: StartupRecoveryPendingOffer) async {
+    switch await lookupMembership() {
+    case .member(let role, let ownerUserRecordName):
+      guard ownerUserRecordName == pendingOffer.ownerUserRecordName, role == pendingOffer.role else {
+        rollback(pendingOffer)
+        await beginRecovery(
+          role: role,
+          ownerUserRecordName: ownerUserRecordName,
+          classification: captureLocalClassification())
+        return
+      }
+      switch pendingOffer.path {
+      case .freshMember:
+        await checkProfiles(for: pendingOffer)
+      case .localStatePresentMember:
+        setSyncEnabled(false)
+        state = .roleRestored(role: role)
+        releaseStartupIfNeeded()
+      }
+    case .confirmedNone:
+      rollback(pendingOffer)
+      showNormal(recheckArmed: false)
+    case .indeterminate:
+      state = .retryMembership(canContinueSetup: true)
+    }
+  }
+
+  private func checkProfiles(for pendingOffer: StartupRecoveryPendingOffer) async {
+    state = .checkingProfiles(role: pendingOffer.role)
+    switch await lookupSyncedProfileCount(pendingOffer.ownerUserRecordName) {
     case .confirmed(let profileCount):
       let confirmedCount = max(profileCount, 0)
       store.pendingOffer = StartupRecoveryPendingOffer(
-        ownerUserRecordName: ownerUserRecordName,
-        role: role,
-        profileCount: confirmedCount)
-      state = .offer(role: role, profileCount: confirmedCount)
+        ownerUserRecordName: pendingOffer.ownerUserRecordName,
+        role: pendingOffer.role,
+        path: pendingOffer.path,
+        profileCountHint: confirmedCount,
+        profileCountConfirmedAt: Date(),
+        origin: pendingOffer.origin)
+      state = .offer(role: pendingOffer.role, profileCount: confirmedCount)
     case .indeterminate:
-      state = .retryProfiles(role: role)
+      state = .retryProfiles(role: pendingOffer.role)
     }
+  }
+
+  private func validateOffer(expectedProfileCount: Int) async -> Bool {
+    guard let pendingOffer = store.pendingOffer, pendingOffer.path == .freshMember else {
+      return false
+    }
+    state = .checkingProfiles(role: pendingOffer.role)
+
+    switch await lookupMembership() {
+    case .member(let role, let ownerUserRecordName):
+      guard ownerUserRecordName == pendingOffer.ownerUserRecordName, role == pendingOffer.role else {
+        rollback(pendingOffer)
+        await beginRecovery(
+          role: role,
+          ownerUserRecordName: ownerUserRecordName,
+          classification: captureLocalClassification())
+        return false
+      }
+    case .confirmedNone:
+      rollback(pendingOffer)
+      showNormal(recheckArmed: false)
+      return false
+    case .indeterminate:
+      state = .retryProfiles(role: pendingOffer.role)
+      return false
+    }
+
+    switch await lookupSyncedProfileCount(pendingOffer.ownerUserRecordName) {
+    case .confirmed(let count):
+      let confirmedCount = max(count, 0)
+      let refreshedOffer = StartupRecoveryPendingOffer(
+        ownerUserRecordName: pendingOffer.ownerUserRecordName,
+        role: pendingOffer.role,
+        path: pendingOffer.path,
+        profileCountHint: confirmedCount,
+        profileCountConfirmedAt: Date(),
+        origin: pendingOffer.origin)
+      store.pendingOffer = refreshedOffer
+      if confirmedCount != expectedProfileCount {
+        state = .offer(role: pendingOffer.role, profileCount: confirmedCount)
+        return false
+      }
+      return true
+    case .indeterminate:
+      state = .retryProfiles(role: pendingOffer.role)
+      return false
+    }
+  }
+
+  private func rollback(_ pendingOffer: StartupRecoveryPendingOffer) {
+    restoreOrigin(pendingOffer.origin)
+    store.pendingOffer = nil
+    store.clearRecheckPending()
   }
 
   private func completeOffer() {
@@ -228,5 +430,25 @@ final class StartupRecoveryCoordinator: ObservableObject {
     guard !didReleaseStartup else { return }
     didReleaseStartup = true
     releaseStartup()
+  }
+
+  private func performSingleFlight(
+    _ operation: @escaping @MainActor () async -> Void
+  ) async {
+    if let inFlightTask {
+      await inFlightTask.value
+      return
+    }
+
+    inFlightID += 1
+    let operationID = inFlightID
+    let task = Task { @MainActor in
+      await operation()
+    }
+    inFlightTask = task
+    await task.value
+    if inFlightID == operationID {
+      inFlightTask = nil
+    }
   }
 }

--- a/Foqos/Utils/StartupRecoveryCoordinator.swift
+++ b/Foqos/Utils/StartupRecoveryCoordinator.swift
@@ -2,8 +2,8 @@ import Combine
 import Foundation
 
 enum StartupRecoveryMembershipResult: Equatable {
-  case member(FamilyRole)
-  case confirmedNone
+  case member(role: FamilyRole, ownerUserRecordName: String)
+  case confirmedNone(ownerUserRecordName: String)
   case indeterminate
 }
 
@@ -13,6 +13,7 @@ enum StartupRecoveryProfileCountResult: Equatable {
 }
 
 struct StartupRecoveryPendingOffer: Codable, Equatable {
+  let ownerUserRecordName: String
   let role: FamilyRole
   let profileCount: Int?
 }
@@ -68,7 +69,7 @@ final class StartupRecoveryCoordinator: ObservableObject {
 
   private let store: StartupRecoveryStore
   private let lookupMembership: () async -> StartupRecoveryMembershipResult
-  private let lookupSyncedProfileCount: () async -> StartupRecoveryProfileCountResult
+  private let lookupSyncedProfileCount: (String) async -> StartupRecoveryProfileCountResult
   private let restoreFamilyRole: (FamilyRole) -> Void
   private let refreshChildLockCodes: () async -> Void
   private let setSyncEnabled: (Bool) -> Void
@@ -78,7 +79,7 @@ final class StartupRecoveryCoordinator: ObservableObject {
   init(
     store: StartupRecoveryStore,
     lookupMembership: @escaping () async -> StartupRecoveryMembershipResult,
-    lookupSyncedProfileCount: @escaping () async -> StartupRecoveryProfileCountResult,
+    lookupSyncedProfileCount: @escaping (String) async -> StartupRecoveryProfileCountResult,
     restoreFamilyRole: @escaping (FamilyRole) -> Void,
     refreshChildLockCodes: @escaping () async -> Void,
     setSyncEnabled: @escaping (Bool) -> Void,
@@ -98,7 +99,9 @@ final class StartupRecoveryCoordinator: ObservableObject {
       if let profileCount = pendingOffer.profileCount {
         state = .offer(role: pendingOffer.role, profileCount: profileCount)
       } else {
-        await recover(role: pendingOffer.role)
+        await recover(
+          role: pendingOffer.role,
+          ownerUserRecordName: pendingOffer.ownerUserRecordName)
       }
       return
     }
@@ -124,7 +127,11 @@ final class StartupRecoveryCoordinator: ObservableObject {
       state = .checking
       await checkMembership(canContinueAfterFailure: true, releasesStartup: true)
     case .retryProfiles(let role):
-      await checkProfiles(for: role)
+      guard let ownerUserRecordName = store.pendingOffer?.ownerUserRecordName else {
+        state = .retryMembership(canContinueSetup: true)
+        return
+      }
+      await checkProfiles(for: role, ownerUserRecordName: ownerUserRecordName)
     default:
       break
     }
@@ -140,8 +147,8 @@ final class StartupRecoveryCoordinator: ObservableObject {
     guard store.recheckPending else { return }
 
     switch await lookupMembership() {
-    case .member(let role):
-      await recover(role: role)
+    case .member(let role, let ownerUserRecordName):
+      await recover(role: role, ownerUserRecordName: ownerUserRecordName)
     case .confirmedNone:
       store.clearRecheckPending()
       state = .normal(recheckArmed: false)
@@ -168,8 +175,8 @@ final class StartupRecoveryCoordinator: ObservableObject {
 
   private func checkMembership(canContinueAfterFailure: Bool, releasesStartup: Bool) async {
     switch await lookupMembership() {
-    case .member(let role):
-      await recover(role: role)
+    case .member(let role, let ownerUserRecordName):
+      await recover(role: role, ownerUserRecordName: ownerUserRecordName)
     case .confirmedNone:
       store.clearRecheckPending()
       state = .normal(recheckArmed: false)
@@ -179,22 +186,26 @@ final class StartupRecoveryCoordinator: ObservableObject {
     }
   }
 
-  private func recover(role: FamilyRole) async {
-    store.pendingOffer = StartupRecoveryPendingOffer(role: role, profileCount: nil)
+  private func recover(role: FamilyRole, ownerUserRecordName: String) async {
+    store.pendingOffer = StartupRecoveryPendingOffer(
+      ownerUserRecordName: ownerUserRecordName,
+      role: role,
+      profileCount: nil)
     store.clearRecheckPending()
     restoreFamilyRole(role)
     if role == .child {
       await refreshChildLockCodes()
     }
-    await checkProfiles(for: role)
+    await checkProfiles(for: role, ownerUserRecordName: ownerUserRecordName)
   }
 
-  private func checkProfiles(for role: FamilyRole) async {
+  private func checkProfiles(for role: FamilyRole, ownerUserRecordName: String) async {
     state = .checkingProfiles(role: role)
-    switch await lookupSyncedProfileCount() {
+    switch await lookupSyncedProfileCount(ownerUserRecordName) {
     case .confirmed(let profileCount):
       let confirmedCount = max(profileCount, 0)
       store.pendingOffer = StartupRecoveryPendingOffer(
+        ownerUserRecordName: ownerUserRecordName,
         role: role,
         profileCount: confirmedCount)
       state = .offer(role: role, profileCount: confirmedCount)

--- a/Foqos/Utils/StartupRecoveryCoordinator.swift
+++ b/Foqos/Utils/StartupRecoveryCoordinator.swift
@@ -99,6 +99,7 @@ final class StartupRecoveryCoordinator: ObservableObject {
   private var membershipClassification = StartupRecoveryLocalClassification.fresh
   private var inFlightTask: Task<Void, Never>?
   private var inFlightID = 0
+  private var acceptanceInFlight = false
 
   init(
     store: StartupRecoveryStore,
@@ -196,6 +197,27 @@ final class StartupRecoveryCoordinator: ObservableObject {
     showNormal(recheckArmed: true)
   }
 
+  func beginShareAcceptance() {
+    guard !acceptanceInFlight else { return }
+    acceptanceInFlight = true
+    inFlightID += 1
+    inFlightTask?.cancel()
+    inFlightTask = nil
+  }
+
+  func failShareAcceptance() {
+    guard acceptanceInFlight else { return }
+    acceptanceInFlight = false
+  }
+
+  func completeShareAcceptanceAfterModeApplied() {
+    guard acceptanceInFlight else { return }
+    acceptanceInFlight = false
+    store.pendingOffer = nil
+    store.clearRecheckPending()
+    showNormal(recheckArmed: false)
+  }
+
   func recheckIfNeeded() async {
     await performSingleFlight { [weak self] in
       await self?.recheckWorkIfNeeded()
@@ -208,7 +230,9 @@ final class StartupRecoveryCoordinator: ObservableObject {
     membershipClassification = classification
     guard classification != .indeterminate else { return }
 
-    switch await lookupMembership() {
+    let membership = await lookupMembership()
+    guard recoveryWorkMayCommit else { return }
+    switch membership {
     case .member(let role, let ownerUserRecordName):
       await beginRecovery(
         role: role,
@@ -264,7 +288,9 @@ final class StartupRecoveryCoordinator: ObservableObject {
     canContinueAfterFailure: Bool,
     releasesStartup: Bool
   ) async {
-    switch await lookupMembership() {
+    let membership = await lookupMembership()
+    guard recoveryWorkMayCommit else { return }
+    switch membership {
     case .member(let role, let ownerUserRecordName):
       await beginRecovery(
         role: role,
@@ -307,6 +333,7 @@ final class StartupRecoveryCoordinator: ObservableObject {
     restoreFamilyRole(role)
     if role == .child {
       await refreshChildLockCodes()
+      guard recoveryWorkMayCommit else { return }
     }
     switch path {
     case .freshMember:
@@ -319,7 +346,9 @@ final class StartupRecoveryCoordinator: ObservableObject {
   }
 
   private func resume(_ pendingOffer: StartupRecoveryPendingOffer) async {
-    switch await lookupMembership() {
+    let membership = await lookupMembership()
+    guard recoveryWorkMayCommit else { return }
+    switch membership {
     case .member(let role, let ownerUserRecordName):
       guard ownerUserRecordName == pendingOffer.ownerUserRecordName, role == pendingOffer.role else {
         rollback(pendingOffer)
@@ -347,7 +376,9 @@ final class StartupRecoveryCoordinator: ObservableObject {
 
   private func checkProfiles(for pendingOffer: StartupRecoveryPendingOffer) async {
     state = .checkingProfiles(role: pendingOffer.role)
-    switch await lookupSyncedProfileCount(pendingOffer.ownerUserRecordName) {
+    let countResult = await lookupSyncedProfileCount(pendingOffer.ownerUserRecordName)
+    guard recoveryWorkMayCommit else { return }
+    switch countResult {
     case .confirmed(let profileCount):
       let confirmedCount = max(profileCount, 0)
       store.pendingOffer = StartupRecoveryPendingOffer(
@@ -369,7 +400,9 @@ final class StartupRecoveryCoordinator: ObservableObject {
     }
     state = .checkingProfiles(role: pendingOffer.role)
 
-    switch await lookupMembership() {
+    let membership = await lookupMembership()
+    guard recoveryWorkMayCommit else { return false }
+    switch membership {
     case .member(let role, let ownerUserRecordName):
       guard ownerUserRecordName == pendingOffer.ownerUserRecordName, role == pendingOffer.role else {
         rollback(pendingOffer)
@@ -388,7 +421,9 @@ final class StartupRecoveryCoordinator: ObservableObject {
       return false
     }
 
-    switch await lookupSyncedProfileCount(pendingOffer.ownerUserRecordName) {
+    let countResult = await lookupSyncedProfileCount(pendingOffer.ownerUserRecordName)
+    guard recoveryWorkMayCommit else { return false }
+    switch countResult {
     case .confirmed(let count):
       let confirmedCount = max(count, 0)
       let refreshedOffer = StartupRecoveryPendingOffer(
@@ -435,6 +470,7 @@ final class StartupRecoveryCoordinator: ObservableObject {
   private func performSingleFlight(
     _ operation: @escaping @MainActor () async -> Void
   ) async {
+    guard !acceptanceInFlight else { return }
     if let inFlightTask {
       await inFlightTask.value
       return
@@ -450,5 +486,9 @@ final class StartupRecoveryCoordinator: ObservableObject {
     if inFlightID == operationID {
       inFlightTask = nil
     }
+  }
+
+  private var recoveryWorkMayCommit: Bool {
+    !acceptanceInFlight && !Task.isCancelled
   }
 }

--- a/Foqos/Utils/StartupRecoveryCoordinator.swift
+++ b/Foqos/Utils/StartupRecoveryCoordinator.swift
@@ -1,0 +1,221 @@
+import Combine
+import Foundation
+
+enum StartupRecoveryMembershipResult: Equatable {
+  case member(FamilyRole)
+  case confirmedNone
+  case indeterminate
+}
+
+enum StartupRecoveryProfileCountResult: Equatable {
+  case confirmed(Int)
+  case indeterminate
+}
+
+struct StartupRecoveryPendingOffer: Codable, Equatable {
+  let role: FamilyRole
+  let profileCount: Int?
+}
+
+struct StartupRecoveryStore {
+  private enum Key {
+    static let pendingOffer = "startup_recovery_pending_offer"
+    static let recheckPending = "startup_recovery_recheck_pending"
+  }
+
+  let defaults: UserDefaults
+
+  var pendingOffer: StartupRecoveryPendingOffer? {
+    get {
+      guard let data = defaults.data(forKey: Key.pendingOffer) else { return nil }
+      return try? JSONDecoder().decode(StartupRecoveryPendingOffer.self, from: data)
+    }
+    nonmutating set {
+      guard let newValue else {
+        defaults.removeObject(forKey: Key.pendingOffer)
+        return
+      }
+      guard let data = try? JSONEncoder().encode(newValue) else { return }
+      defaults.set(data, forKey: Key.pendingOffer)
+    }
+  }
+
+  var recheckPending: Bool {
+    defaults.bool(forKey: Key.recheckPending)
+  }
+
+  func markRecheckPending() {
+    defaults.set(true, forKey: Key.recheckPending)
+  }
+
+  func clearRecheckPending() {
+    defaults.removeObject(forKey: Key.recheckPending)
+  }
+}
+
+enum StartupRecoveryState: Equatable {
+  case checking
+  case retryMembership(canContinueSetup: Bool)
+  case retryProfiles(role: FamilyRole)
+  case normal(recheckArmed: Bool)
+  case checkingProfiles(role: FamilyRole)
+  case offer(role: FamilyRole, profileCount: Int)
+}
+
+@MainActor
+final class StartupRecoveryCoordinator: ObservableObject {
+  @Published private(set) var state = StartupRecoveryState.checking
+
+  private let store: StartupRecoveryStore
+  private let lookupMembership: () async -> StartupRecoveryMembershipResult
+  private let lookupSyncedProfileCount: () async -> StartupRecoveryProfileCountResult
+  private let restoreFamilyRole: (FamilyRole) -> Void
+  private let refreshChildLockCodes: () async -> Void
+  private let setSyncEnabled: (Bool) -> Void
+  private let releaseStartup: () -> Void
+  private var didReleaseStartup = false
+
+  init(
+    store: StartupRecoveryStore,
+    lookupMembership: @escaping () async -> StartupRecoveryMembershipResult,
+    lookupSyncedProfileCount: @escaping () async -> StartupRecoveryProfileCountResult,
+    restoreFamilyRole: @escaping (FamilyRole) -> Void,
+    refreshChildLockCodes: @escaping () async -> Void,
+    setSyncEnabled: @escaping (Bool) -> Void,
+    releaseStartup: @escaping () -> Void
+  ) {
+    self.store = store
+    self.lookupMembership = lookupMembership
+    self.lookupSyncedProfileCount = lookupSyncedProfileCount
+    self.restoreFamilyRole = restoreFamilyRole
+    self.refreshChildLockCodes = refreshChildLockCodes
+    self.setSyncEnabled = setSyncEnabled
+    self.releaseStartup = releaseStartup
+  }
+
+  func start(classification: StartupRecoveryLocalClassification) async {
+    if let pendingOffer = store.pendingOffer {
+      if let profileCount = pendingOffer.profileCount {
+        state = .offer(role: pendingOffer.role, profileCount: profileCount)
+      } else {
+        await recover(role: pendingOffer.role)
+      }
+      return
+    }
+
+    if store.recheckPending {
+      showNormal(recheckArmed: true)
+      return
+    }
+
+    switch classification {
+    case .existing:
+      showNormal(recheckArmed: false)
+    case .fresh:
+      await checkMembership(canContinueAfterFailure: false, releasesStartup: true)
+    case .indeterminate:
+      state = .retryMembership(canContinueSetup: false)
+    }
+  }
+
+  func retry() async {
+    switch state {
+    case .retryMembership:
+      state = .checking
+      await checkMembership(canContinueAfterFailure: true, releasesStartup: true)
+    case .retryProfiles(let role):
+      await checkProfiles(for: role)
+    default:
+      break
+    }
+  }
+
+  func continueSetup() {
+    guard state == .retryMembership(canContinueSetup: true) else { return }
+    store.markRecheckPending()
+    showNormal(recheckArmed: true)
+  }
+
+  func recheckIfNeeded() async {
+    guard store.recheckPending else { return }
+
+    switch await lookupMembership() {
+    case .member(let role):
+      await recover(role: role)
+    case .confirmedNone:
+      store.clearRecheckPending()
+      state = .normal(recheckArmed: false)
+    case .indeterminate:
+      state = .normal(recheckArmed: true)
+    }
+  }
+
+  func restoreProfiles() {
+    guard case .offer(_, let profileCount) = state, profileCount > 0 else { return }
+    setSyncEnabled(true)
+    completeOffer()
+  }
+
+  func declineProfiles() {
+    guard case .offer(_, let profileCount) = state, profileCount > 0 else { return }
+    completeOffer()
+  }
+
+  func continueWithoutProfiles() {
+    guard case .offer(_, let profileCount) = state, profileCount == 0 else { return }
+    completeOffer()
+  }
+
+  private func checkMembership(canContinueAfterFailure: Bool, releasesStartup: Bool) async {
+    switch await lookupMembership() {
+    case .member(let role):
+      await recover(role: role)
+    case .confirmedNone:
+      store.clearRecheckPending()
+      state = .normal(recheckArmed: false)
+      if releasesStartup { releaseStartupIfNeeded() }
+    case .indeterminate:
+      state = .retryMembership(canContinueSetup: canContinueAfterFailure)
+    }
+  }
+
+  private func recover(role: FamilyRole) async {
+    store.pendingOffer = StartupRecoveryPendingOffer(role: role, profileCount: nil)
+    store.clearRecheckPending()
+    restoreFamilyRole(role)
+    if role == .child {
+      await refreshChildLockCodes()
+    }
+    await checkProfiles(for: role)
+  }
+
+  private func checkProfiles(for role: FamilyRole) async {
+    state = .checkingProfiles(role: role)
+    switch await lookupSyncedProfileCount() {
+    case .confirmed(let profileCount):
+      let confirmedCount = max(profileCount, 0)
+      store.pendingOffer = StartupRecoveryPendingOffer(
+        role: role,
+        profileCount: confirmedCount)
+      state = .offer(role: role, profileCount: confirmedCount)
+    case .indeterminate:
+      state = .retryProfiles(role: role)
+    }
+  }
+
+  private func completeOffer() {
+    store.pendingOffer = nil
+    showNormal(recheckArmed: false)
+  }
+
+  private func showNormal(recheckArmed: Bool) {
+    state = .normal(recheckArmed: recheckArmed)
+    releaseStartupIfNeeded()
+  }
+
+  private func releaseStartupIfNeeded() {
+    guard !didReleaseStartup else { return }
+    didReleaseStartup = true
+    releaseStartup()
+  }
+}

--- a/Foqos/Utils/StartupRecoveryCoordinator.swift
+++ b/Foqos/Utils/StartupRecoveryCoordinator.swift
@@ -153,7 +153,7 @@ final class StartupRecoveryCoordinator: ObservableObject {
     }
 
     switch classification {
-    case .existing:
+    case .localStatePresent:
       showNormal(recheckArmed: false)
     case .fresh:
       await checkMembership(
@@ -216,6 +216,14 @@ final class StartupRecoveryCoordinator: ObservableObject {
     store.pendingOffer = nil
     store.clearRecheckPending()
     showNormal(recheckArmed: false)
+  }
+
+  func dismissRoleRestoredNotice() {
+    guard case .roleRestored = state,
+      store.pendingOffer?.path == .localStatePresentMember
+    else { return }
+    store.pendingOffer = nil
+    state = .normal(recheckArmed: false)
   }
 
   func recheckIfNeeded() async {
@@ -314,7 +322,7 @@ final class StartupRecoveryCoordinator: ObservableObject {
     switch classification {
     case .fresh:
       path = .freshMember
-    case .existing:
+    case .localStatePresent:
       path = .localStatePresentMember
     case .indeterminate:
       state = .retryMembership(canContinueSetup: true)

--- a/Foqos/Utils/StartupRecoveryLocalState.swift
+++ b/Foqos/Utils/StartupRecoveryLocalState.swift
@@ -1,0 +1,151 @@
+import CoreFoundation
+import Foundation
+import SQLite3
+
+enum StartupRecoveryStoreFinding: Equatable {
+  case storeAbsent
+  case tableMissing
+  case profileCount(Int)
+  case readFailed
+}
+
+struct StartupRecoveryLocalSnapshot: Equatable {
+  let onboardingValuePresent: Bool
+  let appGroupStatePresent: Bool
+  let store: StartupRecoveryStoreFinding
+}
+
+enum StartupRecoveryLocalClassification: Equatable {
+  case existing
+  case fresh
+  case indeterminate
+}
+
+enum StartupRecoveryLocalState {
+  static let currentOnboardingKey = "family_foqos_has_completed_onboarding"
+  static let legacyOnboardingKey = "hasCompletedOnboarding"
+
+  static var standardDomain: String {
+    Bundle.main.bundleIdentifier ?? ""
+  }
+
+  static var appGroupDomain: String {
+    Log.appGroupIdentifier
+  }
+
+  static func classify(
+    _ snapshot: StartupRecoveryLocalSnapshot
+  ) -> StartupRecoveryLocalClassification {
+    if snapshot.onboardingValuePresent || snapshot.appGroupStatePresent {
+      return .existing
+    }
+
+    switch snapshot.store {
+    case .storeAbsent, .tableMissing, .profileCount(0):
+      return .fresh
+    case .profileCount:
+      return .existing
+    case .readFailed:
+      return .indeterminate
+    }
+  }
+
+  static func capture() -> StartupRecoveryLocalSnapshot {
+    capture(
+      storeURL: AppModelStore.storeURL,
+      preferenceValue: { key, domain in
+        CFPreferencesCopyAppValue(key as CFString, domain as CFString)
+      },
+      appGroupValues: { domain in
+        CFPreferencesCopyMultiple(
+          nil,
+          domain as CFString,
+          kCFPreferencesCurrentUser,
+          kCFPreferencesAnyHost) as? [String: Any]
+      },
+      fileExists: { FileManager.default.fileExists(atPath: $0) },
+      readStore: readStore)
+  }
+
+  static func capture(
+    storeURL: URL,
+    preferenceValue: (_ key: String, _ domain: String) -> Any?,
+    appGroupValues: (_ domain: String) -> [String: Any]?,
+    fileExists: (_ path: String) -> Bool,
+    readStore: (_ storeURL: URL) -> StartupRecoveryStoreFinding
+  ) -> StartupRecoveryLocalSnapshot {
+    let onboardingValuePresent =
+      preferenceValue(currentOnboardingKey, standardDomain) != nil
+      || preferenceValue(legacyOnboardingKey, standardDomain) != nil
+    let appGroupStatePresent = !(appGroupValues(appGroupDomain) ?? [:]).isEmpty
+    let store = fileExists(storeURL.path) ? readStore(storeURL) : .storeAbsent
+
+    return StartupRecoveryLocalSnapshot(
+      onboardingValuePresent: onboardingValuePresent,
+      appGroupStatePresent: appGroupStatePresent,
+      store: store)
+  }
+
+  static func readStore(at storeURL: URL) -> StartupRecoveryStoreFinding {
+    let uri = storeURL.absoluteString + "?mode=ro"
+    var database: OpaquePointer?
+    let openCode = sqlite3_open_v2(
+      uri,
+      &database,
+      SQLITE_OPEN_READONLY | SQLITE_OPEN_URI,
+      nil)
+    guard openCode == SQLITE_OK, let database else {
+      if let database {
+        sqlite3_close(database)
+      }
+      return .readFailed
+    }
+    defer { sqlite3_close(database) }
+
+    guard sqlite3_exec(database, "PRAGMA query_only=ON", nil, nil, nil) == SQLITE_OK else {
+      return .readFailed
+    }
+    guard profileTableExists(in: database) else {
+      return .tableMissing
+    }
+
+    var statement: OpaquePointer?
+    let prepareCode = sqlite3_prepare_v2(
+      database,
+      "SELECT COUNT(*) FROM ZBLOCKEDPROFILES",
+      -1,
+      &statement,
+      nil)
+    guard prepareCode == SQLITE_OK, let statement else {
+      if let statement {
+        sqlite3_finalize(statement)
+      }
+      return .readFailed
+    }
+    defer { sqlite3_finalize(statement) }
+    guard sqlite3_step(statement) == SQLITE_ROW,
+      let count = Int(exactly: sqlite3_column_int64(statement, 0))
+    else {
+      return .readFailed
+    }
+    return .profileCount(count)
+  }
+
+  private static func profileTableExists(in database: OpaquePointer) -> Bool {
+    var statement: OpaquePointer?
+    let prepareCode = sqlite3_prepare_v2(
+      database,
+      "SELECT 1 FROM sqlite_master WHERE type='table' AND name='ZBLOCKEDPROFILES' LIMIT 1",
+      -1,
+      &statement,
+      nil)
+    guard prepareCode == SQLITE_OK, let statement else {
+      if let statement {
+        sqlite3_finalize(statement)
+      }
+      return false
+    }
+    defer { sqlite3_finalize(statement) }
+    return sqlite3_step(statement) == SQLITE_ROW
+  }
+}

--- a/Foqos/Utils/StartupRecoveryLocalState.swift
+++ b/Foqos/Utils/StartupRecoveryLocalState.swift
@@ -36,7 +36,7 @@ enum StartupRecoveryLocalState {
   static func classify(
     _ snapshot: StartupRecoveryLocalSnapshot
   ) -> StartupRecoveryLocalClassification {
-    if snapshot.onboardingValuePresent || snapshot.appGroupStatePresent {
+    if snapshot.onboardingValuePresent {
       return .existing
     }
 

--- a/Foqos/Utils/StartupRecoveryLocalState.swift
+++ b/Foqos/Utils/StartupRecoveryLocalState.swift
@@ -16,7 +16,7 @@ struct StartupRecoveryLocalSnapshot: Equatable {
 }
 
 enum StartupRecoveryLocalClassification: Equatable {
-  case existing
+  case localStatePresent
   case fresh
   case indeterminate
 }
@@ -37,14 +37,14 @@ enum StartupRecoveryLocalState {
     _ snapshot: StartupRecoveryLocalSnapshot
   ) -> StartupRecoveryLocalClassification {
     if snapshot.onboardingValuePresent {
-      return .existing
+      return .localStatePresent
     }
 
     switch snapshot.store {
     case .storeAbsent, .tableMissing, .profileCount(0):
       return .fresh
     case .profileCount:
-      return .existing
+      return .localStatePresent
     case .readFailed:
       return .indeterminate
     }

--- a/Foqos/Utils/StartupRecoveryRuntime.swift
+++ b/Foqos/Utils/StartupRecoveryRuntime.swift
@@ -1,0 +1,33 @@
+import Combine
+
+@MainActor
+final class StartupRecoveryRuntime: ObservableObject {
+  static let shared = StartupRecoveryRuntime()
+
+  @Published private(set) var isHeld = true
+  private(set) weak var coordinator: StartupRecoveryCoordinator?
+
+  func register(coordinator: StartupRecoveryCoordinator) {
+    self.coordinator = coordinator
+  }
+
+  func release() {
+    guard isHeld else { return }
+    isHeld = false
+  }
+}
+
+enum StartupRecoveryPushRouter {
+  @MainActor
+  static func route(
+    isHeld: Bool,
+    onHeld: () -> Void,
+    onReleased: () async -> Void
+  ) async {
+    guard !isHeld else {
+      onHeld()
+      return
+    }
+    await onReleased()
+  }
+}

--- a/Foqos/Utils/StartupRecoveryRuntime.swift
+++ b/Foqos/Utils/StartupRecoveryRuntime.swift
@@ -15,6 +15,18 @@ final class StartupRecoveryRuntime: ObservableObject {
     guard isHeld else { return }
     isHeld = false
   }
+
+  func beginShareAcceptance() {
+    coordinator?.beginShareAcceptance()
+  }
+
+  func failShareAcceptance() {
+    coordinator?.failShareAcceptance()
+  }
+
+  func completeShareAcceptanceAfterModeApplied() {
+    coordinator?.completeShareAcceptanceAfterModeApplied()
+  }
 }
 
 enum StartupRecoveryPushRouter {

--- a/Foqos/Utils/StartupRecoveryRuntime.swift
+++ b/Foqos/Utils/StartupRecoveryRuntime.swift
@@ -17,15 +17,29 @@ final class StartupRecoveryRuntime: ObservableObject {
   }
 
   func beginShareAcceptance() {
-    coordinator?.beginShareAcceptance()
+    guard let coordinator = coordinatorForArbitration() else { return }
+    coordinator.beginShareAcceptance()
   }
 
   func failShareAcceptance() {
-    coordinator?.failShareAcceptance()
+    guard let coordinator = coordinatorForArbitration() else { return }
+    coordinator.failShareAcceptance()
   }
 
   func completeShareAcceptanceAfterModeApplied() {
-    coordinator?.completeShareAcceptanceAfterModeApplied()
+    guard let coordinator = coordinatorForArbitration() else { return }
+    coordinator.completeShareAcceptanceAfterModeApplied()
+  }
+
+  private func coordinatorForArbitration() -> StartupRecoveryCoordinator? {
+    guard let coordinator else {
+      assertionFailure("Startup recovery coordinator is not registered")
+      Log.error(
+        "Startup recovery arbitration unavailable because the coordinator is not registered",
+        category: .app)
+      return nil
+    }
+    return coordinator
   }
 }
 

--- a/Foqos/Views/StartupRecoveryView.swift
+++ b/Foqos/Views/StartupRecoveryView.swift
@@ -3,7 +3,12 @@ import SwiftUI
 enum StartupRecoveryCopy {
   static let title = "We found your family"
   static let introduction =
-    "This device no longer has its previous local data, but this iCloud account is still part of a Family Foqos family. Your family role has been restored."
+    "This device doesn't have local Family Foqos data, but this iCloud account is part of a Family Foqos family. Your family role has been restored."
+  static let availabilityDisclosure =
+    "Family Foqos checked this iCloud account's Device Sync storage only to see whether synced profiles are available. Device Sync is still off."
+  static let roleRestoredTitle = "Your family role was restored"
+  static let roleRestoredMessage =
+    "This device already has local setup or profiles, so Family Foqos restored only its family role. Device Sync is off to avoid merging profiles automatically. You can review Device Sync in Settings."
   static let noProfiles =
     "We couldn't find any profiles saved with Device Sync. Profiles that existed only on this device can't be recovered."
 
@@ -107,6 +112,10 @@ struct StartupRecoveryView: View {
         .font(.title.bold())
         .multilineTextAlignment(.center)
       Text(StartupRecoveryCopy.introduction)
+        .multilineTextAlignment(.center)
+        .foregroundStyle(.secondary)
+      Text(StartupRecoveryCopy.availabilityDisclosure)
+        .font(.footnote)
         .multilineTextAlignment(.center)
         .foregroundStyle(.secondary)
       Text(

--- a/Foqos/Views/StartupRecoveryView.swift
+++ b/Foqos/Views/StartupRecoveryView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+enum StartupRecoveryCopy {
+  static let title = "We found your family"
+  static let introduction =
+    "This device no longer has its previous local data, but this iCloud account is still part of a Family Foqos family. Your family role has been restored."
+  static let noProfiles =
+    "We couldn't find any profiles saved with Device Sync. Profiles that existed only on this device can't be recovered."
+
+  static func profilePrompt(count: Int) -> String {
+    if count == 1 {
+      return "We found 1 synced profile. Restore it to this device?"
+    }
+    return "We found \(count) synced profiles. Restore them to this device?"
+  }
+}
+
+enum StartupRecoveryStartupPolicy {
+  static func isReleased(_ state: StartupRecoveryState) -> Bool {
+    switch state {
+    case .normal, .roleRestored:
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+struct StartupRecoveryView: View {
+  @ObservedObject var coordinator: StartupRecoveryCoordinator
+
+  var body: some View {
+    VStack(spacing: 24) {
+      Spacer()
+      content
+        .frame(maxWidth: 440)
+      Spacer()
+    }
+    .padding(32)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color(.systemBackground))
+  }
+
+  @ViewBuilder
+  private var content: some View {
+    switch coordinator.state {
+    case .checking:
+      checkingView(message: "Checking iCloud for your family…")
+    case .checkingProfiles:
+      checkingView(message: "Checking Device Sync for profiles…")
+    case .retryMembership(let canContinueSetup):
+      retryView(
+        message: "We couldn't check your family in iCloud. Check your connection and try again.",
+        canContinueSetup: canContinueSetup)
+    case .retryProfiles:
+      retryView(
+        message:
+          "Your family role was restored, but we couldn't check Device Sync for profiles. Check your connection and try again.",
+        canContinueSetup: false)
+    case .offer(_, let profileCount):
+      offerView(profileCount: profileCount)
+    case .normal, .roleRestored:
+      EmptyView()
+    }
+  }
+
+  private func checkingView(message: String) -> some View {
+    VStack(spacing: 20) {
+      ProgressView()
+        .controlSize(.large)
+      Text(message)
+        .multilineTextAlignment(.center)
+        .foregroundStyle(.secondary)
+    }
+  }
+
+  private func retryView(message: String, canContinueSetup: Bool) -> some View {
+    VStack(spacing: 20) {
+      Image(systemName: "icloud.slash")
+        .font(.system(size: 42))
+        .foregroundStyle(.secondary)
+      Text("We couldn't finish checking")
+        .font(.title2.bold())
+        .multilineTextAlignment(.center)
+      Text(message)
+        .multilineTextAlignment(.center)
+        .foregroundStyle(.secondary)
+      Button("Retry") {
+        Task { await coordinator.retry() }
+      }
+      .buttonStyle(.borderedProminent)
+      if canContinueSetup {
+        Button("Continue Setup") {
+          coordinator.continueSetup()
+        }
+        .buttonStyle(.bordered)
+      }
+    }
+  }
+
+  private func offerView(profileCount: Int) -> some View {
+    VStack(spacing: 20) {
+      Image(systemName: "person.2.fill")
+        .font(.system(size: 42))
+        .foregroundStyle(.tint)
+      Text(StartupRecoveryCopy.title)
+        .font(.title.bold())
+        .multilineTextAlignment(.center)
+      Text(StartupRecoveryCopy.introduction)
+        .multilineTextAlignment(.center)
+        .foregroundStyle(.secondary)
+      Text(
+        profileCount > 0
+          ? StartupRecoveryCopy.profilePrompt(count: profileCount)
+          : StartupRecoveryCopy.noProfiles
+      )
+      .multilineTextAlignment(.center)
+
+      if profileCount > 0 {
+        Button("Restore") {
+          Task { await coordinator.restoreProfiles() }
+        }
+        .buttonStyle(.borderedProminent)
+        Button("Not Now") {
+          Task { await coordinator.declineProfiles() }
+        }
+        .buttonStyle(.bordered)
+      } else {
+        Button("Continue") {
+          Task { await coordinator.continueWithoutProfiles() }
+        }
+        .buttonStyle(.borderedProminent)
+      }
+    }
+  }
+}

--- a/FoqosTests/StartupRecoveryCloudServiceTests.swift
+++ b/FoqosTests/StartupRecoveryCloudServiceTests.swift
@@ -5,17 +5,21 @@ import XCTest
 final class StartupRecoveryCloudServiceTests: XCTestCase {
   func testMembershipObservationMapsOnlyConfirmedEvidenceToDefinitiveResults() {
     XCTAssertEqual(
-      StartupRecoveryCloudService.resolveMembership(.recordRole("parent")),
-      .member(.parent))
+      StartupRecoveryCloudService.resolveMembership(
+        .recordRole(role: "parent", ownerUserRecordName: "owner-A")),
+      .member(role: .parent, ownerUserRecordName: "owner-A"))
     XCTAssertEqual(
-      StartupRecoveryCloudService.resolveMembership(.recordRole("child")),
-      .member(.child))
+      StartupRecoveryCloudService.resolveMembership(
+        .recordRole(role: "child", ownerUserRecordName: "owner-B")),
+      .member(role: .child, ownerUserRecordName: "owner-B"))
     XCTAssertEqual(
-      StartupRecoveryCloudService.resolveMembership(.sharedZoneAbsent),
-      .confirmedNone)
+      StartupRecoveryCloudService.resolveMembership(
+        .zoneListSucceededWithoutPolicyZone(ownerUserRecordName: "owner-A")),
+      .confirmedNone(ownerUserRecordName: "owner-A"))
     XCTAssertEqual(
-      StartupRecoveryCloudService.resolveMembership(.recordAbsent),
-      .confirmedNone)
+      StartupRecoveryCloudService.resolveMembership(
+        .recordAbsent(ownerUserRecordName: "owner-B")),
+      .confirmedNone(ownerUserRecordName: "owner-B"))
   }
 
   func testMembershipObservationKeepsUnavailableOrInvalidEvidenceIndeterminate() {
@@ -23,8 +27,9 @@ final class StartupRecoveryCloudServiceTests: XCTestCase {
       .accountUnavailable,
       .accountIndeterminate,
       .sharedZoneIndeterminate,
-      .recordFailed,
-      .recordRole("owner"),
+      .recordFetchFailed,
+      .recordZoneMissing,
+      .recordRole(role: "owner", ownerUserRecordName: "owner-A"),
     ]
 
     for observation in observations {
@@ -51,15 +56,23 @@ final class StartupRecoveryCloudServiceTests: XCTestCase {
     XCTAssertEqual(fold.profileCount, 2)
   }
 
-  func testProfileFetchOutcomeMapsSuccessfulEmptyAndMissingZoneToZero() {
+  func testProfileFetchOutcomeMapsOnlySuccessfulEvidenceToZero() {
     XCTAssertEqual(
       StartupRecoveryCloudService.resolveProfileCount(
         fold: StartupRecoveryProfileRecordFold(), outcome: .success),
       .confirmed(0))
     XCTAssertEqual(
       StartupRecoveryCloudService.resolveProfileCount(
-        fold: StartupRecoveryProfileRecordFold(), outcome: .zoneMissing),
+        fold: StartupRecoveryProfileRecordFold(),
+        outcome: .zoneListSucceededWithoutSyncZone),
       .confirmed(0))
+  }
+
+  func testProfileFetchMissingZoneErrorRemainsIndeterminateWithoutSuccessfulZoneList() {
+    XCTAssertEqual(
+      StartupRecoveryCloudService.resolveProfileCount(
+        fold: StartupRecoveryProfileRecordFold(), outcome: .zoneFetchReportedMissing),
+      .indeterminate)
   }
 
   func testProfileFetchOutcomeReturnsCountOnlyAfterSuccessfulFetch() {

--- a/FoqosTests/StartupRecoveryCloudServiceTests.swift
+++ b/FoqosTests/StartupRecoveryCloudServiceTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class StartupRecoveryCloudServiceTests: XCTestCase {
+  func testMembershipObservationMapsOnlyConfirmedEvidenceToDefinitiveResults() {
+    XCTAssertEqual(
+      StartupRecoveryCloudService.resolveMembership(.recordRole("parent")),
+      .member(.parent))
+    XCTAssertEqual(
+      StartupRecoveryCloudService.resolveMembership(.recordRole("child")),
+      .member(.child))
+    XCTAssertEqual(
+      StartupRecoveryCloudService.resolveMembership(.sharedZoneAbsent),
+      .confirmedNone)
+    XCTAssertEqual(
+      StartupRecoveryCloudService.resolveMembership(.recordAbsent),
+      .confirmedNone)
+  }
+
+  func testMembershipObservationKeepsUnavailableOrInvalidEvidenceIndeterminate() {
+    let observations: [StartupRecoveryMembershipObservation] = [
+      .accountUnavailable,
+      .accountIndeterminate,
+      .sharedZoneIndeterminate,
+      .recordFailed,
+      .recordRole("owner"),
+    ]
+
+    for observation in observations {
+      XCTAssertEqual(
+        StartupRecoveryCloudService.resolveMembership(observation),
+        .indeterminate,
+        "Expected \(observation) to stay indeterminate")
+    }
+  }
+
+  func testProfileFoldTracksMultiplePagesDeletionsUnrelatedTypesAndDuplicateCallbacks() {
+    var fold = StartupRecoveryProfileRecordFold()
+
+    fold.applyModification(recordName: "profile-a", recordType: SyncedProfile.recordType)
+    fold.applyModification(recordName: "profile-b", recordType: SyncedProfile.recordType)
+    fold.applyModification(recordName: "location", recordType: "SyncedLocation")
+    fold.applyModification(recordName: "profile-a", recordType: SyncedProfile.recordType)
+
+    fold.applyModification(recordName: "profile-c", recordType: SyncedProfile.recordType)
+    fold.applyDeletion(recordName: "profile-b", recordType: SyncedProfile.recordType)
+    fold.applyDeletion(recordName: "unknown", recordType: SyncedProfile.recordType)
+    fold.applyDeletion(recordName: "profile-c", recordType: "SyncedLocation")
+
+    XCTAssertEqual(fold.profileCount, 2)
+  }
+
+  func testProfileFetchOutcomeMapsSuccessfulEmptyAndMissingZoneToZero() {
+    XCTAssertEqual(
+      StartupRecoveryCloudService.resolveProfileCount(
+        fold: StartupRecoveryProfileRecordFold(), outcome: .success),
+      .confirmed(0))
+    XCTAssertEqual(
+      StartupRecoveryCloudService.resolveProfileCount(
+        fold: StartupRecoveryProfileRecordFold(), outcome: .zoneMissing),
+      .confirmed(0))
+  }
+
+  func testProfileFetchOutcomeReturnsCountOnlyAfterSuccessfulFetch() {
+    var fold = StartupRecoveryProfileRecordFold()
+    fold.applyModification(recordName: "profile-a", recordType: SyncedProfile.recordType)
+    fold.applyModification(recordName: "profile-b", recordType: SyncedProfile.recordType)
+
+    XCTAssertEqual(
+      StartupRecoveryCloudService.resolveProfileCount(fold: fold, outcome: .success),
+      .confirmed(2))
+    XCTAssertEqual(
+      StartupRecoveryCloudService.resolveProfileCount(fold: fold, outcome: .indeterminate),
+      .indeterminate)
+  }
+}

--- a/FoqosTests/StartupRecoveryCoordinatorTests.swift
+++ b/FoqosTests/StartupRecoveryCoordinatorTests.swift
@@ -1,0 +1,229 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class StartupRecoveryCoordinatorTests: XCTestCase {
+  func testGivenFreshChildMembership_WhenStarting_ThenPendingStatePrecedesRoleAndOffer() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    var steps: [String] = []
+
+    let coordinator = StartupRecoveryCoordinator(
+      store: store,
+      lookupMembership: {
+        steps.append("membership")
+        return .member(.child)
+      },
+      lookupSyncedProfileCount: {
+        steps.append("profiles")
+        return .confirmed(2)
+      },
+      restoreFamilyRole: { role in
+        XCTAssertEqual(role, .child)
+        XCTAssertEqual(store.pendingOffer, .init(role: .child, profileCount: nil))
+        steps.append("role")
+      },
+      refreshChildLockCodes: { steps.append("locks") },
+      setSyncEnabled: { _ in XCTFail("Sync requires an explicit decision") },
+      releaseStartup: { XCTFail("Offer must hold startup") })
+
+    await coordinator.start(classification: .fresh)
+
+    XCTAssertEqual(steps, ["membership", "role", "locks", "profiles"])
+    XCTAssertEqual(coordinator.state, .offer(role: .child, profileCount: 2))
+    XCTAssertEqual(store.pendingOffer, .init(role: .child, profileCount: 2))
+  }
+
+  func testGivenIndeterminateMembershipTwice_WhenContinuingSetup_ThenRecheckIsDurable() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    var releaseCount = 0
+    let coordinator = makeCoordinator(
+      store: store,
+      membership: { .indeterminate },
+      releaseStartup: { releaseCount += 1 })
+
+    await coordinator.start(classification: .fresh)
+    XCTAssertEqual(coordinator.state, .retryMembership(canContinueSetup: false))
+
+    await coordinator.retry()
+    XCTAssertEqual(coordinator.state, .retryMembership(canContinueSetup: true))
+
+    coordinator.continueSetup()
+
+    XCTAssertEqual(coordinator.state, .normal(recheckArmed: true))
+    XCTAssertTrue(StartupRecoveryStore(defaults: defaults).recheckPending)
+    XCTAssertEqual(releaseCount, 1)
+  }
+
+  func testGivenRecheckArmed_WhenLaterMembershipIsConfirmed_ThenRecoveryRuns() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    store.markRecheckPending()
+    var membership = StartupRecoveryMembershipResult.indeterminate
+    var restoredRole: FamilyRole?
+    let coordinator = makeCoordinator(
+      store: store,
+      membership: { membership },
+      profileCount: { .confirmed(0) },
+      restoreRole: { restoredRole = $0 })
+
+    await coordinator.start(classification: .existing)
+    XCTAssertEqual(coordinator.state, .normal(recheckArmed: true))
+
+    membership = .member(.parent)
+    await coordinator.recheckIfNeeded()
+
+    XCTAssertEqual(restoredRole, .parent)
+    XCTAssertEqual(coordinator.state, .offer(role: .parent, profileCount: 0))
+    XCTAssertFalse(store.recheckPending)
+  }
+
+  func testGivenRecheckArmed_WhenNoMembershipIsConfirmed_ThenRecheckClears() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    store.markRecheckPending()
+    let coordinator = makeCoordinator(store: store, membership: { .confirmedNone })
+
+    await coordinator.start(classification: .existing)
+    await coordinator.recheckIfNeeded()
+
+    XCTAssertFalse(store.recheckPending)
+    XCTAssertEqual(coordinator.state, .normal(recheckArmed: false))
+  }
+
+  func testGivenPendingRoleWithoutCount_WhenRelaunching_ThenRoleAndProfileLookupResume() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    store.pendingOffer = .init(role: .child, profileCount: nil)
+    var steps: [String] = []
+    let coordinator = makeCoordinator(
+      store: store,
+      membership: {
+        XCTFail("Pending offer bypasses membership lookup")
+        return .indeterminate
+      },
+      profileCount: {
+        steps.append("profiles")
+        return .confirmed(1)
+      },
+      restoreRole: { _ in steps.append("role") },
+      refreshLocks: { steps.append("locks") })
+
+    await coordinator.start(classification: .existing)
+
+    XCTAssertEqual(steps, ["role", "locks", "profiles"])
+    XCTAssertEqual(coordinator.state, .offer(role: .child, profileCount: 1))
+  }
+
+  func testGivenPendingOfferWithCount_WhenRelaunching_ThenOfferReturnsWithoutCloudLookup() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    store.pendingOffer = .init(role: .parent, profileCount: 3)
+    let coordinator = makeCoordinator(
+      store: store,
+      membership: {
+        XCTFail("Stored offer bypasses membership lookup")
+        return .indeterminate
+      },
+      profileCount: {
+        XCTFail("Stored count bypasses profile lookup")
+        return .indeterminate
+      })
+
+    await coordinator.start(classification: .existing)
+
+    XCTAssertEqual(coordinator.state, .offer(role: .parent, profileCount: 3))
+  }
+
+  func testGivenPositiveOffer_WhenRestoreChosen_ThenSyncEnablesAndPendingOfferClears() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    var syncValues: [Bool] = []
+    var releaseCount = 0
+    let coordinator = makeCoordinator(
+      store: store,
+      membership: { .member(.parent) },
+      profileCount: { .confirmed(2) },
+      setSyncEnabled: { syncValues.append($0) },
+      releaseStartup: { releaseCount += 1 })
+    await coordinator.start(classification: .fresh)
+
+    coordinator.restoreProfiles()
+
+    XCTAssertEqual(syncValues, [true])
+    XCTAssertNil(store.pendingOffer)
+    XCTAssertEqual(coordinator.state, .normal(recheckArmed: false))
+    XCTAssertEqual(releaseCount, 1)
+  }
+
+  func testGivenPositiveOffer_WhenNotNowChosen_ThenSyncStaysDisabledAndPendingOfferClears() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    var didEnableSync = false
+    let coordinator = makeCoordinator(
+      store: store,
+      membership: { .member(.parent) },
+      profileCount: { .confirmed(2) },
+      setSyncEnabled: { _ in didEnableSync = true })
+    await coordinator.start(classification: .fresh)
+
+    coordinator.declineProfiles()
+
+    XCTAssertFalse(didEnableSync)
+    XCTAssertNil(store.pendingOffer)
+    XCTAssertEqual(coordinator.state, .normal(recheckArmed: false))
+  }
+
+  func testGivenZeroProfileOffer_WhenContinueChosen_ThenPendingOfferClearsWithoutSync() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    var didEnableSync = false
+    let coordinator = makeCoordinator(
+      store: store,
+      membership: { .member(.child) },
+      profileCount: { .confirmed(0) },
+      setSyncEnabled: { _ in didEnableSync = true })
+    await coordinator.start(classification: .fresh)
+
+    coordinator.continueWithoutProfiles()
+
+    XCTAssertFalse(didEnableSync)
+    XCTAssertNil(store.pendingOffer)
+    XCTAssertEqual(coordinator.state, .normal(recheckArmed: false))
+  }
+
+  private func makeCoordinator(
+    store: StartupRecoveryStore,
+    membership: @escaping () async -> StartupRecoveryMembershipResult,
+    profileCount: @escaping () async -> StartupRecoveryProfileCountResult = { .confirmed(0) },
+    restoreRole: @escaping (FamilyRole) -> Void = { _ in },
+    refreshLocks: @escaping () async -> Void = {},
+    setSyncEnabled: @escaping (Bool) -> Void = { _ in },
+    releaseStartup: @escaping () -> Void = {}
+  ) -> StartupRecoveryCoordinator {
+    StartupRecoveryCoordinator(
+      store: store,
+      lookupMembership: membership,
+      lookupSyncedProfileCount: profileCount,
+      restoreFamilyRole: restoreRole,
+      refreshChildLockCodes: refreshLocks,
+      setSyncEnabled: setSyncEnabled,
+      releaseStartup: releaseStartup)
+  }
+
+  private func makeDefaults() -> (UserDefaults, String) {
+    let suiteName = "StartupRecoveryCoordinatorTests-\(UUID().uuidString)"
+    return (UserDefaults(suiteName: suiteName)!, suiteName)
+  }
+}

--- a/FoqosTests/StartupRecoveryCoordinatorTests.swift
+++ b/FoqosTests/StartupRecoveryCoordinatorTests.swift
@@ -85,7 +85,7 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
       profileCount: { _ in .confirmed(0) },
       restoreRole: { restoredRole = $0 })
 
-    await coordinator.start(classification: .existing)
+    await coordinator.start(classification: .localStatePresent)
     XCTAssertEqual(coordinator.state, .normal(recheckArmed: true))
 
     membership = .member(role: .parent, ownerUserRecordName: "owner-A")
@@ -105,7 +105,7 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
       store: store,
       membership: { .confirmedNone(ownerUserRecordName: "owner-A") })
 
-    await coordinator.start(classification: .existing)
+    await coordinator.start(classification: .localStatePresent)
     await coordinator.recheckIfNeeded()
 
     XCTAssertFalse(store.recheckPending)
@@ -138,7 +138,7 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
       restoreRole: { _ in XCTFail("Durable role restoration must be idempotent") },
       refreshLocks: { XCTFail("Durable role restoration must not repeat lock refresh") })
 
-    await coordinator.start(classification: .existing)
+    await coordinator.start(classification: .localStatePresent)
 
     XCTAssertEqual(steps, ["membership", "profiles"])
     XCTAssertEqual(coordinator.state, .offer(role: .child, profileCount: 1))
@@ -162,7 +162,7 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
       },
       profileCount: { _ in .confirmed(3) })
 
-    await coordinator.start(classification: .existing)
+    await coordinator.start(classification: .localStatePresent)
 
     XCTAssertEqual(coordinator.state, .offer(role: .parent, profileCount: 3))
   }
@@ -333,7 +333,7 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
     var syncValues: [Bool] = []
     let coordinator = StartupRecoveryCoordinator(
       store: store,
-      captureLocalClassification: { .existing },
+      captureLocalClassification: { .localStatePresent },
       lookupMembership: {
         .member(role: .child, ownerUserRecordName: "owner-A")
       },
@@ -345,7 +345,7 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
       refreshChildLockCodes: {},
       setSyncEnabled: { syncValues.append($0) },
       releaseStartup: {})
-    await coordinator.start(classification: .existing)
+    await coordinator.start(classification: .localStatePresent)
 
     await coordinator.recheckIfNeeded()
 
@@ -379,6 +379,29 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
     }
     await first.value
     await second.value
+  }
+
+  func testGivenRoleOnlyNotice_WhenDismissed_ThenOwnerBoundPayloadClears() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    store.pendingOffer = .init(
+      ownerUserRecordName: "owner-A",
+      role: .parent,
+      path: .localStatePresentMember,
+      profileCountHint: nil,
+      profileCountConfirmedAt: nil,
+      origin: emptyOrigin())
+    let coordinator = makeAccountScopedCoordinator(
+      store: store,
+      membership: { .member(role: .parent, ownerUserRecordName: "owner-A") })
+    await coordinator.start(classification: .localStatePresent)
+    XCTAssertEqual(coordinator.state, .roleRestored(role: .parent))
+
+    coordinator.dismissRoleRestoredNotice()
+
+    XCTAssertNil(store.pendingOffer)
+    XCTAssertEqual(coordinator.state, .normal(recheckArmed: false))
   }
 
   private func makeAccountScopedCoordinator(

--- a/FoqosTests/StartupRecoveryCoordinatorTests.swift
+++ b/FoqosTests/StartupRecoveryCoordinatorTests.swift
@@ -14,15 +14,18 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
       store: store,
       lookupMembership: {
         steps.append("membership")
-        return .member(.child)
+        return .member(role: .child, ownerUserRecordName: "owner-A")
       },
-      lookupSyncedProfileCount: {
+      lookupSyncedProfileCount: { ownerUserRecordName in
+        XCTAssertEqual(ownerUserRecordName, "owner-A")
         steps.append("profiles")
         return .confirmed(2)
       },
       restoreFamilyRole: { role in
         XCTAssertEqual(role, .child)
-        XCTAssertEqual(store.pendingOffer, .init(role: .child, profileCount: nil))
+        XCTAssertEqual(
+          store.pendingOffer,
+          .init(ownerUserRecordName: "owner-A", role: .child, profileCount: nil))
         steps.append("role")
       },
       refreshChildLockCodes: { steps.append("locks") },
@@ -33,7 +36,9 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
 
     XCTAssertEqual(steps, ["membership", "role", "locks", "profiles"])
     XCTAssertEqual(coordinator.state, .offer(role: .child, profileCount: 2))
-    XCTAssertEqual(store.pendingOffer, .init(role: .child, profileCount: 2))
+    XCTAssertEqual(
+      store.pendingOffer,
+      .init(ownerUserRecordName: "owner-A", role: .child, profileCount: 2))
   }
 
   func testGivenIndeterminateMembershipTwice_WhenContinuingSetup_ThenRecheckIsDurable() async {
@@ -69,13 +74,13 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
     let coordinator = makeCoordinator(
       store: store,
       membership: { membership },
-      profileCount: { .confirmed(0) },
+      profileCount: { _ in .confirmed(0) },
       restoreRole: { restoredRole = $0 })
 
     await coordinator.start(classification: .existing)
     XCTAssertEqual(coordinator.state, .normal(recheckArmed: true))
 
-    membership = .member(.parent)
+    membership = .member(role: .parent, ownerUserRecordName: "owner-A")
     await coordinator.recheckIfNeeded()
 
     XCTAssertEqual(restoredRole, .parent)
@@ -88,7 +93,9 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
     defer { defaults.removePersistentDomain(forName: suiteName) }
     let store = StartupRecoveryStore(defaults: defaults)
     store.markRecheckPending()
-    let coordinator = makeCoordinator(store: store, membership: { .confirmedNone })
+    let coordinator = makeCoordinator(
+      store: store,
+      membership: { .confirmedNone(ownerUserRecordName: "owner-A") })
 
     await coordinator.start(classification: .existing)
     await coordinator.recheckIfNeeded()
@@ -101,7 +108,10 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
     let (defaults, suiteName) = makeDefaults()
     defer { defaults.removePersistentDomain(forName: suiteName) }
     let store = StartupRecoveryStore(defaults: defaults)
-    store.pendingOffer = .init(role: .child, profileCount: nil)
+    store.pendingOffer = .init(
+      ownerUserRecordName: "owner-A",
+      role: .child,
+      profileCount: nil)
     var steps: [String] = []
     let coordinator = makeCoordinator(
       store: store,
@@ -109,7 +119,8 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
         XCTFail("Pending offer bypasses membership lookup")
         return .indeterminate
       },
-      profileCount: {
+      profileCount: { ownerUserRecordName in
+        XCTAssertEqual(ownerUserRecordName, "owner-A")
         steps.append("profiles")
         return .confirmed(1)
       },
@@ -126,14 +137,17 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
     let (defaults, suiteName) = makeDefaults()
     defer { defaults.removePersistentDomain(forName: suiteName) }
     let store = StartupRecoveryStore(defaults: defaults)
-    store.pendingOffer = .init(role: .parent, profileCount: 3)
+    store.pendingOffer = .init(
+      ownerUserRecordName: "owner-A",
+      role: .parent,
+      profileCount: 3)
     let coordinator = makeCoordinator(
       store: store,
       membership: {
         XCTFail("Stored offer bypasses membership lookup")
         return .indeterminate
       },
-      profileCount: {
+      profileCount: { _ in
         XCTFail("Stored count bypasses profile lookup")
         return .indeterminate
       })
@@ -151,8 +165,8 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
     var releaseCount = 0
     let coordinator = makeCoordinator(
       store: store,
-      membership: { .member(.parent) },
-      profileCount: { .confirmed(2) },
+      membership: { .member(role: .parent, ownerUserRecordName: "owner-A") },
+      profileCount: { _ in .confirmed(2) },
       setSyncEnabled: { syncValues.append($0) },
       releaseStartup: { releaseCount += 1 })
     await coordinator.start(classification: .fresh)
@@ -172,8 +186,8 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
     var didEnableSync = false
     let coordinator = makeCoordinator(
       store: store,
-      membership: { .member(.parent) },
-      profileCount: { .confirmed(2) },
+      membership: { .member(role: .parent, ownerUserRecordName: "owner-A") },
+      profileCount: { _ in .confirmed(2) },
       setSyncEnabled: { _ in didEnableSync = true })
     await coordinator.start(classification: .fresh)
 
@@ -191,8 +205,8 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
     var didEnableSync = false
     let coordinator = makeCoordinator(
       store: store,
-      membership: { .member(.child) },
-      profileCount: { .confirmed(0) },
+      membership: { .member(role: .child, ownerUserRecordName: "owner-A") },
+      profileCount: { _ in .confirmed(0) },
       setSyncEnabled: { _ in didEnableSync = true })
     await coordinator.start(classification: .fresh)
 
@@ -206,7 +220,9 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
   private func makeCoordinator(
     store: StartupRecoveryStore,
     membership: @escaping () async -> StartupRecoveryMembershipResult,
-    profileCount: @escaping () async -> StartupRecoveryProfileCountResult = { .confirmed(0) },
+    profileCount: @escaping (String) async -> StartupRecoveryProfileCountResult = { _ in
+      .confirmed(0)
+    },
     restoreRole: @escaping (FamilyRole) -> Void = { _ in },
     refreshLocks: @escaping () async -> Void = {},
     setSyncEnabled: @escaping (Bool) -> Void = { _ in },

--- a/FoqosTests/StartupRecoveryCoordinatorTests.swift
+++ b/FoqosTests/StartupRecoveryCoordinatorTests.swift
@@ -25,7 +25,13 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
         XCTAssertEqual(role, .child)
         XCTAssertEqual(
           store.pendingOffer,
-          .init(ownerUserRecordName: "owner-A", role: .child, profileCount: nil))
+          .init(
+            ownerUserRecordName: "owner-A",
+            role: .child,
+            path: .freshMember,
+            profileCountHint: nil,
+            profileCountConfirmedAt: nil,
+            origin: self.emptyOrigin()))
         steps.append("role")
       },
       refreshChildLockCodes: { steps.append("locks") },
@@ -36,9 +42,11 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
 
     XCTAssertEqual(steps, ["membership", "role", "locks", "profiles"])
     XCTAssertEqual(coordinator.state, .offer(role: .child, profileCount: 2))
-    XCTAssertEqual(
-      store.pendingOffer,
-      .init(ownerUserRecordName: "owner-A", role: .child, profileCount: 2))
+    XCTAssertEqual(store.pendingOffer?.ownerUserRecordName, "owner-A")
+    XCTAssertEqual(store.pendingOffer?.role, .child)
+    XCTAssertEqual(store.pendingOffer?.path, .freshMember)
+    XCTAssertEqual(store.pendingOffer?.profileCountHint, 2)
+    XCTAssertNotNil(store.pendingOffer?.profileCountConfirmedAt)
   }
 
   func testGivenIndeterminateMembershipTwice_WhenContinuingSetup_ThenRecheckIsDurable() async {
@@ -104,53 +112,55 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
     XCTAssertEqual(coordinator.state, .normal(recheckArmed: false))
   }
 
-  func testGivenPendingRoleWithoutCount_WhenRelaunching_ThenRoleAndProfileLookupResume() async {
+  func testGivenPendingRoleWithoutCount_WhenRelaunching_ThenOwnerAndProfileLookupResume() async {
     let (defaults, suiteName) = makeDefaults()
     defer { defaults.removePersistentDomain(forName: suiteName) }
     let store = StartupRecoveryStore(defaults: defaults)
     store.pendingOffer = .init(
       ownerUserRecordName: "owner-A",
       role: .child,
-      profileCount: nil)
+      path: .freshMember,
+      profileCountHint: nil,
+      profileCountConfirmedAt: nil,
+      origin: emptyOrigin())
     var steps: [String] = []
     let coordinator = makeCoordinator(
       store: store,
       membership: {
-        XCTFail("Pending offer bypasses membership lookup")
-        return .indeterminate
+        steps.append("membership")
+        return .member(role: .child, ownerUserRecordName: "owner-A")
       },
       profileCount: { ownerUserRecordName in
         XCTAssertEqual(ownerUserRecordName, "owner-A")
         steps.append("profiles")
         return .confirmed(1)
       },
-      restoreRole: { _ in steps.append("role") },
-      refreshLocks: { steps.append("locks") })
+      restoreRole: { _ in XCTFail("Durable role restoration must be idempotent") },
+      refreshLocks: { XCTFail("Durable role restoration must not repeat lock refresh") })
 
     await coordinator.start(classification: .existing)
 
-    XCTAssertEqual(steps, ["role", "locks", "profiles"])
+    XCTAssertEqual(steps, ["membership", "profiles"])
     XCTAssertEqual(coordinator.state, .offer(role: .child, profileCount: 1))
   }
 
-  func testGivenPendingOfferWithCount_WhenRelaunching_ThenOfferReturnsWithoutCloudLookup() async {
+  func testGivenPendingOfferWithCount_WhenRelaunching_ThenOwnerAndCountAreRevalidated() async {
     let (defaults, suiteName) = makeDefaults()
     defer { defaults.removePersistentDomain(forName: suiteName) }
     let store = StartupRecoveryStore(defaults: defaults)
     store.pendingOffer = .init(
       ownerUserRecordName: "owner-A",
       role: .parent,
-      profileCount: 3)
+      path: .freshMember,
+      profileCountHint: 3,
+      profileCountConfirmedAt: Date(timeIntervalSince1970: 1),
+      origin: emptyOrigin())
     let coordinator = makeCoordinator(
       store: store,
       membership: {
-        XCTFail("Stored offer bypasses membership lookup")
-        return .indeterminate
+        return .member(role: .parent, ownerUserRecordName: "owner-A")
       },
-      profileCount: { _ in
-        XCTFail("Stored count bypasses profile lookup")
-        return .indeterminate
-      })
+      profileCount: { _ in .confirmed(3) })
 
     await coordinator.start(classification: .existing)
 
@@ -171,7 +181,7 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
       releaseStartup: { releaseCount += 1 })
     await coordinator.start(classification: .fresh)
 
-    coordinator.restoreProfiles()
+    await coordinator.restoreProfiles()
 
     XCTAssertEqual(syncValues, [true])
     XCTAssertNil(store.pendingOffer)
@@ -191,7 +201,7 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
       setSyncEnabled: { _ in didEnableSync = true })
     await coordinator.start(classification: .fresh)
 
-    coordinator.declineProfiles()
+    await coordinator.declineProfiles()
 
     XCTAssertFalse(didEnableSync)
     XCTAssertNil(store.pendingOffer)
@@ -210,11 +220,196 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
       setSyncEnabled: { _ in didEnableSync = true })
     await coordinator.start(classification: .fresh)
 
-    coordinator.continueWithoutProfiles()
+    await coordinator.continueWithoutProfiles()
 
     XCTAssertFalse(didEnableSync)
     XCTAssertNil(store.pendingOffer)
     XCTAssertEqual(coordinator.state, .normal(recheckArmed: false))
+  }
+
+  func testGivenStoredOffer_WhenOwnerMatches_ThenMembershipAndCountAreRevalidated() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    let origin = StartupRecoveryOriginState(
+      modeRawValue: nil,
+      hasSelectedMode: false,
+      onboardingCompleted: false,
+      showIntro: true,
+      showModeSelection: true,
+      deviceSyncEnabled: false)
+    store.pendingOffer = .init(
+      ownerUserRecordName: "owner-A",
+      role: .parent,
+      path: .freshMember,
+      profileCountHint: 2,
+      profileCountConfirmedAt: Date(timeIntervalSince1970: 1),
+      origin: origin)
+    var membershipCalls = 0
+    var countCalls = 0
+    let coordinator = makeAccountScopedCoordinator(
+      store: store,
+      membership: {
+        membershipCalls += 1
+        return .member(role: .parent, ownerUserRecordName: "owner-A")
+      },
+      profileCount: { ownerUserRecordName in
+        XCTAssertEqual(ownerUserRecordName, "owner-A")
+        countCalls += 1
+        return .confirmed(2)
+      })
+
+    await coordinator.start(classification: .fresh)
+
+    XCTAssertEqual(membershipCalls, 1)
+    XCTAssertEqual(countCalls, 1)
+    XCTAssertEqual(coordinator.state, .offer(role: .parent, profileCount: 2))
+  }
+
+  func testGivenStoredOffer_WhenAccountChangedToConfirmedNonmember_ThenOriginRollsBack() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    let origin = StartupRecoveryOriginState(
+      modeRawValue: nil,
+      hasSelectedMode: false,
+      onboardingCompleted: false,
+      showIntro: true,
+      showModeSelection: true,
+      deviceSyncEnabled: nil)
+    store.pendingOffer = .init(
+      ownerUserRecordName: "owner-A",
+      role: .child,
+      path: .freshMember,
+      profileCountHint: 1,
+      profileCountConfirmedAt: Date(timeIntervalSince1970: 1),
+      origin: origin)
+    var restoredOrigin: StartupRecoveryOriginState?
+    var releaseCount = 0
+    let coordinator = makeAccountScopedCoordinator(
+      store: store,
+      membership: { .confirmedNone(ownerUserRecordName: "owner-B") },
+      restoreOrigin: { restoredOrigin = $0 },
+      releaseStartup: { releaseCount += 1 })
+
+    await coordinator.start(classification: .fresh)
+
+    XCTAssertEqual(restoredOrigin, origin)
+    XCTAssertNil(store.pendingOffer)
+    XCTAssertEqual(coordinator.state, .normal(recheckArmed: false))
+    XCTAssertEqual(releaseCount, 1)
+  }
+
+  func testGivenChangedCountBeforeRestore_WhenTapped_ThenOfferUpdatesAndRequiresSecondTap() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    var counts = [2, 3, 3]
+    var syncValues: [Bool] = []
+    let coordinator = makeAccountScopedCoordinator(
+      store: store,
+      membership: { .member(role: .parent, ownerUserRecordName: "owner-A") },
+      profileCount: { _ in .confirmed(counts.removeFirst()) },
+      setSyncEnabled: { syncValues.append($0) })
+    await coordinator.start(classification: .fresh)
+
+    await coordinator.restoreProfiles()
+    XCTAssertEqual(coordinator.state, .offer(role: .parent, profileCount: 3))
+    XCTAssertTrue(syncValues.isEmpty)
+    XCTAssertNotNil(store.pendingOffer)
+
+    await coordinator.restoreProfiles()
+    XCTAssertEqual(syncValues, [true])
+    XCTAssertNil(store.pendingOffer)
+    XCTAssertEqual(coordinator.state, .normal(recheckArmed: false))
+  }
+
+  func testGivenRecheckFindsLocalStateAndMembership_WhenRunning_ThenOnlyRoleIsRestored() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    store.markRecheckPending()
+    var profileCalls = 0
+    var syncValues: [Bool] = []
+    let coordinator = StartupRecoveryCoordinator(
+      store: store,
+      captureLocalClassification: { .existing },
+      lookupMembership: {
+        .member(role: .child, ownerUserRecordName: "owner-A")
+      },
+      lookupSyncedProfileCount: { _ in
+        profileCalls += 1
+        return .confirmed(4)
+      },
+      restoreFamilyRole: { _ in },
+      refreshChildLockCodes: {},
+      setSyncEnabled: { syncValues.append($0) },
+      releaseStartup: {})
+    await coordinator.start(classification: .existing)
+
+    await coordinator.recheckIfNeeded()
+
+    XCTAssertEqual(profileCalls, 0)
+    XCTAssertEqual(syncValues, [false])
+    XCTAssertEqual(coordinator.state, .roleRestored(role: .child))
+    XCTAssertEqual(store.pendingOffer?.path, .localStatePresentMember)
+  }
+
+  func testGivenOverlappingStarts_WhenMembershipIsSuspended_ThenLookupIsSingleFlight() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    var membershipCalls = 0
+    var continuations: [CheckedContinuation<StartupRecoveryMembershipResult, Never>] = []
+    let coordinator = makeAccountScopedCoordinator(
+      store: store,
+      membership: {
+        membershipCalls += 1
+        return await withCheckedContinuation { continuations.append($0) }
+      })
+
+    let first = Task { @MainActor in await coordinator.start(classification: .fresh) }
+    while continuations.isEmpty { await Task.yield() }
+    let second = Task { @MainActor in await coordinator.start(classification: .fresh) }
+    for _ in 0..<10 { await Task.yield() }
+
+    XCTAssertEqual(membershipCalls, 1)
+    for continuation in continuations {
+      continuation.resume(returning: .confirmedNone(ownerUserRecordName: "owner-A"))
+    }
+    await first.value
+    await second.value
+  }
+
+  private func makeAccountScopedCoordinator(
+    store: StartupRecoveryStore,
+    membership: @escaping () async -> StartupRecoveryMembershipResult,
+    profileCount: @escaping (String) async -> StartupRecoveryProfileCountResult = { _ in
+      .confirmed(0)
+    },
+    restoreOrigin: @escaping (StartupRecoveryOriginState) -> Void = { _ in },
+    setSyncEnabled: @escaping (Bool) -> Void = { _ in },
+    releaseStartup: @escaping () -> Void = {}
+  ) -> StartupRecoveryCoordinator {
+    StartupRecoveryCoordinator(
+      store: store,
+      captureLocalClassification: { .fresh },
+      captureOrigin: {
+        StartupRecoveryOriginState(
+          modeRawValue: nil,
+          hasSelectedMode: false,
+          onboardingCompleted: false,
+          showIntro: true,
+          showModeSelection: true,
+          deviceSyncEnabled: false)
+      },
+      restoreOrigin: restoreOrigin,
+      lookupMembership: membership,
+      lookupSyncedProfileCount: profileCount,
+      restoreFamilyRole: { _ in },
+      refreshChildLockCodes: {},
+      setSyncEnabled: setSyncEnabled,
+      releaseStartup: releaseStartup)
   }
 
   private func makeCoordinator(
@@ -241,5 +436,15 @@ final class StartupRecoveryCoordinatorTests: XCTestCase {
   private func makeDefaults() -> (UserDefaults, String) {
     let suiteName = "StartupRecoveryCoordinatorTests-\(UUID().uuidString)"
     return (UserDefaults(suiteName: suiteName)!, suiteName)
+  }
+
+  private func emptyOrigin() -> StartupRecoveryOriginState {
+    StartupRecoveryOriginState(
+      modeRawValue: nil,
+      hasSelectedMode: nil,
+      onboardingCompleted: nil,
+      showIntro: nil,
+      showModeSelection: nil,
+      deviceSyncEnabled: nil)
   }
 }

--- a/FoqosTests/StartupRecoveryCopyTests.swift
+++ b/FoqosTests/StartupRecoveryCopyTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class StartupRecoveryCopyTests: XCTestCase {
+  func testRecoveryIntroductionUsesPlainHonestLanguage() {
+    XCTAssertEqual(StartupRecoveryCopy.title, "We found your family")
+    XCTAssertEqual(
+      StartupRecoveryCopy.introduction,
+      "This device doesn't have local Family Foqos data, but this iCloud account is part of a Family Foqos family. Your family role has been restored.")
+    for forbidden in ["no longer", "previous", "lost", "wiped"] {
+      XCTAssertFalse(
+        StartupRecoveryCopy.introduction.localizedCaseInsensitiveContains(forbidden))
+    }
+  }
+
+  func testAvailabilityDisclosureStatesThatDeviceSyncRemainsOff() {
+    XCTAssertEqual(
+      StartupRecoveryCopy.availabilityDisclosure,
+      "Family Foqos checked this iCloud account's Device Sync storage only to see whether synced profiles are available. Device Sync is still off.")
+  }
+
+  func testRoleOnlyNoticeExplainsWhyProfilesAreNotMerged() {
+    XCTAssertEqual(StartupRecoveryCopy.roleRestoredTitle, "Your family role was restored")
+    XCTAssertEqual(
+      StartupRecoveryCopy.roleRestoredMessage,
+      "This device already has local setup or profiles, so Family Foqos restored only its family role. Device Sync is off to avoid merging profiles automatically. You can review Device Sync in Settings.")
+  }
+
+  func testProfilePromptUsesSingularAndPluralGrammar() {
+    XCTAssertEqual(
+      StartupRecoveryCopy.profilePrompt(count: 1),
+      "We found 1 synced profile. Restore it to this device?")
+    XCTAssertEqual(
+      StartupRecoveryCopy.profilePrompt(count: 3),
+      "We found 3 synced profiles. Restore them to this device?")
+  }
+
+  func testNoProfileMessageDoesNotPromiseLocalOnlyRecovery() {
+    XCTAssertEqual(
+      StartupRecoveryCopy.noProfiles,
+      "We couldn't find any profiles saved with Device Sync. Profiles that existed only on this device can't be recovered.")
+  }
+}

--- a/FoqosTests/StartupRecoveryLocalStateTests.swift
+++ b/FoqosTests/StartupRecoveryLocalStateTests.swift
@@ -20,15 +20,11 @@ final class StartupRecoveryLocalStateTests: XCTestCase {
     }
   }
 
-  func testGivenAnyPersistedLocalSentinel_WhenClassifying_ThenNormalStartupIsPreserved() {
+  func testGivenPersistedOnboardingOrProfiles_WhenClassifying_ThenNormalStartupIsPreserved() {
     let snapshots = [
       StartupRecoveryLocalSnapshot(
         onboardingValuePresent: true,
         appGroupStatePresent: false,
-        store: .storeAbsent),
-      StartupRecoveryLocalSnapshot(
-        onboardingValuePresent: false,
-        appGroupStatePresent: true,
         store: .storeAbsent),
       StartupRecoveryLocalSnapshot(
         onboardingValuePresent: false,
@@ -39,6 +35,16 @@ final class StartupRecoveryLocalStateTests: XCTestCase {
     for snapshot in snapshots {
       XCTAssertEqual(StartupRecoveryLocalState.classify(snapshot), .existing)
     }
+  }
+
+  func testGivenOnlyAppGroupState_WhenOnboardingAndProfilesAreEmpty_ThenRecoveryCheckIsRequired() {
+    XCTAssertEqual(
+      StartupRecoveryLocalState.classify(
+        StartupRecoveryLocalSnapshot(
+          onboardingValuePresent: false,
+          appGroupStatePresent: true,
+          store: .profileCount(0))),
+      .fresh)
   }
 
   func testGivenUnreadableStore_WhenClassifying_ThenFreshStateIsNotAssumed() {

--- a/FoqosTests/StartupRecoveryLocalStateTests.swift
+++ b/FoqosTests/StartupRecoveryLocalStateTests.swift
@@ -33,7 +33,7 @@ final class StartupRecoveryLocalStateTests: XCTestCase {
     ]
 
     for snapshot in snapshots {
-      XCTAssertEqual(StartupRecoveryLocalState.classify(snapshot), .existing)
+      XCTAssertEqual(StartupRecoveryLocalState.classify(snapshot), .localStatePresent)
     }
   }
 

--- a/FoqosTests/StartupRecoveryLocalStateTests.swift
+++ b/FoqosTests/StartupRecoveryLocalStateTests.swift
@@ -1,0 +1,151 @@
+import SQLite3
+import XCTest
+
+@testable import FamilyFoqos
+
+final class StartupRecoveryLocalStateTests: XCTestCase {
+  func testGivenEveryFreshStoreShape_WhenClassifying_ThenRecoveryCheckIsRequired() {
+    for store in [
+      StartupRecoveryStoreFinding.storeAbsent,
+      .tableMissing,
+      .profileCount(0),
+    ] {
+      XCTAssertEqual(
+        StartupRecoveryLocalState.classify(
+          StartupRecoveryLocalSnapshot(
+            onboardingValuePresent: false,
+            appGroupStatePresent: false,
+            store: store)),
+        .fresh)
+    }
+  }
+
+  func testGivenAnyPersistedLocalSentinel_WhenClassifying_ThenNormalStartupIsPreserved() {
+    let snapshots = [
+      StartupRecoveryLocalSnapshot(
+        onboardingValuePresent: true,
+        appGroupStatePresent: false,
+        store: .storeAbsent),
+      StartupRecoveryLocalSnapshot(
+        onboardingValuePresent: false,
+        appGroupStatePresent: true,
+        store: .storeAbsent),
+      StartupRecoveryLocalSnapshot(
+        onboardingValuePresent: false,
+        appGroupStatePresent: false,
+        store: .profileCount(1)),
+    ]
+
+    for snapshot in snapshots {
+      XCTAssertEqual(StartupRecoveryLocalState.classify(snapshot), .existing)
+    }
+  }
+
+  func testGivenUnreadableStore_WhenClassifying_ThenFreshStateIsNotAssumed() {
+    XCTAssertEqual(
+      StartupRecoveryLocalState.classify(
+        StartupRecoveryLocalSnapshot(
+          onboardingValuePresent: false,
+          appGroupStatePresent: false,
+          store: .readFailed)),
+      .indeterminate)
+  }
+
+  func testGivenCurrentOnboardingKey_WhenCapturing_ThenOnboardingSentinelIsPresent() {
+    let snapshot = capture { key in
+      key == StartupRecoveryLocalState.currentOnboardingKey ? true : nil
+    }
+
+    XCTAssertTrue(snapshot.onboardingValuePresent)
+  }
+
+  func testGivenLegacyOnboardingKey_WhenCapturingBeforeMigration_ThenOnboardingSentinelIsPresent() {
+    let snapshot = capture { key in
+      key == StartupRecoveryLocalState.legacyOnboardingKey ? true : nil
+    }
+
+    XCTAssertTrue(snapshot.onboardingValuePresent)
+  }
+
+  func testGivenAnyAppGroupValue_WhenCapturing_ThenAppGroupSentinelIsPresent() {
+    let snapshot = StartupRecoveryLocalState.capture(
+      storeURL: URL(fileURLWithPath: "/missing/default.store"),
+      preferenceValue: { _, _ in nil },
+      appGroupValues: { _ in ["family_foqos_device_sync_enabled": false] },
+      fileExists: { _ in false },
+      readStore: { _ in
+        XCTFail("Missing store must not be opened")
+        return .readFailed
+      })
+
+    XCTAssertTrue(snapshot.appGroupStatePresent)
+  }
+
+  func testGivenMissingStore_WhenCapturing_ThenSQLiteIsNeverOpened() {
+    var readCount = 0
+
+    let snapshot = StartupRecoveryLocalState.capture(
+      storeURL: URL(fileURLWithPath: "/missing/default.store"),
+      preferenceValue: { _, _ in nil },
+      appGroupValues: { _ in [:] },
+      fileExists: { _ in false },
+      readStore: { _ in
+        readCount += 1
+        return .readFailed
+      })
+
+    XCTAssertEqual(snapshot.store, .storeAbsent)
+    XCTAssertEqual(readCount, 0)
+  }
+
+  func testGivenTemporaryModelConfiguration_WhenConstructed_ThenStoreIsNotCreated() {
+    let storeURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("StartupRecoveryLocalStateTests-\(UUID().uuidString).store")
+
+    _ = AppModelStore.makeConfiguration(url: storeURL)
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: storeURL.path))
+  }
+
+  func testGivenSQLiteWithoutProfileTable_WhenReading_ThenTableMissingIsDistinct() throws {
+    let storeURL = try makeSQLiteStore(sql: "CREATE TABLE OTHER (VALUE INTEGER)")
+    defer { try? FileManager.default.removeItem(at: storeURL) }
+
+    XCTAssertEqual(StartupRecoveryLocalState.readStore(at: storeURL), .tableMissing)
+  }
+
+  func testGivenSQLiteProfileRows_WhenReading_ThenLiteralCountIsReturned() throws {
+    let storeURL = try makeSQLiteStore(
+      sql: "CREATE TABLE ZBLOCKEDPROFILES (Z_PK INTEGER); INSERT INTO ZBLOCKEDPROFILES VALUES (1); INSERT INTO ZBLOCKEDPROFILES VALUES (2)")
+    defer { try? FileManager.default.removeItem(at: storeURL) }
+
+    XCTAssertEqual(StartupRecoveryLocalState.readStore(at: storeURL), .profileCount(2))
+  }
+
+  private func capture(
+    preferenceForKey: @escaping (String) -> Any?
+  ) -> StartupRecoveryLocalSnapshot {
+    StartupRecoveryLocalState.capture(
+      storeURL: URL(fileURLWithPath: "/missing/default.store"),
+      preferenceValue: { key, _ in preferenceForKey(key) },
+      appGroupValues: { _ in [:] },
+      fileExists: { _ in false },
+      readStore: { _ in
+        XCTFail("Missing store must not be opened")
+        return .readFailed
+      })
+  }
+
+  private func makeSQLiteStore(sql: String) throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("StartupRecoveryLocalStateTests-\(UUID().uuidString).sqlite")
+    var database: OpaquePointer?
+    XCTAssertEqual(sqlite3_open(url.path, &database), SQLITE_OK)
+    guard let database else {
+      throw NSError(domain: "StartupRecoveryLocalStateTests", code: 1)
+    }
+    defer { sqlite3_close(database) }
+    XCTAssertEqual(sqlite3_exec(database, sql, nil, nil, nil), SQLITE_OK)
+    return url
+  }
+}

--- a/FoqosTests/StartupRecoveryOrderingTests.swift
+++ b/FoqosTests/StartupRecoveryOrderingTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+final class StartupRecoveryOrderingTests: XCTestCase {
+  func testOnlyNormalStateReleasesHomeAndSyncAttachment() {
+    let heldStates: [StartupRecoveryState] = [
+      .checking,
+      .retryMembership(canContinueSetup: false),
+      .retryMembership(canContinueSetup: true),
+      .retryProfiles(role: .parent),
+      .checkingProfiles(role: .child),
+      .offer(role: .parent, profileCount: 2),
+    ]
+
+    for state in heldStates {
+      XCTAssertFalse(StartupRecoveryStartupPolicy.isReleased(state))
+    }
+    XCTAssertTrue(StartupRecoveryStartupPolicy.isReleased(.normal(recheckArmed: false)))
+    XCTAssertTrue(StartupRecoveryStartupPolicy.isReleased(.normal(recheckArmed: true)))
+    XCTAssertTrue(StartupRecoveryStartupPolicy.isReleased(.roleRestored(role: .parent)))
+  }
+
+  func testAppSourceKeepsSnapshotBeforeStateObjectsAndCoordinatorBeforeMigration() throws {
+    let source = try appSource()
+
+    assertOrder(
+      [
+        "private let startupRecoverySnapshot",
+        "@StateObject private var requestAuthorizer",
+        "_startupRecoveryCoordinator = StateObject",
+        "UserDefaultsMigration.migrateIfNeeded()",
+      ],
+      in: source)
+  }
+
+  func testForegroundSourceRechecksRecoveryBeforeAuthorizationVerification() throws {
+    let source = try appSource()
+    let foreground = try functionBody(named: "handleActiveScene", in: source)
+
+    assertOrder(
+      ["startupRecoveryCoordinator.recheckIfNeeded()", "verifyChildAuthorizationIfNeeded()"],
+      in: String(foreground))
+  }
+
+  func testRoleRecoverySourcePersistsRoleAndOnboardingBeforeChildLockRefresh() throws {
+    let source = try appSource()
+    let restore = try functionBody(named: "restoreRecoveredFamilyRole", in: source)
+
+    assertOrder(
+      [
+        "AppModeManager.shared.selectMode",
+        "family_foqos_has_completed_onboarding",
+        "family_foqos_show_intro_screen",
+        "family_foqos_show_mode_selection",
+      ],
+      in: String(restore))
+    XCTAssertFalse(restore.contains("refreshSharedLockCodesForVerification"))
+  }
+
+  private func assertOrder(
+    _ needles: [String],
+    in source: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    var cursor = source.startIndex
+    for needle in needles {
+      guard let range = source.range(of: needle, range: cursor..<source.endIndex) else {
+        XCTFail("Missing or out-of-order source marker: \(needle)", file: file, line: line)
+        return
+      }
+      cursor = range.upperBound
+    }
+  }
+
+  private func functionBody(named name: String, in source: String) throws -> Substring {
+    guard let signature = source.range(of: "func \(name)(") else {
+      throw SourceError.missingFunction(name)
+    }
+    guard let openingBrace = source[signature.lowerBound...].firstIndex(of: "{") else {
+      throw SourceError.malformedFunction(name)
+    }
+
+    var depth = 1
+    var index = source.index(after: openingBrace)
+    while index < source.endIndex {
+      switch source[index] {
+      case "{":
+        depth += 1
+      case "}":
+        depth -= 1
+        if depth == 0 {
+          return source[source.index(after: openingBrace)..<index]
+        }
+      default:
+        break
+      }
+      index = source.index(after: index)
+    }
+    throw SourceError.malformedFunction(name)
+  }
+
+  private func appSource() throws -> String {
+    let repositoryRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let sourceURL = repositoryRoot.appendingPathComponent("Foqos/FoqosApp.swift")
+    return try String(contentsOf: sourceURL, encoding: .utf8)
+  }
+
+  private enum SourceError: Error {
+    case missingFunction(String)
+    case malformedFunction(String)
+  }
+}

--- a/FoqosTests/StartupRecoveryRuntimeTests.swift
+++ b/FoqosTests/StartupRecoveryRuntimeTests.swift
@@ -50,4 +50,19 @@ final class StartupRecoveryRuntimeTests: XCTestCase {
     XCTAssertEqual(heldCompletions, 0)
     XCTAssertEqual(releasedCalls, 1)
   }
+
+  func testShareArbitrationSourceMakesMissingCoordinatorObservable() throws {
+    let repositoryRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let sourceURL = repositoryRoot.appendingPathComponent(
+      "Foqos/Utils/StartupRecoveryRuntime.swift")
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+    XCTAssertTrue(source.contains("assertionFailure("))
+    XCTAssertTrue(source.contains("Log.error("))
+    XCTAssertFalse(source.contains("coordinator?.beginShareAcceptance()"))
+    XCTAssertFalse(source.contains("coordinator?.failShareAcceptance()"))
+    XCTAssertFalse(source.contains("coordinator?.completeShareAcceptanceAfterModeApplied()"))
+  }
 }

--- a/FoqosTests/StartupRecoveryRuntimeTests.swift
+++ b/FoqosTests/StartupRecoveryRuntimeTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class StartupRecoveryRuntimeTests: XCTestCase {
+  func testGivenConsumerAccessBeforeComposition_WhenRuntimeLoads_ThenItIsHeld() {
+    let runtime = StartupRecoveryRuntime()
+
+    XCTAssertTrue(runtime.isHeld)
+
+    runtime.release()
+    runtime.release()
+    XCTAssertFalse(runtime.isHeld)
+  }
+
+  func testGivenHeldRuntime_WhenRoutingSilentPush_ThenReleasedWorkDoesNotRun() async {
+    var heldCompletions = 0
+    var accountCalls = 0
+    var membershipCalls = 0
+    var syncCalls = 0
+    var heartbeatCalls = 0
+
+    await StartupRecoveryPushRouter.route(
+      isHeld: true,
+      onHeld: { heldCompletions += 1 },
+      onReleased: {
+        accountCalls += 1
+        membershipCalls += 1
+        syncCalls += 1
+        heartbeatCalls += 1
+      })
+
+    XCTAssertEqual(heldCompletions, 1)
+    XCTAssertEqual(accountCalls, 0)
+    XCTAssertEqual(membershipCalls, 0)
+    XCTAssertEqual(syncCalls, 0)
+    XCTAssertEqual(heartbeatCalls, 0)
+  }
+
+  func testGivenReleasedRuntime_WhenRoutingSilentPush_ThenExistingRouteRuns() async {
+    var heldCompletions = 0
+    var releasedCalls = 0
+
+    await StartupRecoveryPushRouter.route(
+      isHeld: false,
+      onHeld: { heldCompletions += 1 },
+      onReleased: { releasedCalls += 1 })
+
+    XCTAssertEqual(heldCompletions, 0)
+    XCTAssertEqual(releasedCalls, 1)
+  }
+}

--- a/FoqosTests/StartupRecoveryShareAcceptanceTests.swift
+++ b/FoqosTests/StartupRecoveryShareAcceptanceTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+
+@testable import FamilyFoqos
+
+@MainActor
+final class StartupRecoveryShareAcceptanceTests: XCTestCase {
+  func testGivenSuspendedLookup_WhenAcceptanceBeginsAndFails_ThenStaleWorkCannotChangeIntent() async {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    let pendingOffer = makePendingOffer()
+    store.pendingOffer = pendingOffer
+    var continuation: CheckedContinuation<StartupRecoveryMembershipResult, Never>?
+    let coordinator = makeCoordinator(
+      store: store,
+      membership: {
+        await withCheckedContinuation { continuation = $0 }
+      })
+    let runtime = StartupRecoveryRuntime()
+    runtime.register(coordinator: coordinator)
+
+    let start = Task { @MainActor in await coordinator.start(classification: .fresh) }
+    while continuation == nil { await Task.yield() }
+    runtime.beginShareAcceptance()
+    continuation?.resume(
+      returning: .member(role: .parent, ownerUserRecordName: "owner-A"))
+    await start.value
+
+    XCTAssertEqual(store.pendingOffer, pendingOffer)
+    XCTAssertTrue(runtime.isHeld)
+
+    runtime.failShareAcceptance()
+    XCTAssertEqual(store.pendingOffer, pendingOffer)
+    XCTAssertTrue(runtime.isHeld)
+  }
+
+  func testGivenPendingRecovery_WhenAcceptedModeApplied_ThenIntentClearsAndReleasesOnce() {
+    let (defaults, suiteName) = makeDefaults()
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let store = StartupRecoveryStore(defaults: defaults)
+    store.pendingOffer = makePendingOffer()
+    let runtime = StartupRecoveryRuntime()
+    var releaseCount = 0
+    let coordinator = makeCoordinator(
+      store: store,
+      releaseStartup: {
+        releaseCount += 1
+        runtime.release()
+      })
+    runtime.register(coordinator: coordinator)
+
+    runtime.beginShareAcceptance()
+    runtime.completeShareAcceptanceAfterModeApplied()
+    runtime.completeShareAcceptanceAfterModeApplied()
+
+    XCTAssertNil(store.pendingOffer)
+    XCTAssertFalse(store.recheckPending)
+    XCTAssertEqual(coordinator.state, .normal(recheckArmed: false))
+    XCTAssertFalse(runtime.isHeld)
+    XCTAssertEqual(releaseCount, 1)
+  }
+
+  private func makeCoordinator(
+    store: StartupRecoveryStore,
+    membership: @escaping () async -> StartupRecoveryMembershipResult = { .indeterminate },
+    releaseStartup: @escaping () -> Void = {}
+  ) -> StartupRecoveryCoordinator {
+    StartupRecoveryCoordinator(
+      store: store,
+      lookupMembership: membership,
+      lookupSyncedProfileCount: { _ in .confirmed(1) },
+      restoreFamilyRole: { _ in },
+      refreshChildLockCodes: {},
+      setSyncEnabled: { _ in },
+      releaseStartup: releaseStartup)
+  }
+
+  private func makePendingOffer() -> StartupRecoveryPendingOffer {
+    StartupRecoveryPendingOffer(
+      ownerUserRecordName: "owner-A",
+      role: .parent,
+      path: .freshMember,
+      profileCountHint: 1,
+      profileCountConfirmedAt: Date(timeIntervalSince1970: 1),
+      origin: StartupRecoveryOriginState(
+        modeRawValue: nil,
+        hasSelectedMode: false,
+        onboardingCompleted: false,
+        showIntro: true,
+        showModeSelection: true,
+        deviceSyncEnabled: false))
+  }
+
+  private func makeDefaults() -> (UserDefaults, String) {
+    let suiteName = "StartupRecoveryShareAcceptanceTests-\(UUID().uuidString)"
+    return (UserDefaults(suiteName: suiteName)!, suiteName)
+  }
+}

--- a/docs/superpowers/plans/2026-08-16-issue-447-empty-store-family-recovery-v2.md
+++ b/docs/superpowers/plans/2026-08-16-issue-447-empty-store-family-recovery-v2.md
@@ -1,0 +1,456 @@
+# Issue #447 Empty-Store Family Recovery V2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recover confirmed family authority before startup side effects, offer only account-validated synced profiles for a genuinely fresh local store, and avoid automatic profile merging when local state appears before delayed recovery.
+
+**Architecture:** A read-only first-property snapshot feeds a main-actor, single-flight coordinator. A literal-default-held process runtime gates foreground composition, silent pushes, and sync attachment; successful share acceptance is the only alternate authority exit. Durable recovery intent is account-scoped, current-account membership and profile counts are revalidated before surface and action, and the corrected #449 notice pattern supplies defer/surface/invalidate behavior.
+
+**Tech Stack:** Swift 6, SwiftUI, SwiftData, Core Foundation preferences, SQLite3 read-only inspection, CloudKit zone-change operations, XCTest, and the project Xcode simulator gate.
+
+## Global Constraints
+
+- Approved design: signed commit `a95781a54c42f65a17540ff11b398773f6d4ba94`, plus the maintainer-authored M1/M2 rulings and reviewer-approved copy correction recorded on 2026-08-16.
+- Existing signed implementation commits `be49cda`, `6f60fba`, and `bb632d3` remain intact; revise forward with new signed commits only.
+- The held Task 4 diff in `FoqosApp.swift`, `StartupRecoveryView.swift`, `StartupRecoveryCopyTests.swift`, and `StartupRecoveryOrderingTests.swift` is preserved and audited before reuse.
+- Missing onboarding completion plus an absent, table-missing, or zero-profile store is `fresh` regardless of app-group values. Positive profiles or persisted onboarding are `localStatePresent`; read failure is `indeterminate`.
+- After two indeterminate membership attempts, Continue Setup is unbounded and enters normal onboarding. Persist only `recheckPending`; implement no grace counter, elapsed/launch cap, or capability restriction.
+- Every recovery claim is bound to the current iCloud user record name. Unknown account defers without clearing; mismatch holds startup, invalidates stale claims, and reruns membership.
+- Inherit the corrected notice pattern from exact merged main `f0293418539aeced376c121f410b1152faed3a11`. Use explicit verb-shaped names for operations that can clear or rewrite durable state, and never create an ownerless recovery intent.
+- Successful lookup absence is authoritative. A thrown `.zoneNotFound`, `.userDeletedZone`, partial failure, record failure, or operation failure remains indeterminate unless a fresh successful zone list proves absence.
+- Only `freshMember` counts remote profiles. `localStatePresentMember` restores the role, persists Device Sync disabled, shows distinct copy, and never enumerates, attaches, seeds, or merges profiles.
+- Stored profile count is a hint. Reconfirm account and count before surfacing and before every Restore, Not Now, or zero-profile Continue action; a changed count updates the offer and requires a new tap.
+- `StartupRecoveryRuntime` is lazy static state with literal default `held`. No consumer can observe released before an allowed coordinator transition.
+- Durable transitions are mutually exclusive with share acceptance; asynchronous CloudKit lookups are not. No critical section spans an `await`.
+- Silent pushes return `.noData` while held and invoke no account, membership, child-data, sync, heartbeat, or app-group mutation path.
+- The profile-availability read occurs before Device Sync consent, uses `CKFetchRecordZoneChangesOperation` only, and discloses that read honestly.
+- The fresh-member introduction is exactly: `This device doesn't have local Family Foqos data, but this iCloud account is part of a Family Foqos family. Your family role has been restored.` It must not contain `no longer`, `previous`, `lost`, or `wiped`.
+- All 12 configurations target `MARKETING_VERSION = 2.0.49` and `CURRENT_PROJECT_VERSION = 67` after v2.0.48/66 merges.
+- Build and test only through `scripts/xcode-stream.sh --agent build2 --session issue_447`; never use a device-name destination.
+- No CloudKit schema change, dependency addition, #430 root-cause claim, local-only reconstruction, or naive local/remote merge.
+
+---
+
+### Task 1: Close the maintainer rulings and forward plan
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-16-issue-447-empty-store-family-recovery-design.md`
+- Create: `docs/superpowers/plans/2026-08-16-issue-447-empty-store-family-recovery-v2.md`
+
+**Interfaces:**
+- Consumes: immutable reviewer approval on `a95781a` and planner rulings for M1, M2, and fresh-member copy.
+- Produces: a signed docs-only commit that removes both open slots, names maintainer authorship, and defines the remaining implementation sequence.
+
+- [x] **Step 1: Replace OPEN-M1 with the maintainer's unbounded escape**
+
+  State Retry then Continue Setup, durable `recheckPending`, and explicit absence of bound machinery.
+
+- [x] **Step 2: Replace OPEN-M2 with the concrete classifier**
+
+  State that app-group values inform recovery but never veto `fresh` when onboarding is absent and the profile store is empty/absent.
+
+- [x] **Step 3: Adopt account-neutral fresh-member copy**
+
+  Replace the false lost-data claim with the exact Global Constraints string.
+
+- [x] **Step 4: Verify and commit**
+
+  Run:
+
+  ```bash
+  rg -n "OPEN-M1|OPEN-M2|no longer has its previous" docs/superpowers/specs/2026-08-16-issue-447-empty-store-family-recovery-design.md
+  git diff --check
+  ```
+
+  Expected: `rg` exits 1 with no stale open-slot/copy text; `git diff --check` exits 0. Commit only the two docs:
+
+  ```bash
+  git add docs/superpowers/specs/2026-08-16-issue-447-empty-store-family-recovery-design.md docs/superpowers/plans/2026-08-16-issue-447-empty-store-family-recovery-v2.md
+  git commit -S -m "docs(#447): apply maintainer recovery rulings"
+  ```
+
+### Task 2: Apply the loosened local classifier
+
+**Files:**
+- Modify: `Foqos/Utils/StartupRecoveryLocalState.swift`
+- Modify: `FoqosTests/StartupRecoveryLocalStateTests.swift`
+
+**Interfaces:**
+- Produces: `StartupRecoveryLocalClassification.localStatePresent`, `.fresh`, and `.indeterminate`.
+- Preserves: `StartupRecoveryLocalSnapshot.appGroupStatePresent` as informational evidence.
+
+- [ ] **Step 1: Write the failing app-group-crumb test and rename expectations**
+
+  Replace the old app-group-veto fixture with:
+
+  ```swift
+  func testGivenOnlyAppGroupState_WhenOnboardingAndProfilesAreEmpty_ThenRecoveryCheckIsRequired() {
+    XCTAssertEqual(
+      StartupRecoveryLocalState.classify(
+        .init(
+          onboardingValuePresent: false,
+          appGroupStatePresent: true,
+          store: .profileCount(0))),
+      .fresh)
+  }
+  ```
+
+  Rename `.existing` expectations to `.localStatePresent` and prove onboarding or a positive profile count still takes that path.
+
+- [ ] **Step 2: Run focused RED**
+
+  ```bash
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -only-testing:FoqosTests/StartupRecoveryLocalStateTests
+  ```
+
+  Expected: the app-group-only assertion fails because current code returns `.existing`.
+
+- [ ] **Step 3: Implement the minimal classifier**
+
+  ```swift
+  enum StartupRecoveryLocalClassification: Equatable {
+    case localStatePresent
+    case fresh
+    case indeterminate
+  }
+
+  static func classify(_ snapshot: StartupRecoveryLocalSnapshot)
+    -> StartupRecoveryLocalClassification
+  {
+    if snapshot.onboardingValuePresent { return .localStatePresent }
+    switch snapshot.store {
+    case .storeAbsent, .tableMissing, .profileCount(0): return .fresh
+    case .profileCount: return .localStatePresent
+    case .readFailed: return .indeterminate
+    }
+  }
+  ```
+
+- [ ] **Step 4: Run focused GREEN and commit**
+
+  Run the Task 2 command again. Expected: all local-state tests pass. Then:
+
+  ```bash
+  git add Foqos/Utils/StartupRecoveryLocalState.swift FoqosTests/StartupRecoveryLocalStateTests.swift
+  git commit -S -m "fix(#447): treat app-group crumbs as recovery evidence"
+  ```
+
+### Task 3: Bind CloudKit recovery evidence to a successful account lookup
+
+**Files:**
+- Modify: `Foqos/CloudKit/StartupRecoveryCloudService.swift`
+- Modify: `Foqos/Utils/StartupRecoveryCoordinator.swift`
+- Modify: `FoqosTests/StartupRecoveryCloudServiceTests.swift`
+
+**Interfaces:**
+- Produces:
+
+  ```swift
+  enum StartupRecoveryMembershipResult: Equatable {
+    case member(role: FamilyRole, ownerUserRecordName: String)
+    case confirmedNone(ownerUserRecordName: String)
+    case indeterminate
+  }
+  ```
+
+- Produces: `fetchSyncedProfileCount(expectedOwnerUserRecordName:)` which verifies the current account before reading the private zone.
+
+- [ ] **Step 1: Write failing semantic mapping tests**
+
+  Add exact fixtures for:
+
+  ```swift
+  XCTAssertEqual(
+    StartupRecoveryCloudService.resolveMembership(
+      .recordRole(role: FamilyRole.child.rawValue, ownerUserRecordName: "owner-A")),
+    .member(role: .child, ownerUserRecordName: "owner-A"))
+  XCTAssertEqual(
+    StartupRecoveryCloudService.resolveMembership(.recordFetchFailed),
+    .indeterminate)
+  XCTAssertEqual(
+    StartupRecoveryCloudService.resolveMembership(.zoneListSucceededWithoutPolicyZone(ownerUserRecordName: "owner-A")),
+    .confirmedNone(ownerUserRecordName: "owner-A"))
+  ```
+
+  Prove thrown missing-zone and partial-failure observations remain indeterminate. Prove a successful list missing the private `DeviceSync` zone confirms count zero, while a thrown missing-zone fetch does not.
+
+- [ ] **Step 2: Run focused RED**
+
+  ```bash
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -only-testing:FoqosTests/StartupRecoveryCloudServiceTests
+  ```
+
+  Expected: compile failures for account-bearing result cases and the stricter observation cases.
+
+- [ ] **Step 3: Implement the exact #427 evidence boundary**
+
+  Carry `userRecordID.recordName` through only successful account observations. Never map an operation error directly to absence. If a zone-change fetch reports `.zoneNotFound` or `.userDeletedZone`, perform a fresh `allRecordZones()` read; confirm none/zero only when that new list succeeds without the exact zone.
+
+- [ ] **Step 4: Run focused GREEN and sync guards**
+
+  ```bash
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -only-testing:FoqosTests/StartupRecoveryCloudServiceTests
+  scripts/check-sync-guards.sh
+  ```
+
+  Expected: focused tests pass; I5 reports no private-path `CKQuery` and I2 reports no new outbound enqueue.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add Foqos/CloudKit/StartupRecoveryCloudService.swift Foqos/Utils/StartupRecoveryCoordinator.swift FoqosTests/StartupRecoveryCloudServiceTests.swift
+  git commit -S -m "fix(#447): bind recovery evidence to iCloud account"
+  ```
+
+### Task 4: Make recovery intent account-scoped, single-flight, and honest after re-arm
+
+**Files:**
+- Modify: `Foqos/Utils/StartupRecoveryCoordinator.swift`
+- Modify: `FoqosTests/StartupRecoveryCoordinatorTests.swift`
+
+**Interfaces:**
+- Produces:
+
+  ```swift
+  enum StartupRecoveryPath: String, Codable { case freshMember, localStatePresentMember }
+
+  struct StartupRecoveryOriginState: Codable, Equatable {
+    let modeRawValue: String?
+    let hasSelectedMode: Bool?
+    let onboardingCompleted: Bool?
+    let showIntro: Bool?
+    let showModeSelection: Bool?
+    let deviceSyncEnabled: Bool?
+  }
+
+  struct StartupRecoveryPendingOffer: Codable, Equatable {
+    let ownerUserRecordName: String
+    let role: FamilyRole
+    let path: StartupRecoveryPath
+    let profileCountHint: Int?
+    let profileCountConfirmedAt: Date?
+    let origin: StartupRecoveryOriginState
+  }
+  ```
+
+- Consumes: injected `captureLocalClassification`, `captureOrigin`, `restoreOrigin`, account-bearing membership lookup, account-bound profile count, role restore, lock refresh, sync toggle, and release callbacks.
+- Produces async `restoreProfiles()`, `declineProfiles()`, and `continueWithoutProfiles()` actions that revalidate before commit.
+
+- [ ] **Step 1: Write failing account/durability tests**
+
+  Test matching owner resume, unknown-account defer, different-account invalidation plus rerun, new-account confirmed-none origin rollback, and indeterminate mismatch holding startup. Recreate `StartupRecoveryStore` between actions to prove persistence.
+
+- [ ] **Step 2: Write failing count/action tests**
+
+  A stored count must trigger a new count fetch before `.offer`. Before each action, return a changed count and assert the coordinator updates the offer without enabling sync, clearing intent, or releasing. A second tap after an unchanged confirmation may commit.
+
+- [ ] **Step 3: Write failing single-flight and re-arm tests**
+
+  Use continuations to overlap cold start, Retry, foreground, and connectivity triggers. Assert one membership call, one profile call, stale completion suppression, and one release. After Continue Setup, return `.localStatePresent` from the injected classifier and confirmed membership; assert role-only state, no count call, `[false]` sync writes, and distinct notice.
+
+- [ ] **Step 4: Run focused RED**
+
+  ```bash
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -only-testing:FoqosTests/StartupRecoveryCoordinatorTests
+  ```
+
+  Expected: compile failures for the new account-scoped intent and async action API.
+
+- [ ] **Step 5: Implement minimal coordinator generations and synchronous write sections**
+
+  Keep every `UserDefaults`, mode, onboarding, consent, intent, state, and release mutation in non-suspending main-actor helpers. Increment a generation before each async lookup; after every `await`, guard the captured generation and `!acceptanceInFlight` before opening a durable write section. Coalesce repeated triggers onto the current task.
+
+- [ ] **Step 6: Run focused GREEN and commit**
+
+  Run Task 4's focused command. Expected: all durability, mismatch, stale-count, single-flight, re-arm, and role-only tests pass. Then:
+
+  ```bash
+  git add Foqos/Utils/StartupRecoveryCoordinator.swift FoqosTests/StartupRecoveryCoordinatorTests.swift
+  git commit -S -m "feat(#447): make recovery account-scoped and single-flight"
+  ```
+
+### Task 5: Enforce the literal-default-held runtime across startup and silent pushes
+
+**Files:**
+- Create: `Foqos/Utils/StartupRecoveryRuntime.swift`
+- Modify: `Foqos/FoqosApp.swift`
+- Modify: `FoqosTests/StartupRecoveryOrderingTests.swift`
+- Create: `FoqosTests/StartupRecoveryRuntimeTests.swift`
+
+**Interfaces:**
+- Produces `@MainActor final class StartupRecoveryRuntime` with `static let shared`, literal `private(set) var isHeld = true`, coordinator registration, monotonic `release()`, and share-acceptance forwarding.
+- `AppDelegate.didReceiveRemoteNotification` reads `StartupRecoveryRuntime.shared.isHeld` before any current-mode singleton access or CloudKit work.
+
+- [ ] **Step 1: Write failing consumer-first and push tests**
+
+  Instantiate/access the runtime before constructing any app composition helper and assert `isHeld`. Inject closures into a pure push router and assert all counters remain zero while held and completion is `.noData`; after release, assert the existing route runs.
+
+- [ ] **Step 2: Run focused RED**
+
+  ```bash
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -only-testing:FoqosTests/StartupRecoveryRuntimeTests -only-testing:FoqosTests/StartupRecoveryOrderingTests
+  ```
+
+  Expected: compile failures for the absent runtime/router API.
+
+- [ ] **Step 3: Implement the runtime and route gate**
+
+  Gate before `AppModeManager.shared.currentMode`, `CloudKitManager.shared`, `LockCodeManager.shared`, `ProfileSyncManager.shared`, or `HeartbeatManager.shared` is touched. Keep Home, migrations, foreground refresh, and `attachEngine` behind the same monotonic release.
+
+- [ ] **Step 4: Run focused GREEN and commit**
+
+  ```bash
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -only-testing:FoqosTests/StartupRecoveryRuntimeTests -only-testing:FoqosTests/StartupRecoveryOrderingTests
+  git add Foqos/Utils/StartupRecoveryRuntime.swift Foqos/FoqosApp.swift FoqosTests/StartupRecoveryRuntimeTests.swift FoqosTests/StartupRecoveryOrderingTests.swift
+  git commit -S -m "feat(#447): gate startup and silent pushes"
+  ```
+
+### Task 6: Serialize successful share acceptance with durable recovery writes
+
+**Files:**
+- Modify: `Foqos/FoqosApp.swift`
+- Modify: `Foqos/Utils/StartupRecoveryCoordinator.swift`
+- Modify: `Foqos/Utils/StartupRecoveryRuntime.swift`
+- Create: `FoqosTests/StartupRecoveryShareAcceptanceTests.swift`
+
+**Interfaces:**
+- Produces `beginShareAcceptance()`, `failShareAcceptance()`, and `completeShareAcceptanceAfterModeApplied()` on the runtime/coordinator bridge.
+- Preserves existing global `completeShareAcceptance(metadata:role:)` entry point and calls the bridge inside its `Task { @MainActor in ... }`.
+
+- [ ] **Step 1: Write failing acceptance arbitration tests**
+
+  Cover Cancel/no-op; acceptance beginning while a lookup is suspended; a stale lookup completion being ignored; failed `acceptShareDirect` preserving intent byte-for-byte and gate held; and successful `applyAcceptedFamilyMode` atomically clearing intent, standing down, and releasing once.
+
+- [ ] **Step 2: Run focused RED**
+
+  ```bash
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -only-testing:FoqosTests/StartupRecoveryShareAcceptanceTests
+  ```
+
+  Expected: compile failures for the absent arbitration API.
+
+- [ ] **Step 3: Implement bounded main-actor write arbitration**
+
+  Mark `acceptanceInFlight` before awaiting `acceptShareDirect`. Do not hold a lock or durable section over that await. Because the main actor cannot enter `beginShareAcceptance` during a synchronous local write, acceptance waits at most for that write. On failure clear only the in-flight marker and restart recovery with a fresh generation; on successful `applyAcceptedFamilyMode`, clear the intent and release before best-effort registration/lock refresh.
+
+- [ ] **Step 4: Run focused GREEN and commit**
+
+  ```bash
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -only-testing:FoqosTests/StartupRecoveryShareAcceptanceTests
+  git add Foqos/FoqosApp.swift Foqos/Utils/StartupRecoveryCoordinator.swift Foqos/Utils/StartupRecoveryRuntime.swift FoqosTests/StartupRecoveryShareAcceptanceTests.swift
+  git commit -S -m "feat(#447): serialize share acceptance with recovery"
+  ```
+
+### Task 7: Present account-neutral recovery and inherit the corrected #449 notice pattern
+
+**Files:**
+- Modify: `Foqos/Views/StartupRecoveryView.swift`
+- Modify: `Foqos/Utils/StartupRecoveryCoordinator.swift`
+- Modify: `FoqosTests/StartupRecoveryCopyTests.swift`
+- Modify: `FoqosTests/StartupRecoveryCoordinatorTests.swift`
+
+**Interfaces:**
+- Mirrors the merged #449 account-resolution pattern: unknown account defers without clearing; matching owner surfaces; mismatch invalidates without surfacing; a dismissed matching notice clears both payload and owner.
+- Produces separate fresh-member and `localStatePresentMember` notice states and exact copy.
+
+- [ ] **Step 1: Confirm the corrected #449 merged head is an ancestor**
+
+  ```bash
+  git merge-base --is-ancestor f0293418539aeced376c121f410b1152faed3a11 HEAD
+  ```
+
+  Expected: exit 0 after merging the corrected-pattern head into #447. Do not implement this task against an unmerged mutable worktree.
+
+- [ ] **Step 2: Write failing copy and notice-resolution tests**
+
+  Require the exact fresh-member introduction and assert forbidden fault words are absent:
+
+  ```swift
+  XCTAssertEqual(StartupRecoveryCopy.introduction, expectedIntroduction)
+  for forbidden in ["no longer", "previous", "lost", "wiped"] {
+    XCTAssertFalse(StartupRecoveryCopy.introduction.localizedCaseInsensitiveContains(forbidden))
+  }
+  ```
+
+  Assert role-only copy says existing local setup/profiles, Device Sync off, and no merge. Assert unknown/matching/mismatched account resolution follows the merged #449 pattern.
+
+- [ ] **Step 3: Run focused RED**
+
+  ```bash
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -only-testing:FoqosTests/StartupRecoveryCopyTests -only-testing:FoqosTests/StartupRecoveryCoordinatorTests
+  ```
+
+  Expected: current lost-data copy and ownerless pending-offer behavior fail.
+
+- [ ] **Step 4: Implement minimal UI and notice resolution**
+
+  Show the pre-consent Device Sync availability disclosure. Keep Restore/Not Now/Continue disabled during final validation. Surface no stored role/count until owner and count are current. Use the role-only notice for `localStatePresentMember` and never show profile actions there.
+
+- [ ] **Step 5: Run focused/full GREEN and commit**
+
+  ```bash
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -only-testing:FoqosTests/StartupRecoveryCopyTests -only-testing:FoqosTests/StartupRecoveryCoordinatorTests
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos
+  git add Foqos/Views/StartupRecoveryView.swift Foqos/Utils/StartupRecoveryCoordinator.swift FoqosTests/StartupRecoveryCopyTests.swift FoqosTests/StartupRecoveryCoordinatorTests.swift
+  git commit -S -m "feat(#447): present account-validated recovery choices"
+  ```
+
+### Task 8: Version, verify, review, merge, and upload in sequence
+
+**Files:**
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+- Modify only if verification finds a tested defect: files already owned by Tasks 2–7.
+
+**Interfaces:**
+- Produces a signed exact head at v2.0.49/67, independent exact-head code approval, a non-draft PR, planner merge, and one attended TestFlight upload from verified merged main. There is no V1 or diagnostic-experiment upload leg.
+
+- [ ] **Step 1: Verify the version gate is RED before editing**
+
+  ```bash
+  scripts/check-version-increment.sh origin/main HEAD
+  ```
+
+  Expected: nonzero because #447 has not yet set v2.0.49/67.
+
+- [ ] **Step 2: Set and count all configurations**
+
+  Set all 12 `MARKETING_VERSION` values to `2.0.49` and all 12 `CURRENT_PROJECT_VERSION` values to `67`. Verify:
+
+  ```bash
+  rg -n "MARKETING_VERSION = 2.0.49;" FamilyFoqos.xcodeproj/project.pbxproj
+  rg -n "CURRENT_PROJECT_VERSION = 67;" FamilyFoqos.xcodeproj/project.pbxproj
+  ```
+
+  Expected: exactly 12 lines from each command.
+
+- [ ] **Step 3: Commit version and verify the gate GREEN**
+
+  ```bash
+  git add FamilyFoqos.xcodeproj/project.pbxproj
+  git commit -S -m "chore(#447): bump release to 2.0.49 build 67"
+  scripts/test-check-version-increment.sh
+  scripts/check-version-increment.sh origin/main HEAD
+  ```
+
+  Expected: fixture suite and live version gate pass.
+
+- [ ] **Step 4: Run the complete verification matrix**
+
+  ```bash
+  swift-format lint --recursive .
+  ruby scripts/check-log-privacy.rb
+  scripts/check-sync-guards.sh
+  git diff --check origin/main...HEAD
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos
+  scripts/xcode-stream.sh --agent build2 --session issue_447 --xcbeautify -- xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -configuration Debug build
+  ```
+
+  Record exact test count, failures, build exit, lints, guard output, and version counts. Any defect returns to a new RED test and a new signed commit; never amend.
+
+- [ ] **Step 5: Obtain immutable exact-head review**
+
+  Send the reviewer exact base/head SHAs, signed design/plan SHAs, diff scope, every RED/GREEN command, full matrix output, account-mismatch and count-revalidation evidence, consumer-first gate proof, push/share arbitration evidence, no-`CKQuery` guard, and version counts. Address findings in new signed commits and request re-review of each new exact head.
+
+- [ ] **Step 6: Publish and preserve release order**
+
+  Push the approved head, open a non-draft PR closing #447, and hand merge ownership to the planner. After the planner confirms merge and fresh-main verification, announce the single attended credential operation, run `scripts/fastlane.sh beta`, and report the exact accepted v2.0.49/67 artifact and merged head. Use bobbithy's standing authorization for the newer artifact; if the execution harness independently requires an external-action escalation, route that gate instead of bypassing it.

--- a/docs/superpowers/plans/2026-08-16-issue-447-empty-store-family-recovery.md
+++ b/docs/superpowers/plans/2026-08-16-issue-447-empty-store-family-recovery.md
@@ -1,0 +1,303 @@
+# Issue #447 Empty-Store Family Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect a locally fresh device that still belongs to a Family Foqos family before onboarding or sync writes, restore its family role, and offer only CloudKit-confirmed synced profiles for explicit restoration.
+
+**Architecture:** A first-property, read-only local snapshot classifies the launch before migrations, SwiftData materialization, onboarding, or sync attachment can mask evidence. A durable main-actor coordinator gates startup, calls a dedicated CloudKit reader for membership and private-zone profile count, survives termination, and supports the planner-approved offline Continue Setup plus re-armed membership checks.
+
+**Tech Stack:** Swift 6, SwiftUI, SwiftData, Core Foundation preferences, SQLite3 read-only inspection, CloudKit shared-zone query, `CKFetchRecordZoneChangesOperation`, XCTest, the project Xcode simulator gate.
+
+## Global Constraints
+
+- The first local snapshot must run before `@StateObject` initialization, `UserDefaultsMigration`, `ModelContainer` access, `HomeView`, and `ProfileSyncManager.attachEngine`.
+- The snapshot creates no preferences suite, SwiftData store, or WAL. Store read failure is indeterminate, never fresh.
+- A confirmed `FamilyMember` restores role/onboarding regardless of Device Sync or synced-profile count.
+- Child role persistence and the pending offer are durable before authorization verification; shared lock codes refresh after role restoration.
+- Private `DeviceSync` discovery uses `CKFetchRecordZoneChangesOperation`, never `CKQuery`, and performs no writes.
+- After one failed explicit Retry, Continue Setup is available; it durably re-arms membership checks on later foreground/connectivity until a confirmed answer.
+- A pending recovery offer survives termination and clears only on Restore, Not Now, or the zero-profile Continue decision.
+- Genuinely new users with confirmed no membership follow current onboarding unchanged.
+- All 12 build configurations use `MARKETING_VERSION = 2.0.47` and `CURRENT_PROJECT_VERSION = 65`.
+- No CloudKit schema change, dependency addition, #430 root-cause diagnosis, or local-only profile reconstruction.
+
+---
+
+### Task 1: Pre-startup read-only local classifier
+
+**Files:**
+- Create: `Foqos/Utils/AppModelStore.swift`
+- Create: `Foqos/Utils/StartupRecoveryLocalState.swift`
+- Create: `FoqosTests/StartupRecoveryLocalStateTests.swift`
+- Modify: `Foqos/FoqosApp.swift`
+
+**Interfaces:**
+- Produces: `AppModelStore.schema`, `configuration`, `storeURL`, and `makeContainer()` as the one production SwiftData configuration.
+- Produces: `StartupRecoveryStoreFinding`, `StartupRecoveryLocalSnapshot`, and `StartupRecoveryLocalClassification`.
+- `StartupRecoveryLocalState.capture(...)` accepts injected preference, file-existence, and SQLite readers for deterministic tests.
+
+- [ ] **Step 1: Write failing classifier and physical-effect tests**
+
+  Add tests whose wished-for API is:
+
+  ```swift
+  XCTAssertEqual(
+    StartupRecoveryLocalState.classify(
+      .init(onboardingValuePresent: false, appGroupStatePresent: false, store: .profileCount(0))),
+    .fresh)
+  XCTAssertEqual(
+    StartupRecoveryLocalState.classify(
+      .init(onboardingValuePresent: false, appGroupStatePresent: false, store: .readFailed)),
+    .indeterminate)
+  ```
+
+  Cover store absent, table missing, zero, positive count, read failure, current and pre-migration onboarding-key presence, and any app-group value. Prove a missing store never calls SQLite and construction of `AppModelStore.configuration` does not create its URL.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+  Run:
+
+  ```bash
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -only-testing:FoqosTests/StartupRecoveryLocalStateTests
+  ```
+
+  Expected: compile failure because the new types do not exist.
+
+- [ ] **Step 3: Implement the minimal read-only snapshot**
+
+  Move the existing three-model configuration from the global `FoqosApp` closure into `AppModelStore`. Implement Core Foundation preference reads and the #430-proven WAL-aware read-only SQLite table/count reader. The classifier must be equivalent to:
+
+  ```swift
+  static func classify(_ value: StartupRecoveryLocalSnapshot)
+    -> StartupRecoveryLocalClassification
+  {
+    if value.onboardingValuePresent || value.appGroupStatePresent { return .existing }
+    switch value.store {
+    case .profileCount(let count) where count > 0: return .existing
+    case .storeAbsent, .tableMissing, .profileCount(0): return .fresh
+    case .readFailed: return .indeterminate
+    default: return .indeterminate
+    }
+  }
+  ```
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+  Run the Task 1 command again. Expected: all `StartupRecoveryLocalStateTests` pass, with no created store/WAL.
+
+- [ ] **Step 5: Commit the task**
+
+  ```bash
+  git add Foqos/Utils/AppModelStore.swift Foqos/Utils/StartupRecoveryLocalState.swift Foqos/FoqosApp.swift FoqosTests/StartupRecoveryLocalStateTests.swift
+  git commit -S -m "feat(#447): classify fresh local state before startup"
+  ```
+
+### Task 2: Durable recovery state machine and offline escape
+
+**Files:**
+- Create: `Foqos/Utils/StartupRecoveryCoordinator.swift`
+- Create: `FoqosTests/StartupRecoveryCoordinatorTests.swift`
+
+**Interfaces:**
+- Produces: `StartupRecoveryMembershipResult` with `.member(FamilyRole)`, `.confirmedNone`, `.indeterminate`.
+- Produces: `StartupRecoveryProfileCountResult` with `.confirmed(Int)` and `.indeterminate`.
+- Produces: `StartupRecoveryState` for checking, retry, normal startup, profile lookup, and recovery offer.
+- Produces: `StartupRecoveryStore` with a durable recheck bit and a Codable pending offer containing `role` plus optional `profileCount`.
+- Consumes injected async closures for membership lookup, profile count, role/onboarding persistence, child lock refresh, sync enablement, and startup release.
+
+- [ ] **Step 1: Write failing durability and transition tests**
+
+  Test these transitions with recording closures:
+
+  ```swift
+  fresh -> member(.child) -> persistPending(role, nil) -> restoreRole -> refreshLocks
+    -> profileCount(.confirmed(2)) -> persistPending(role, 2) -> offer
+
+  fresh -> indeterminate -> retry -> indeterminate -> retry(canContinueSetup: true)
+    -> continueSetup -> normal(recheckArmed: true)
+  ```
+
+  Recreate `StartupRecoveryStore` with the same isolated defaults and prove both `recheckPending` and a pending offer survive. Prove pending state clears only after explicit decisions. Prove `confirmedNone` clears recheck state. Prove a relaunched offer with `profileCount == nil` resumes profile lookup, while a stored count immediately reconstructs the offer.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+  Run the Xcode stream command from Task 1 with `-only-testing:FoqosTests/StartupRecoveryCoordinatorTests`. Expected: compile failure for missing coordinator/store types.
+
+- [ ] **Step 3: Implement the minimal coordinator**
+
+  Keep the coordinator `@MainActor`. Persist the pending offer before role/onboarding writes. After membership confirmation, execute dependency callbacks in this tested order:
+
+  ```swift
+  store.pendingOffer = .init(role: role, profileCount: nil)
+  restoreFamilyRole(role)
+  if role == .child { await refreshChildLockCodes() }
+  let count = await lookupSyncedProfileCount()
+  ```
+
+  `restoreProfiles()` enables Device Sync, clears pending state, and releases startup. `declineProfiles()` and `continueWithoutProfiles()` clear pending state without enabling sync. `continueSetup()` sets `recheckPending = true` before releasing startup.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+  Expected: transition ordering, relaunch, retry/escape, re-arm, and clearing tests all pass.
+
+- [ ] **Step 5: Commit the task**
+
+  ```bash
+  git add Foqos/Utils/StartupRecoveryCoordinator.swift FoqosTests/StartupRecoveryCoordinatorTests.swift
+  git commit -S -m "feat(#447): persist startup family recovery state"
+  ```
+
+### Task 3: Read-only CloudKit membership and synced-profile discovery
+
+**Files:**
+- Create: `Foqos/CloudKit/StartupRecoveryCloudService.swift`
+- Create: `FoqosTests/StartupRecoveryCloudServiceTests.swift`
+
+**Interfaces:**
+- Produces: `StartupRecoveryCloudService.lookupMembership()` and `fetchSyncedProfileCount()`.
+- Produces a pure `StartupRecoveryProfileRecordFold` that accepts modification `(recordName, recordType)` and deletion `(recordName, recordType)` events and returns the current `SyncedProfile` count.
+- The production service owns the CloudKit container/database objects; tests exercise semantic mapping and folding without live CloudKit.
+
+- [ ] **Step 1: Write failing membership mapping and profile-fold tests**
+
+  Cover available account plus matching child/parent record, successful no-zone/no-record as confirmed none, signed-out/transient/invalid-role as indeterminate, multi-page profile modifications/deletions, unrelated record types, duplicate callbacks, empty/missing private zone, and transient private-zone failure.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+  Run the Xcode stream command with `-only-testing:FoqosTests/StartupRecoveryCloudServiceTests`. Expected: compile failure for the absent service/fold.
+
+- [ ] **Step 3: Implement shared membership lookup and private zone-change reader**
+
+  Shared membership may use the existing `FamilyMember` query shape in the shared `FamilyPolicies` zone. The private path must construct `CKFetchRecordZoneChangesOperation` for `CloudKitConstants.syncZoneName` with a nil previous token, `fetchAllChanges = true`, and read-only callbacks. Fold only records whose type equals `SyncedProfile.recordType`; apply deletions before returning the final count. Map `.zoneNotFound`, `.userDeletedZone`, and an empty result to confirmed zero; map all retryable/ambiguous failures to indeterminate.
+
+- [ ] **Step 4: Run focused tests and sync guard**
+
+  Expected: focused tests pass and:
+
+  ```bash
+  scripts/check-sync-guards.sh
+  ```
+
+  reports no private-path `CKQuery` and no outbound enqueue violations.
+
+- [ ] **Step 5: Commit the task**
+
+  ```bash
+  git add Foqos/CloudKit/StartupRecoveryCloudService.swift FoqosTests/StartupRecoveryCloudServiceTests.swift
+  git commit -S -m "feat(#447): inspect CloudKit recovery state read-only"
+  ```
+
+### Task 4: Gate app startup and present honest recovery UI
+
+**Files:**
+- Create: `Foqos/Views/StartupRecoveryView.swift`
+- Create: `FoqosTests/StartupRecoveryCopyTests.swift`
+- Create: `FoqosTests/StartupRecoveryOrderingTests.swift`
+- Modify: `Foqos/FoqosApp.swift`
+- Modify: `Foqos/Views/HomeView.swift`
+
+**Interfaces:**
+- `StartupRecoveryView` consumes `StartupRecoveryState` and coordinator actions only.
+- `FoqosApp` owns the first-property snapshot and one coordinator `@StateObject`.
+- Existing startup attachment is extracted into an idempotent method that runs only after coordinator release.
+
+- [ ] **Step 1: Write failing copy, action, and ordering tests**
+
+  Assert exact strings from the design, including:
+
+  ```swift
+  "We found 1 synced profile. Restore it to this device?"
+  "We found 3 synced profiles. Restore them to this device?"
+  ```
+
+  Add a pure startup-order recorder proving snapshot precedes migration/container/singletons, recovery role persistence precedes authorization verification, and attach is absent while checking/retrying/offering. Test new-user confirmed-none invisibility and later foreground re-arm after Continue Setup.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+  Run the Xcode stream command with both new test classes. Expected: compile failure for absent UI/order seams.
+
+- [ ] **Step 3: Wire the first-property snapshot and startup gate**
+
+  Declare the snapshot before every `@StateObject`. Construct the coordinator in `FoqosApp.init` before migrations. Render `StartupRecoveryView` for checking/retry/profile/offer states and construct `HomeView` only for released normal startup. Move `attachEngine` behind the idempotent release callback. Gate the existing scene-active CloudKit/auth/sync work so it cannot bypass recovery; when recheck is armed, run membership recovery before child authorization.
+
+  Role restoration must set:
+
+  ```swift
+  AppModeManager.shared.selectMode(role == .parent ? .parent : .child)
+  UserDefaults.standard.set(true, forKey: "family_foqos_has_completed_onboarding")
+  UserDefaults.standard.set(false, forKey: "family_foqos_show_intro_screen")
+  UserDefaults.standard.set(false, forKey: "family_foqos_show_mode_selection")
+  ```
+
+  Preserve screenshot-demo and XCTest side-effect guards.
+
+- [ ] **Step 4: Implement the recovery view and run focused/full tests**
+
+  Use plain language from the design, ProgressView for checking, Retry plus delayed Continue Setup for indeterminate state, Restore/Not Now for positive counts, and Continue for zero. Run focused tests, then all tests through the same build2 stream. Expected: all tests pass with no onboarding or attach ordering regression.
+
+- [ ] **Step 5: Commit the task**
+
+  ```bash
+  git add Foqos/FoqosApp.swift Foqos/Views/HomeView.swift Foqos/Views/StartupRecoveryView.swift FoqosTests/StartupRecoveryCopyTests.swift FoqosTests/StartupRecoveryOrderingTests.swift
+  git commit -S -m "feat(#447): gate onboarding on family recovery"
+  ```
+
+### Task 5: Version, verify, review, and publish for planner merge
+
+**Files:**
+- Modify: `FamilyFoqos.xcodeproj/project.pbxproj`
+
+**Interfaces:**
+- Produces one exact signed head on `fix/447-empty-store-recovery`, a ready-for-review PR, and independent approval for planner merge.
+
+- [ ] **Step 1: Write/run the version RED check**
+
+  Change no project values yet. Run:
+
+  ```bash
+  scripts/check-version-increment.sh origin/main HEAD
+  ```
+
+  Expected: nonzero with unchanged 2.0.45/64 settings, proving the live release gate rejects the pre-bump branch.
+
+- [ ] **Step 2: Set all 12 configurations to 2.0.47/65**
+
+  Mechanically replace the 12 marketing versions and 12 build numbers. Verify `rg -n "MARKETING_VERSION = 2.0.47;" FamilyFoqos.xcodeproj/project.pbxproj` prints exactly 12 lines and `rg -n "CURRENT_PROJECT_VERSION = 65;" FamilyFoqos.xcodeproj/project.pbxproj` prints exactly 12 lines, with no remaining 2.0.45 or build 64 setting.
+
+- [ ] **Step 3: Commit the version bump and verify GREEN**
+
+  ```bash
+  git add FamilyFoqos.xcodeproj/project.pbxproj
+  git commit -S -m "chore(#447): bump release to 2.0.47 build 65"
+  scripts/test-check-version-increment.sh
+  scripts/check-version-increment.sh origin/main HEAD
+  ```
+
+  Expected: the fixture suite passes and the live gate reports 2.0.45 -> 2.0.47 and 64 -> 65.
+
+- [ ] **Step 4: Run the complete verification matrix**
+
+  Run:
+
+  ```bash
+  swift-format lint --recursive .
+  ruby scripts/check-log-privacy.rb
+  scripts/check-sync-guards.sh
+  git diff --check origin/main...HEAD
+  scripts/xcode-stream.sh --agent build2 --session issue_447 -- xcodebuild test -project FamilyFoqos.xcodeproj -scheme FamilyFoqos
+  scripts/xcode-stream.sh --agent build2 --session issue_447 --xcbeautify -- xcodebuild -project FamilyFoqos.xcodeproj -scheme FamilyFoqos -configuration Debug build
+  ```
+
+  Record exact test count, failures, build exit, lints, and version counts.
+
+- [ ] **Step 5: Commit any verification fixes**
+
+  If verification exposes a defect, return to RED with the smallest reproducing test, fix it, rerun the focused and complete matrices, and create a new signed commit. Never amend or force-push.
+
+- [ ] **Step 6: Obtain independent review and publish**
+
+  Send the reviewer exact base/head, design/plan paths, diff scope, RED/GREEN evidence, full test/build/lint results, private-zone no-`CKQuery` evidence, and the offline/pending-offer ordering. Address findings in new signed commits and obtain approval of the new exact head. Then push, open a non-draft PR closing #447, and hand the merge to the planner.
+
+- [ ] **Step 7: Coordinate the attended beta after planner merge**
+
+  After the planner confirms merge and fresh-main verification, announce immediately before the attended `scripts/fastlane.sh beta` credential operation. Confirm App Store Connect accepted version 2.0.47 with a build strictly above 64 and report the exact build/head to the planner.

--- a/docs/superpowers/specs/2026-08-16-issue-447-empty-store-family-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-16-issue-447-empty-store-family-recovery-design.md
@@ -3,8 +3,9 @@
 ## Status and scope
 
 This design's engineering received final independent adversarial approval on 2026-08-16. It is
-not implementation-ready until the two maintainer decisions marked **OPEN-M1** and **OPEN-M2** are
-resolved. Production implementation remains frozen in the meantime.
+implementation-ready after the maintainer resolved both product decisions directly on 2026-08-16.
+Implementation is unfrozen; the recovery notice must inherit the corrected pattern from #449
+after the planner supplies its exact merged head.
 
 The recovery guard handles a device whose local family setup may have disappeared while the
 current iCloud account still has a `FamilyMember` record. It restores family authority
@@ -15,30 +16,31 @@ local and remote profiles remain out of scope.
 
 The planned release target is version 2.0.49 build 67, after version 2.0.48 build 66 lands first.
 
-## Open maintainer decisions
+## Maintainer decisions resolved on 2026-08-16
 
-### OPEN-M1: bounded offline escape
+### M1: unbounded offline escape
 
-The product must choose the bound applied after repeated indeterminate CloudKit checks: a single
-grace session, an elapsed-time or launch-count cap, or provisional capability restrictions. The
-current unbounded Continue Setup behavior is rejected because a wiped Child device could remain
-unrestricted forever by staying offline.
+The maintainer ruled that startup recovery is a recovery mechanic, not a security boundary, and
+that new-user experience wins. After an indeterminate result, the UI offers Retry. After the
+explicit retry also fails, it offers Continue Setup into normal onboarding. The guard re-arms on
+later foreground and connectivity recovery until CloudKit returns a confirmed answer.
 
-Whichever bound is chosen must be enforced by durable state that survives force-quit. That state
-must store the owning iCloud user record ID, be revalidated before every surface or enforcement
-decision, and be invalidated when restored onto another device or account. A backup transfer must
-not carry a spent or unspent grace period into a different account/device context. No
-offline-escape UI or enforcement implementation may proceed until this choice is settled.
+There is no grace-session counter, elapsed or launch cap, capability withholding, or durable bound
+record. The previously specified bound-enforcement machinery is deleted rather than implemented.
+Only the existing durable `recheckPending` signal survives termination so a later confirmed
+membership still enters recovery. The maintainer explicitly accepted the possibility that a wiped
+Child reinstall kept offline indefinitely remains in normal new-user behavior.
 
-### OPEN-M2: partial-wipe trigger breadth
+### M2: inconsistency trigger ignores app-group vetoes
 
-The product must decide whether any app-group value suppresses recovery, or whether an empty
-profile store plus missing onboarding may still qualify when app-group crumbs remain. No trigger
-broadening may be implemented until this choice is settled.
+The maintainer ruled that the local signals are indications, not cryptographic proof. Missing
+onboarding completion plus an empty or absent profile store classifies as `fresh` regardless of
+surviving app-group values. CloudKit membership confirmation still gates every recovery surface.
 
-The architecture does not depend on this ruling. `membership confirmed + local state present` is
-a first-class outcome below. OPEN-M2 changes only which local inputs are routed into membership
-checking; it does not add a new state-machine branch.
+App-group state remains captured and informs recovery. In particular, a surviving Device Sync
+consent crumb must be disabled before any role-only release so it cannot cause an automatic merge.
+It never vetoes the initial inconsistency check. `membership confirmed + local state present`
+remains a first-class outcome for re-arm after onboarding/local writes.
 
 ## Design choice
 
@@ -71,15 +73,17 @@ The capture is read-only:
   absent, table absent, and count zero are empty; a positive count is local state present; a read
   failure is indeterminate.
 - The app-group preferences domain is copied with Core Foundation preferences without
-  constructing `UserDefaults(suiteName:)`. The treatment of app-group values is OPEN-M2.
+  constructing `UserDefaults(suiteName:)`. Its values inform recovery handling but do not veto a
+  `fresh` classification.
 
 No capture path creates a preferences suite, the main store, or its WAL. A read-only SQLite SHM
 artifact is acceptable only if the WAL-aware reader requires it; creation of the main store or WAL
 is a hard failure.
 
-The pure local classifier returns `fresh`, `localStatePresent`, or `indeterminate`. Under the
-current narrow trigger, any onboarding, positive-profile, or app-group sentinel produces
-`localStatePresent`; OPEN-M2 may change only the app-group part of that routing rule.
+The pure local classifier returns `fresh`, `localStatePresent`, or `indeterminate`. Missing
+onboarding completion plus an absent, table-missing, or zero-profile store is `fresh`, regardless
+of app-group values. Persisted onboarding completion or a positive profile count is
+`localStatePresent`; unreadable local evidence is `indeterminate`.
 
 ## Process-wide startup and silent-push gate
 
@@ -212,10 +216,10 @@ Local classification and confirmed membership combine into two explicit recovery
 | `fresh` | confirmed member | `freshMember(role, owner)` |
 | `localStatePresent` | confirmed member | `localStatePresentMember(role, owner)` |
 | either | confirmed none | release the normal new-user path |
-| `indeterminate` or membership indeterminate | retry/OPEN-M1 bounded state |
+| `indeterminate` or membership indeterminate | Retry, then unbounded Continue Setup/re-arm |
 
-`localStatePresentMember` is not a re-arm special case. Re-arm and any future OPEN-M2 partial-wipe
-route converge on this same state and copy.
+`localStatePresentMember` is not a re-arm special case. Every membership-confirmed input with
+local state present converges on this same state and copy.
 
 Every async entry point—cold start, Retry, connectivity recovery, foreground re-arm, count
 refresh, and user action—coalesces into one coordinator-owned task. The coordinator uses a
@@ -226,8 +230,9 @@ and gate release are idempotent.
 
 ## Re-arm must reclassify local state
 
-After the bounded OPEN-M1 escape releases setup, every later membership re-arm first captures and
-classifies local evidence again. It must not reuse the cold-launch `fresh` result.
+After Continue Setup releases normal onboarding without a bound, every later membership re-arm
+first captures and classifies local evidence again. It must not reuse the cold-launch `fresh`
+result.
 
 If membership is later confirmed and local state is now present, route to
 `localStatePresentMember`. Restore only family role/authority. Do not enumerate remote profiles,
@@ -307,8 +312,8 @@ After current-account membership and profile count are confirmed, show:
 
 > **We found your family**
 >
-> This device no longer has its previous local data, but this iCloud account is still part of a
-> Family Foqos family. Your family role has been restored.
+> This device doesn't have local Family Foqos data, but this iCloud account is part of a Family
+> Foqos family. Your family role has been restored.
 
 The view also states that Family Foqos checked the account's Device Sync storage without enabling
 Device Sync.
@@ -340,17 +345,20 @@ Migration, schedule refresh, account verification, authorization verification, l
 and sync composition run once after an allowed release point. The process-wide gate is released
 only after the applicable durable transition and account validation finish.
 
-The selected OPEN-M1 policy will define the bounded indeterminate release point. Existing local
-state that is outside the OPEN-M2 trigger releases normal startup immediately. Confirmed
-membership with local state present goes through the role-only notice and sync-disabled release,
-never the fresh-member restoration offer.
+After one explicit Retry also returns indeterminate, Continue Setup is the unbounded indeterminate
+release point and durably re-arms the check. Existing local state that does not meet the concrete
+M2 trigger releases normal startup immediately. Confirmed membership with local state present
+goes through the role-only notice and sync-disabled release, never the fresh-member restoration
+offer.
 
 ## Testing and verification
 
 Implementation resumes with strict RED-GREEN-REFACTOR cycles only after maintainer rulings and
 reviewer approval. Tests must cover:
 
-1. The full local classifier matrix and both OPEN-M2 outcomes without changing the state machine.
+1. The full local classifier matrix, including app-group-only crumbs remaining `fresh`, persisted
+   onboarding or positive profiles producing `localStatePresent`, and read failure remaining
+   indeterminate.
 2. Read-only physical effects: no defaults suite, main store, or WAL creation; WAL visibility and
    SHM classification.
 3. A consumer-first gate proof: an `AppDelegate`-representing consumer accesses the static before
@@ -365,8 +373,7 @@ reviewer approval. Tests must cover:
    exact durable state; and successful mode application atomically invalidating intent and
    releasing exactly once.
 7. Exact #427 absence mapping, including every failed missing-zone form remaining indeterminate.
-8. `freshMember` and first-class `localStatePresentMember` outcomes from cold start, re-arm, and
-   both possible OPEN-M2 trigger policies.
+8. `freshMember` and first-class `localStatePresentMember` outcomes from cold start and re-arm.
 9. Re-arm reclassification after local writes, role-only copy, Device Sync forced off, no profile
    count, no engine attach, and no merge.
 10. Single-flight coalescing, stale-generation suppression, and idempotent durable transitions
@@ -376,11 +383,12 @@ reviewer approval. Tests must cover:
 12. Count re-confirmation before every surface and action, including changed-count retap.
 13. Private-zone counting across pages and deletions, read-before-consent disclosure, and zero
     confirmed only by successful evidence.
-14. Child fail-closed ordering, exact copy, privacy logging, and the complete OPEN-M1 durable,
-    account/device-scoped enforcement selected by the maintainer.
+14. Child fail-closed ordering, exact copy, privacy logging, unbounded Continue Setup, durable
+    re-arm across termination, and absence of grace/cap/capability-bound state.
 15. All 12 target configurations at marketing version 2.0.49 and build 67.
 
 Final verification includes focused tests, the full suite through build2's stable simulator
 stream, Debug build, recursive Swift formatting lint, log privacy lint, sync guards, version
 checks, and `git diff --check`. An independent reviewer must approve the exact signed head before
-the planner merges. The attended beta upload occurs only after merge and after 2.0.48 build 66.
+the planner merges. The release is one attended beta upload of v2.0.49 build 67 from verified
+merged main; there is no V1 or diagnostic-experiment upload leg.

--- a/docs/superpowers/specs/2026-08-16-issue-447-empty-store-family-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-16-issue-447-empty-store-family-recovery-design.md
@@ -2,120 +2,385 @@
 
 ## Status and scope
 
-This design implements the release-blocking recovery guard approved by the planner on 2026-08-16. It handles a device whose local onboarding, SwiftData profile store, and app-group state are all fresh or empty while the current iCloud account still has a `FamilyMember` record. The guard restores the family role independently of Device Sync and offers restoration only for profiles confirmed in the private `DeviceSync` zone.
+This design's engineering received final independent adversarial approval on 2026-08-16. It is
+not implementation-ready until the two maintainer decisions marked **OPEN-M1** and **OPEN-M2** are
+resolved. Production implementation remains frozen in the meantime.
 
-The change ships in version 2.0.47 build 65. Version 2.0.46 remains burned by the never-merged #430 diagnostic build. Diagnosing why local state disappeared and reconstructing local-only profiles remain out of scope.
+The recovery guard handles a device whose local family setup may have disappeared while the
+current iCloud account still has a `FamilyMember` record. It restores family authority
+independently of Device Sync. Profile restoration is offered only when both local state is fresh
+and profiles are confirmed in the current account's private `DeviceSync` zone. Diagnosing why
+local state disappeared, reconstructing local-only profiles, and merging independently-created
+local and remote profiles remain out of scope.
+
+The planned release target is version 2.0.49 build 67, after version 2.0.48 build 66 lands first.
+
+## Open maintainer decisions
+
+### OPEN-M1: bounded offline escape
+
+The product must choose the bound applied after repeated indeterminate CloudKit checks: a single
+grace session, an elapsed-time or launch-count cap, or provisional capability restrictions. The
+current unbounded Continue Setup behavior is rejected because a wiped Child device could remain
+unrestricted forever by staying offline.
+
+Whichever bound is chosen must be enforced by durable state that survives force-quit. That state
+must store the owning iCloud user record ID, be revalidated before every surface or enforcement
+decision, and be invalidated when restored onto another device or account. A backup transfer must
+not carry a spent or unspent grace period into a different account/device context. No
+offline-escape UI or enforcement implementation may proceed until this choice is settled.
+
+### OPEN-M2: partial-wipe trigger breadth
+
+The product must decide whether any app-group value suppresses recovery, or whether an empty
+profile store plus missing onboarding may still qualify when app-group crumbs remain. No trigger
+broadening may be implemented until this choice is settled.
+
+The architecture does not depend on this ruling. `membership confirmed + local state present` is
+a first-class outcome below. OPEN-M2 changes only which local inputs are routed into membership
+checking; it does not add a new state-machine branch.
 
 ## Design choice
 
-Use a pre-startup local snapshot plus a main-actor `StartupRecoveryCoordinator` state machine.
+Use a read-only local snapshot, a process-wide startup gate that defaults closed, and a main-actor
+`StartupRecoveryCoordinator` state machine. The gate controls both UI/startup composition and
+background CloudKit push work.
 
-The alternatives do not preserve the required ordering. A check launched from `HomeView.task` can lose the race to its onboarding covers and `onAppear` side effects. Attaching the sync engine before classification creates app-group device identity and can seed the empty local store, masking the contradiction the guard needs to detect.
+A check launched from `HomeView.task` can lose the race to onboarding covers and `onAppear` side
+effects. Attaching the sync engine before classification creates app-group device identity and can
+seed the empty local store, masking the contradiction the guard needs to detect. Gating only the
+foreground view is also insufficient because a silent push can launch the process and run the app
+delegate before foreground classification.
 
 ## Pre-startup local evidence
 
-`FoqosApp` captures immutable local evidence in its first stored-property initialization, following the ordering proven by the #430 V2 probe. The capture runs before singleton-backed `@StateObject` properties, `UserDefaultsMigration`, the global `ModelContainer` request, onboarding, CloudKit verification, or `ProfileSyncManager.attachEngine`.
+`FoqosApp` captures immutable local evidence in its first stored-property initialization,
+following the ordering proven by the #430 V2 probe. The capture runs before singleton-backed
+`@StateObject` properties, `UserDefaultsMigration`, app-group suite construction, the global
+`ModelContainer` request, onboarding, CloudKit verification, or
+`ProfileSyncManager.attachEngine`.
 
 The capture is read-only:
 
-- The standard defaults domain is read with Core Foundation preferences. The onboarding sentinel is present when either the current `family_foqos_has_completed_onboarding` key or its pre-migration `hasCompletedOnboarding` predecessor has a persisted value, preventing an older installed build from being mistaken for a fresh user before migration runs.
-- The production SwiftData URL comes from one extracted `AppModelStore` configuration shared by the app and inspector. If `default.store` is absent, the profile store is empty. If it exists, a WAL-aware read-only SQLite connection checks for `ZBLOCKEDPROFILES` and counts rows. Store absent, table absent, and count zero are empty; a positive count is existing state; a read failure is indeterminate.
-- The app-group preferences domain is copied with Core Foundation preferences without constructing `UserDefaults(suiteName:)`. Any persisted app-group value counts as existing state, including Device Sync consent, device identity, snapshots, or schedule/session data.
+- The standard defaults domain is read with Core Foundation preferences. The onboarding sentinel
+  is present when either the current `family_foqos_has_completed_onboarding` key or its
+  pre-migration `hasCompletedOnboarding` predecessor has a persisted value.
+- The production SwiftData URL comes from one extracted `AppModelStore` configuration shared by
+  the app and inspector. If `default.store` is absent, the profile store is empty. If it exists, a
+  WAL-aware read-only SQLite connection checks for `ZBLOCKEDPROFILES` and counts rows. Store
+  absent, table absent, and count zero are empty; a positive count is local state present; a read
+  failure is indeterminate.
+- The app-group preferences domain is copied with Core Foundation preferences without
+  constructing `UserDefaults(suiteName:)`. The treatment of app-group values is OPEN-M2.
 
-No capture path creates a preferences suite, the main store, or its WAL. The expected read-only SQLite SHM artifact remains acceptable only if the WAL-aware reader requires it; creation of the main store or WAL is a hard failure.
+No capture path creates a preferences suite, the main store, or its WAL. A read-only SQLite SHM
+artifact is acceptable only if the WAL-aware reader requires it; creation of the main store or WAL
+is a hard failure.
 
-The pure classifier returns:
+The pure local classifier returns `fresh`, `localStatePresent`, or `indeterminate`. Under the
+current narrow trigger, any onboarding, positive-profile, or app-group sentinel produces
+`localStatePresent`; OPEN-M2 may change only the app-group part of that routing rule.
 
-- `existing`: any onboarding, positive-profile, or app-group sentinel exists. Release normal startup immediately and keep the guard invisible.
-- `fresh`: onboarding is absent, profiles are confirmed empty, and the app-group domain is empty. Hold onboarding and sync attachment while checking CloudKit.
-- `indeterminate`: local evidence could not be read reliably. Show the same retryable checking state used for indeterminate CloudKit results.
+## Process-wide startup and silent-push gate
 
-## Startup and membership state machine
+`StartupRecoveryRuntimeGate` has static stored state whose literal default value is held. Static
+storage is lazy, so the design does not claim that a pre-main initializer runs before SwiftUI or
+UIKit lifecycle construction. The stronger invariant is that no consumer can observe the gate
+unheld unless the coordinator has completed an allowed release transition: whichever consumer
+accesses the static first creates it in the held state. The frozen snapshot is registered before
+ordinary startup dependencies are allowed through. Release is monotonic for the process and
+idempotent.
 
-While classification is unresolved, `FoqosApp` shows a neutral checking view instead of constructing `HomeView`. This prevents its onboarding covers and startup cleanup from running. `ProfileSyncManager.attachEngine` is also withheld, so no Device Sync identity, zone, seed, or write can occur before the guard decides.
+While held:
 
-For a fresh candidate, a dedicated read-only CloudKit service performs this sequence:
+- `FoqosApp` constructs only the neutral startup-recovery surface, not `HomeView`;
+- `ProfileSyncManager.attachEngine`, migrations, normal foreground refresh, and onboarding side
+  effects do not run; and
+- `AppDelegate.didReceiveRemoteNotification` completes with `.noData` without invoking account
+  verification, membership verification, child shared-data refresh, profile sync, or heartbeat
+  refresh.
 
-1. Confirm iCloud account availability.
-2. Find the shared `FamilyPolicies` zone.
-3. Fetch the current user record ID.
-4. Query the shared zone for that user's `FamilyMember` record and decode its role.
+This is the same structural release gate used before `attachEngine`, so a future change to the
+push call graph cannot silently weaken the invariant. The ordering proof observes behavior rather
+than asserting initialization order: a test consumer representing `AppDelegate` reaches the gate
+before constructing `FoqosApp` and must observe held.
 
-The lookup returns one of three semantic outcomes:
+Current code trace motivating the gate:
 
-- `member(role)`: enter recovery.
-- `confirmedNone`: release normal startup and current onboarding without showing recovery UI.
-- `indeterminate`: show an honest retry state and do not claim either membership or absence.
+- `Foqos/FoqosApp.swift:64` captures recovery evidence, while app-group construction and migration
+  currently follow at `Foqos/FoqosApp.swift:118-126`; engine attachment is currently released at
+  `Foqos/FoqosApp.swift:333-347`.
+- The silent-push callback starts at `Foqos/FoqosApp.swift:520-538`. Its task can verify family
+  membership and refresh child data at `Foqos/FoqosApp.swift:539-553`, invoke profile sync at
+  `Foqos/FoqosApp.swift:557-563`, and refresh parent heartbeats at
+  `Foqos/FoqosApp.swift:564-566`.
+- Account status alone currently changes only in-memory CloudKit properties
+  (`Foqos/CloudKit/CloudKitManager.swift:105-114`), but membership verification can persist app
+  mode or run confirmed-revocation cleanup (`Foqos/CloudKit/CloudKitManager.swift:339-374`).
+- Child refresh persists lock caches and processes pending commands
+  (`Foqos/Utils/LockCodeManager.swift:219-253`, `:264-280`, `:404-466`); a reset-emergency command
+  triggers additional persisted and CloudKit side effects. Parent heartbeat refresh saves local
+  monitored-device state (`Foqos/Utils/HeartbeatManager.swift:131-142`).
 
-An indeterminate result is not an infinite hold. The UI first offers Retry. After an explicit retry also fails, it additionally offers Continue Setup. Continue Setup releases current onboarding and re-arms the membership check on every later foreground and relevant connectivity recovery until CloudKit returns `member(role)` or `confirmedNone`. This deliberately allows a wiped child device launched offline to remain temporarily in the pre-existing Individual behavior until connectivity returns; permanently blocking a genuinely new offline user is the worse failure. A later confirmed membership immediately enters recovery and closes the temporary unrestricted window.
+The trace therefore does not prove the callback harmless. The default-closed gate prevents this
+entire mutating graph from starting before classification. A push skipped while held is not
+replayed directly; the recovery lookup and the normal post-release foreground/sync refresh obtain
+authoritative current state.
 
-## Family-role recovery and durability
+### Accepted APNs delivery-budget consequence
 
-On `member(role)`, the coordinator first persists the recovery intent, then restores the role through `AppModeManager.selectMode`, marks onboarding completed, and suppresses both onboarding screens. These writes are recovery actions made only after the pre-startup evidence is frozen and membership is confirmed.
+Completing every held silent push with `.noData` is honest, but iOS may reduce future background
+delivery when an app repeatedly reports no data. A device held across several pushes may therefore
+receive later lock-code propagation less promptly. This is an accepted correctness-over-promptness
+trade-off: the persisted Child lock cache remains fail-closed, and the mandatory post-release or
+foreground refresh fetches authoritative membership, lock codes, commands, profiles, and
+heartbeats. The product must not promise immediate background propagation after a prolonged hold.
 
-Child recovery completes role persistence before authorization verification and refreshes shared lock-code caches. Parent recovery restores Parent equivalently. Family-role restoration never depends on the Device Sync setting or the presence of synced profiles.
+## Share acceptance is a legitimate exit
 
-A durable `StartupRecoveryNoticeStore`, modeled on the #446 one-shot notice store, records that the recovery offer is pending. It is set before the restored onboarding state can make the next launch look non-fresh. Startup checks this flag before the local fresh-state classifier, reconstructs the recovery screen after termination, and clears the flag only after the user explicitly chooses Restore, Not Now, or Continue for the no-profile result. A crash at any point before a decision therefore cannot lose the offer.
+CloudKit share acceptance remains available while startup recovery is held because a parent's new
+invitation is a natural remediation for a wiped child. It is not ordinary work released through
+the runtime gate; it is an explicit, mutually exclusive authority transition that can resolve the
+hold.
 
-The durable record stores only non-sensitive recovery state: the restored role and the last confirmed synced-profile count. It stores no name, CloudKit record identifier, profile fields, or lock code.
+The current entry points receive share metadata at `Foqos/FoqosApp.swift:590-641`, detect a role
+and stage confirmation at `Foqos/FoqosApp.swift:655-692`, then call
+`completeShareAcceptance` from the user's Continue action at `Foqos/FoqosApp.swift:218-229`.
+Completion accepts the share and applies the accepted family mode at
+`Foqos/FoqosApp.swift:710-725`; registration and Child lock-code refresh follow at
+`Foqos/FoqosApp.swift:727-746`.
 
-## Synced-profile discovery
+The coordinator arbitrates recovery and acceptance on the main actor. Durable transitions are
+mutually exclusive with acceptance; asynchronous lookups are not. The critical section covers
+only local, bounded, fast writes to mode, onboarding, sync consent, coordinator state, and durable
+intent. It never spans a CloudKit call, so a hung membership lookup cannot block this remediation
+exit.
 
-After membership restoration and before any Device Sync enablement, the coordinator reads the current private `DeviceSync` zone with `CKFetchRecordZoneChangesOperation` starting from a nil change token. It never uses `CKQuery`, preserving the private-sync I5 invariant.
+1. Metadata detection, role detection, and Cancel do not change recovery state.
+2. Continue marks `acceptanceInFlight` before `acceptShareDirect` starts. A membership or profile
+   lookup may remain in flight, but its generation becomes stale and its completion cannot commit.
+   If a recovery durable-write section is already executing, acceptance waits only for that local
+   write to finish. Once acceptance is observable, no new recovery durable-write section may open
+   until acceptance succeeds or fails.
+3. A failed or aborted share acceptance releases only the lease. The runtime gate remains held,
+   the durable recovery intent and coordinator state remain byte-for-byte unchanged, and recovery
+   may retry.
+4. After the share is accepted and `applyAcceptedFamilyMode` completes successfully, the
+   coordinator atomically invalidates its account-scoped recovery intent, marks recovery stood
+   down, and releases the runtime gate. These operations are one main-actor transition; no stale
+   recovery completion may write afterward.
+5. Best-effort FamilyMember registration and Child lock-code refresh continue through the
+   existing acceptance flow. Their failure does not resurrect the invalidated recovery intent;
+   normal activation retries them under the accepted family authority.
 
-The reader follows `moreComing` pages and folds `SyncedProfile` modifications and deletions into a set of current record IDs. A missing or empty zone is a confirmed count of zero. Transient CloudKit errors are indeterminate and return to the retry screen; the app does not guess that profiles are absent. The lookup performs no save, zone creation, subscription creation, engine attachment, or sync-state mutation.
+This makes successful accepted authority win exactly once. It avoids both blocking remediation
+and racing two writers over mode/onboarding state.
 
-## User experience and copy
+## Membership lookup and exact absence semantics
 
-Recovery UI appears only after CloudKit confirms membership, preventing false alarms for new users.
+For every candidate requiring membership resolution, a dedicated read-only CloudKit service:
 
-Title:
+1. Confirms iCloud account availability.
+2. Fetches the current iCloud user record ID.
+3. Lists shared zones and finds an exact `FamilyPolicies` zone-name match.
+4. Fetches that zone's changes from a nil token and finds a `FamilyMember` whose
+   `userRecordName` exactly matches the current user record ID.
 
-> We found your family
+The result carries account identity: `member(role, userRecordID)`, `confirmedNone(userRecordID)`,
+or `indeterminate`.
 
-Introductory message:
+The #427 evidence boundary applies exactly:
 
-> This device no longer has its previous local data, but this iCloud account is still part of a Family Foqos family. Your family role has been restored.
+- A successful shared-zone list with no exact `FamilyPolicies` match is `confirmedNone`.
+- A successful, complete member-record fetch with no matching record is `confirmedNone`.
+- A successful fetch with a matching, valid role is `member`.
+- An unavailable account, account-ID failure, zone-list failure, per-record failure, undecodable
+  role, zone-fetch failure, or operation failure is `indeterminate`. A thrown `.zoneNotFound`,
+  `.userDeletedZone`, or partial failure is still a failed lookup, not confirmed absence. The
+  service may convert it to `confirmedNone` only after a new successful zone list proves the exact
+  zone absent.
 
-When the confirmed count is one:
+Thus successful absence is authoritative; failed absence is never treated as absence. Reads log
+only privacy-safe error categories and never the record ID.
+
+## First-class state-machine outcomes
+
+Local classification and confirmed membership combine into two explicit recovery outcomes:
+
+| Local evidence at decision time | Membership | Outcome |
+| --- | --- | --- |
+| `fresh` | confirmed member | `freshMember(role, owner)` |
+| `localStatePresent` | confirmed member | `localStatePresentMember(role, owner)` |
+| either | confirmed none | release the normal new-user path |
+| `indeterminate` or membership indeterminate | retry/OPEN-M1 bounded state |
+
+`localStatePresentMember` is not a re-arm special case. Re-arm and any future OPEN-M2 partial-wipe
+route converge on this same state and copy.
+
+Every async entry point—cold start, Retry, connectivity recovery, foreground re-arm, count
+refresh, and user action—coalesces into one coordinator-owned task. The coordinator uses a
+monotonic generation token: only the current generation may commit state, stale completions are
+ignored, and repeated triggers await the same in-flight operation. Durable transitions compare
+the expected owner and state before writing, so role restoration, notice creation, offer clearing,
+and gate release are idempotent.
+
+## Re-arm must reclassify local state
+
+After the bounded OPEN-M1 escape releases setup, every later membership re-arm first captures and
+classifies local evidence again. It must not reuse the cold-launch `fresh` result.
+
+If membership is later confirmed and local state is now present, route to
+`localStatePresentMember`. Restore only family role/authority. Do not enumerate remote profiles,
+offer restoration, attach/start the sync engine, seed, or merge. Persist Device Sync disabled
+before releasing normal startup, so an earlier app-group consent crumb cannot cause an automatic
+merge.
+
+The role-only notice uses distinct copy:
+
+> **Your family role was restored**
+>
+> This device already has local setup or profiles, so Family Foqos restored only its family role.
+> Device Sync is off to avoid merging profiles automatically. You can review Device Sync in
+> Settings.
+
+For a recovered Child, role persistence completes before authorization verification and shared
+lock-code refresh. The role-only notice is durable and account-scoped under the same rules as the
+fresh-profile offer.
+
+## Fresh-member family-role recovery and durability
+
+On `freshMember`, the coordinator persists an account-scoped recovery intent before restoring the
+role through `AppModeManager.selectMode`, marking onboarding complete, and suppressing both
+onboarding screens. Child recovery persists the Child role before authorization verification and
+refreshes the fail-closed shared lock-code cache. Parent recovery restores Parent equivalently.
+Role restoration never depends on Device Sync or synced-profile presence.
+
+The durable record contains:
+
+- the owning iCloud `userRecordID`;
+- the recovered role;
+- the recovery path (`freshMember` or `localStatePresentMember`);
+- an optional synced-profile count hint and the time it was confirmed; and
+- enough origin state to roll back a stale recovery safely if account ownership changes.
+
+The record stores no name, profile field, lock code, or CloudKit error. The account identifier is
+required security context, not user-facing copy, and is never logged.
+
+Before reconstructing or acting on any durable notice, the coordinator fetches the current
+account identity. On a mismatch it must not surface the stale role, count, or action. It holds the
+startup gate, invalidates the old-account intent, and reruns membership for the current account.
+If the new account is a member, it replaces the intent with the new owner and result. If a
+successful lookup confirms no membership, it rolls back the recovery-only role/onboarding writes
+recorded by the intent and releases the normal new-user path. If the lookup is indeterminate, it
+holds and retries; it never exposes Home under stale recovered authority.
+
+The intent is cleared only after the account-validated decision completes. A crash before that
+point reconstructs the same state without duplicating side effects.
+
+## Synced-profile discovery and consent boundary
+
+Only `freshMember` performs profile discovery. The coordinator reads the current account's
+private `DeviceSync` zone with `CKFetchRecordZoneChangesOperation` from a nil change token. It
+follows all pages and folds `SyncedProfile` modifications and deletions into the current set.
+It never uses `CKQuery` and performs no save, zone creation, subscription creation, engine
+attachment, or sync-state mutation.
+
+A successful complete fetch yields the confirmed count, including zero. A successful zone list
+that proves the private zone absent also confirms zero. Record, zone, or operation failure is
+indeterminate; a thrown missing-zone error must be rechecked by successful zone listing before it
+can become confirmed zero.
+
+This CloudKit read intentionally occurs **before Device Sync consent**. The app reads only record
+identifiers and types to tell the user whether restoration is available; it does not download
+profile fields or mutate sync state. The recovery UI must disclose this pre-consent availability
+check in its privacy/accessibility copy. Restore remains the only action that enables Device Sync.
+
+The stored count is only a hint. Before presenting a resumed offer, the coordinator validates the
+account and re-fetches the count. Immediately before acting on Restore, Not Now, or zero-profile
+Continue, it validates the account and count again. If the count changed, it updates the copy and
+requires a new explicit tap; it never acts on a stale number or on a count belonging to another
+account.
+
+## Fresh-member user experience and copy
+
+After current-account membership and profile count are confirmed, show:
+
+> **We found your family**
+>
+> This device no longer has its previous local data, but this iCloud account is still part of a
+> Family Foqos family. Your family role has been restored.
+
+The view also states that Family Foqos checked the account's Device Sync storage without enabling
+Device Sync.
+
+For one profile:
 
 > We found 1 synced profile. Restore it to this device?
 
-When the confirmed count is greater than one:
+For more than one:
 
 > We found N synced profiles. Restore them to this device?
 
-Restore explicitly enables Device Sync and only then attaches/starts the existing engine so it can fetch the profiles. Not Now leaves Device Sync disabled. Either decision clears the durable pending offer and continues into the restored family mode.
+Restore enables Device Sync only after the final account/count validation, then releases the gate
+and attaches the existing engine. Not Now persists Device Sync disabled, clears the validated
+offer, and releases into the restored family mode.
 
-When the confirmed count is zero:
+For a confirmed zero count:
 
-> We couldn't find any profiles saved with Device Sync. Profiles that existed only on this device can't be recovered.
+> We couldn't find any profiles saved with Device Sync. Profiles that existed only on this device
+> can't be recovered.
 
-Continue clears the durable pending offer and enters the restored family mode. The copy never promises recovery of local-only data.
+Continue clears the validated offer and enters the restored family mode with Device Sync off. No
+copy promises recovery of local-only data or claims that existing local and remote profiles were
+merged.
 
-## Existing startup integration
+## Normal startup integration
 
-The current migration, schedule refresh, account verification, authorization verification, lock-code refresh, and sync composition run once after one of these release points:
+Migration, schedule refresh, account verification, authorization verification, lock-code refresh,
+and sync composition run once after an allowed release point. The process-wide gate is released
+only after the applicable durable transition and account validation finish.
 
-- local evidence is existing;
-- CloudKit confirms no membership;
-- the user chooses Continue Setup after the required retry;
-- the user completes the recovery decision.
-
-When Continue Setup re-arms the guard, later membership checks run before the existing foreground child-authorization sequence. If membership is later confirmed, recovery role persistence happens before authorization verification and HomeView is replaced by the durable recovery offer.
+The selected OPEN-M1 policy will define the bounded indeterminate release point. Existing local
+state that is outside the OPEN-M2 trigger releases normal startup immediately. Confirmed
+membership with local state present goes through the role-only notice and sync-disabled release,
+never the fresh-member restoration offer.
 
 ## Testing and verification
 
-Implementation follows strict RED-GREEN-REFACTOR cycles. Tests cover:
+Implementation resumes with strict RED-GREEN-REFACTOR cycles only after maintainer rulings and
+reviewer approval. Tests must cover:
 
-1. The full local classifier matrix, including absent/table-missing/zero/positive/read-failed store states and any app-group value.
-2. Read-only physical effects: no defaults suite, main store, or WAL creation; WAL visibility and SHM classification.
-3. Startup ordering: preflight capture precedes migrations/container/singletons, HomeView is withheld, and sync attachment cannot occur before resolution.
-4. Membership outcomes: confirmed member roles, confirmed none, signed-out/transient indeterminate results, retry, Continue Setup, and foreground/connectivity re-arm.
-5. Durable offer recovery across termination and clearing only on explicit decisions.
-6. Child fail-closed ordering: role and onboarding persistence precede authorization checks; shared lock-code refresh occurs.
-7. Private-zone profile counting across pages, modifications/deletions, missing/empty zones, and transient errors without `CKQuery` or writes.
-8. Exact user copy, singular/plural count text, Restore, Not Now, zero-profile Continue, and invisibility for normal existing/new-user paths.
-9. All 12 target configurations at marketing version 2.0.47 and build 65.
+1. The full local classifier matrix and both OPEN-M2 outcomes without changing the state machine.
+2. Read-only physical effects: no defaults suite, main store, or WAL creation; WAL visibility and
+   SHM classification.
+3. A consumer-first gate proof: an `AppDelegate`-representing consumer accesses the static before
+   `FoqosApp` construction and observes held; only an allowed coordinator transition can make a
+   later observation unheld.
+4. Silent pushes while held invoking none of membership verification, command processing, sync,
+   heartbeat refresh, or app-group writes; pushes resume after monotonic release.
+5. Repeated held pushes honestly returning `.noData`, foreground repair, and no correctness
+   dependence on immediate post-hold APNs delivery.
+6. Share metadata detection and Cancel leaving recovery untouched; acceptance acquiring exclusive
+   ownership; concurrent recovery commits being impossible; failure preserving the held gate and
+   exact durable state; and successful mode application atomically invalidating intent and
+   releasing exactly once.
+7. Exact #427 absence mapping, including every failed missing-zone form remaining indeterminate.
+8. `freshMember` and first-class `localStatePresentMember` outcomes from cold start, re-arm, and
+   both possible OPEN-M2 trigger policies.
+9. Re-arm reclassification after local writes, role-only copy, Device Sync forced off, no profile
+   count, no engine attach, and no merge.
+10. Single-flight coalescing, stale-generation suppression, and idempotent durable transitions
+   under repeated foreground/connectivity/retry/action events.
+11. Account-scoped durable recovery across termination, account mismatch, rollback on confirmed
+   none, and indeterminate fail-closed handling.
+12. Count re-confirmation before every surface and action, including changed-count retap.
+13. Private-zone counting across pages and deletions, read-before-consent disclosure, and zero
+    confirmed only by successful evidence.
+14. Child fail-closed ordering, exact copy, privacy logging, and the complete OPEN-M1 durable,
+    account/device-scoped enforcement selected by the maintainer.
+15. All 12 target configurations at marketing version 2.0.49 and build 67.
 
-Final verification includes the focused tests, full suite through build2's stable simulator stream, Debug build, recursive Swift formatting lint, log privacy lint, sync guards, version checks, and `git diff --check`. An independent reviewer must approve the exact signed head before the planner merges. The attended beta upload occurs only after merge.
+Final verification includes focused tests, the full suite through build2's stable simulator
+stream, Debug build, recursive Swift formatting lint, log privacy lint, sync guards, version
+checks, and `git diff --check`. An independent reviewer must approve the exact signed head before
+the planner merges. The attended beta upload occurs only after merge and after 2.0.48 build 66.

--- a/docs/superpowers/specs/2026-08-16-issue-447-empty-store-family-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-16-issue-447-empty-store-family-recovery-design.md
@@ -18,7 +18,7 @@ The alternatives do not preserve the required ordering. A check launched from `H
 
 The capture is read-only:
 
-- The standard defaults domain is read with Core Foundation preferences. The onboarding sentinel is present when `family_foqos_has_completed_onboarding` has a persisted value.
+- The standard defaults domain is read with Core Foundation preferences. The onboarding sentinel is present when either the current `family_foqos_has_completed_onboarding` key or its pre-migration `hasCompletedOnboarding` predecessor has a persisted value, preventing an older installed build from being mistaken for a fresh user before migration runs.
 - The production SwiftData URL comes from one extracted `AppModelStore` configuration shared by the app and inspector. If `default.store` is absent, the profile store is empty. If it exists, a WAL-aware read-only SQLite connection checks for `ZBLOCKEDPROFILES` and counts rows. Store absent, table absent, and count zero are empty; a positive count is existing state; a read failure is indeterminate.
 - The app-group preferences domain is copied with Core Foundation preferences without constructing `UserDefaults(suiteName:)`. Any persisted app-group value counts as existing state, including Device Sync consent, device identity, snapshots, or schedule/session data.
 

--- a/docs/superpowers/specs/2026-08-16-issue-447-empty-store-family-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-16-issue-447-empty-store-family-recovery-design.md
@@ -1,0 +1,121 @@
+# Issue #447 Empty-Store Family Recovery Design
+
+## Status and scope
+
+This design implements the release-blocking recovery guard approved by the planner on 2026-08-16. It handles a device whose local onboarding, SwiftData profile store, and app-group state are all fresh or empty while the current iCloud account still has a `FamilyMember` record. The guard restores the family role independently of Device Sync and offers restoration only for profiles confirmed in the private `DeviceSync` zone.
+
+The change ships in version 2.0.47 build 65. Version 2.0.46 remains burned by the never-merged #430 diagnostic build. Diagnosing why local state disappeared and reconstructing local-only profiles remain out of scope.
+
+## Design choice
+
+Use a pre-startup local snapshot plus a main-actor `StartupRecoveryCoordinator` state machine.
+
+The alternatives do not preserve the required ordering. A check launched from `HomeView.task` can lose the race to its onboarding covers and `onAppear` side effects. Attaching the sync engine before classification creates app-group device identity and can seed the empty local store, masking the contradiction the guard needs to detect.
+
+## Pre-startup local evidence
+
+`FoqosApp` captures immutable local evidence in its first stored-property initialization, following the ordering proven by the #430 V2 probe. The capture runs before singleton-backed `@StateObject` properties, `UserDefaultsMigration`, the global `ModelContainer` request, onboarding, CloudKit verification, or `ProfileSyncManager.attachEngine`.
+
+The capture is read-only:
+
+- The standard defaults domain is read with Core Foundation preferences. The onboarding sentinel is present when `family_foqos_has_completed_onboarding` has a persisted value.
+- The production SwiftData URL comes from one extracted `AppModelStore` configuration shared by the app and inspector. If `default.store` is absent, the profile store is empty. If it exists, a WAL-aware read-only SQLite connection checks for `ZBLOCKEDPROFILES` and counts rows. Store absent, table absent, and count zero are empty; a positive count is existing state; a read failure is indeterminate.
+- The app-group preferences domain is copied with Core Foundation preferences without constructing `UserDefaults(suiteName:)`. Any persisted app-group value counts as existing state, including Device Sync consent, device identity, snapshots, or schedule/session data.
+
+No capture path creates a preferences suite, the main store, or its WAL. The expected read-only SQLite SHM artifact remains acceptable only if the WAL-aware reader requires it; creation of the main store or WAL is a hard failure.
+
+The pure classifier returns:
+
+- `existing`: any onboarding, positive-profile, or app-group sentinel exists. Release normal startup immediately and keep the guard invisible.
+- `fresh`: onboarding is absent, profiles are confirmed empty, and the app-group domain is empty. Hold onboarding and sync attachment while checking CloudKit.
+- `indeterminate`: local evidence could not be read reliably. Show the same retryable checking state used for indeterminate CloudKit results.
+
+## Startup and membership state machine
+
+While classification is unresolved, `FoqosApp` shows a neutral checking view instead of constructing `HomeView`. This prevents its onboarding covers and startup cleanup from running. `ProfileSyncManager.attachEngine` is also withheld, so no Device Sync identity, zone, seed, or write can occur before the guard decides.
+
+For a fresh candidate, a dedicated read-only CloudKit service performs this sequence:
+
+1. Confirm iCloud account availability.
+2. Find the shared `FamilyPolicies` zone.
+3. Fetch the current user record ID.
+4. Query the shared zone for that user's `FamilyMember` record and decode its role.
+
+The lookup returns one of three semantic outcomes:
+
+- `member(role)`: enter recovery.
+- `confirmedNone`: release normal startup and current onboarding without showing recovery UI.
+- `indeterminate`: show an honest retry state and do not claim either membership or absence.
+
+An indeterminate result is not an infinite hold. The UI first offers Retry. After an explicit retry also fails, it additionally offers Continue Setup. Continue Setup releases current onboarding and re-arms the membership check on every later foreground and relevant connectivity recovery until CloudKit returns `member(role)` or `confirmedNone`. This deliberately allows a wiped child device launched offline to remain temporarily in the pre-existing Individual behavior until connectivity returns; permanently blocking a genuinely new offline user is the worse failure. A later confirmed membership immediately enters recovery and closes the temporary unrestricted window.
+
+## Family-role recovery and durability
+
+On `member(role)`, the coordinator first persists the recovery intent, then restores the role through `AppModeManager.selectMode`, marks onboarding completed, and suppresses both onboarding screens. These writes are recovery actions made only after the pre-startup evidence is frozen and membership is confirmed.
+
+Child recovery completes role persistence before authorization verification and refreshes shared lock-code caches. Parent recovery restores Parent equivalently. Family-role restoration never depends on the Device Sync setting or the presence of synced profiles.
+
+A durable `StartupRecoveryNoticeStore`, modeled on the #446 one-shot notice store, records that the recovery offer is pending. It is set before the restored onboarding state can make the next launch look non-fresh. Startup checks this flag before the local fresh-state classifier, reconstructs the recovery screen after termination, and clears the flag only after the user explicitly chooses Restore, Not Now, or Continue for the no-profile result. A crash at any point before a decision therefore cannot lose the offer.
+
+The durable record stores only non-sensitive recovery state: the restored role and the last confirmed synced-profile count. It stores no name, CloudKit record identifier, profile fields, or lock code.
+
+## Synced-profile discovery
+
+After membership restoration and before any Device Sync enablement, the coordinator reads the current private `DeviceSync` zone with `CKFetchRecordZoneChangesOperation` starting from a nil change token. It never uses `CKQuery`, preserving the private-sync I5 invariant.
+
+The reader follows `moreComing` pages and folds `SyncedProfile` modifications and deletions into a set of current record IDs. A missing or empty zone is a confirmed count of zero. Transient CloudKit errors are indeterminate and return to the retry screen; the app does not guess that profiles are absent. The lookup performs no save, zone creation, subscription creation, engine attachment, or sync-state mutation.
+
+## User experience and copy
+
+Recovery UI appears only after CloudKit confirms membership, preventing false alarms for new users.
+
+Title:
+
+> We found your family
+
+Introductory message:
+
+> This device no longer has its previous local data, but this iCloud account is still part of a Family Foqos family. Your family role has been restored.
+
+When the confirmed count is one:
+
+> We found 1 synced profile. Restore it to this device?
+
+When the confirmed count is greater than one:
+
+> We found N synced profiles. Restore them to this device?
+
+Restore explicitly enables Device Sync and only then attaches/starts the existing engine so it can fetch the profiles. Not Now leaves Device Sync disabled. Either decision clears the durable pending offer and continues into the restored family mode.
+
+When the confirmed count is zero:
+
+> We couldn't find any profiles saved with Device Sync. Profiles that existed only on this device can't be recovered.
+
+Continue clears the durable pending offer and enters the restored family mode. The copy never promises recovery of local-only data.
+
+## Existing startup integration
+
+The current migration, schedule refresh, account verification, authorization verification, lock-code refresh, and sync composition run once after one of these release points:
+
+- local evidence is existing;
+- CloudKit confirms no membership;
+- the user chooses Continue Setup after the required retry;
+- the user completes the recovery decision.
+
+When Continue Setup re-arms the guard, later membership checks run before the existing foreground child-authorization sequence. If membership is later confirmed, recovery role persistence happens before authorization verification and HomeView is replaced by the durable recovery offer.
+
+## Testing and verification
+
+Implementation follows strict RED-GREEN-REFACTOR cycles. Tests cover:
+
+1. The full local classifier matrix, including absent/table-missing/zero/positive/read-failed store states and any app-group value.
+2. Read-only physical effects: no defaults suite, main store, or WAL creation; WAL visibility and SHM classification.
+3. Startup ordering: preflight capture precedes migrations/container/singletons, HomeView is withheld, and sync attachment cannot occur before resolution.
+4. Membership outcomes: confirmed member roles, confirmed none, signed-out/transient indeterminate results, retry, Continue Setup, and foreground/connectivity re-arm.
+5. Durable offer recovery across termination and clearing only on explicit decisions.
+6. Child fail-closed ordering: role and onboarding persistence precede authorization checks; shared lock-code refresh occurs.
+7. Private-zone profile counting across pages, modifications/deletions, missing/empty zones, and transient errors without `CKQuery` or writes.
+8. Exact user copy, singular/plural count text, Restore, Not Now, zero-profile Continue, and invisibility for normal existing/new-user paths.
+9. All 12 target configurations at marketing version 2.0.47 and build 65.
+
+Final verification includes the focused tests, full suite through build2's stable simulator stream, Debug build, recursive Swift formatting lint, log privacy lint, sync guards, version checks, and `git diff --check`. An independent reviewer must approve the exact signed head before the planner merges. The attended beta upload occurs only after merge.


### PR DESCRIPTION
## Summary

- detect genuinely fresh or unreadable local stores before startup side effects
- bind family recovery, durable notices, and profile availability checks to the current iCloud account
- hold Home, sync attachment, foreground work, and silent pushes until recovery releases startup
- serialize successful CloudKit share acceptance against recovery writes
- present account-neutral recovery choices and a role-only no-merge path
- set all configurations to marketing version 2.0.49 and project build 67

## Why

A device with an empty local store could enter normal startup before its existing Family Foqos authority was recovered. That risked onboarding under stale assumptions or automatically mixing local and synced profiles. The new state machine restores only account-validated authority and requires an explicit Device Sync choice before profile restoration.

## Validation

- immutable exact-head review approved at `78910470af36ec85fdaa679695548736762a1e20`
- 1,356 tests passed; 0 failed; 0 skipped
- Debug build succeeded through the owned Xcode stream
- `swift-format lint --recursive .`
- log privacy lint: 240 files, 517 sites, 0 annotations
- sync guards I5/I2 passed
- version fixture and live increment gates passed
- 12 configurations at `MARKETING_VERSION = 2.0.49`
- 12 configurations at `CURRENT_PROJECT_VERSION = 67`
- corrected #449 head `f0293418539aeced376c121f410b1152faed3a11` is an ancestor

Closes #447
